### PR TITLE
Add a pluggable event listener facility

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeployUpdate.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeployUpdate.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
 
-public class SingularityDeployWebhook {
+public class SingularityDeployUpdate {
 
   public enum DeployEventType {
     STARTING, FINISHED;
@@ -16,7 +16,7 @@ public class SingularityDeployWebhook {
   private final Optional<SingularityDeployResult> deployResult;
 
   @JsonCreator
-  public SingularityDeployWebhook(@JsonProperty("deployMarker") SingularityDeployMarker deployMarker, @JsonProperty("deploy") Optional<SingularityDeploy> deploy, @JsonProperty("eventType") DeployEventType eventType, @JsonProperty("deployResult") Optional<SingularityDeployResult> deployResult) {
+  public SingularityDeployUpdate(@JsonProperty("deployMarker") SingularityDeployMarker deployMarker, @JsonProperty("deploy") Optional<SingularityDeploy> deploy, @JsonProperty("eventType") DeployEventType eventType, @JsonProperty("deployResult") Optional<SingularityDeployResult> deployResult) {
     this.deployMarker = deployMarker;
     this.deploy = deploy;
     this.eventType = eventType;

--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
@@ -28,7 +28,7 @@ import com.hubspot.singularity.SingularityDeleteResult;
 import com.hubspot.singularity.SingularityDeploy;
 import com.hubspot.singularity.SingularityDeployHistory;
 import com.hubspot.singularity.SingularityDeployKey;
-import com.hubspot.singularity.SingularityDeployWebhook;
+import com.hubspot.singularity.SingularityDeployUpdate;
 import com.hubspot.singularity.SingularityPendingRequest;
 import com.hubspot.singularity.SingularityRack;
 import com.hubspot.singularity.SingularityRequest;
@@ -111,7 +111,7 @@ public class SingularityClient {
   private static final TypeReference<Collection<SingularityRack>> RACKS_COLLECTION = new TypeReference<Collection<SingularityRack>>() {};
   private static final TypeReference<Collection<SingularitySlave>> SLAVES_COLLECTION = new TypeReference<Collection<SingularitySlave>>() {};
   private static final TypeReference<Collection<SingularityWebhook>> WEBHOOKS_COLLECTION = new TypeReference<Collection<SingularityWebhook>>() {};
-  private static final TypeReference<Collection<SingularityDeployWebhook>> DEPLOY_UPDATES_COLLECTION = new TypeReference<Collection<SingularityDeployWebhook>>() {};
+  private static final TypeReference<Collection<SingularityDeployUpdate>> DEPLOY_UPDATES_COLLECTION = new TypeReference<Collection<SingularityDeployUpdate>>() {};
   private static final TypeReference<Collection<SingularityRequestHistory>> REQUEST_UPDATES_COLLECTION = new TypeReference<Collection<SingularityRequestHistory>>() {};
   private static final TypeReference<Collection<SingularityTaskHistoryUpdate>> TASK_UPDATES_COLLECTION = new TypeReference<Collection<SingularityTaskHistoryUpdate>>() {};
   private static final TypeReference<Collection<SingularityTaskRequest>> TASKS_REQUEST_COLLECTION = new TypeReference<Collection<SingularityTaskRequest>>() {};
@@ -662,7 +662,7 @@ public class SingularityClient {
     return getCollection(requestUri, "active webhooks", WEBHOOKS_COLLECTION);
   }
 
-  public Collection<SingularityDeployWebhook> getQueuedDeployUpdates(String webhookId) {
+  public Collection<SingularityDeployUpdate> getQueuedDeployUpdates(String webhookId) {
     final String requestUri = String.format(WEBHOOKS_GET_QUEUED_DEPLOY_UPDATES_FORMAT, getHost(), contextPath, webhookId);
 
     return getCollection(requestUri, "deploy updates", DEPLOY_UPDATES_COLLECTION);

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityManagedScheduledExecutorServiceProvider.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityManagedScheduledExecutorServiceProvider.java
@@ -1,0 +1,46 @@
+package com.hubspot.singularity;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import io.dropwizard.lifecycle.Managed;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.inject.Provider;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+public class SingularityManagedScheduledExecutorServiceProvider implements Provider<ScheduledExecutorService>, Managed {
+
+  private final AtomicBoolean stopped = new AtomicBoolean();
+  private ScheduledExecutorService service;
+
+  private final long timeoutInSeconds;
+
+  public SingularityManagedScheduledExecutorServiceProvider(final int poolSize, final long timeoutInSeconds, final String name) {
+    this.service = Executors.newScheduledThreadPool(poolSize, new ThreadFactoryBuilder().setNameFormat(name + "-pool-%d").setDaemon(true).build());
+    this.timeoutInSeconds = timeoutInSeconds;
+  }
+
+  @Override
+  public synchronized ScheduledExecutorService get() {
+    checkState(!stopped.get(), "already stopped");
+    return service;
+  }
+
+  @Override
+  public void start() throws Exception {
+    // Ignored
+  }
+
+  @Override
+  public void stop() throws Exception {
+    if (!stopped.getAndSet(true)) {
+      service.shutdown();
+      service.awaitTermination(timeoutInSeconds, TimeUnit.SECONDS);
+    }
+  }
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityServiceModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityServiceModule.java
@@ -7,6 +7,7 @@ import com.hubspot.singularity.data.SingularityDataModule;
 import com.hubspot.singularity.data.history.SingularityHistoryModule;
 import com.hubspot.singularity.data.transcoders.SingularityTranscoderModule;
 import com.hubspot.singularity.data.zkmigrations.SingularityZkMigrationsModule;
+import com.hubspot.singularity.event.SingularityEventModule;
 import com.hubspot.singularity.guice.ConfigurationAwareModule;
 import com.hubspot.singularity.jersey.SingularityJerseyModule;
 import com.hubspot.singularity.mesos.SingularityMesosModule;
@@ -27,5 +28,7 @@ public class SingularityServiceModule extends ConfigurationAwareModule<Singulari
     binder.install(new SingularityZkMigrationsModule());
     binder.install(new SingularityMesosClientModule());
     binder.install(new SingularityJerseyModule());
+
+    binder.install(new SingularityEventModule(configuration));
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -135,6 +135,13 @@ public class SingularityConfiguration extends Configuration {
 
   private long zookeeperAsyncTimeout = 5000;
 
+  private long threadpoolShutdownDelayInSeconds = 1;
+
+  private int listenerThreadpoolSize = 3;
+
+  /** If true, the event system waits for all listeners having processed an event. */
+  private boolean waitForListeners = true;
+
   @JsonProperty("zookeeper")
   @Valid
   private ZooKeeperConfiguration zooKeeperConfiguration;
@@ -359,6 +366,18 @@ public class SingularityConfiguration extends Configuration {
     return sandboxDefaultsToTaskId;
   }
 
+  public int getListenerThreadpoolSize() {
+    return listenerThreadpoolSize;
+  }
+
+  public boolean isWaitForListeners() {
+    return waitForListeners;
+  }
+
+  public long getThreadpoolShutdownDelayInSeconds() {
+    return threadpoolShutdownDelayInSeconds;
+  }
+
   public void setAllowRequestsWithoutOwners(boolean allowRequestsWithoutOwners) {
     this.allowRequestsWithoutOwners = allowRequestsWithoutOwners;
   }
@@ -579,4 +598,15 @@ public class SingularityConfiguration extends Configuration {
     this.zooKeeperConfiguration = zooKeeperConfiguration;
   }
 
+  public void setThreadpoolShutdownDelayInSeconds(long threadpoolShutdownDelayInSeconds) {
+    this.threadpoolShutdownDelayInSeconds = threadpoolShutdownDelayInSeconds;
+  }
+
+  public void setListenerThreadpoolSize(int listenerThreadpoolSize) {
+    this.listenerThreadpoolSize = listenerThreadpoolSize;
+  }
+
+  public void setWaitForListeners(boolean waitForListeners) {
+    this.waitForListeners = waitForListeners;
+  }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/DeployManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/DeployManager.java
@@ -23,21 +23,22 @@ import com.hubspot.singularity.SingularityDeployKey;
 import com.hubspot.singularity.SingularityDeployMarker;
 import com.hubspot.singularity.SingularityDeployResult;
 import com.hubspot.singularity.SingularityDeployStatistics;
-import com.hubspot.singularity.SingularityDeployWebhook;
-import com.hubspot.singularity.SingularityDeployWebhook.DeployEventType;
+import com.hubspot.singularity.SingularityDeployUpdate;
+import com.hubspot.singularity.SingularityDeployUpdate.DeployEventType;
 import com.hubspot.singularity.SingularityPendingDeploy;
 import com.hubspot.singularity.SingularityRequest;
 import com.hubspot.singularity.SingularityRequestDeployState;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.transcoders.IdTranscoder;
 import com.hubspot.singularity.data.transcoders.Transcoder;
+import com.hubspot.singularity.event.SingularityEventListener;
 
 @Singleton
 public class DeployManager extends CuratorAsyncManager {
 
   private static final Logger LOG = LoggerFactory.getLogger(DeployManager.class);
 
-  private final WebhookManager webhookManager;
+  private final SingularityEventListener singularityEventListener;
   private final Transcoder<SingularityDeploy> deployTranscoder;
   private final Transcoder<SingularityPendingDeploy> pendingDeployTranscoder;
   private final Transcoder<SingularityDeployMarker> deployMarkerTranscoder;
@@ -63,12 +64,12 @@ public class DeployManager extends CuratorAsyncManager {
   private static final String DEPLOY_RESULT_KEY = "RESULT_STATE";
 
   @Inject
-  public DeployManager(SingularityConfiguration configuration, CuratorFramework curator, WebhookManager webhookManager, Transcoder<SingularityDeploy> deployTranscoder,
+  public DeployManager(SingularityConfiguration configuration, CuratorFramework curator, SingularityEventListener singularityEventListener, Transcoder<SingularityDeploy> deployTranscoder,
       Transcoder<SingularityRequestDeployState> requestDeployStateTranscoder, Transcoder<SingularityPendingDeploy> pendingDeployTranscoder, Transcoder<SingularityDeployMarker> deployMarkerTranscoder,
       Transcoder<SingularityDeployStatistics> deployStatisticsTranscoder, Transcoder<SingularityDeployResult> deployStateTranscoder, IdTranscoder<SingularityDeployKey> deployKeyTranscoder) {
     super(curator, configuration.getZookeeperAsyncTimeout());
 
-    this.webhookManager = webhookManager;
+    this.singularityEventListener = singularityEventListener;
     this.pendingDeployTranscoder = pendingDeployTranscoder;
     this.deployTranscoder = deployTranscoder;
     this.deployStatisticsTranscoder = deployStatisticsTranscoder;
@@ -182,7 +183,7 @@ public class DeployManager extends CuratorAsyncManager {
       LOG.info(String.format("Deploy object for %s already existed (new marker: %s)", deploy, deployMarker));
     }
 
-    webhookManager.enqueueDeployUpdate(new SingularityDeployWebhook(deployMarker, Optional.of(deploy), DeployEventType.STARTING, Optional.<SingularityDeployResult>absent()));
+    singularityEventListener.deployHistoryEvent(new SingularityDeployUpdate(deployMarker, Optional.of(deploy), DeployEventType.STARTING, Optional.<SingularityDeployResult>absent()));
 
     create(getDeployMarkerPath(deploy.getRequestId(), deploy.getId()), deployMarker, deployMarkerTranscoder);
 
@@ -302,7 +303,7 @@ public class DeployManager extends CuratorAsyncManager {
   }
 
   public SingularityCreateResult saveDeployResult(SingularityDeployMarker deployMarker, Optional<SingularityDeploy> deploy, SingularityDeployResult result) {
-    webhookManager.enqueueDeployUpdate(new SingularityDeployWebhook(deployMarker, deploy, DeployEventType.FINISHED, Optional.of(result)));
+    singularityEventListener.deployHistoryEvent(new SingularityDeployUpdate(deployMarker, deploy, DeployEventType.FINISHED, Optional.of(result)));
 
     return save(getDeployResultPath(deployMarker.getRequestId(), deployMarker.getDeployId()), result, deployStateTranscoder);
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
@@ -27,6 +27,7 @@ import com.hubspot.singularity.SingularityRequestHistory.RequestHistoryType;
 import com.hubspot.singularity.SingularityRequestWithState;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.transcoders.Transcoder;
+import com.hubspot.singularity.event.SingularityEventListener;
 
 @Singleton
 public class RequestManager extends CuratorAsyncManager {
@@ -38,7 +39,7 @@ public class RequestManager extends CuratorAsyncManager {
   private final Transcoder<SingularityRequestCleanup> requestCleanupTranscoder;
   private final Transcoder<SingularityRequestHistory> requestHistoryTranscoder;
 
-  private final WebhookManager webhookManager;
+  private final SingularityEventListener singularityEventListener;
 
   private static final String REQUEST_ROOT = "/requests";
 
@@ -48,7 +49,7 @@ public class RequestManager extends CuratorAsyncManager {
   private static final String HISTORY_PATH_ROOT = REQUEST_ROOT + "/history";
 
   @Inject
-  public RequestManager(SingularityConfiguration configuration, CuratorFramework curator, WebhookManager webhookManager, Transcoder<SingularityRequestCleanup> requestCleanupTranscoder,
+  public RequestManager(SingularityConfiguration configuration, CuratorFramework curator, SingularityEventListener singularityEventListener, Transcoder<SingularityRequestCleanup> requestCleanupTranscoder,
       Transcoder<SingularityRequestWithState> requestTranscoder, Transcoder<SingularityPendingRequest> pendingRequestTranscoder, Transcoder<SingularityRequestHistory> requestHistoryTranscoder) {
     super(curator, configuration.getZookeeperAsyncTimeout());
 
@@ -56,7 +57,7 @@ public class RequestManager extends CuratorAsyncManager {
     this.requestCleanupTranscoder = requestCleanupTranscoder;
     this.pendingRequestTranscoder = pendingRequestTranscoder;
     this.requestHistoryTranscoder = requestHistoryTranscoder;
-    this.webhookManager = webhookManager;
+    this.singularityEventListener = singularityEventListener;
   }
 
   private String getRequestPath(String requestId) {
@@ -170,7 +171,7 @@ public class RequestManager extends CuratorAsyncManager {
   protected SingularityCreateResult saveHistory(SingularityRequestHistory history) {
     final String path = getHistoryPath(history);
 
-    webhookManager.enqueueRequestUpdate(history);
+    singularityEventListener.requestHistoryEvent(history);
 
     return save(path, history, requestHistoryTranscoder);
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/WebhookManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/WebhookManager.java
@@ -30,11 +30,11 @@ public class WebhookManager extends CuratorAsyncManager {
   private final Transcoder<SingularityWebhook> webhookTranscoder;
   private final Transcoder<SingularityRequestHistory> requestHistoryTranscoder;
   private final Transcoder<SingularityTaskHistoryUpdate> taskHistoryUpdateTranscoder;
-  private final Transcoder<SingularityDeployWebhook> deployWebhookTranscoder;
+  private final Transcoder<SingularityDeployUpdate> deployWebhookTranscoder;
 
   @Inject
   public WebhookManager(SingularityConfiguration configuration, CuratorFramework curator, Transcoder<SingularityWebhook> webhookTranscoder,
-      Transcoder<SingularityRequestHistory> requestHistoryTranscoder, Transcoder<SingularityTaskHistoryUpdate> taskHistoryUpdateTranscoder, Transcoder<SingularityDeployWebhook> deployWebhookTranscoder) {
+      Transcoder<SingularityRequestHistory> requestHistoryTranscoder, Transcoder<SingularityTaskHistoryUpdate> taskHistoryUpdateTranscoder, Transcoder<SingularityDeployUpdate> deployWebhookTranscoder) {
     super(curator, configuration.getZookeeperAsyncTimeout());
     this.webhookTranscoder = webhookTranscoder;
     this.taskHistoryUpdateTranscoder = taskHistoryUpdateTranscoder;
@@ -65,7 +65,7 @@ public class WebhookManager extends CuratorAsyncManager {
     return requestUpdate.getRequest().getId() + "-" + requestUpdate.getEventType().name() + "-" + requestUpdate.getCreatedAt();
   }
 
-  private String getDeployUpdateId(SingularityDeployWebhook deployUpdate) {
+  private String getDeployUpdateId(SingularityDeployUpdate deployUpdate) {
     return SingularityDeployKey.fromDeployMarker(deployUpdate.getDeployMarker()) + "-" + deployUpdate.getEventType().name();
   }
 
@@ -85,7 +85,7 @@ public class WebhookManager extends CuratorAsyncManager {
     return ZKPaths.makePath(getEnqueuePathForWebhook(webhookId, WebhookType.TASK), getTaskHistoryUpdateId(taskUpdate));
   }
 
-  private String getEnqueuePathForDeployUpdate(String webhookId, SingularityDeployWebhook deployUpdate) {
+  private String getEnqueuePathForDeployUpdate(String webhookId, SingularityDeployUpdate deployUpdate) {
     return ZKPaths.makePath(getEnqueuePathForWebhook(webhookId, WebhookType.DEPLOY), getDeployUpdateId(deployUpdate));
   }
 
@@ -107,7 +107,7 @@ public class WebhookManager extends CuratorAsyncManager {
     return delete(path);
   }
 
-  public SingularityDeleteResult deleteDeployUpdate(SingularityWebhook webhook, SingularityDeployWebhook deployUpdate) {
+  public SingularityDeleteResult deleteDeployUpdate(SingularityWebhook webhook, SingularityDeployUpdate deployUpdate) {
     final String path = getEnqueuePathForDeployUpdate(webhook.getId(), deployUpdate);
 
     return delete(path);
@@ -119,7 +119,7 @@ public class WebhookManager extends CuratorAsyncManager {
     return delete(path);
   }
 
-  public List<SingularityDeployWebhook> getQueuedDeployUpdatesForHook(String webhookId) {
+  public List<SingularityDeployUpdate> getQueuedDeployUpdatesForHook(String webhookId) {
     return getAsyncChildren(getEnqueuePathForWebhook(webhookId, WebhookType.DEPLOY), deployWebhookTranscoder);
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/WebhookManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/WebhookManager.java
@@ -12,16 +12,17 @@ import com.google.inject.Singleton;
 import com.hubspot.singularity.SingularityCreateResult;
 import com.hubspot.singularity.SingularityDeleteResult;
 import com.hubspot.singularity.SingularityDeployKey;
-import com.hubspot.singularity.SingularityDeployWebhook;
+import com.hubspot.singularity.SingularityDeployUpdate;
 import com.hubspot.singularity.SingularityRequestHistory;
 import com.hubspot.singularity.SingularityTaskHistoryUpdate;
 import com.hubspot.singularity.SingularityWebhook;
 import com.hubspot.singularity.WebhookType;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.transcoders.Transcoder;
+import com.hubspot.singularity.event.SingularityEventListener;
 
 @Singleton
-public class WebhookManager extends CuratorAsyncManager {
+public class WebhookManager extends CuratorAsyncManager implements SingularityEventListener {
 
   private static final String ROOT_PATH = "/hooks";
   private static final String QUEUES_PATH = ROOT_PATH + "/queues";
@@ -133,7 +134,8 @@ public class WebhookManager extends CuratorAsyncManager {
 
   // TODO consider caching the list of hooks (at the expense of needing to refresh the cache and not
   // immediately make some webhooks)
-  public void enqueueRequestUpdate(SingularityRequestHistory requestUpdate) {
+  @Override
+  public void requestHistoryEvent(SingularityRequestHistory requestUpdate) {
     for (SingularityWebhook webhook : getActiveWebhooksByType(WebhookType.REQUEST)) {
       final String enqueuePath = getEnqueuePathForRequestUpdate(webhook.getId(), requestUpdate);
 
@@ -141,7 +143,8 @@ public class WebhookManager extends CuratorAsyncManager {
     }
   }
 
-  public void enqueueTaskUpdate(SingularityTaskHistoryUpdate taskUpdate) {
+  @Override
+  public void taskHistoryUpdateEvent(SingularityTaskHistoryUpdate taskUpdate) {
     for (SingularityWebhook webhook : getActiveWebhooksByType(WebhookType.TASK)) {
       final String enqueuePath = getEnqueuePathForTaskUpdate(webhook.getId(), taskUpdate);
 
@@ -149,7 +152,8 @@ public class WebhookManager extends CuratorAsyncManager {
     }
   }
 
-  public void enqueueDeployUpdate(SingularityDeployWebhook deployUpdate) {
+  @Override
+  public void deployHistoryEvent(SingularityDeployUpdate deployUpdate) {
     for (SingularityWebhook webhook : getActiveWebhooksByType(WebhookType.DEPLOY)) {
       final String enqueuePath = getEnqueuePathForDeployUpdate(webhook.getId(), deployUpdate);
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/transcoders/SingularityTranscoderModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/transcoders/SingularityTranscoderModule.java
@@ -10,7 +10,7 @@ import com.hubspot.singularity.SingularityDeployKey;
 import com.hubspot.singularity.SingularityDeployMarker;
 import com.hubspot.singularity.SingularityDeployResult;
 import com.hubspot.singularity.SingularityDeployStatistics;
-import com.hubspot.singularity.SingularityDeployWebhook;
+import com.hubspot.singularity.SingularityDeployUpdate;
 import com.hubspot.singularity.SingularityHostState;
 import com.hubspot.singularity.SingularityKilledTaskIdRecord;
 import com.hubspot.singularity.SingularityLoadBalancerUpdate;
@@ -62,7 +62,7 @@ public class SingularityTranscoderModule implements Module {
 
     bindTranscoder(binder).asCompressedJson(SingularityDeployHistory.class);
     bindTranscoder(binder).asCompressedJson(SingularityDeploy.class);
-    bindTranscoder(binder).asCompressedJson(SingularityDeployWebhook.class);
+    bindTranscoder(binder).asCompressedJson(SingularityDeployUpdate.class);
     bindTranscoder(binder).asCompressedJson(SingularityRequestHistory.class);
     bindTranscoder(binder).asCompressedJson(SingularityState.class);
     bindTranscoder(binder).asCompressedJson(SingularityTaskHealthcheckResult.class);

--- a/SingularityService/src/main/java/com/hubspot/singularity/event/SingularityEventController.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/event/SingularityEventController.java
@@ -1,0 +1,107 @@
+package com.hubspot.singularity.event;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.hubspot.singularity.event.SingularityEventModule.LISTENER_THREADPOOL_NAME;
+
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.google.inject.name.Named;
+import com.hubspot.singularity.SingularityDeployUpdate;
+import com.hubspot.singularity.SingularityRequestHistory;
+import com.hubspot.singularity.SingularityTaskHistoryUpdate;
+import com.hubspot.singularity.config.SingularityConfiguration;
+
+@Singleton
+public class SingularityEventController implements SingularityEventListener {
+  private static final Logger LOG = LoggerFactory.getLogger(SingularityEventController.class);
+
+  private final Set<SingularityEventListener> eventListeners;
+  private final ListeningExecutorService listenerExecutorService;
+  private final boolean waitForListeners;
+
+  @Inject
+  SingularityEventController(final Set<SingularityEventListener> eventListeners, final SingularityConfiguration configuration,
+      @Named(LISTENER_THREADPOOL_NAME) final ScheduledExecutorService listenerExecutorService) {
+    this.eventListeners = ImmutableSet.copyOf(checkNotNull(eventListeners, "eventListeners is null"));
+    this.listenerExecutorService = MoreExecutors.listeningDecorator(checkNotNull(listenerExecutorService, "listenerExecutorService is null"));
+    this.waitForListeners = configuration.isWaitForListeners();
+  }
+
+  @Override
+  public void requestHistoryEvent(final SingularityRequestHistory singularityRequestHistory) {
+    ImmutableSet.Builder<ListenableFuture<Void>> builder = ImmutableSet.builder();
+
+    for (final SingularityEventListener eventListener : eventListeners) {
+      builder.add(listenerExecutorService.submit(new Callable<Void>() {
+        @Override
+        public Void call() {
+          eventListener.requestHistoryEvent(singularityRequestHistory);
+          return null;
+        }
+      }));
+    }
+
+    processFutures(builder.build());
+  }
+
+  @Override
+  public void taskHistoryUpdateEvent(final SingularityTaskHistoryUpdate singularityTaskHistoryUpdate) {
+    ImmutableSet.Builder<ListenableFuture<Void>> builder = ImmutableSet.builder();
+
+    for (final SingularityEventListener eventListener : eventListeners) {
+      builder.add(listenerExecutorService.submit(new Callable<Void>() {
+        @Override
+        public Void call() {
+          eventListener.taskHistoryUpdateEvent(singularityTaskHistoryUpdate);
+          return null;
+        }
+      }));
+    }
+
+
+    processFutures(builder.build());
+  }
+
+  @Override
+  public void deployHistoryEvent(final SingularityDeployUpdate singularityDeployUpdate) {
+    ImmutableSet.Builder<ListenableFuture<Void>> builder = ImmutableSet.builder();
+
+    for (final SingularityEventListener eventListener : eventListeners) {
+      builder.add(listenerExecutorService.submit(new Callable<Void>() {
+        @Override
+        public Void call() {
+          eventListener.deployHistoryEvent(singularityDeployUpdate);
+          return null;
+        }
+      }));
+    }
+
+    processFutures(builder.build());
+  }
+
+  private void processFutures(Iterable<? extends ListenableFuture<?>> futures)
+  {
+    if (waitForListeners) {
+      try {
+        Futures.allAsList(futures).get();
+      } catch (ExecutionException e) {
+        LOG.warn("While waiting for event listeners", e.getCause());
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/event/SingularityEventListener.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/event/SingularityEventListener.java
@@ -1,0 +1,13 @@
+package com.hubspot.singularity.event;
+
+import com.hubspot.singularity.SingularityDeployUpdate;
+import com.hubspot.singularity.SingularityRequestHistory;
+import com.hubspot.singularity.SingularityTaskHistoryUpdate;
+
+public interface SingularityEventListener {
+  void requestHistoryEvent(SingularityRequestHistory singularityRequestHistory);
+
+  void taskHistoryUpdateEvent(SingularityTaskHistoryUpdate singularityTaskHistoryUpdate);
+
+  void deployHistoryEvent(SingularityDeployUpdate singularityDeployUpdate);
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/event/SingularityEventModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/event/SingularityEventModule.java
@@ -1,0 +1,36 @@
+package com.hubspot.singularity.event;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import com.google.inject.multibindings.Multibinder;
+import com.google.inject.name.Named;
+import com.google.inject.name.Names;
+import com.hubspot.singularity.SingularityManagedScheduledExecutorServiceProvider;
+import com.hubspot.singularity.config.SingularityConfiguration;
+import com.hubspot.singularity.data.WebhookManager;
+
+public class SingularityEventModule implements Module {
+  public static final String LISTENER_THREADPOOL_NAME = "_listener_threadpool";
+  public static final Named LISTENER_THREADPOOL_NAMED = Names.named(LISTENER_THREADPOOL_NAME);
+
+  private final SingularityConfiguration configuration;
+
+  public SingularityEventModule(final SingularityConfiguration configuration) {
+    this.configuration = checkNotNull(configuration, "configuration is null");
+  }
+
+  @Override
+  public void configure(final Binder binder) {
+    Multibinder<SingularityEventListener> eventListeners = Multibinder.newSetBinder(binder, SingularityEventListener.class);
+    eventListeners.addBinding().to(WebhookManager.class).in(Scopes.SINGLETON);
+
+    binder.bind(SingularityEventListener.class).to(SingularityEventController.class).in(Scopes.SINGLETON);
+
+    binder.bind(ScheduledExecutorService.class).annotatedWith(LISTENER_THREADPOOL_NAMED).toProvider(new SingularityManagedScheduledExecutorServiceProvider(configuration.getListenerThreadpoolSize(), configuration.getThreadpoolShutdownDelayInSeconds(), "listener")).in(Scopes.SINGLETON);
+  }
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/hooks/SingularityDeployWebhookAsyncHandler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/hooks/SingularityDeployWebhookAsyncHandler.java
@@ -1,14 +1,14 @@
 package com.hubspot.singularity.hooks;
 
-import com.hubspot.singularity.SingularityDeployWebhook;
+import com.hubspot.singularity.SingularityDeployUpdate;
 import com.hubspot.singularity.SingularityWebhook;
 import com.hubspot.singularity.data.WebhookManager;
 
-public class SingularityDeployWebhookAsyncHandler extends AbstractSingularityWebhookAsyncHandler<SingularityDeployWebhook>  {
+public class SingularityDeployWebhookAsyncHandler extends AbstractSingularityWebhookAsyncHandler<SingularityDeployUpdate>  {
 
   private final WebhookManager webhookManager;
 
-  public SingularityDeployWebhookAsyncHandler(WebhookManager webhookManager, SingularityWebhook webhook, SingularityDeployWebhook deployUpdate, boolean shouldDeleteUpdateDueToQueueAboveCapacity) {
+  public SingularityDeployWebhookAsyncHandler(WebhookManager webhookManager, SingularityWebhook webhook, SingularityDeployUpdate deployUpdate, boolean shouldDeleteUpdateDueToQueueAboveCapacity) {
     super(webhook, deployUpdate, shouldDeleteUpdateDueToQueueAboveCapacity);
 
     this.webhookManager = webhookManager;

--- a/SingularityService/src/main/java/com/hubspot/singularity/hooks/SingularityWebhookSender.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/hooks/SingularityWebhookSender.java
@@ -15,7 +15,7 @@ import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.google.inject.Inject;
 import com.hubspot.mesos.JavaUtils;
-import com.hubspot.singularity.SingularityDeployWebhook;
+import com.hubspot.singularity.SingularityDeployUpdate;
 import com.hubspot.singularity.SingularityRequestHistory;
 import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.SingularityTaskHistoryUpdate;
@@ -92,11 +92,11 @@ public class SingularityWebhookSender {
   }
 
   private int checkDeployUpdates(SingularityWebhook webhook) {
-    final List<SingularityDeployWebhook> deployUpdates = webhookManager.getQueuedDeployUpdatesForHook(webhook.getId());
+    final List<SingularityDeployUpdate> deployUpdates = webhookManager.getQueuedDeployUpdatesForHook(webhook.getId());
 
     int numDeployUpdates = 0;
 
-    for (SingularityDeployWebhook deployUpdate : deployUpdates) {
+    for (SingularityDeployUpdate deployUpdate : deployUpdates) {
       executeWebhook(webhook, deployUpdate, new SingularityDeployWebhookAsyncHandler(webhookManager, webhook, deployUpdate, numDeployUpdates++ > configuration.getMaxQueuedUpdatesPerWebhook()));
     }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/WebhookResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/WebhookResource.java
@@ -14,7 +14,7 @@ import com.google.inject.Inject;
 import com.hubspot.mesos.JavaUtils;
 import com.hubspot.singularity.SingularityCreateResult;
 import com.hubspot.singularity.SingularityDeleteResult;
-import com.hubspot.singularity.SingularityDeployWebhook;
+import com.hubspot.singularity.SingularityDeployUpdate;
 import com.hubspot.singularity.SingularityRequestHistory;
 import com.hubspot.singularity.SingularityService;
 import com.hubspot.singularity.SingularityTaskHistoryUpdate;
@@ -58,7 +58,7 @@ public class WebhookResource {
   @GET
   @Path("/deploy/{webhookId}")
   @ApiOperation("Retrieve a list of queued deploy updates for a specific webhook.")
-  public List<SingularityDeployWebhook> getQueuedDeployUpdates(@PathParam("webhookId") String webhookId) {
+  public List<SingularityDeployUpdate> getQueuedDeployUpdates(@PathParam("webhookId") String webhookId) {
     return webhookManager.getQueuedDeployUpdatesForHook(JavaUtils.urlEncode(webhookId));
   }
 


### PR DESCRIPTION
Replace the webhooks with being a plugin into a general purpose event reporting facility. It currently processes three event types (task, deploy, request) and allows additional listeners to react on these events.

We (Groupon) plug an AMQP sender into this facility and send events onto a message bus topic to allow additional code to listen to what is going on without having to register webhooks and check the state of webhooks all the time. 