### PR TITLE
Remove resources section.

### DIFF
--- a/SingularityService/pom.xml
+++ b/SingularityService/pom.xml
@@ -312,14 +312,6 @@
   </dependencies>
 
   <build>
-    <resources>
-      <resource>
-        <directory>${project.basedir}/src/main/resources</directory>
-      </resource>
-      <resource>
-        <directory>${project.basedir}/target/generated-resources</directory>
-      </resource>
-    </resources>
     <plugins>
       <plugin>
         <groupId>com.github.eirslett</groupId>


### PR DESCRIPTION
This section should not be required, the generated-resources folder is picked up by the
build-helper plugin in the pom.
