### PR TITLE
use custom URL for node download

### DIFF
--- a/SingularityService/pom.xml
+++ b/SingularityService/pom.xml
@@ -312,6 +312,7 @@
         <artifactId>frontend-maven-plugin</artifactId>
         <configuration>
           <workingDirectory>../SingularityUI</workingDirectory>
+          <nodeDownloadRoot>https://hubspot-boxen-public.s3.amazonaws.com/nodejs/</nodeDownloadRoot>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
I copied over all the node binaries for `v0.10.28` to one of our public S3 buckets. (Hopefully) fixes #246.

/cc @wsorenson @jloisel 
