### PR TITLE
Fix reconciler lockup with no driver present.

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityTaskReconciliation.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityTaskReconciliation.java
@@ -99,6 +99,7 @@ public class SingularityTaskReconciliation implements Managed {
 
     if (!schedulerDriver.isPresent()) {
       LOG.trace("Not running reconciliation - no schedulerDriver present");
+      isRunningReconciliation.set(false);
       return ReconciliationState.NO_DRIVER;
     }
 


### PR DESCRIPTION
Otherwise, if the reconciler runs without a driver, it will lock up and never run again.