### PR TITLE
exclude log4j from zookeeper dependency in SingularityClient

### DIFF
--- a/SingularityClient/pom.xml
+++ b/SingularityClient/pom.xml
@@ -69,13 +69,6 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
-      <!-- clashes with ning async-http-client -->
-      <exclusions>
-        <exclusion>
-          <artifactId>netty</artifactId>
-          <groupId>org.jboss.netty</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -397,6 +397,11 @@
             <artifactId>jline</artifactId>
             <groupId>jline</groupId>
           </exclusion>
+          <!-- Replaced by io.netty:netty; clashes with ning async-http-client -->
+          <exclusion>
+            <groupId>org.jboss.netty</groupId>
+            <artifactId>netty</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 


### PR DESCRIPTION
sucks to include SingularityClient and then suddenly discover a rogue log4j included for you
