### PR TITLE
remove commons-lang 2.x dependency

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityDeployChecker.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityDeployChecker.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.lang.time.DurationFormatUtils;
+import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityHealthchecker.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityHealthchecker.java
@@ -6,7 +6,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.lang.time.DurationFormatUtils;
+import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityNewTaskChecker.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityNewTaskChecker.java
@@ -8,7 +8,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.lang.time.DurationFormatUtils;
+import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/smtp/JadeHelper.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/smtp/JadeHelper.java
@@ -7,8 +7,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.WordUtils;
-import org.apache.commons.lang.time.DateFormatUtils;
+import org.apache.commons.lang3.text.WordUtils;
+import org.apache.commons.lang3.time.DateFormatUtils;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;


### PR DESCRIPTION
In the ongoing quest to eradicate commons-lang 2.x from the face of
the earth, make Singularity use commons-lang3 everywhere.
