### PR TITLE
Tailer tweaks

### DIFF
--- a/SingularityUI/app/styles/tailer.styl
+++ b/SingularityUI/app/styles/tailer.styl
@@ -89,6 +89,14 @@
         &:before
             content ""
 
+    &.hover-last-5
+
+        .tail-corner-container
+            opacity .25
+        
+            &:hover
+                opacity 1
+
 .tail-outer
     position relative
     font-family Consolas, "Liberation Mono", Courier, monospace

--- a/SingularityUI/app/views/tailer.coffee
+++ b/SingularityUI/app/views/tailer.coffee
@@ -11,6 +11,7 @@ class TailerView extends Backbone.View
 
     events:
         'scroll': 'handleScroll'
+        'mouseover [data-offset]': 'lineHover'
 
     initialize: ->
         @tailing = null
@@ -65,6 +66,13 @@ class TailerView extends Backbone.View
     remove: =>
         @stopTailing()
         super
+
+    lineHover: (event) =>
+        $last5 = @$container.find("[data-offset]:nth-last-child(-n+5)")
+        if event.currentTarget in $last5
+            @parent.$el.addClass "hover-last-5"
+        else
+            @parent.$el.removeClass "hover-last-5"
 
     scrollToBottom: =>
         @$el.scrollTop @el.scrollHeight


### PR DESCRIPTION
[The PaaS issue](https://git.hubteam.com/HubSpot/PaaS/issues/25) (please discuss it there) brings up the problem that the "To X" buttons hide the text behind them.

The tweaks involve fading out the tailing indicator and the buttons (unless you hover over them) if you're hovering over the last 5 lines.

Example: http://imgur.com/a/tsYIN
