### PR TITLE
Switch from commons-logging to jcl-over-slf4j

### DIFF
--- a/SingularityS3Base/pom.xml
+++ b/SingularityS3Base/pom.xml
@@ -36,6 +36,13 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
 
+    <!-- for jade and jets3t -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>

--- a/SingularityS3Uploader/pom.xml
+++ b/SingularityS3Uploader/pom.xml
@@ -45,6 +45,13 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
 
+    <!-- for jade and jets3t -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>

--- a/SingularityService/pom.xml
+++ b/SingularityService/pom.xml
@@ -90,6 +90,13 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
 
+    <!-- for jade and jets3t -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -312,6 +312,12 @@
         <groupId>net.java.dev.jets3t</groupId>
         <artifactId>jets3t</artifactId>
         <version>${jets3t.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
@@ -437,6 +443,12 @@
         <groupId>de.neuland-bfi</groupId>
         <artifactId>jade4j</artifactId>
         <version>0.4.0</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Dropwizard 0.7.1 will include jcl-over-slf4j in dropwizard logging, which
clashes with jade4j and jets3t. Exclude the c-l dependency, pull in
jcl-over-slf4j at runtime.
