### PR TITLE
Update Mesos to 0.21.0 and add option for pure java API code.

### DIFF
--- a/SingularityService/pom.xml
+++ b/SingularityService/pom.xml
@@ -113,6 +113,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.groupon.mesos</groupId>
+      <artifactId>jesos</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/MesosConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/MesosConfiguration.java
@@ -6,6 +6,8 @@ import com.google.common.base.Optional;
 
 public class MesosConfiguration {
 
+  private boolean useNativeCode = true;
+
   @NotNull
   private String master;
   @NotNull
@@ -36,6 +38,14 @@ public class MesosConfiguration {
   private int maxNumCpusPerRequest = 900;
   private int maxMemoryMbPerInstance = 24000;
   private int maxMemoryMbPerRequest = 450000;
+
+  public boolean isUseNativeCode() {
+    return useNativeCode;
+  }
+
+  public void setUseNativeCode(boolean useNativeCode) {
+    this.useNativeCode = useNativeCode;
+  }
 
   public int getMaxNumInstancesPerRequest() {
     return maxNumInstancesPerRequest;

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityDriver.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityDriver.java
@@ -10,12 +10,14 @@ import org.apache.mesos.Protos.FrameworkID;
 import org.apache.mesos.Protos.MasterInfo;
 import org.apache.mesos.Protos.TaskID;
 import org.apache.mesos.Scheduler;
+import org.apache.mesos.SchedulerDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
+import com.groupon.mesos.JesosSchedulerDriver;
 import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.config.MesosConfiguration;
 
@@ -26,7 +28,7 @@ public class SingularityDriver {
 
   private final Protos.FrameworkInfo frameworkInfo;
   private final SingularityMesosSchedulerDelegator scheduler;
-  private final MesosSchedulerDriver driver;
+  private final SchedulerDriver driver;
 
   @Inject
   SingularityDriver(final SingularityMesosSchedulerDelegator scheduler, final MesosConfiguration configuration) throws IOException {
@@ -39,7 +41,12 @@ public class SingularityDriver {
         .build();
 
     this.scheduler = scheduler;
-    this.driver = new MesosSchedulerDriver(scheduler, frameworkInfo, configuration.getMaster());
+
+    if (configuration.isUseNativeCode()) {
+        this.driver = new MesosSchedulerDriver(scheduler, frameworkInfo, configuration.getMaster());
+    } else {
+        this.driver = new JesosSchedulerDriver(scheduler, frameworkInfo, configuration.getMaster());
+    }
   }
 
   @VisibleForTesting

--- a/pom.xml
+++ b/pom.xml
@@ -52,11 +52,13 @@
     <dep.metrics.version>3.0.2</dep.metrics.version>
     <dep.zookeeper.version>3.4.5</dep.zookeeper.version>
 
+    <dep.jesos.version>1.1</dep.jesos.version>
+
     <baragon.version>0.1.2</baragon.version>
     <curator.version>2.4.2</curator.version>
     <dropwizard.version>0.7.1</dropwizard.version>
     <jets3t.version>0.9.0</jets3t.version>
-    <mesos.version>0.20.1</mesos.version>
+    <mesos.version>0.21.0</mesos.version>
     <ning.async.version>1.8.12</ning.async.version>
     <snappy.version>0.3</snappy.version>
     <sentry.version>5.0</sentry.version>
@@ -311,6 +313,18 @@
         <groupId>org.apache.mesos</groupId>
         <artifactId>mesos</artifactId>
         <version>${mesos.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.groupon.mesos</groupId>
+        <artifactId>jesos</artifactId>
+        <version>${dep.jesos.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.logging</groupId>
+        <artifactId>jboss-logging</artifactId>
+        <version>3.1.4.GA</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Add a configuration flag that allows switching between using the native library from Mesos and the
jesos pure java API. Default is to still use native code.

This also updates the mesos version to 0.21.0.
