### PR TITLE
Move SingularityUI generation to target/generated-resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ SingularityUI/node_modules/*
 SingularityUI/bower_components/*
 SingularityUI/brunchlog
 SingularityUI/app/env.coffee
-SingularityService/src/main/resources/static
 
 .vagrant
 vagrant/Berksfile.lock

--- a/SingularityBase/pom.xml
+++ b/SingularityBase/pom.xml
@@ -41,7 +41,7 @@
       <artifactId>mesos</artifactId>
       <version>${mesos.version}</version>
     </dependency>
-    
+
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>

--- a/SingularityUI/config.coffee
+++ b/SingularityUI/config.coffee
@@ -6,7 +6,7 @@ handlebars = require 'handlebars-brunch/node_modules/handlebars'
 # Brunch settings
 exports.config =
     paths:
-        public: path.resolve(__dirname, '../SingularityService/src/main/resources/static')
+        public: path.resolve(__dirname, '../SingularityService/target/generated-resources/static')
 
     files:
         javascripts:

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,8 @@
   </parent>
 
   <properties>
+    <project.build.generated-resources>${project.build.directory}/generated-resources</project.build.generated-resources>
+
     <mesos.version>0.19.1</mesos.version>
     <sentry.version>5.0</sentry.version>
     <java.abi>1.7</java.abi>
@@ -79,6 +81,21 @@
   </modules>
 
   <build>
+    <resources>
+      <resource>
+        <directory>${basedir}/src/main/resources</directory>
+      </resource>
+      <resource>
+        <directory>${basedir}/src/main/java</directory>
+        <excludes>
+          <exclude>**/*.java</exclude>
+        </excludes>
+      </resource>
+      <resource>
+        <directory>${project.build.generated-resources}</directory>
+      </resource>
+    </resources>
+
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This is the Maven standard location for generated resources.  IDEs know to look
there, and this also means that 'mvn clean' will clean the UI out as well.

Also restores the entire src/ directory to being version-controlled
