### PR TITLE
Add a bundle to set the correct MetricsRegistry on the ServletContext

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/MetricsBundle.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/MetricsBundle.java
@@ -1,0 +1,34 @@
+package com.hubspot.singularity;
+
+import com.codahale.metrics.servlets.MetricsServlet;
+import io.dropwizard.Bundle;
+import io.dropwizard.lifecycle.ServerLifecycleListener;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import org.eclipse.jetty.server.Server;
+
+import javax.servlet.ServletContext;
+
+/**
+ * Expose Dropwizard's metrics registry to {@link com.hubspot.jackson.jaxrs.PropertyFilteringMessageBodyWriter}
+ * via the servlet context.
+ *
+ * This class is picked up by autoconfig
+ */
+public class MetricsBundle implements Bundle {
+
+  @Override
+  public void initialize(Bootstrap<?> bootstrap) { }
+
+  @Override
+  public void run(final Environment environment) {
+    // need to wait until the server is started to do this otherwise an IllegalStateException is thrown
+    environment.lifecycle().addServerLifecycleListener(new ServerLifecycleListener() {
+      @Override
+      public void serverStarted(Server server) {
+        ServletContext context = environment.getJerseyServletContainer().getServletContext();
+        context.setAttribute(MetricsServlet.METRICS_REGISTRY, environment.metrics());
+      }
+    });
+  }
+}


### PR DESCRIPTION
It seems that the idiomatic way to pass the desired `MetricRegistry` between libraries is by setting it as an attribute on the `ServletContext` ([see here](http://metrics.codahale.com/manual/servlets/)). This PR does just that, allowing other libraries to contribute metrics to Dropwizard's metric registry (specifically this will be used by [HubSpot/jackson-jaxrs-propertyfiltering](https://github.com/HubSpot/jackson-jaxrs-propertyfiltering) to contribute timing information)

@wsorenson @tpetr 
