### PR TITLE
remove extra / from app root if there is one

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/views/IndexView.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/views/IndexView.java
@@ -31,7 +31,9 @@ public class IndexView extends View {
 
     checkNotNull(singularityUriBase, "singularityUriBase is null");
 
-    this.appRoot = String.format("%s%s", singularityUriBase, appRoot);
+    String rawAppRoot = String.format("%s%s", singularityUriBase, appRoot);
+
+    this.appRoot = (rawAppRoot.endsWith("/")) ? rawAppRoot.substring(0, rawAppRoot.length() - 1) : rawAppRoot;
     this.staticRoot = String.format("%s/static", singularityUriBase);
     this.apiDocs = String.format("%s/api-docs", singularityUriBase);
     this.apiRoot = String.format("%s%s", singularityUriBase, SingularityService.API_BASE_PATH);


### PR DESCRIPTION
Removes the trailing / from the app root if it exists, should keep us from getting the weird // in our link paths
@tpetr @wsorenson 