### PR TITLE
add a request type column in the requests table

### DIFF
--- a/SingularityUI/app/models/Request.coffee
+++ b/SingularityUI/app/models/Request.coffee
@@ -27,9 +27,19 @@ class Request extends Model
         data.onDemand = data.request.daemon? and not data.request.daemon and not data.scheduled
         data.daemon = not data.scheduled and not data.onDemand
 
+        if data.scheduled
+            data.deployableType = 'Scheduled Job'
+        else if data.onDemand
+            data.deployableType = 'On Demand'
+        else
+            if data.request.loadBalanced? and data.request.loadBalanced
+                data.deployableType = 'Web Service'
+            else
+                data.deployableType = 'Worker'
+
         data.instances = data.request.instances or 1
         data.hasMoreThanOneInstance = data.instances > 1
-          
+
         data.paused = data.state is 'PAUSED'
         data.deleted = data.state is 'DELETED'
 

--- a/SingularityUI/app/templates/requestsTable/requestsActiveBody.hbs
+++ b/SingularityUI/app/templates/requestsTable/requestsActiveBody.hbs
@@ -9,6 +9,9 @@
                     <th data-sort-attribute="request.id">
                         Name
                     </th>
+                    <th data-sort-attribute="request.deployableType">
+                        Type
+                    </th>
                     <th data-sort-attribute="request.instances" class="visible-lg visible-xl">
                         Instances
                     </th>
@@ -47,6 +50,9 @@
                             <a href="{{appRoot}}/request/{{ request.id }}" title="{{ request.id }}">
                                 {{ request.id }}
                             </a>
+                        </td>
+                        <td>
+                            {{deployableType}}
                         </td>
                         <td class="visible-lg visible-xl centered">
                             {{ request.instances }}

--- a/SingularityUI/app/templates/requestsTable/requestsAllBody.hbs
+++ b/SingularityUI/app/templates/requestsTable/requestsAllBody.hbs
@@ -12,6 +12,9 @@
                     <th data-sort-attribute="state">
                         State
                     </th>
+                    <th data-sort-attribute="request.deployableType">
+                        Type
+                    </th>
                     <th data-sort-attribute="request.instances" class="visible-lg visible-xl">
                         Instances
                     </th>
@@ -53,6 +56,9 @@
                         </td>
                         <td>
                             {{humanizeText state}}
+                        </td>
+                        <td>
+                            {{deployableType}}
                         </td>
                         <td class="visible-lg visible-xl centered">
                             {{ request.instances }}

--- a/SingularityUI/app/templates/requestsTable/requestsCleaningBody.hbs
+++ b/SingularityUI/app/templates/requestsTable/requestsCleaningBody.hbs
@@ -6,6 +6,9 @@
                     <th data-sort-attribute="requestId">
                         ID
                     </th>
+                    <th data-sort-attribute="request.deployableType">
+                        Type
+                    </th>
                     <th data-sort-attribute="user" class="visible-md">
                         User
                     </th>
@@ -24,6 +27,9 @@
                 <tr data-request-id="{{ requestId }}">
                     <td>
                         {{ requestId }}
+                    </td>
+                    <td>
+                        {{deployableType}}
                     </td>
                     <td class="visible-md">
                         {{ user }}

--- a/SingularityUI/app/templates/requestsTable/requestsCooldownBody.hbs
+++ b/SingularityUI/app/templates/requestsTable/requestsCooldownBody.hbs
@@ -6,6 +6,9 @@
                     <th data-sort-attribute="request.id">
                         Name
                     </th>
+                    <th data-sort-attribute="request.deployableType">
+                        Type
+                    </th>
                     <th data-sort-attribute="requestDeployState.activeDeploy.timestamp" class="hidden-xs">
                         Requested
                     </th>
@@ -37,6 +40,9 @@
                                 {{ request.id }}
                             </a>
                         </span></td>
+                        <td>
+                            {{deployableType}}
+                        </td>
                         <td data-value="{{ requestDeployState.activeDeploy.timestamp }}" class="hidden-xs">
                             {{timestampFromNow requestDeployState.activeDeploy.timestamp}}
                         </td>

--- a/SingularityUI/app/templates/requestsTable/requestsPausedBody.hbs
+++ b/SingularityUI/app/templates/requestsTable/requestsPausedBody.hbs
@@ -6,6 +6,9 @@
                     <th data-sort-attribute="request.id">
                         Name
                     </th>
+                    <th data-sort-attribute="request.deployableType">
+                        Type
+                    </th>
                     <th data-sort-attribute="requestDeployState.activeDeploy.timestamp" class="hidden-xs">
                         Requested
                     </th>
@@ -34,6 +37,9 @@
                                 {{ request.id }}
                             </a>
                         </span></td>
+                        <td>
+                            {{deployableType}}
+                        </td>
                         <td class="hidden-xs">
                             {{timestampFromNow requestDeployState.activeDeploy.timestamp}}
                         </td>

--- a/SingularityUI/app/templates/requestsTable/requestsPendingBody.hbs
+++ b/SingularityUI/app/templates/requestsTable/requestsPendingBody.hbs
@@ -6,6 +6,9 @@
                     <th data-sort-attribute="requestId">
                         ID
                     </th>
+                    <th data-sort-attribute="request.deployableType">
+                        Type
+                    </th>
                     <th data-sort-attribute="pendingType">
                         Pending Type
                     </th>
@@ -17,6 +20,7 @@
                 {{#each requests}}
                     <tr data-request-id="{{ requestId }}">
                         <td>{{ requestId }}</td>
+                        <td>{{deployableType}}</td>
                         <td>{{humanizeText pendingType}}</td>
                     </tr>
                 {{/each}}


### PR DESCRIPTION
Adds the deployable type in a 'Type' column in the requests table
![screen shot 2015-01-09 at 12 16 47 pm](https://cloud.githubusercontent.com/assets/6034439/5683890/ae1e83ec-97f9-11e4-9c52-fe69043ff3ac.png)
