### PR TITLE
Turn off load balancing and rack sensitive by default, since both require setup

### DIFF
--- a/SingularityUI/app/templates/newRequest.hbs
+++ b/SingularityUI/app/templates/newRequest.hbs
@@ -48,7 +48,7 @@
             <div class="col-sm-4">
                 <div class="form-group">
                     <label for="rack-sensitive-service">
-                        <input type="checkbox" id="rack-sensitive-service" checked>    
+                        <input type="checkbox" id="rack-sensitive-service">
                         Rack sensitive
                     </label>
                 </div>
@@ -56,7 +56,7 @@
             <div class="col-sm-4">
                 <div class="form-group">
                     <label for="load-balanced">
-                        <input type="checkbox" id="load-balanced" checked>
+                        <input type="checkbox" id="load-balanced">
                         Load balanced
                     </label>
                 </div>


### PR DESCRIPTION
Turn off load balancing and rack sensitive by default, since both require extra
administrative setup that users seem to be confused about.

(We've noticed this both at OpenTable and @eliast mentions the same in #277)
