### PR TITLE
Make JavaUtilsTest a bit more resilient.

### DIFF
--- a/SingularityService/src/test/java/com/hubspot/singularity/JavaUtilsTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/JavaUtilsTest.java
@@ -19,7 +19,7 @@ public class JavaUtilsTest {
 
     ThreadPoolExecutor es = JavaUtils.newFixedTimingOutThreadPool(numMaxThreads, timeoutMillis, "test");
 
-    Thread.sleep(timeoutMillis + 1);
+    Thread.sleep(timeoutMillis + 100);
 
     Assert.assertTrue(es.getPoolSize() == 0);
 
@@ -47,7 +47,7 @@ public class JavaUtilsTest {
     Assert.assertTrue(es.getPoolSize() == numMaxThreads);
     block.countDown();
 
-    Thread.sleep(timeoutMillis + 1);
+    Thread.sleep(timeoutMillis + 100);
     Assert.assertTrue(es.getMaximumPoolSize() == numMaxThreads);
     Assert.assertTrue(es.getPoolSize() == 0);
 


### PR DESCRIPTION
One millisecond won't work on a busy system.
