### PR TITLE
Fix historical tasks ordering

### DIFF
--- a/SingularityUI/app/collections/HistoricalTasks.coffee
+++ b/SingularityUI/app/collections/HistoricalTasks.coffee
@@ -4,7 +4,8 @@ class HistoricalTasks extends Mixen(RequestTasks, Teeble.ServerCollection)
 
     model: Backbone.Model
 
-    comparator: undefined
+    comparator: (task0, task1) =>
+        -(task0.get("startedAt") - task1.get("startedAt"))
 
     url: ->
         params =


### PR DESCRIPTION
Fixes #149 

Added comparator to appropriate collection so that it can automatically sort tasks client-side.

@tpetr @wsorenson @gchomatas 
