### PR TITLE
add filter for cleaning invalid Accept-Language values

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityService.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityService.java
@@ -1,6 +1,8 @@
 package com.hubspot.singularity;
 
 
+import com.hubspot.singularity.bundles.AcceptLanguageFilterBundle;
+import com.hubspot.singularity.bundles.CorsBundle;
 import io.dropwizard.Application;
 import io.dropwizard.assets.AssetsBundle;
 import io.dropwizard.db.DataSourceFactory;
@@ -27,6 +29,7 @@ public class SingularityService extends Application<SingularityConfiguration> {
         .build();
     bootstrap.addBundle(guiceBundle);
 
+    bootstrap.addBundle(new AcceptLanguageFilterBundle());
     bootstrap.addBundle(new CorsBundle());
     bootstrap.addBundle(new ViewBundle());
     bootstrap.addBundle(new AssetsBundle("/static/static/", "/static/"));

--- a/SingularityService/src/main/java/com/hubspot/singularity/bundles/AcceptLanguageFilterBundle.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/bundles/AcceptLanguageFilterBundle.java
@@ -1,0 +1,53 @@
+package com.hubspot.singularity.bundles;
+
+import com.google.common.net.HttpHeaders;
+import com.hubspot.singularity.config.SingularityConfiguration;
+import com.sun.jersey.core.header.InBoundHeaders;
+import com.sun.jersey.spi.container.ContainerRequest;
+import com.sun.jersey.spi.container.ContainerRequestFilter;
+import io.dropwizard.ConfiguredBundle;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+
+import javax.ws.rs.core.MultivaluedMap;
+import java.util.List;
+
+public class AcceptLanguageFilterBundle implements ConfiguredBundle<SingularityConfiguration> {
+  public static final String ES_419 = "es-419";
+  public static final String ES_ES = "es-ES";
+
+  @Override
+  public void run(SingularityConfiguration configuration, Environment environment) throws Exception {
+    environment.jersey().getResourceConfig().getContainerRequestFilters().add(new AcceptLanguageFilter());
+  }
+
+  @Override
+  public void initialize(Bootstrap<?> bootstrap) {
+
+  }
+
+  public static class AcceptLanguageFilter implements ContainerRequestFilter {
+    @Override
+    public ContainerRequest filter(ContainerRequest request) {
+      MultivaluedMap<String, String> headers = request.getRequestHeaders();
+      if(headers.containsKey(HttpHeaders.ACCEPT_LANGUAGE)) {
+        List<String> acceptLanguageValues = headers.remove(HttpHeaders.ACCEPT_LANGUAGE);
+
+        for (int i = 0; i < acceptLanguageValues.size(); i++) {
+          final String acceptLanguageValue = acceptLanguageValues.get(i);
+
+          // replace es-419 (invalid) with es_ES (valid, hopefully good enough.)
+          if (acceptLanguageValue.contains(ES_419)) {
+            acceptLanguageValues.set(i, acceptLanguageValue.replace(ES_419, ES_ES));
+          }
+        }
+
+        headers.put(HttpHeaders.ACCEPT_LANGUAGE, acceptLanguageValues);
+
+        request.setHeaders((InBoundHeaders)headers);
+      }
+
+      return request;
+    }
+  }
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/bundles/CorsBundle.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/bundles/CorsBundle.java
@@ -1,4 +1,4 @@
-package com.hubspot.singularity;
+package com.hubspot.singularity.bundles;
 
 import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.setup.Bootstrap;


### PR DESCRIPTION
Browsers that have Latin American Spanish selected as a preferred language send `Accept-Language` headers containing `es-419`, which isn't supported in Jersey 1.x (which Dropwizard uses). This PR adds a filter that replaces `es-419` with `es-ES`, which should be good enough. Fixes #308.

/cc @wsorenson @HiJon89 @natea
