### PR TITLE
Clean up typeahead search styles.

### DIFF
--- a/SingularityUI/app/styles/globalSearch.styl
+++ b/SingularityUI/app/styles/globalSearch.styl
@@ -11,7 +11,7 @@
     left 0
     bottom 0
     right 0
-    background rgba(255, 255, 255, .9)
+    background rgba(255, 255, 255, .98)
 
     .close-button-container
         margin 20px 0 50px
@@ -44,8 +44,15 @@
             display block !important
             width 100%
 
+        .tt-dropdown-menu
+            right: 0px !important
+
         .tt-suggestion
-            padding 15px 10px
+            padding 10px
+            cursor: pointer
+
+            p
+                margin-bottom: 0
 
             &.tt-cursor
                 background rgba(0, 0, 0, .03)

--- a/SingularityUI/app/views/globalSearch.coffee
+++ b/SingularityUI/app/views/globalSearch.coffee
@@ -77,6 +77,9 @@ class GlobalSearchView extends View
         if event?
             return if not $(event.target).data('action')? is 'close-global-seach'
 
+            # Don't hide if you click the input box
+            return if $(event.target).is('input')
+
         @$el.parent().removeClass 'global-search-active'
 
     toggle: ->


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/60455/5056395/0747eda8-6c50-11e4-95dc-dd15fa3d59a5.png)
- More opaque background
- Results are full width, have pointer cursor, and even padding
- Don’t hide the search UI if you click inside the input

/cc @wsorenson 
