### PR TITLE
replace : with _ in executor ID

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilder.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilder.java
@@ -85,7 +85,7 @@ public class SingularityMesosTaskBuilder {
     bldr.setExecutor(
         ExecutorInfo.newBuilder()
           .setCommand(CommandInfo.newBuilder().setValue(task.getRequest().getExecutor()))
-          .setExecutorId(ExecutorID.newBuilder().setValue(String.format("singularity-%s", taskId.toString())))
+          .setExecutorId(ExecutorID.newBuilder().setValue(String.format("singularity-%s", taskId.toString().replace(':', '_'))))
     );
     
     Object executorData = task.getRequest().getExecutorData();


### PR DESCRIPTION
Many of our tasks have been having issues due to the fact that `:` is a path separator character for many things.

@wsorenson 
