### PR TITLE
Fix executor cleanup

### DIFF
--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
@@ -71,7 +71,7 @@ public class SingularityClient {
   private static final String TASKS_FORMAT = "http://%s/%s/tasks";
   private static final String TASKS_KILL_TASK_FORMAT = TASKS_FORMAT + "/task/%s";
   private static final String TASKS_GET_ACTIVE_FORMAT = TASKS_FORMAT + "/active";
-  private static final String TASKS_GET_ACTIVE_PER_HOST_FORMAT = TASKS_FORMAT + "/active/%s";
+  private static final String TASKS_GET_ACTIVE_ON_SLAVE_FORMAT = TASKS_FORMAT + "/active/slave/%s";
   private static final String TASKS_GET_SCHEDULED_FORMAT = TASKS_FORMAT + "/scheduled";
 
   private static final String HISTORY_FORMAT = "http://%s/%s/history";
@@ -506,10 +506,10 @@ public class SingularityClient {
     return getCollection(requestUri, "active tasks", TASKS_COLLECTION);
   }
 
-  public Collection<SingularityTask> getActiveTasks(final String host) {
-    final String requestUri = String.format(TASKS_GET_ACTIVE_PER_HOST_FORMAT, getHost(), contextPath, host);
+  public Collection<SingularityTask> getActiveTasksOnSlave(final String slaveId) {
+    final String requestUri = String.format(TASKS_GET_ACTIVE_ON_SLAVE_FORMAT, getHost(), contextPath, slaveId);
 
-    return getCollection(requestUri, String.format("active tasks on %s", host), TASKS_COLLECTION);
+    return getCollection(requestUri, String.format("active tasks on slave %s", slaveId), TASKS_COLLECTION);
   }
 
   public Optional<SingularityTaskCleanupResult> killTask(String taskId, Optional<String> user) {

--- a/SingularityExecutorCleanup/pom.xml
+++ b/SingularityExecutorCleanup/pom.xml
@@ -41,6 +41,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.hubspot</groupId>
+      <artifactId>HorizonCore</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
     </dependency>

--- a/SingularityExecutorCleanup/pom.xml
+++ b/SingularityExecutorCleanup/pom.xml
@@ -42,6 +42,11 @@
 
     <dependency>
       <groupId>com.hubspot</groupId>
+      <artifactId>SingularityMesosClient</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.hubspot</groupId>
       <artifactId>HorizonCore</artifactId>
     </dependency>
 

--- a/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/SingularityExecutorCleanup.java
+++ b/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/SingularityExecutorCleanup.java
@@ -11,15 +11,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Optional;
-import com.google.common.base.Throwables;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import com.hubspot.horizon.HttpClient;
+import com.hubspot.horizon.HttpRequest;
+import com.hubspot.horizon.HttpResponse;
 import com.hubspot.mesos.JavaUtils;
+import com.hubspot.mesos.json.MesosSlaveStateObject;
 import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.SingularityTaskHistory;
 import com.hubspot.singularity.SingularityTaskHistoryUpdate;
 import com.hubspot.singularity.client.SingularityClient;
 import com.hubspot.singularity.client.SingularityClientException;
+import com.hubspot.singularity.client.SingularityClientModule;
 import com.hubspot.singularity.executor.SingularityExecutorCleanupStatistics;
 import com.hubspot.singularity.executor.SingularityExecutorCleanupStatistics.SingularityExecutorCleanupStatisticsBuilder;
 import com.hubspot.singularity.executor.TemplateManager;
@@ -35,19 +40,23 @@ public class SingularityExecutorCleanup {
 
   private static final Logger LOG = LoggerFactory.getLogger(SingularityExecutorCleanup.class);
 
+  public static final String LOCAL_SLAVE_STATE_URL_FORMAT = "http://%s:5051/slave(1)/state.json";
+
   private final JsonObjectFileHelper jsonObjectFileHelper;
   private final SingularityExecutorConfiguration executorConfiguration;
   private final SingularityClient singularityClient;
   private final TemplateManager templateManager;
   private final SingularityExecutorCleanupConfiguration cleanupConfiguration;
+  private final HttpClient httpClient;
 
   @Inject
-  public SingularityExecutorCleanup(SingularityClient singularityClient, JsonObjectFileHelper jsonObjectFileHelper, SingularityExecutorConfiguration executorConfiguration, SingularityExecutorCleanupConfiguration cleanupConfiguration, TemplateManager templateManager) {
+  public SingularityExecutorCleanup(SingularityClient singularityClient, JsonObjectFileHelper jsonObjectFileHelper, SingularityExecutorConfiguration executorConfiguration, SingularityExecutorCleanupConfiguration cleanupConfiguration, TemplateManager templateManager, @Named(SingularityClientModule.HTTP_CLIENT_NAME) HttpClient httpClient) {
     this.jsonObjectFileHelper = jsonObjectFileHelper;
     this.executorConfiguration = executorConfiguration;
     this.cleanupConfiguration = cleanupConfiguration;
     this.singularityClient = singularityClient;
     this.templateManager = templateManager;
+    this.httpClient = httpClient;
   }
 
   public SingularityExecutorCleanupStatistics clean() {
@@ -58,9 +67,9 @@ public class SingularityExecutorCleanup {
 
     try {
       runningTaskIds = getRunningTaskIds();
-    } catch (SingularityClientException sce) {
-      LOG.error("While fetching running tasks from singularity", sce);
-      statisticsBldr.setErrorMessage(sce.getMessage());
+    } catch (Exception e) {
+      LOG.error("While fetching running tasks from singularity", e);
+      statisticsBldr.setErrorMessage(e.getMessage());
       return statisticsBldr.build();
     }
 
@@ -129,16 +138,23 @@ public class SingularityExecutorCleanup {
     return statisticsBldr.build();
   }
 
-  private Collection<SingularityTask> getActiveTasksOnSlave() {
+  private String getLocalSlaveID() {
     try {
-      return singularityClient.getActiveTasks(JavaUtils.getHostAddress());
-    } catch (SocketException e) {
-      throw Throwables.propagate(e);
+      final HttpRequest request = HttpRequest.newBuilder().setUrl(String.format(LOCAL_SLAVE_STATE_URL_FORMAT, JavaUtils.getHostAddress())).build();
+      final HttpResponse response = httpClient.execute(request);
+
+      if (response.isSuccess()) {
+        return response.getAs(MesosSlaveStateObject.class).getId();
+      } else {
+        throw new RuntimeException(String.format("Failed to get local Slave ID -- HTTP %d: %s", response.getStatusCode(), response.getAsString()));
+      }
+    } catch (SocketException se) {
+      throw new RuntimeException("Failed to get host address", se);
     }
   }
 
   private Set<String> getRunningTaskIds() {
-    final Collection<SingularityTask> activeTasks = getActiveTasksOnSlave();
+    final Collection<SingularityTask> activeTasks = singularityClient.getActiveTasksOnSlave(getLocalSlaveID());
 
     final Set<String> runningTaskIds = Sets.newHashSet();
 

--- a/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/SingularityExecutorCleanupRunner.java
+++ b/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/SingularityExecutorCleanupRunner.java
@@ -8,6 +8,7 @@ import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Stage;
 import com.hubspot.mesos.JavaUtils;
+import com.hubspot.mesos.client.SingularityMesosClientModule;
 import com.hubspot.singularity.client.SingularityClientModule;
 import com.hubspot.singularity.executor.SingularityExecutorCleanupStatistics;
 import com.hubspot.singularity.executor.cleanup.config.SingularityExecutorCleanupConfiguration;
@@ -27,7 +28,7 @@ public class SingularityExecutorCleanupRunner {
     final long start = System.currentTimeMillis();
 
     try {
-      final Injector injector = Guice.createInjector(Stage.PRODUCTION, new SingularityRunnerBaseModule(new SingularityS3ConfigurationLoader(), new SingularityExecutorConfigurationLoader(), new SingularityExecutorCleanupConfigurationLoader()), new SingularityExecutorModule(), new SingularityClientModule());
+      final Injector injector = Guice.createInjector(Stage.PRODUCTION, new SingularityRunnerBaseModule(new SingularityS3ConfigurationLoader(), new SingularityExecutorConfigurationLoader(), new SingularityExecutorCleanupConfigurationLoader()), new SingularityExecutorModule(), new SingularityClientModule(), new SingularityMesosClientModule());
       final SingularityExecutorCleanupRunner runner = injector.getInstance(SingularityExecutorCleanupRunner.class);
 
       LOG.info("Starting cleanup");


### PR DESCRIPTION
SingularityExecutorCleanup was using a deprecated endpoint to load tasks for a specific slave by its hostname. This PR changes the code to use the endpoint that looks up tasks by slave ID.

@wsorenson 