### PR TITLE
Quartz dialog

### DIFF
--- a/SingularityUI/app/styles/requestsTasksTable.styl
+++ b/SingularityUI/app/styles/requestsTasksTable.styl
@@ -31,7 +31,7 @@
         z-index 500
         background #f3f3f3
 
-        span.glyphicon
+        span.glyphicon-chevron-up,span.glyphicon-chevron-down
             font-size 10px
             line-height 10px
             height 19px

--- a/SingularityUI/app/styles/requestsTasksTable.styl
+++ b/SingularityUI/app/styles/requestsTasksTable.styl
@@ -43,3 +43,7 @@
 
     td
         overflow hidden
+
+.tooltip-inner
+    max-width: 250px
+    white-space: pre-wrap

--- a/SingularityUI/app/styles/table.styl
+++ b/SingularityUI/app/styles/table.styl
@@ -101,3 +101,7 @@ table.files-table
     
     tr td:first-child span.glyphicon
         margin-right 1em
+
+.popover
+    font-size 12px
+    width 230px

--- a/SingularityUI/app/styles/table.styl
+++ b/SingularityUI/app/styles/table.styl
@@ -98,10 +98,21 @@
         margin-bottom 0
 
 table.files-table
-    
+
     tr td:first-child span.glyphicon
         margin-right 1em
 
-.popover
+.table-header-popover
+    font-weight normal
+    text-align center
     font-size 12px
-    width 230px
+    width 18em
+
+    .popover-content
+        padding 6px
+
+    p
+        margin-bottom 0
+
+th #schedule
+    display block

--- a/SingularityUI/app/templates/requestsTable/requestsActiveBody.hbs
+++ b/SingularityUI/app/templates/requestsTable/requestsActiveBody.hbs
@@ -66,7 +66,15 @@
 
                         {{#ifInSubFilter 'scheduled' ../requestsSubFilter}}
                             <td class="visible-lg visible-xl">
-                                {{ request.schedule }}
+                                {{#if request.quartzSchedule}}
+                                    {{ request.quartzSchedule }}
+                                {{else}}
+                                    {{#ifEqual request.scheduleType "quartz"}}
+                                        {{ request.schedule }}
+                                    {{else}}
+                                        {{ request.schedule }} {{ request.scheduleType }}
+                                    {{/ifEqual}}
+                                {{/if}}
                             </td>
                         {{/ifInSubFilter}}
 

--- a/SingularityUI/app/templates/requestsTable/requestsActiveBody.hbs
+++ b/SingularityUI/app/templates/requestsTable/requestsActiveBody.hbs
@@ -25,9 +25,6 @@
                     {{#ifInSubFilter 'scheduled' requestsSubFilter}}
                         <th data-sort-attribute="request.schedule" class="visible-lg visible-xl">
                             Schedule
-                            <a data-action="show-quartz" title="Quartz Schedules">
-                                <span class='glyphicon glyphicon-question-sign'></span>
-                            </a>
                         </th>
                     {{/ifInSubFilter}}
 

--- a/SingularityUI/app/templates/requestsTable/requestsActiveBody.hbs
+++ b/SingularityUI/app/templates/requestsTable/requestsActiveBody.hbs
@@ -25,6 +25,9 @@
                     {{#ifInSubFilter 'scheduled' requestsSubFilter}}
                         <th data-sort-attribute="request.schedule" class="visible-lg visible-xl">
                             Schedule
+                            <a data-action="show-quartz" title="Quartz Schedules">
+                                <span class='glyphicon glyphicon-question-sign'></span>
+                            </a>
                         </th>
                     {{/ifInSubFilter}}
 
@@ -60,7 +63,7 @@
                         <td class="hidden-xs">
                             {{timestampFromNow requestDeployState.activeDeploy.timestamp}}
                         </td>
-                        
+
                         {{#ifInSubFilter 'scheduled' ../requestsSubFilter}}
                             <td class="visible-lg visible-xl">
                                 {{ request.schedule }}

--- a/SingularityUI/app/templates/requestsTable/requestsAllBody.hbs
+++ b/SingularityUI/app/templates/requestsTable/requestsAllBody.hbs
@@ -26,11 +26,13 @@
                     </th>
 
                     {{#ifInSubFilter 'scheduled' requestsSubFilter}}
-                        <th data-sort-attribute="request.schedule" class="visible-lg visible-xl" title="All schedules are in quartz format unless specified otherwise">
-                            Schedule
-                            <a data-action="show-quartz" title="Quartz Schedules">
-                                <span class='glyphicon glyphicon-question-sign'></span>
-                            </a>
+                        <th data-sort-attribute="request.schedule" class="visible-lg visible-xl schedule-header">
+                            <span title="All schedules are in quartz format unless specified otherwise, click the ? icon for more info">
+                                Schedule
+                                <a data-action="show-quartz">
+                                    <span class='glyphicon glyphicon-question-sign'></span>
+                                </a>
+                            </span>
                         </th>
 
                     {{/ifInSubFilter}}

--- a/SingularityUI/app/templates/requestsTable/requestsAllBody.hbs
+++ b/SingularityUI/app/templates/requestsTable/requestsAllBody.hbs
@@ -27,11 +27,8 @@
 
                     {{#ifInSubFilter 'scheduled' requestsSubFilter}}
                         <th data-sort-attribute="request.schedule" class="visible-lg visible-xl schedule-header">
-                            <span title="All schedules are in quartz format unless specified otherwise, click the ? icon for more info">
+                            <span id="schedule">
                                 Schedule
-                                <a data-action="show-quartz">
-                                    <span class='glyphicon glyphicon-question-sign'></span>
-                                </a>
                             </span>
                         </th>
 

--- a/SingularityUI/app/templates/requestsTable/requestsAllBody.hbs
+++ b/SingularityUI/app/templates/requestsTable/requestsAllBody.hbs
@@ -26,7 +26,7 @@
                     </th>
 
                     {{#ifInSubFilter 'scheduled' requestsSubFilter}}
-                        <th data-sort-attribute="request.schedule" class="visible-lg visible-xl">
+                        <th data-sort-attribute="request.schedule" class="visible-lg visible-xl" title="All schedules are in quartz format unless specified otherwise">
                             Schedule
                             <a data-action="show-quartz" title="Quartz Schedules">
                                 <span class='glyphicon glyphicon-question-sign'></span>
@@ -73,7 +73,15 @@
 
                         {{#ifInSubFilter 'scheduled' ../requestsSubFilter}}
                             <td class="visible-lg visible-xl">
-                                {{ request.schedule }}
+                                {{#if request.quartzSchedule}}
+                                    {{ request.quartzSchedule }}
+                                {{else}}
+                                    {{#ifEqual request.scheduleType "quartz"}}
+                                        {{ request.schedule }}
+                                    {{else}}
+                                        {{ request.schedule }} {{ request.scheduleType }}
+                                    {{/ifEqual}}
+                                {{/if}}
                             </td>
                         {{/ifInSubFilter}}
 

--- a/SingularityUI/app/templates/requestsTable/requestsAllBody.hbs
+++ b/SingularityUI/app/templates/requestsTable/requestsAllBody.hbs
@@ -24,11 +24,15 @@
                     <th data-sort-attribute="requestDeployState.activeDeploy.timestamp" class="hidden-xs">
                         Deploy time
                     </th>
-                    
+
                     {{#ifInSubFilter 'scheduled' requestsSubFilter}}
                         <th data-sort-attribute="request.schedule" class="visible-lg visible-xl">
                             Schedule
+                            <a data-action="show-quartz" title="Quartz Schedules">
+                                <span class='glyphicon glyphicon-question-sign'></span>
+                            </a>
                         </th>
+
                     {{/ifInSubFilter}}
 
                     <th class="hidden-xs">

--- a/SingularityUI/app/templates/requestsTable/requestsCooldownBody.hbs
+++ b/SingularityUI/app/templates/requestsTable/requestsCooldownBody.hbs
@@ -19,6 +19,9 @@
                     {{#ifInSubFilter 'scheduled' requestsSubFilter}}
                         <th data-sort-attribute="request.schedule" class="visible-lg visible-xl">
                             Schedule
+                            <a data-action="show-quartz" title="Quartz Schedules">
+                                <span class='glyphicon glyphicon-question-sign'></span>
+                            </a>
                         </th>
                     {{/ifInSubFilter}}
 

--- a/SingularityUI/app/templates/requestsTable/requestsCooldownBody.hbs
+++ b/SingularityUI/app/templates/requestsTable/requestsCooldownBody.hbs
@@ -19,9 +19,6 @@
                     {{#ifInSubFilter 'scheduled' requestsSubFilter}}
                         <th data-sort-attribute="request.schedule" class="visible-lg visible-xl">
                             Schedule
-                            <a data-action="show-quartz" title="Quartz Schedules">
-                                <span class='glyphicon glyphicon-question-sign'></span>
-                            </a>
                         </th>
                     {{/ifInSubFilter}}
 

--- a/SingularityUI/app/templates/requestsTable/requestsCooldownBody.hbs
+++ b/SingularityUI/app/templates/requestsTable/requestsCooldownBody.hbs
@@ -52,7 +52,15 @@
 
                         {{#ifInSubFilter 'scheduled' ../requestsSubFilter}}
                             <td class="visible-lg visible-xl">
-                                {{ request.schedule }}
+                                {{#if request.quartzSchedule}}
+                                    {{ request.quartzSchedule }}
+                                {{else}}
+                                    {{#ifEqual request.scheduleType "quartz"}}
+                                        {{ request.schedule }}
+                                    {{else}}
+                                        {{ request.schedule }} {{ request.scheduleType }}
+                                    {{/ifEqual}}
+                                {{/if}}
                             </td>
                         {{/ifInSubFilter}}
 

--- a/SingularityUI/app/templates/requestsTable/requestsFilter.hbs
+++ b/SingularityUI/app/templates/requestsTable/requestsFilter.hbs
@@ -16,6 +16,9 @@
             <span class="glyphicon glyphicon-ok"></span>
             Scheduled
         </a>
+        <a data-action="show-quartz" title="Quartz Schedules">
+            <span class='glyphicon glyphicon-question-sign'></span>
+        </a>
     </li>
 </ul>
 

--- a/SingularityUI/app/templates/requestsTable/requestsFilter.hbs
+++ b/SingularityUI/app/templates/requestsTable/requestsFilter.hbs
@@ -16,9 +16,6 @@
             <span class="glyphicon glyphicon-ok"></span>
             Scheduled
         </a>
-        <a data-action="show-quartz" title="Quartz Schedules">
-            <span class='glyphicon glyphicon-question-sign'></span>
-        </a>
     </li>
 </ul>
 

--- a/SingularityUI/app/templates/requestsTable/requestsPausedBody.hbs
+++ b/SingularityUI/app/templates/requestsTable/requestsPausedBody.hbs
@@ -46,7 +46,15 @@
 
                         {{#ifInSubFilter 'scheduled' ../requestsSubFilter}}
                             <td class="visible-lg visible-xl">
-                                {{ request.schedule }}
+                                {{#if request.quartzSchedule}}
+                                    {{ request.quartzSchedule }}
+                                {{else}}
+                                    {{#ifEqual request.scheduleType "quartz"}}
+                                        {{ request.schedule }}
+                                    {{else}}
+                                        {{ request.schedule }} {{ request.scheduleType }}
+                                    {{/ifEqual}}
+                                {{/if}}
                             </td>
                         {{/ifInSubFilter}}
 

--- a/SingularityUI/app/templates/requestsTable/requestsPausedBody.hbs
+++ b/SingularityUI/app/templates/requestsTable/requestsPausedBody.hbs
@@ -16,6 +16,9 @@
                     {{#ifInSubFilter 'scheduled' requestsSubFilter}}
                         <th data-sort-attribute="request.schedule" class="visible-lg visible-xl">
                             Schedule
+                            <a data-action="show-quartz" title="Quartz Schedules">
+                                <span class='glyphicon glyphicon-question-sign'></span>
+                            </a>
                         </th>
                     {{/ifInSubFilter}}
 

--- a/SingularityUI/app/templates/vex/quartzInfo.hbs
+++ b/SingularityUI/app/templates/vex/quartzInfo.hbs
@@ -86,63 +86,47 @@
 │ └───────────── min (0 - 59)
 └─────────────── seconds
 -->
+<h3>Special Characters</h3>
 <table class="table-condensed">
     <tbody>
         <tr>
-            <th>Field Name</th>
-            <th></th>
-            <th>Allowed Values</th>
-            <th></th>
-            <th>Allowed Special Characters</th>
+            <th>Character</th>
+            <th>Function</th>
         </tr>
         <tr>
-            <td>Seconds</td>
-            <td>
-            </td><td>0-59</td>
-            <td>
-            </td><td>, - * /</td>
+            <td>*</td>
+            <td>All values</td>
         </tr>
         <tr>
-            <td>Minutes</td>
-            <td>
-            </td><td>0-59</td>
-            <td>
-            </td><td>, - * /</td>
+            <td>?</td>
+            <td>No specific value (day of month/day of week)</td>
         </tr>
         <tr>
-            <td>Hours</td>
-            <td>
-            </td><td>0-23</td>
-            <td>
-            </td><td>, - * /</td>
+            <td>-</td>
+            <td>Used to specify ranges (10-12)</td>
         </tr>
         <tr>
-            <td>Day-of-month</td>
-            <td>
-            </td><td>1-31</td>
-            <td>
-            </td><td>, - * ? / L W</td>
+            <td>,</td>
+            <td>Specify additional values (MON,WED,FRI)</td>
         </tr>
         <tr>
-            <td>Month</td>
-            <td>
-            </td><td>1-12 or JAN-DEC</td>
-            <td>
-            </td><td>, - * /</td>
+            <td>/</td>
+            <td>Specify increments (S/N every Nth value of a set starting from value S)</td>
         </tr>
         <tr>
-            <td>Day-of-Week</td>
+            <td>L</td>
             <td>
-            </td><td>0-7 or SUN-SAT (0 or 7 is SUN)</td>
-            <td>
-            </td><td>, - * ? / L #</td>
+                <li>last day of week (7), or if used with a value last n day of month (ex. 6L - last friday of month)</li>
+                <li>last day of the month, can also specify with an offset (ex. L-3)</li>
+            </td>
         </tr>
         <tr>
-            <td>Year (Optional)</td>
-            <td>
-            </td><td>empty, 1970-2199</td>
-            <td>
-            </td><td>, - * /</td>
+            <td>W</td>
+            <td>Weekday (15W, nearest weekday to 15th of the month) only for day of month</td>
+        </tr>
+        <tr>
+            <td>#</td>
+            <td>Nth XXX day of the month (6#3 - third friday of the month) only for day of week</td>
         </tr>
     </tbody>
 </table>

--- a/SingularityUI/app/templates/vex/quartzInfo.hbs
+++ b/SingularityUI/app/templates/vex/quartzInfo.hbs
@@ -1,0 +1,148 @@
+<h2>Quartz Schedule Format</h2>
+<table class="table-condensed">
+    <thead>
+        <th>*</th>
+        <th>*</th>
+        <th>*</th>
+        <th>*</th>
+        <th>*</th>
+        <th>*</th>
+        <th>(year optional)</th>
+    </thead>
+    <tbody>
+        <tr>
+            <td>┬</td>
+            <td>┬</td>
+            <td>┬</td>
+            <td>┬</td>
+            <td>┬</td>
+            <td>┬</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>│</td>
+            <td>│</td>
+            <td>│</td>
+            <td>│</td>
+            <td>│</td>
+            <td>└</td>
+            <td> day of week (0 - 7, or use names)</td>
+        </tr>
+        <tr>
+            <td>│</td>
+            <td>│</td>
+            <td>│</td>
+            <td>│</td>
+            <td>└</td>
+            <td>─ </td>
+            <td> month (1 - 12)</td>
+        </tr>
+        <tr>
+            <td>│</td>
+            <td>│</td>
+            <td>│</td>
+            <td>└</td>
+            <td>─ </td>
+            <td>─ </td>
+            <td> day of month (1 - 31)</td>
+        </tr>
+        <tr>
+            <td>│</td>
+            <td>│</td>
+            <td>└</td>
+            <td>─ </td>
+            <td>─ </td>
+            <td>─ </td>
+            <td> hour (0 - 23)</td>
+        </tr>
+        <tr>
+            <td>│</td>
+            <td>└</td>
+            <td>─ </td>
+            <td>─ </td>
+            <td>─ </td>
+            <td>─ </td>
+            <td> min (0 - 59)</td>
+        </tr>
+        <tr>
+            <td>└</td>
+            <td>─ </td>
+            <td>─ </td>
+            <td>─ </td>
+            <td>─ </td>
+            <td>─ </td>
+            <td> seconds</td>
+        </tr>
+    </tbody>
+</table>
+
+<!--
+* * * * * *   (year optional)
+┬ ┬ ┬ ┬ ┬ ┬
+│ │ │ │ │ └───── day of week (0 - 7, or use names)
+│ │ │ │ └─────── month (1 - 12)
+│ │ │ └───────── day of month (1 - 31)
+│ │ └─────────── hour (0 - 23)
+│ └───────────── min (0 - 59)
+└─────────────── seconds
+-->
+<table class="table-condensed">
+    <tbody>
+        <tr>
+            <th>Field Name</th>
+            <th></th>
+            <th>Allowed Values</th>
+            <th></th>
+            <th>Allowed Special Characters</th>
+        </tr>
+        <tr>
+            <td>Seconds</td>
+            <td>
+            </td><td>0-59</td>
+            <td>
+            </td><td>, - * /</td>
+        </tr>
+        <tr>
+            <td>Minutes</td>
+            <td>
+            </td><td>0-59</td>
+            <td>
+            </td><td>, - * /</td>
+        </tr>
+        <tr>
+            <td>Hours</td>
+            <td>
+            </td><td>0-23</td>
+            <td>
+            </td><td>, - * /</td>
+        </tr>
+        <tr>
+            <td>Day-of-month</td>
+            <td>
+            </td><td>1-31</td>
+            <td>
+            </td><td>, - * ? / L W</td>
+        </tr>
+        <tr>
+            <td>Month</td>
+            <td>
+            </td><td>1-12 or JAN-DEC</td>
+            <td>
+            </td><td>, - * /</td>
+        </tr>
+        <tr>
+            <td>Day-of-Week</td>
+            <td>
+            </td><td>0-7 or SUN-SAT (0 or 7 is SUN)</td>
+            <td>
+            </td><td>, - * ? / L #</td>
+        </tr>
+        <tr>
+            <td>Year (Optional)</td>
+            <td>
+            </td><td>empty, 1970-2199</td>
+            <td>
+            </td><td>, - * /</td>
+        </tr>
+    </tbody>
+</table>

--- a/SingularityUI/app/views/requests.coffee
+++ b/SingularityUI/app/views/requests.coffee
@@ -199,6 +199,7 @@ class RequestsView extends View
             $tableBody.append $contents
 
         @$('.actions-column a[title]').tooltip()
+        @$('.schedule-header span[title]').tooltip()
 
     sortTable: (event) =>
         @isSorted = true

--- a/SingularityUI/app/views/requests.coffee
+++ b/SingularityUI/app/views/requests.coffee
@@ -206,8 +206,8 @@ class RequestsView extends View
             delay: {hide: 400},
             container: 'span#schedule',
             html: true,
-            content: "<p>All schedules are in <a data-action='show-quartz'>quartz format</a> unless otherwise specified.<p>",
-            template: '<div class="popover" role="tooltip"><div class="popover-content"></div></div>'
+            content: "<p>All schedules are in <a data-action='show-quartz'>quartz format</a> unless otherwise specified.</p>",
+            template: '<div class="popover table-header-popover" role="tooltip"><div class="popover-content"></div></div>'
         }).on
             show: (e) ->
                 @showPopover(e)

--- a/SingularityUI/app/views/requests.coffee
+++ b/SingularityUI/app/views/requests.coffee
@@ -208,7 +208,8 @@ class RequestsView extends View
 
         $currentlySortedHeading = @$ "[data-sorted=true]"
         $currentlySortedHeading.removeAttr "data-sorted"
-        $currentlySortedHeading.find('span').remove()
+        $currentlySortedHeading.find("span.glyphicon-chevron-up").remove()
+        $currentlySortedHeading.find("span.glyphicon-chevron-down").remove()
 
         if newSortAttribute is @sortAttribute and @sortAscending?
             @sortAscending = not @sortAscending

--- a/SingularityUI/app/views/requests.coffee
+++ b/SingularityUI/app/views/requests.coffee
@@ -199,7 +199,42 @@ class RequestsView extends View
             $tableBody.append $contents
 
         @$('.actions-column a[title]').tooltip()
-        @$('.schedule-header span[title]').tooltip()
+        @$('.schedule-header span#schedule').popover({
+            animation: false,
+            placement : 'auto',
+            trigger: 'hover',
+            delay: {hide: 400},
+            container: 'span#schedule',
+            html: true,
+            content: "All schedules are in <a data-action='show-quartz'>quartz format</a> unless otherwise specified.",
+            template: '<div class="popover" role="tooltip"><div class="popover-content"></div></div>'
+        }).on
+            show: (e) ->
+                @showPopover(e)
+            hide: (e) ->
+                @hidePopover(e)
+
+    hidePopover: (e) ->
+        $this = $(this)
+        if $this.data("forceHidePopover")
+            $this.data "forceHidePopover", false
+            return true
+        e.stopImmediatePropagation()
+        clearTimeout $this.data("popoverTO")
+        $this.data "hoveringPopover", false
+        $this.data "waitingForPopoverTO", true
+        $this.data "popoverTO", setTimeout(->
+            unless $this.data("hoveringPopover")
+                $this.data "forceHidePopover", true
+                $this.data "waitingForPopoverTO", false
+                $this.popover "hide"
+        , 1500)
+        false
+
+    showPopover: (e) ->
+        $this = $(this)
+        $this.data "hoveringPopover", true
+        e.stopImmediatePropagation()  if $this.data("waitingForPopoverTO")
 
     sortTable: (event) =>
         @isSorted = true

--- a/SingularityUI/app/views/requests.coffee
+++ b/SingularityUI/app/views/requests.coffee
@@ -16,6 +16,8 @@ class RequestsView extends View
         pending:  require '../templates/requestsTable/requestsPendingBody'
         cleaning: require '../templates/requestsTable/requestsCleaningBody'
 
+    quartzTemplate: require '../templates/vex/quartzInfo'
+
     # Which table views have sub-filters (daemon, scheduled, on-demand)
     haveSubfilter: ['all', 'active', 'paused', 'cooldown']
 
@@ -33,6 +35,7 @@ class RequestsView extends View
             'click [data-action="unpause"]': 'unpauseRequest'
             'click [data-action="starToggle"]': 'toggleStar'
             'click [data-action="run-now"]': 'runRequest'
+            'click [data-action="show-quartz"]': 'showQuartz'
             'click [data-filter]': 'changeFilters'
 
             'change input[type="search"]': 'searchChange'
@@ -57,16 +60,16 @@ class RequestsView extends View
             requests = _.filter requests, (request) =>
                 searchFilter = @searchFilter.toLowerCase().split("@")[0]
                 valuesToSearch = []
-                
+
                 for user in request.request.owners ? []
                   valuesToSearch.push(user.split("@")[0])
-                  
+
                 valuesToSearch.push(request.request.id)
                 valuesToSearch.push(request.requestDeployState?.activeDeploy?.user)
-                
+
                 searchTarget = valuesToSearch.join("")
                 searchTarget.toLowerCase().indexOf(searchFilter) isnt -1
-        
+
         # Only show requests that match the clicky filters
         if @state in @haveSubfilter and @subFilter isnt 'all'
             requests = _.filter requests, (request) =>
@@ -257,15 +260,15 @@ class RequestsView extends View
         @collection.get(id).promptUnpause =>
             $row.remove()
             @trigger 'refreshrequest'
-            
+
     scaleRequest: (e) ->
         $row = $(e.target).parents 'tr'
         id = $row.data('request-id')
-        
+
         @collection.get(id).promptScale =>
           $row.addClass 'flash'
           @trigger 'refreshrequest'
-          
+
     runRequest: (e) ->
         $row = $(e.target).parents 'tr'
         id = $row.data('request-id')
@@ -273,13 +276,13 @@ class RequestsView extends View
         @collection.get(id).promptRun =>
             $row.addClass 'flash'
             setTimeout (=> $row.removeClass 'flash'), 500
-                        
+
     toggleStar: (e) ->
         $target = $(e.currentTarget)
         $row = $target.parents 'tr'
 
         id = $row.data 'request-id'
-        
+
         @collection.toggleStar id
 
         starred = $target.attr('data-starred') is "true"
@@ -323,5 +326,9 @@ class RequestsView extends View
         if @searchFilter isnt previousSearchFilter
             @updateUrl()
             @renderTable()
+
+    showQuartz: (event) =>
+        vex.dialog.alert
+            message: @quartzTemplate
 
 module.exports = RequestsView

--- a/SingularityUI/app/views/requests.coffee
+++ b/SingularityUI/app/views/requests.coffee
@@ -206,7 +206,7 @@ class RequestsView extends View
             delay: {hide: 400},
             container: 'span#schedule',
             html: true,
-            content: "All schedules are in <a data-action='show-quartz'>quartz format</a> unless otherwise specified.",
+            content: "<p>All schedules are in <a data-action='show-quartz'>quartz format</a> unless otherwise specified.<p>",
             template: '<div class="popover" role="tooltip"><div class="popover-content"></div></div>'
         }).on
             show: (e) ->


### PR DESCRIPTION
Adds an icon to the requests table when the Schedule column is present:
![screen shot 2015-01-06 at 11 42 46 am](https://cloud.githubusercontent.com/assets/6034439/5632041/7173ea20-9599-11e4-9206-08d53b58ff6c.png)

clicking the icon produces a vex dialog with info about quartz schedule format:
![screen shot 2015-01-06 at 11 43 00 am](https://cloud.githubusercontent.com/assets/6034439/5632049/889b31fe-9599-11e4-89a2-33fa8149dff0.png)

Let me know if the dialog is too verbose, maybe we just want the top half with the simple explanation? Or maybe the bottom should have special character explanations instead of the current content?

@tpetr 