### PR TITLE
More interrupt exception logic clarification.

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityCreateResult.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityCreateResult.java
@@ -1,5 +1,15 @@
 package com.hubspot.singularity;
 
 public enum SingularityCreateResult {
-  CREATED, EXISTED;
+  CREATED(true), EXISTED(true), UNKNOWN(false);
+
+  private final boolean successful;
+
+  private SingularityCreateResult(final boolean successful) {
+    this.successful = successful;
+  }
+
+  public boolean isSuccessful() {
+    return successful;
+  }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeleteResult.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeleteResult.java
@@ -1,5 +1,15 @@
 package com.hubspot.singularity;
 
 public enum SingularityDeleteResult {
-  DELETED, DIDNT_EXIST;
+  DELETED(true), DIDNT_EXIST(true), UNKNOWN(false);
+
+  private final boolean successful;
+
+  private SingularityDeleteResult(final boolean successful) {
+    this.successful = successful;
+  }
+
+  public boolean isSuccessful() {
+    return successful;
+  }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/AbstractMachineManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/AbstractMachineManager.java
@@ -137,7 +137,7 @@ public abstract class AbstractMachineManager<T extends SingularityMachineAbstrac
       return;
     }
 
-    if (delete(getActivePath(objectId)) != SingularityDeleteResult.DELETED) {
+    if (delete(getActivePath(objectId)).isSuccessful()) {
       LOG.warn(format("Deleting active object at %s failed", getActivePath(objectId)));
     }
 
@@ -146,7 +146,7 @@ public abstract class AbstractMachineManager<T extends SingularityMachineAbstrac
     object.setState(SingularityMachineState.DEAD);
     object.setDeadAt(Optional.of(System.currentTimeMillis()));
 
-    if (create(getDeadPath(objectId), Optional.of(transcoder.toBytes(object))) != SingularityCreateResult.CREATED) {
+    if (!create(getDeadPath(objectId), Optional.of(transcoder.toBytes(object))).isSuccessful()) {
       LOG.warn(format("Creating dead object at %s failed", getDeadPath(objectId)));
     }
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/CuratorManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/CuratorManager.java
@@ -33,15 +33,15 @@ public abstract class CuratorManager {
   protected int getNumChildren(String path) {
     try {
       Stat s = curator.checkExists().forPath(path);
-      if (s != null) {
-        return s.getNumChildren();
-      }
+      return (s != null) ? s.getNumChildren() : 0;
     } catch (NoNodeException nne) {
+      return 0;
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      return 0;
     } catch (Throwable t) {
       throw Throwables.propagate(t);
     }
-
-    return 0;
   }
 
   protected Optional<Stat> checkExists(String path) {
@@ -67,6 +67,9 @@ public abstract class CuratorManager {
       return curator.getChildren().forPath(root);
     } catch (NoNodeException nne) {
       return Collections.emptyList();
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      return Collections.emptyList();
     } catch (Throwable t) {
       throw Throwables.propagate(t);
     }
@@ -79,6 +82,9 @@ public abstract class CuratorManager {
     } catch (NoNodeException nne) {
       LOG.trace("Tried to delete an item at path {} that didn't exist", path);
       return SingularityDeleteResult.DIDNT_EXIST;
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      return SingularityDeleteResult.UNKNOWN;
     } catch (Throwable t) {
       throw Throwables.propagate(t);
     }
@@ -99,6 +105,9 @@ public abstract class CuratorManager {
       return SingularityCreateResult.CREATED;
     } catch (NodeExistsException nee) {
       return SingularityCreateResult.EXISTED;
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      return SingularityCreateResult.UNKNOWN;
     } catch (Throwable t) {
       throw Throwables.propagate(t);
     }
@@ -126,6 +135,9 @@ public abstract class CuratorManager {
       return SingularityCreateResult.CREATED;
     } catch (NodeExistsException nee) {
       return set(path, data);
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      return SingularityCreateResult.UNKNOWN;
     } catch (Throwable t) {
       throw Throwables.propagate(t);
     }
@@ -144,6 +156,9 @@ public abstract class CuratorManager {
       return SingularityCreateResult.EXISTED;
     } catch (NoNodeException nne) {
       return save(path, data);
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      return SingularityCreateResult.UNKNOWN;
     } catch (Throwable t) {
       throw Throwables.propagate(t);
     }
@@ -166,6 +181,9 @@ public abstract class CuratorManager {
 
       return Optional.of(transcoder.fromBytes(data));
     } catch (NoNodeException nne) {
+      return Optional.absent();
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
       return Optional.absent();
     } catch (Throwable t) {
       throw Throwables.propagate(t);

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/StateManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/StateManager.java
@@ -74,6 +74,9 @@ public class StateManager extends CuratorManager {
         } else {
           curator.create().creatingParentsIfNeeded().withMode(CreateMode.EPHEMERAL).forPath(path, data);
         }
+      } catch (InterruptedException ie) {
+        Thread.currentThread().interrupt();
+        throw ie;
       } catch (Throwable t) {
         throw Throwables.propagate(t);
       }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -380,7 +380,7 @@ public class SingularityScheduler {
       return Optional.absent();
     }
 
-    if (taskHistoryUpdateCreateResult == SingularityCreateResult.CREATED && requestState != RequestState.SYSTEM_COOLDOWN) {
+    if (taskHistoryUpdateCreateResult.isSuccessful() && requestState != RequestState.SYSTEM_COOLDOWN) {
       mailer.sendTaskCompletedMail(taskId, request, state);
     } else if (requestState == RequestState.SYSTEM_COOLDOWN) {
       LOG.debug("Not sending a task completed email because task {} is in SYSTEM_COOLDOWN", taskId);
@@ -388,7 +388,7 @@ public class SingularityScheduler {
       LOG.debug("Not sending a task completed email for task {} because Singularity already processed this update", taskId);
     }
 
-    if (!state.isSuccess() && taskHistoryUpdateCreateResult == SingularityCreateResult.CREATED && cooldown.shouldEnterCooldown(request, taskId, requestState, deployStatistics, timestamp)) {
+    if (!state.isSuccess() && taskHistoryUpdateCreateResult.isSuccessful() && cooldown.shouldEnterCooldown(request, taskId, requestState, deployStatistics, timestamp)) {
       LOG.info("Request {} is entering cooldown due to task {}", request.getId(), taskId);
       requestState = RequestState.SYSTEM_COOLDOWN;
       requestManager.cooldown(request, System.currentTimeMillis());


### PR DESCRIPTION
Setting the interrupt bit in the CuratorManager will make sure that
threads do not hang forever and report ending conditions back
properly.

Adding a specific UNKNOWN state to the create and delete results; this
allows checking for success in the places where that code is used.