### PR TITLE
Fix appRoot for catchall resource.

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/StaticCatchallResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/StaticCatchallResource.java
@@ -28,6 +28,6 @@ public class StaticCatchallResource {
   @GET
   @Produces(MediaType.TEXT_HTML)
   public IndexView getIndex() {
-    return new IndexView(singularityUriBase, "/", configuration);
+    return new IndexView(singularityUriBase, "", configuration);
   }
 }


### PR DESCRIPTION
When using the catchall resource, explicitly setting "/" the appRoot makes
"http://<stuff>/singularity/" become the appRoot in the index script.

The rest of the UI expects the appRoot to not end in a "/".