### PR TITLE
hide icon for run-now when daemon task

### DIFF
--- a/SingularityUI/app/controllers/RequestDetail.coffee
+++ b/SingularityUI/app/controllers/RequestDetail.coffee
@@ -65,6 +65,7 @@ class RequestDetailController extends Controller
             template:   @templates.activeTasks
 
         @subviews.scheduledTasks = new SimpleSubview
+            model:      @models.request
             collection: @collections.scheduledTasks
             template:   @templates.scheduledTasks
 

--- a/SingularityUI/app/controllers/RequestDetail.coffee
+++ b/SingularityUI/app/controllers/RequestDetail.coffee
@@ -65,9 +65,10 @@ class RequestDetailController extends Controller
             template:   @templates.activeTasks
 
         @subviews.scheduledTasks = new SimpleSubview
-            model:      @models.request
-            collection: @collections.scheduledTasks
-            template:   @templates.scheduledTasks
+            collection:      @collections.scheduledTasks
+            template:        @templates.scheduledTasks
+            extraRenderData: (subView) =>
+                { request: @models.request.toJSON() }
 
         @subviews.taskHistory = new ExpandableTableSubview
             collection: @collections.taskHistory

--- a/SingularityUI/app/templates/requestDetail/requestScheduledTasks.hbs
+++ b/SingularityUI/app/templates/requestDetail/requestScheduledTasks.hbs
@@ -26,7 +26,7 @@
                         {{timestampFromNow pendingTask.pendingTaskId.nextRunAt}}
                     </td>
                     <td class="hidden-xs actions-column">
-                        {{#unless ../modelData.attributes.daemon}}
+                        {{#unless ../request.attributes.daemon}}
                             <a data-action="run-now" title="Run now">
                                 <span class="glyphicon glyphicon-flash"></span>
                             </a>

--- a/SingularityUI/app/templates/requestDetail/requestScheduledTasks.hbs
+++ b/SingularityUI/app/templates/requestDetail/requestScheduledTasks.hbs
@@ -26,9 +26,11 @@
                         {{timestampFromNow pendingTask.pendingTaskId.nextRunAt}}
                     </td>
                     <td class="hidden-xs actions-column">
-                        <a data-action="run-now" title="Run now">
-                            <span class="glyphicon glyphicon-flash"></span>
-                        </a>
+                        {{#unless ../modelData.attributes.daemon}}
+                            <a data-action="run-now" title="Run now">
+                                <span class="glyphicon glyphicon-flash"></span>
+                            </a>
+                        {{/unless}}
                         <a data-action="viewJSON" title="JSON">
                             { }
                         </a>

--- a/SingularityUI/app/views/request.coffee
+++ b/SingularityUI/app/views/request.coffee
@@ -70,7 +70,7 @@ class RequestView extends View
     scaleRequest: (e) =>
         @model.promptScale =>
             @trigger 'refreshrequest'
-  
+
     pauseRequest: (e) =>
         @model.promptPause =>
             @trigger 'refreshrequest'
@@ -78,7 +78,7 @@ class RequestView extends View
     unpauseRequest: (e) =>
         @model.promptUnpause =>
             @trigger 'refreshrequest'
-    
+
     bounceRequest: (e) =>
         @model.promptBounce =>
             @trigger 'refreshrequest'

--- a/SingularityUI/app/views/simpleSubview.coffee
+++ b/SingularityUI/app/views/simpleSubview.coffee
@@ -15,7 +15,8 @@ class SimpleSubview extends View
         _.extend super,
             'click [data-action="expandToggle"]': 'expandToggle'
 
-    initialize: ({@template}) ->
+    initialize: (@params) ->
+        { @template } = @params
         @data = if @collection? then @collection else @model
 
         for eventName in ['sync', 'add', 'remove', 'change']
@@ -27,16 +28,22 @@ class SimpleSubview extends View
     render: ->
         return if not @data.synced and @data.isEmpty?()
 
-        @$el.html @template
-            config:    config
-            data:      @data.toJSON()
-            synced:    @data.synced
-            expanded:  @expanded
-            modelData: @model?.toJSON()
+        @$el.html @template(@renderData())
 
         @$('.actions-column a[title]').tooltip()
 
         utils.setupCopyLinks @$el if @$('.horizontal-description-list').length
+
+    renderData: ->
+        data =
+            config:    config
+            data:      @data.toJSON()
+            synced:    @data.synced
+            expanded:  @expanded
+        if @params.extraRenderData?
+            _.extend data, @params.extraRenderData(this)
+
+        data
 
     expandToggle: (event) ->
         @expanded = not @expanded

--- a/SingularityUI/app/views/simpleSubview.coffee
+++ b/SingularityUI/app/views/simpleSubview.coffee
@@ -20,18 +20,19 @@ class SimpleSubview extends View
 
         for eventName in ['sync', 'add', 'remove', 'change']
             @listenTo @data, eventName, @render
-            
+
         @listenTo @data, 'reset', =>
             @$el.empty()
 
     render: ->
         return if not @data.synced and @data.isEmpty?()
-        
+
         @$el.html @template
-            config:   config
-            data:     @data.toJSON()
-            synced:   @data.synced
-            expanded: @expanded
+            config:    config
+            data:      @data.toJSON()
+            synced:    @data.synced
+            expanded:  @expanded
+            modelData: @model?.toJSON()
 
         @$('.actions-column a[title]').tooltip()
 


### PR DESCRIPTION
@tpetr fixes the error that some users were getting back when hitting the lightning bolt on a daemon task, now it won't be there