### PR TITLE
customizable nav color

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -6,6 +6,7 @@ import io.dropwizard.db.DataSourceFactory;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -32,6 +33,7 @@ public class SingularityConfiguration extends Configuration {
   private SMTPConfiguration smtpConfiguration;
 
   @JsonProperty("ui")
+  @Valid
   private UIConfiguration uiConfiguration = new UIConfiguration();
 
   @JsonProperty("zookeeper")

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/UIConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/UIConfiguration.java
@@ -1,15 +1,24 @@
 package com.hubspot.singularity.config;
 
+import javax.validation.constraints.Pattern;
+
 import org.hibernate.validator.constraints.NotEmpty;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 
 public class UIConfiguration {
 
   @NotEmpty
+  @JsonProperty
   private String title = "Singularity";
 
+  @JsonProperty
+  @Pattern( regexp = "^|#[0-9a-fA-F]{6}$" )
+  private String navColor = "";
+
+  @JsonProperty
   private String baseUrl;
 
   public String getTitle() {
@@ -28,4 +37,11 @@ public class UIConfiguration {
     this.baseUrl = baseUrl;
   }
 
+  public String getNavColor() {
+    return navColor;
+  }
+
+  public void setNavColor(String navColor) {
+    this.navColor = navColor;
+  }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/views/IndexView.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/views/IndexView.java
@@ -10,6 +10,7 @@ public class IndexView extends View {
   private final String appRoot;
   private final String staticRoot;
   private final String apiRoot;
+  private final String navColor;
 
   private final String title;
 
@@ -27,6 +28,8 @@ public class IndexView extends View {
 
     mesosLogsPort = configuration.getMesosConfiguration().getSlaveHttpPort();
     mesosLogsPortHttps = configuration.getMesosConfiguration().getSlaveHttpsPort().orNull();
+
+    navColor = configuration.getUiConfiguration().getNavColor();
   }
 
   public String getAppRoot() {
@@ -51,5 +54,9 @@ public class IndexView extends View {
 
   public String getTitle() {
     return title;
+  }
+
+  public String getNavColor() {
+    return navColor;
   }
 }

--- a/SingularityUI/app/assets/_index.mustache
+++ b/SingularityUI/app/assets/_index.mustache
@@ -10,6 +10,13 @@
     <link rel="shortcut icon" href="{{{staticRoot}}}/images/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
     <link rel="stylesheet" href="{{{staticRoot}}}/css/app.css">
+    {{#navColor}}
+    <style>
+        .navbar-default {
+            background-color: {{{navColor}}};
+        }
+    </style>
+    {{/navColor}}
     <script>
         window.config = {
             appRoot: "{{{appRoot}}}",

--- a/SingularityUI/config.coffee
+++ b/SingularityUI/config.coffee
@@ -42,6 +42,7 @@ exports.config =
             apiRoot: ''
             mesosLogsPort: 5051
             title: 'Singularity (local dev)'
+            navColor: ''
 
         compiledTemplate = handlebars.compile(indexTemplate)(templateData)
         fs.writeFileSync destination, compiledTemplate


### PR DESCRIPTION
Some of our tools at HubSpot use color-coding to help clarify what environment you're working with (i.e. QA vs. PROD), and we've gotten requests for Singularity to support this too. This PR allows the background color of the nav bar to be overridden in the config YAML.

Example:

``` yaml
ui:
    navColor: "#ff0000"
```

/cc @timmfin  @wsorenson
