### PR TITLE
Added copy button to JSON dialog

### DIFF
--- a/SingularityUI/app/utils.coffee
+++ b/SingularityUI/app/utils.coffee
@@ -43,15 +43,38 @@ class Utils
         if type is 'requestHistory'
             lookupObject = app.allRequestHistories
 
+        copyButton =
+            text: "Copy"
+            type: "button"
+            className: "vex-dialog-button-secondary copy-button"
+                
         vex.dialog.alert
             buttons: [
-                $.extend({}, vex.dialog.buttons.YES, text: 'Done')
+                $.extend({}, vex.dialog.buttons.YES, text: 'Done'),
+                copyButton
             ]
             className: 'vex-theme-default vex-theme-default-json-view'
             message: "<pre>#{ utils.htmlEncode lookupObject[objectId].JSONString }</pre>"
             afterOpen: ($vexContent) ->
                 utils.scrollPreventDefaultAtBounds $vexContent.find('pre')
                 utils.scrollPreventAlways $vexContent.parent()
+                
+                # Dity hack to make ZeroClipboard play along
+                # The Flash element doesn't work if it falls outside the
+                # bounds of the body, even if it's inside the dialog
+                overlayHeight = $(".vex-overlay").height()
+                $("body").css "min-height", overlayHeight + "px"
+                
+                $button = $vexContent.find ".copy-button"
+                $button.attr "data-clipboard-text", $vexContent.find("pre").html()
+                
+                zeroClipboardClient = new ZeroClipboard $button[0],
+                    moviePath: "#{ config.appRoot }/static/swf/ZeroClipboard.swf"
+                
+                zeroClipboardClient.on "load", ->
+                    zeroClipboardClient.on "complete", ->
+                        $button.val "Copied"
+                        setTimeout (-> $button.val "Copy"), 800
 
     @scrollPreventDefaultAtBounds: ($scroll) ->
         $scroll.bind 'mousewheel', (e, delta) ->


### PR DESCRIPTION
Added Copy (to clipboard) button to JSON dialogs - issue #124 

The flash element from ZeroClipboard acts up if it falls outside the body, which is can if there are next to no requests, so I had to add the "dirty hack" to help with that.

This'd only occur if the page body is so small such that the copy button would actually be outside it because of the Vex dialog. This is really unlikely in a production environment, but I added it just in case.

It can still be a problem if that holds true AND the user resizes their window vertically, which again, is very very unlikely to happen.

@gchomatas @tpetr @wsorenson 
