### PR TITLE
Factor out the Scheduler lock.

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosModule.java
@@ -1,9 +1,18 @@
 package com.hubspot.singularity.mesos;
 
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
 import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
 import com.google.inject.Scopes;
+import com.google.inject.Singleton;
+import com.google.inject.name.Named;
 
 public class SingularityMesosModule extends AbstractModule {
+
+  public static final String SCHEDULER_LOCK_NAME = "scheduler-lock";
+
   @Override
   public void configure() {
     bind(SingularityDriver.class).in(Scopes.SINGLETON);
@@ -14,5 +23,12 @@ public class SingularityMesosModule extends AbstractModule {
     bind(SingularitySlaveAndRackManager.class).in(Scopes.SINGLETON);
     bind(SingularityStartup.class).in(Scopes.SINGLETON);
     bind(SchedulerDriverSupplier.class).in(Scopes.SINGLETON);
+  }
+
+  @Provides
+  @Named(SCHEDULER_LOCK_NAME)
+  @Singleton
+  public Lock getSchedulerLock() {
+    return new ReentrantLock();
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleanupPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleanupPoller.java
@@ -1,16 +1,15 @@
 package com.hubspot.singularity.scheduler;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
 
 import javax.inject.Singleton;
 
-import org.apache.curator.framework.recipes.leader.LeaderLatch;
-
+import com.google.common.base.Optional;
 import com.google.inject.Inject;
-import com.hubspot.singularity.SingularityAbort;
+import com.google.inject.name.Named;
 import com.hubspot.singularity.config.SingularityConfiguration;
-import com.hubspot.singularity.mesos.SingularityMesosSchedulerDelegator;
-import com.hubspot.singularity.sentry.SingularityExceptionNotifier;
+import com.hubspot.singularity.mesos.SingularityMesosModule;
 
 @Singleton
 public class SingularityCleanupPoller extends SingularityLeaderOnlyPoller {
@@ -18,11 +17,11 @@ public class SingularityCleanupPoller extends SingularityLeaderOnlyPoller {
   private final SingularityCleaner cleaner;
 
   @Inject
-  public SingularityCleanupPoller(LeaderLatch leaderLatch, SingularityMesosSchedulerDelegator mesosScheduler, SingularityExceptionNotifier exceptionNotifier, SingularityConfiguration configuration,
-      SingularityCleaner cleaner, SingularityAbort abort) {
-    super(leaderLatch, mesosScheduler, exceptionNotifier, abort, configuration.getCleanupEverySeconds(), TimeUnit.SECONDS,  SchedulerLockType.LOCK);
+  SingularityCleanupPoller(SingularityConfiguration configuration, SingularityCleaner cleaner, @Named(SingularityMesosModule.SCHEDULER_LOCK_NAME) final Lock lock) {
+    super(configuration.getCleanupEverySeconds(), TimeUnit.SECONDS);
 
     this.cleaner = cleaner;
+    this.lockHolder = Optional.of(lock);
   }
 
   @Override

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCooldownPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCooldownPoller.java
@@ -1,16 +1,15 @@
 package com.hubspot.singularity.scheduler;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
 
 import javax.inject.Singleton;
 
-import org.apache.curator.framework.recipes.leader.LeaderLatch;
-
+import com.google.common.base.Optional;
 import com.google.inject.Inject;
-import com.hubspot.singularity.SingularityAbort;
+import com.google.inject.name.Named;
 import com.hubspot.singularity.config.SingularityConfiguration;
-import com.hubspot.singularity.mesos.SingularityMesosSchedulerDelegator;
-import com.hubspot.singularity.sentry.SingularityExceptionNotifier;
+import com.hubspot.singularity.mesos.SingularityMesosModule;
 
 @Singleton
 public class SingularityCooldownPoller extends SingularityLeaderOnlyPoller {
@@ -18,10 +17,11 @@ public class SingularityCooldownPoller extends SingularityLeaderOnlyPoller {
   private final SingularityCooldownChecker checker;
 
   @Inject
-  public SingularityCooldownPoller(LeaderLatch leaderLatch, SingularityMesosSchedulerDelegator mesosScheduler, SingularityExceptionNotifier exceptionNotifier, SingularityConfiguration configuration, SingularityCooldownChecker checker, SingularityAbort abort) {
-      super(leaderLatch, mesosScheduler, exceptionNotifier, abort, TimeUnit.MINUTES.toMillis(configuration.getCooldownExpiresAfterMinutes()) / 2, TimeUnit.MILLISECONDS, SchedulerLockType.LOCK);
+  SingularityCooldownPoller(SingularityConfiguration configuration, SingularityCooldownChecker checker, @Named(SingularityMesosModule.SCHEDULER_LOCK_NAME) final Lock lock) {
+    super(TimeUnit.MINUTES.toMillis(configuration.getCooldownExpiresAfterMinutes()) / 2, TimeUnit.MILLISECONDS);
 
     this.checker = checker;
+    this.lockHolder = Optional.of(lock);
   }
 
   @Override

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityDeployPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityDeployPoller.java
@@ -1,19 +1,19 @@
 package com.hubspot.singularity.scheduler;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
 
 import javax.inject.Singleton;
 
-import org.apache.curator.framework.recipes.leader.LeaderLatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Optional;
 import com.google.inject.Inject;
+import com.google.inject.name.Named;
 import com.hubspot.mesos.JavaUtils;
-import com.hubspot.singularity.SingularityAbort;
 import com.hubspot.singularity.config.SingularityConfiguration;
-import com.hubspot.singularity.mesos.SingularityMesosSchedulerDelegator;
-import com.hubspot.singularity.sentry.SingularityExceptionNotifier;
+import com.hubspot.singularity.mesos.SingularityMesosModule;
 
 @Singleton
 public class SingularityDeployPoller extends SingularityLeaderOnlyPoller {
@@ -23,10 +23,11 @@ public class SingularityDeployPoller extends SingularityLeaderOnlyPoller {
   private final SingularityDeployChecker deployChecker;
 
   @Inject
-  public SingularityDeployPoller(final LeaderLatch leaderLatch, final SingularityMesosSchedulerDelegator mesosScheduler, SingularityExceptionNotifier exceptionNotifier, SingularityDeployChecker deployChecker, SingularityConfiguration configuration, SingularityAbort abort) {
-      super(leaderLatch, mesosScheduler, exceptionNotifier, abort, configuration.getCheckDeploysEverySeconds(), TimeUnit.SECONDS, SchedulerLockType.LOCK);
+  SingularityDeployPoller(SingularityDeployChecker deployChecker, SingularityConfiguration configuration, @Named(SingularityMesosModule.SCHEDULER_LOCK_NAME) final Lock lock) {
+    super(configuration.getCheckDeploysEverySeconds(), TimeUnit.SECONDS);
 
     this.deployChecker = deployChecker;
+    this.lockHolder = Optional.of(lock);
   }
 
   @Override

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderOnlyPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderOnlyPoller.java
@@ -1,17 +1,22 @@
 package com.hubspot.singularity.scheduler;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import io.dropwizard.lifecycle.Managed;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
 
 import org.apache.curator.framework.recipes.leader.LeaderLatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Optional;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.inject.Inject;
 import com.hubspot.mesos.JavaUtils;
 import com.hubspot.singularity.SingularityAbort;
 import com.hubspot.singularity.SingularityAbort.AbortReason;
@@ -22,31 +27,35 @@ public abstract class SingularityLeaderOnlyPoller implements Managed {
 
   private static final Logger LOG = LoggerFactory.getLogger(SingularityLeaderOnlyPoller.class);
 
-  private final LeaderLatch leaderLatch;
-  private final SingularityMesosSchedulerDelegator mesosScheduler;
-  private final SingularityExceptionNotifier exceptionNotifier;
   private final ScheduledExecutorService executorService;
-  private final SingularityAbort abort;
   private final long pollDelay;
   private final TimeUnit pollTimeUnit;
-  private final SchedulerLockType schedulerLockType;
 
-  public static enum SchedulerLockType {
-    LOCK, NO_LOCK
-  }
+  private LeaderLatch leaderLatch;
+  private SingularityExceptionNotifier exceptionNotifier;
+  private SingularityAbort abort;
+  private SingularityMesosSchedulerDelegator mesosScheduler;
 
-  protected SingularityLeaderOnlyPoller(LeaderLatch leaderLatch, SingularityMesosSchedulerDelegator mesosScheduler, SingularityExceptionNotifier exceptionNotifier, SingularityAbort abort,
-      long pollDelay, TimeUnit pollTimeUnit, SchedulerLockType schedulerLockType) {
-    this.leaderLatch = leaderLatch;
-    this.mesosScheduler = mesosScheduler;
-    this.exceptionNotifier = exceptionNotifier;
-    this.abort = abort;
-    this.schedulerLockType = schedulerLockType;
+  protected Optional<Lock> lockHolder = Optional.absent();
+
+  protected SingularityLeaderOnlyPoller(long pollDelay, TimeUnit pollTimeUnit) {
     this.pollDelay = pollDelay;
     this.pollTimeUnit = pollTimeUnit;
 
     this.executorService = Executors.newScheduledThreadPool(1, new ThreadFactoryBuilder().setNameFormat(getClass().getSimpleName() + "-%d").build());
   }
+
+  @Inject
+  void injectPollerDependencies(LeaderLatch leaderLatch,
+      SingularityExceptionNotifier exceptionNotifier,
+      SingularityAbort abort,
+      SingularityMesosSchedulerDelegator mesosScheduler) {
+    this.leaderLatch = checkNotNull(leaderLatch, "leaderLatch is null");
+    this.exceptionNotifier = checkNotNull(exceptionNotifier, "exceptionNotifier is null");
+    this.abort = checkNotNull(abort, "abort is null");
+    this.mesosScheduler = checkNotNull(mesosScheduler, "mesosScheduler is null");
+  }
+
 
   @Override
   public void start() {
@@ -74,8 +83,8 @@ public abstract class SingularityLeaderOnlyPoller implements Managed {
 
     LOG.trace("Running {} (period: {})", getClass().getSimpleName(), JavaUtils.durationFromMillis(pollTimeUnit.toMillis(pollDelay)));
 
-    if (schedulerLockType == SchedulerLockType.LOCK) {
-      mesosScheduler.lock();
+    if (lockHolder.isPresent()) {
+      lockHolder.get().lock();
     }
 
     try {
@@ -85,8 +94,8 @@ public abstract class SingularityLeaderOnlyPoller implements Managed {
       exceptionNotifier.notify(t);
       abort.abort(AbortReason.UNRECOVERABLE_ERROR);
     } finally {
-      if (schedulerLockType == SchedulerLockType.LOCK) {
-        mesosScheduler.release();
+      if (lockHolder.isPresent()) {
+        lockHolder.get().unlock();
       }
     }
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduledJobPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduledJobPoller.java
@@ -9,7 +9,6 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Singleton;
 
-import org.apache.curator.framework.recipes.leader.LeaderLatch;
 import org.quartz.CronExpression;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,7 +17,6 @@ import com.google.common.base.Optional;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
-import com.hubspot.singularity.SingularityAbort;
 import com.hubspot.singularity.SingularityDeployStatistics;
 import com.hubspot.singularity.SingularityRequestWithState;
 import com.hubspot.singularity.SingularityTaskId;
@@ -26,7 +24,6 @@ import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.DeployManager;
 import com.hubspot.singularity.data.RequestManager;
 import com.hubspot.singularity.data.TaskManager;
-import com.hubspot.singularity.mesos.SingularityMesosSchedulerDelegator;
 import com.hubspot.singularity.sentry.SingularityExceptionNotifier;
 import com.hubspot.singularity.smtp.SingularityMailer;
 
@@ -43,9 +40,10 @@ public class SingularityScheduledJobPoller extends SingularityLeaderOnlyPoller {
   private final SingularityExceptionNotifier exceptionNotifier;
 
   @Inject
-  public SingularityScheduledJobPoller(final LeaderLatch leaderLatch, final SingularityMesosSchedulerDelegator mesosScheduler, SingularityExceptionNotifier exceptionNotifier, TaskManager taskManager,
-      SingularityConfiguration configuration, SingularityAbort abort, RequestManager requestManager, DeployManager deployManager, SingularityMailer mailer) {
-    super(leaderLatch, mesosScheduler, exceptionNotifier, abort, configuration.getCheckScheduledJobsEveryMillis(), TimeUnit.MILLISECONDS, SchedulerLockType.NO_LOCK);
+  public SingularityScheduledJobPoller(SingularityExceptionNotifier exceptionNotifier, TaskManager taskManager,
+      SingularityConfiguration configuration, RequestManager requestManager, DeployManager deployManager, SingularityMailer mailer) {
+
+    super(configuration.getCheckScheduledJobsEveryMillis(), TimeUnit.MILLISECONDS);
 
     this.taskManager = taskManager;
     this.deployManager = deployManager;

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityTaskReconciliationPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityTaskReconciliationPoller.java
@@ -4,13 +4,8 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Singleton;
 
-import org.apache.curator.framework.recipes.leader.LeaderLatch;
-
 import com.google.inject.Inject;
-import com.hubspot.singularity.SingularityAbort;
 import com.hubspot.singularity.config.SingularityConfiguration;
-import com.hubspot.singularity.mesos.SingularityMesosSchedulerDelegator;
-import com.hubspot.singularity.sentry.SingularityExceptionNotifier;
 
 @Singleton
 public class SingularityTaskReconciliationPoller extends SingularityLeaderOnlyPoller {
@@ -18,9 +13,8 @@ public class SingularityTaskReconciliationPoller extends SingularityLeaderOnlyPo
   private final SingularityTaskReconciliation taskReconciliation;
 
   @Inject
-  public SingularityTaskReconciliationPoller(LeaderLatch leaderLatch, SingularityMesosSchedulerDelegator mesosScheduler, SingularityConfiguration configuration, SingularityAbort abort,
-      SingularityExceptionNotifier exceptionNotifier, SingularityTaskReconciliation taskReconciliation) {
-    super(leaderLatch, mesosScheduler, exceptionNotifier, abort, configuration.getStartNewReconcileEverySeconds(), TimeUnit.SECONDS, SchedulerLockType.NO_LOCK);
+  SingularityTaskReconciliationPoller(SingularityConfiguration configuration, SingularityTaskReconciliation taskReconciliation) {
+    super(configuration.getStartNewReconcileEverySeconds(), TimeUnit.SECONDS);
 
     this.taskReconciliation = taskReconciliation;
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/smtp/SingularityMailRecordCleaner.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/smtp/SingularityMailRecordCleaner.java
@@ -2,7 +2,6 @@ package com.hubspot.singularity.smtp;
 
 import java.util.concurrent.TimeUnit;
 
-import org.apache.curator.framework.recipes.leader.LeaderLatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -10,12 +9,9 @@ import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.hubspot.mesos.JavaUtils;
-import com.hubspot.singularity.SingularityAbort;
 import com.hubspot.singularity.config.SMTPConfiguration;
 import com.hubspot.singularity.data.MetadataManager;
-import com.hubspot.singularity.mesos.SingularityMesosSchedulerDelegator;
 import com.hubspot.singularity.scheduler.SingularityLeaderOnlyPoller;
-import com.hubspot.singularity.sentry.SingularityExceptionNotifier;
 
 @Singleton
 public class SingularityMailRecordCleaner extends SingularityLeaderOnlyPoller {
@@ -26,8 +22,8 @@ public class SingularityMailRecordCleaner extends SingularityLeaderOnlyPoller {
   private final Optional<SMTPConfiguration> smtpConfiguration;
 
   @Inject
-  public SingularityMailRecordCleaner(LeaderLatch leaderLatch, Optional<SMTPConfiguration> smtpConfiguration, SingularityMesosSchedulerDelegator mesosScheduler, MetadataManager metadataManager, SingularityExceptionNotifier exceptionNotifier, SingularityAbort abort) {
-    super(leaderLatch, mesosScheduler, exceptionNotifier, abort, smtpConfiguration.isPresent() ? Math.max(smtpConfiguration.get().getRateLimitCooldownMillis(), smtpConfiguration.get().getRateLimitPeriodMillis()) : 0, TimeUnit.MILLISECONDS, SchedulerLockType.NO_LOCK);
+  SingularityMailRecordCleaner(Optional<SMTPConfiguration> smtpConfiguration, MetadataManager metadataManager) {
+    super(smtpConfiguration.isPresent() ? Math.max(smtpConfiguration.get().getRateLimitCooldownMillis(), smtpConfiguration.get().getRateLimitPeriodMillis()) : 0, TimeUnit.MILLISECONDS);
 
     this.metadataManager = metadataManager;
     this.smtpConfiguration = smtpConfiguration;


### PR DESCRIPTION
Inject the scheduler lock object everywhere it is needed. Also break
up the "parent injection" pattern which is not needed with DI for the
poller classes that hang off SingularityLeaderOnlyPoller.
