### PR TITLE
optional LDAP auth

### DIFF
--- a/SingularityService/pom.xml
+++ b/SingularityService/pom.xml
@@ -206,6 +206,18 @@
       <version>${jets3t.version}</version>
     </dependency>
 
+      <dependency>
+          <groupId>io.dropwizard</groupId>
+          <artifactId>dropwizard-auth</artifactId>
+          <version>${dropwizard.version}</version>
+      </dependency>
+
+      <dependency>
+          <groupId>com.yammer.dropwizard</groupId>
+          <artifactId>dropwizard-auth-ldap</artifactId>
+          <version>0.1.1-SNAPSHOT</version>
+      </dependency>
+
   </dependencies>
 
   <build>

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityService.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityService.java
@@ -1,6 +1,15 @@
 package com.hubspot.singularity;
 
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.google.inject.Stage;
+import com.hubspot.dropwizard.guice.GuiceBundle;
+import com.hubspot.jackson.datatype.protobuf.ProtobufModule;
+import com.hubspot.jackson.jaxrs.PropertyFilteringMessageBodyWriter;
+import com.hubspot.singularity.auth.SingularityAuthBundle;
+import com.hubspot.singularity.config.SingularityConfiguration;
+import com.hubspot.singularity.sentry.SentryAppenderBundle;
+import com.hubspot.singularity.smtp.SMTPAppenderBundle;
 import io.dropwizard.Application;
 import io.dropwizard.assets.AssetsBundle;
 import io.dropwizard.db.DataSourceFactory;
@@ -8,15 +17,6 @@ import io.dropwizard.migrations.MigrationsBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.views.ViewBundle;
-
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.google.inject.Stage;
-import com.hubspot.dropwizard.guice.GuiceBundle;
-import com.hubspot.jackson.datatype.protobuf.ProtobufModule;
-import com.hubspot.jackson.jaxrs.PropertyFilteringMessageBodyWriter;
-import com.hubspot.singularity.config.SingularityConfiguration;
-import com.hubspot.singularity.sentry.SentryAppenderBundle;
-import com.hubspot.singularity.smtp.SMTPAppenderBundle;
 
 public class SingularityService extends Application<SingularityConfiguration> {
 
@@ -41,6 +41,7 @@ public class SingularityService extends Application<SingularityConfiguration> {
         return configuration.getDataSourceFactory();
       }
     });
+    bootstrap.addBundle(new SingularityAuthBundle());
     
     bootstrap.getObjectMapper().registerModule(new ProtobufModule());
     bootstrap.getObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityServiceModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityServiceModule.java
@@ -1,11 +1,5 @@
 package com.hubspot.singularity;
 
-import io.dropwizard.jackson.Jackson;
-import io.dropwizard.jdbi.DBIFactory;
-import io.dropwizard.jetty.HttpConnectorFactory;
-import io.dropwizard.server.SimpleServerFactory;
-import io.dropwizard.setup.Environment;
-
 import java.io.IOException;
 
 import org.aopalliance.intercept.MethodInterceptor;
@@ -50,10 +44,14 @@ import com.hubspot.singularity.scheduler.SingularityNewTaskChecker;
 import com.hubspot.singularity.smtp.JadeHelper;
 import com.hubspot.singularity.smtp.SingularityMailer;
 import com.ning.http.client.AsyncHttpClient;
-
 import de.neuland.jade4j.parser.Parser;
 import de.neuland.jade4j.parser.node.Node;
 import de.neuland.jade4j.template.JadeTemplate;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jdbi.DBIFactory;
+import io.dropwizard.jetty.HttpConnectorFactory;
+import io.dropwizard.server.SimpleServerFactory;
+import io.dropwizard.setup.Environment;
 
 public class SingularityServiceModule extends AbstractModule {
   

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAnonymousUserProvider.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAnonymousUserProvider.java
@@ -1,0 +1,32 @@
+package com.hubspot.singularity.auth;
+
+import javax.ws.rs.ext.Provider;
+
+import com.sun.jersey.api.core.HttpContext;
+import com.sun.jersey.api.model.Parameter;
+import com.sun.jersey.core.spi.component.ComponentContext;
+import com.sun.jersey.core.spi.component.ComponentScope;
+import com.sun.jersey.server.impl.inject.AbstractHttpContextInjectable;
+import com.sun.jersey.spi.inject.Injectable;
+import com.sun.jersey.spi.inject.InjectableProvider;
+import io.dropwizard.auth.Auth;
+
+@Provider
+public class SingularityAnonymousUserProvider implements InjectableProvider<Auth, Parameter> {
+  private static final AbstractHttpContextInjectable<SingularityUser> INJECTABLE = new AbstractHttpContextInjectable<SingularityUser>() {
+    @Override
+    public SingularityUser getValue(HttpContext c) {
+      return SingularityUser.ANONYMOUS;
+    }
+  };
+
+  @Override
+  public ComponentScope getScope() {
+    return ComponentScope.PerRequest;
+  }
+
+  @Override
+  public Injectable<?> getInjectable(ComponentContext ic, Auth auth, Parameter parameter) {
+    return INJECTABLE;
+  }
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAuthBundle.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAuthBundle.java
@@ -1,0 +1,46 @@
+package com.hubspot.singularity.auth;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.hubspot.singularity.SingularityService;
+import com.hubspot.singularity.config.SingularityConfiguration;
+import com.yammer.dropwizard.authenticator.LdapAuthenticator;
+import com.yammer.dropwizard.authenticator.LdapCanAuthenticate;
+import com.yammer.dropwizard.authenticator.LdapConfiguration;
+import com.yammer.dropwizard.authenticator.ResourceAuthenticator;
+import com.yammer.dropwizard.authenticator.healthchecks.LdapHealthCheck;
+import io.dropwizard.ConfiguredBundle;
+import io.dropwizard.auth.Authenticator;
+import io.dropwizard.auth.CachingAuthenticator;
+import io.dropwizard.auth.basic.BasicAuthProvider;
+import io.dropwizard.auth.basic.BasicCredentials;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+
+public class SingularityAuthBundle implements ConfiguredBundle<SingularityConfiguration> {
+  private final static Logger LOG = LoggerFactory.getLogger(SingularityService.class);
+
+  @Override
+  public void initialize(Bootstrap<?> bootstrap) {
+
+  }
+
+  @Override
+  public void run(SingularityConfiguration configuration, Environment environment) {
+    if (configuration.getLdapConfiguration() != null) {
+      LOG.info("Configuring LDAP authentication...");
+      final LdapConfiguration ldapConfiguration = configuration.getLdapConfiguration();
+
+      final Authenticator<BasicCredentials, SingularityUser> ldapAuthenticator = new SingularityResourceAuthenticator(new LdapAuthenticator(ldapConfiguration));
+      final CachingAuthenticator<BasicCredentials, SingularityUser> cachingLdapAuthenticator = new CachingAuthenticator<BasicCredentials, SingularityUser>(environment.metrics(), ldapAuthenticator, ldapConfiguration.getCachePolicy());
+
+      environment.jersey().register(new BasicAuthProvider<>(cachingLdapAuthenticator, "Singularity"));
+
+      environment.healthChecks().register("ldap", new LdapHealthCheck(new ResourceAuthenticator(new LdapCanAuthenticate(ldapConfiguration))));
+    } else {
+      LOG.info("No authentication defined, using anonymous user {}...", SingularityUser.ANONYMOUS);
+      environment.jersey().register(new SingularityAnonymousUserProvider());
+    }
+  }
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityResourceAuthenticator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityResourceAuthenticator.java
@@ -1,0 +1,26 @@
+package com.hubspot.singularity.auth;
+
+import com.google.common.base.Optional;
+import com.yammer.dropwizard.authenticator.LdapAuthenticator;
+import io.dropwizard.auth.AuthenticationException;
+import io.dropwizard.auth.Authenticator;
+import io.dropwizard.auth.basic.BasicCredentials;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class SingularityResourceAuthenticator implements Authenticator<BasicCredentials, SingularityUser> {
+  private final LdapAuthenticator ldapAuthenticator;
+
+  public SingularityResourceAuthenticator(LdapAuthenticator ldapAuthenticator) {
+    this.ldapAuthenticator = checkNotNull(ldapAuthenticator);
+  }
+
+  @Override
+  public Optional<SingularityUser> authenticate(BasicCredentials credentials) throws AuthenticationException {
+    if (ldapAuthenticator.authenticate(credentials)) {
+      return Optional.of(new SingularityUser(credentials.getUsername()));
+    } else {
+      return Optional.absent();
+    }
+  }
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityUser.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityUser.java
@@ -1,0 +1,22 @@
+package com.hubspot.singularity.auth;
+
+public class SingularityUser {
+  private final String username;
+
+  public SingularityUser(String username) {
+    this.username = username;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  @Override
+  public String toString() {
+    return "SingularityUser [" +
+        "username='" + username + '\'' +
+        ']';
+  }
+
+  public static final SingularityUser ANONYMOUS = new SingularityUser("");
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -1,8 +1,5 @@
 package com.hubspot.singularity.config;
 
-import io.dropwizard.Configuration;
-import io.dropwizard.db.DataSourceFactory;
-
 import java.util.concurrent.TimeUnit;
 
 import javax.validation.Valid;
@@ -11,6 +8,9 @@ import javax.validation.constraints.NotNull;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
+import com.yammer.dropwizard.authenticator.LdapConfiguration;
+import io.dropwizard.Configuration;
+import io.dropwizard.db.DataSourceFactory;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SingularityConfiguration extends Configuration {
@@ -38,6 +38,9 @@ public class SingularityConfiguration extends Configuration {
   
   @JsonProperty("sentry")
   private SentryConfiguration sentryConfiguration;
+
+  @JsonProperty("ldap")
+  private LdapConfiguration ldapConfiguration;
   
   @Valid
   @NotNull
@@ -436,4 +439,11 @@ public class SingularityConfiguration extends Configuration {
     this.zooKeeperConfiguration = zooKeeperConfiguration;
   }
 
+  public LdapConfiguration getLdapConfiguration() {
+    return ldapConfiguration;
+  }
+
+  public void setLdapConfiguration(LdapConfiguration ldapConfiguration) {
+    this.ldapConfiguration = ldapConfiguration;
+  }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/HistoryResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/HistoryResource.java
@@ -21,6 +21,7 @@ import com.hubspot.singularity.SingularityTaskHistory;
 import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.SingularityTaskIdHistory;
 import com.hubspot.singularity.WebExceptions;
+import com.hubspot.singularity.auth.SingularityUser;
 import com.hubspot.singularity.data.DeployManager;
 import com.hubspot.singularity.data.TaskManager;
 import com.hubspot.singularity.data.history.DeployHistoryHelper;
@@ -28,6 +29,7 @@ import com.hubspot.singularity.data.history.HistoryManager;
 import com.hubspot.singularity.data.history.HistoryManager.OrderDirection;
 import com.hubspot.singularity.data.history.HistoryManager.RequestHistoryOrderBy;
 import com.hubspot.singularity.data.history.TaskHistoryHelper;
+import io.dropwizard.auth.Auth;
 
 @Path(SingularityService.API_BASE_PATH + "/history")
 @Produces({ MediaType.APPLICATION_JSON })
@@ -36,6 +38,9 @@ public class HistoryResource extends AbstractHistoryResource {
   private final HistoryManager historyManager;
   private final DeployManager deployManager;
   private final TaskManager taskManager;
+
+  @Auth
+  SingularityUser user;
   
   @Inject
   public HistoryResource(HistoryManager historyManager, DeployManager deployManager, TaskManager taskManager) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/IndexResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/IndexResource.java
@@ -6,13 +6,18 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import com.google.inject.Inject;
+import com.hubspot.singularity.auth.SingularityUser;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.views.IndexView;
+import io.dropwizard.auth.Auth;
 
 @Path("/{wildcard:.*}")
 @Produces(MediaType.TEXT_HTML)
 public class IndexResource {
   private final SingularityConfiguration configuration;
+
+  @Auth
+  SingularityUser user;
 
   @Inject
   public IndexResource(SingularityConfiguration configuration) {
@@ -21,6 +26,6 @@ public class IndexResource {
 
   @GET
   public IndexView getIndex() {
-    return new IndexView(configuration);
+    return new IndexView(configuration, user);
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RackResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RackResource.java
@@ -13,13 +13,18 @@ import javax.ws.rs.core.MediaType;
 import com.google.inject.Inject;
 import com.hubspot.singularity.SingularityRack;
 import com.hubspot.singularity.SingularityService;
+import com.hubspot.singularity.auth.SingularityUser;
 import com.hubspot.singularity.data.RackManager;
+import io.dropwizard.auth.Auth;
 
 @Path(SingularityService.API_BASE_PATH + "/racks")
 @Produces({ MediaType.APPLICATION_JSON })
 public class RackResource extends AbstractMachineResource<SingularityRack> {
   
   private final RackManager rackManager;
+
+  @Auth
+  SingularityUser user;
   
   @Inject
   public RackResource(RackManager rackManager) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -37,12 +37,14 @@ import com.hubspot.singularity.SingularityRequestParent;
 import com.hubspot.singularity.SingularityRequestWithState;
 import com.hubspot.singularity.SingularityService;
 import com.hubspot.singularity.WebExceptions;
+import com.hubspot.singularity.auth.SingularityUser;
 import com.hubspot.singularity.data.DeployManager;
 import com.hubspot.singularity.data.DeployManager.ConditionalPersistResult;
 import com.hubspot.singularity.data.RequestManager;
 import com.hubspot.singularity.data.SingularityValidator;
 import com.hubspot.singularity.data.history.HistoryManager;
 import com.sun.jersey.api.NotFoundException;
+import io.dropwizard.auth.Auth;
 
 @Path(SingularityService.API_BASE_PATH + "/requests")
 @Produces({ MediaType.APPLICATION_JSON })
@@ -53,6 +55,9 @@ public class RequestResource {
   private final RequestManager requestManager;
   private final DeployManager deployManager;
   private final HistoryManager historyManager;
+
+  @Auth
+  SingularityUser user;
   
   @Inject
   public RequestResource(SingularityValidator validator, DeployManager deployManager, RequestManager requestManager, HistoryManager historyManager) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/S3LogResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/S3LogResource.java
@@ -42,12 +42,14 @@ import com.hubspot.singularity.SingularityTaskHistoryUpdate;
 import com.hubspot.singularity.SingularityTaskHistoryUpdate.SimplifiedTaskState;
 import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.WebExceptions;
+import com.hubspot.singularity.auth.SingularityUser;
 import com.hubspot.singularity.config.S3Configuration;
 import com.hubspot.singularity.data.DeployManager;
 import com.hubspot.singularity.data.TaskManager;
 import com.hubspot.singularity.data.history.HistoryManager;
 import com.hubspot.singularity.data.history.HistoryManager.OrderDirection;
 import com.hubspot.singularity.data.history.HistoryManager.RequestHistoryOrderBy;
+import io.dropwizard.auth.Auth;
 
 @Path(SingularityService.API_BASE_PATH + "/logs")
 @Produces({ MediaType.APPLICATION_JSON })
@@ -59,6 +61,9 @@ public class S3LogResource extends AbstractHistoryResource {
   private final Optional<S3Configuration> configuration;
   private final DeployManager deployManager;
   private final HistoryManager historyManager;
+
+  @Auth
+  SingularityUser user;
   
   @Inject
   public S3LogResource(HistoryManager historyManager, TaskManager taskManager, DeployManager deployManager, Optional<S3Service> s3, Optional<S3Configuration> configuration) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/SandboxResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/SandboxResource.java
@@ -23,6 +23,7 @@ import com.hubspot.singularity.SingularityService;
 import com.hubspot.singularity.SingularityTaskHistory;
 import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.WebExceptions;
+import com.hubspot.singularity.auth.SingularityUser;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.DeployManager;
 import com.hubspot.singularity.data.SandboxManager;
@@ -30,6 +31,7 @@ import com.hubspot.singularity.data.SandboxManager.SlaveNotFoundException;
 import com.hubspot.singularity.data.TaskManager;
 import com.hubspot.singularity.data.history.HistoryManager;
 import com.hubspot.singularity.mesos.SingularityLogSupport;
+import io.dropwizard.auth.Auth;
 
 @Path(SingularityService.API_BASE_PATH + "/sandbox")
 @Produces({ MediaType.APPLICATION_JSON })
@@ -38,6 +40,9 @@ public class SandboxResource extends AbstractHistoryResource {
   private final SandboxManager sandboxManager;
   private final SingularityLogSupport logSupport;
   private final SingularityConfiguration configuration;
+
+  @Auth
+  SingularityUser user;
 
   @Inject
   public SandboxResource(HistoryManager historyManager, TaskManager taskManager, SandboxManager sandboxManager, DeployManager deployManager, SingularityLogSupport logSupport, SingularityConfiguration configuration) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/SlaveResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/SlaveResource.java
@@ -13,13 +13,18 @@ import javax.ws.rs.core.MediaType;
 import com.google.inject.Inject;
 import com.hubspot.singularity.SingularityService;
 import com.hubspot.singularity.SingularitySlave;
+import com.hubspot.singularity.auth.SingularityUser;
 import com.hubspot.singularity.data.SlaveManager;
+import io.dropwizard.auth.Auth;
 
 @Path(SingularityService.API_BASE_PATH + "/slaves")
 @Produces({ MediaType.APPLICATION_JSON })
 public class SlaveResource extends AbstractMachineResource<SingularitySlave> {
   
   private final SlaveManager slaveManager;
+
+  @Auth
+  SingularityUser user;
   
   @Inject
   public SlaveResource(SlaveManager slaveManager) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/StateResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/StateResource.java
@@ -14,6 +14,7 @@ import com.hubspot.singularity.SingularityRequestWithState;
 import com.hubspot.singularity.SingularityScheduledTasksInfo;
 import com.hubspot.singularity.SingularityService;
 import com.hubspot.singularity.SingularityState;
+import com.hubspot.singularity.auth.SingularityUser;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.DeployManager;
 import com.hubspot.singularity.data.RackManager;
@@ -21,6 +22,7 @@ import com.hubspot.singularity.data.RequestManager;
 import com.hubspot.singularity.data.SlaveManager;
 import com.hubspot.singularity.data.StateManager;
 import com.hubspot.singularity.data.TaskManager;
+import io.dropwizard.auth.Auth;
 
 @Path(SingularityService.API_BASE_PATH + "/state")
 @Produces({ MediaType.APPLICATION_JSON })
@@ -33,6 +35,9 @@ public class StateResource {
   private final RackManager rackManager;
   private final StateManager stateManager;
   private final SingularityConfiguration singularityConfiguration;
+
+  @Auth
+  SingularityUser user;
   
   @Inject
   public StateResource(RequestManager requestManager, DeployManager deployManager, TaskManager taskManager, StateManager stateManager, SlaveManager slaveManager, RackManager rackManager, SingularityConfiguration singularityConfiguration) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
@@ -26,10 +26,12 @@ import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.SingularityTaskCleanup.TaskCleanupType;
 import com.hubspot.singularity.SingularityTaskCleanupResult;
 import com.hubspot.singularity.SingularityTaskRequest;
+import com.hubspot.singularity.auth.SingularityUser;
 import com.hubspot.singularity.data.SlaveManager;
 import com.hubspot.singularity.data.TaskManager;
 import com.hubspot.singularity.data.TaskRequestManager;
 import com.sun.jersey.api.NotFoundException;
+import io.dropwizard.auth.Auth;
 
 @Path(SingularityService.API_BASE_PATH + "/tasks")
 @Produces({ MediaType.APPLICATION_JSON })
@@ -39,6 +41,9 @@ public class TaskResource {
   private final SlaveManager slaveManager;  
   private final TaskRequestManager taskRequestManager;
   private final MesosClient mesosClient;
+
+  @Auth
+  SingularityUser user;
   
   @Inject
   public TaskResource(TaskRequestManager taskRequestManager, TaskManager taskManager, SlaveManager slaveManager, MesosClient mesosClient) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/TestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/TestResource.java
@@ -13,6 +13,8 @@ import com.hubspot.singularity.SingularityAbort;
 import com.hubspot.singularity.SingularityDriverManager;
 import com.hubspot.singularity.SingularityLeaderController;
 import com.hubspot.singularity.SingularityService;
+import com.hubspot.singularity.auth.SingularityUser;
+import io.dropwizard.auth.Auth;
 
 @Path(SingularityService.API_BASE_PATH + "/test")
 public class TestResource {
@@ -20,6 +22,9 @@ public class TestResource {
   private final SingularityAbort abort;
   private final SingularityLeaderController managed;
   private final SingularityDriverManager driverManager;
+
+  @Auth
+  SingularityUser user;
   
   @Inject
   public TestResource(SingularityLeaderController managed, SingularityAbort abort, SingularityDriverManager driverManager) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/views/IndexView.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/views/IndexView.java
@@ -1,10 +1,10 @@
 package com.hubspot.singularity.views;
 
+import com.hubspot.singularity.SingularityService;
+import com.hubspot.singularity.auth.SingularityUser;
+import com.hubspot.singularity.config.SingularityConfiguration;
 import io.dropwizard.server.SimpleServerFactory;
 import io.dropwizard.views.View;
-
-import com.hubspot.singularity.SingularityService;
-import com.hubspot.singularity.config.SingularityConfiguration;
 
 public class IndexView extends View {
   private final String appRoot;
@@ -14,7 +14,9 @@ public class IndexView extends View {
   private final Integer mesosLogsPort;
   private final Integer mesosLogsPortHttps;
 
-  public IndexView(SingularityConfiguration configuration) {
+  private final SingularityUser user;
+
+  public IndexView(SingularityConfiguration configuration, SingularityUser user) {
     super("index.mustache");
 
     appRoot = configuration.getSingularityUIHostnameAndPath().or(((SimpleServerFactory)configuration.getServerFactory()).getApplicationContextPath());
@@ -23,6 +25,8 @@ public class IndexView extends View {
 
     mesosLogsPort = configuration.getMesosConfiguration().getSlaveHttpPort();
     mesosLogsPortHttps = configuration.getMesosConfiguration().getSlaveHttpsPort().orNull();
+
+    this.user = user;
   }
 
   public String getAppRoot() {
@@ -43,5 +47,9 @@ public class IndexView extends View {
 
   public Integer getMesosLogsPortHttps() {
     return mesosLogsPortHttps;
+  }
+
+  public SingularityUser getUser() {
+    return user;
   }
 }

--- a/SingularityService/src/main/resources/com/hubspot/singularity/views/index.mustache
+++ b/SingularityService/src/main/resources/com/hubspot/singularity/views/index.mustache
@@ -12,6 +12,9 @@
     <link rel="stylesheet" href="{{{staticRoot}}}/css/app.css">
     <script>
         window.config = {
+            {{#user}}
+            username: "{{{username}}}",
+            {{/user}}
             appRoot: "{{{appRoot}}}",
             apiRoot: "{{{apiRoot}}}",
             mesosLogPort: {{{mesosLogsPort}}},

--- a/SingularityUI/app/application.coffee
+++ b/SingularityUI/app/application.coffee
@@ -134,13 +134,16 @@ class Application
             @collections[r.collection_key] = new r.collection
 
     setupUser: ->
-        @user = new User
-        @user.fetch() # Syncronous because it uses localStorage
-        @user.set(@user.get('0')) # Hack because the Backbone.LocalStorage adapter I use is jank
+        if window.config.username isnt ''
+            @user = new User
+                deployUser: window.config.username
+        else
+            @user.fetch() # Syncronous because it uses localStorage
+            @user.set(@user.get('0')) # Hack because the Backbone.LocalStorage adapter I use is jank
 
-        if not @user.get('deployUser')
-            Backbone.history.once 'route', =>
-                setTimeout (=> @deployUserPrompt(welcome = true)), 1000
+            if not @user.get('deployUser')
+                Backbone.history.once 'route', =>
+                    setTimeout (=> @deployUserPrompt(welcome = true)), 1000
 
     getUsername: =>
         @user.get "deployUser" or "Unknown"


### PR DESCRIPTION
Right now it just pops open the browser login dialog, we can add a nicer login page if we want.

example config:

```
ldap:
  uri: ldaps://myldap.com:636
  cachePolicy: maximumSize=10000, expireAfterWrite=10m
  userFilter: ou=people,dc=yourcompany,dc=com
  groupFilter: ou=groups,dc=yourcompany,dc=com
  userNameAttribute: cn
  groupNameAttribute: cn
  groupMembershipAttribute: memberUid
  restrictToGroups:
      - user
      - admin
      - bots
  connectTimeout: 500ms
  readTimeout: 500ms
```

@wsorenson @gchomatas @Eseb 
