### PR TITLE
NoopHistoryManager should be truly no op.

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/NoopHistoryManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/NoopHistoryManager.java
@@ -19,17 +19,14 @@ public class NoopHistoryManager implements HistoryManager {
 
   @Override
   public void saveRequestHistoryUpdate(SingularityRequestHistory requestHistory) {
-    throw new UnsupportedOperationException("NoopHistoryManager can not save");
   }
 
   @Override
   public void saveTaskHistory(SingularityTaskHistory taskHistory) {
-    throw new UnsupportedOperationException("NoopHistoryManager can not save");
   }
 
   @Override
   public void saveDeployHistory(SingularityDeployHistory deployHistory) {
-    throw new UnsupportedOperationException("NoopHistoryManager can not save");
   }
 
   @Override


### PR DESCRIPTION
otherwise, when bound as history manager will throw exceptions for each history save.
