### PR TITLE
fix logfetch date range filter for active task logs

### DIFF
--- a/scripts/logfetch/grep.py
+++ b/scripts/logfetch/grep.py
@@ -3,7 +3,7 @@ import sys
 from termcolor import colored
 
 GREP_COMMAND_FORMAT = 'xargs -n {0} {1} < {2}'
-DEFAULT_GREP_COMMAND = 'grep --color=always \'{1}\''
+DEFAULT_GREP_COMMAND = 'grep --color=always \'{0}\''
 
 def grep_files(args, all_logs):
   if args.grep:

--- a/scripts/logfetch/live_logs.py
+++ b/scripts/logfetch/live_logs.py
@@ -80,7 +80,7 @@ def all_tasks_for_request(args):
   elif len(active_tasks) == 0:
     return historical_tasks
   else:
-      return active_tasks + [h for h in historical_tasks if is_in_date_range(args, int(str(h['updatedAt'])[0:-3]))]
+    return active_tasks + [h for h in historical_tasks if is_in_date_range(args, int(str(h['updatedAt'])[0:-3]))]
 
 def is_in_date_range(args, timestamp):
   timedelta = datetime.utcnow() - datetime.utcfromtimestamp(timestamp)

--- a/scripts/logfetch/log_fetcher.py
+++ b/scripts/logfetch/log_fetcher.py
@@ -26,8 +26,7 @@ def main(args):
   check_dest(args)
   all_logs = []
   all_logs += download_s3_logs(args)
-  if not (args.end_days and args.end_days > 0):
-    all_logs += download_live_logs(args)
+  all_logs += download_live_logs(args)
   grep_files(args, all_logs)
 
 def check_dest(args):

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -10,7 +10,7 @@ requirements = [
 
 setup(
     name='singularity-logfetch',
-    version='0.0.4',
+    version='0.0.5',
     description='Singularity log fetching and searching',
     author="HubSpot",
     author_email='singularity-users@googlegroups.com',


### PR DESCRIPTION
@tpetr this fixes an issue some people were seeing with filtering by date. Now it checks if each of the log files associated with an active task is in the date range as opposed to just checking if the task itself is in that range.