### PR TITLE
Remove singularity.version and use project.version instead so the value does not need to be updated every release

### DIFF
--- a/MesosClient/pom.xml
+++ b/MesosClient/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>com.hubspot</groupId>
       <artifactId>SingularityBase</artifactId>
-      <version>${singularity.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/SingularityClient/pom.xml
+++ b/SingularityClient/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>com.hubspot</groupId>
       <artifactId>SingularityBase</artifactId>
-      <version>${singularity.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/SingularityExecutor/pom.xml
+++ b/SingularityExecutor/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.hubspot</groupId>
       <artifactId>SingularityS3Base</artifactId>
-      <version>${singularity.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/SingularityExecutorCleanup/pom.xml
+++ b/SingularityExecutorCleanup/pom.xml
@@ -29,13 +29,13 @@
     <dependency>
       <groupId>com.hubspot</groupId>
       <artifactId>SingularityExecutor</artifactId>
-      <version>${singularity.version}</version>
+      <version>${project.version}</version>
     </dependency>
     
     <dependency>
       <groupId>com.hubspot</groupId>
       <artifactId>MesosClient</artifactId>
-      <version>${singularity.version}</version>
+      <version>${project.version}</version>
     </dependency>
  
   </dependencies>

--- a/SingularityLogWatcher/pom.xml
+++ b/SingularityLogWatcher/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.hubspot</groupId>
       <artifactId>SingularityRunnerBase</artifactId>
-      <version>${singularity.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/SingularityOOMKiller/pom.xml
+++ b/SingularityOOMKiller/pom.xml
@@ -29,19 +29,19 @@
     <dependency>
       <groupId>com.hubspot</groupId>
       <artifactId>SingularityRunnerBase</artifactId>
-      <version>${singularity.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>com.hubspot</groupId>
       <artifactId>MesosClient</artifactId>
-      <version>${singularity.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>com.hubspot</groupId>
       <artifactId>SingularityClient</artifactId>
-      <version>${singularity.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
   </dependencies>

--- a/SingularityRunnerBase/pom.xml
+++ b/SingularityRunnerBase/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.hubspot</groupId>
       <artifactId>SingularityBase</artifactId>
-      <version>${singularity.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/SingularityS3Base/pom.xml
+++ b/SingularityS3Base/pom.xml
@@ -29,7 +29,7 @@
       <dependency>
         <groupId>com.hubspot</groupId>
         <artifactId>SingularityRunnerBase</artifactId>
-        <version>${singularity.version}</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>

--- a/SingularityS3Downloader/pom.xml
+++ b/SingularityS3Downloader/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>com.hubspot</groupId>
       <artifactId>SingularityS3Base</artifactId>
-      <version>${singularity.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/SingularityS3Uploader/pom.xml
+++ b/SingularityS3Uploader/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.hubspot</groupId>
       <artifactId>SingularityS3Base</artifactId>
-      <version>${singularity.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
   </dependencies>

--- a/SingularityService/pom.xml
+++ b/SingularityService/pom.xml
@@ -29,13 +29,13 @@
     <dependency>
       <groupId>com.hubspot</groupId>
       <artifactId>SingularityBase</artifactId>
-      <version>${singularity.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>com.hubspot</groupId>
       <artifactId>MesosClient</artifactId>
-      <version>${singularity.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,6 @@
     <jets3t.version>0.9.0</jets3t.version>
     <guava.version>17.0</guava.version>
     <baragon.version>0.1.0-SNAPSHOT</baragon.version> <!-- TODO: use release version of Baragon when complete -->
-    <singularity.version>0.3.8-SNAPSHOT</singularity.version>
   </properties>
 
   <groupId>com.hubspot</groupId>


### PR DESCRIPTION
It's not like you can realistically build with mismatched versions anyway, so this makes it work correctly by default.
