### PR TITLE
Explicitly Upgrade Handlebars to 2.0.0.

### DIFF
--- a/SingularityUI/package.json
+++ b/SingularityUI/package.json
@@ -25,7 +25,7 @@
     "clean-css-brunch": ">= 1.0 < 1.8",
     "coffee-script-brunch": ">= 1.0 < 1.8",
     "css-brunch": ">= 1.0 < 1.8",
-    "handlebars-brunch": "^1.7.8",
+    "handlebars-brunch": "^1.9.1",
     "javascript-brunch": ">= 1.0 < 1.8",
     "less-brunch": "^1.7.2",
     "stylus-brunch": ">= 1.0 < 1.8",


### PR DESCRIPTION
handlebars-brunch released an update that bumps Handlebars to 2.0.0.
Due to the version bump used in handlebars-brunch, ^1.7.8 matches 1.9.1 (check footnote) and Handlebars in Singularity was invisibly upgraded to 2.0.0. This change just makes it more clear.

A quick check of the UI makes me believe that nothing was broken, and we are already building SingularityUI with 2.0.0, so this makes no difference.

* - because node interprets the first non-zero number in the version to be the breaking change indicator, and everything past that is considered compatible (0.1.0 is not compatible with 0.2.0, but 1.1.0 is compatible with 1.2.0)