### PR TITLE
Custom executor resources

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/mesos/Resources.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/Resources.java
@@ -3,7 +3,15 @@ package com.hubspot.mesos;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 public class Resources {
+  public static Resources add(Resources a, Resources b) {
+    checkNotNull(a, "first argument of Resources.add() is null");
+    checkNotNull(b, "second argument of Resources.add() is null");
+
+    return new Resources(a.getCpus() + b.getCpus(), a.getMemoryMb() + b.getMemoryMb(), a.getNumPorts() + b.getNumPorts());
+  }
 
   private final double cpus;
   private final double memoryMb;

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeploy.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeploy.java
@@ -29,6 +29,8 @@ public class SingularityDeploy {
   private final Optional<String> customExecutorCmd;
   private final Optional<String> customExecutorId;
   private final Optional<String> customExecutorSource;
+  private final Optional<Resources> customExecutorResources;
+
   private final Optional<Resources> resources;
 
   private final Optional<String> command;
@@ -63,6 +65,7 @@ public class SingularityDeploy {
       @JsonProperty("customExecutorCmd") Optional<String> customExecutorCmd,
       @JsonProperty("customExecutorId") Optional<String> customExecutorId,
       @JsonProperty("customExecutorSource") Optional<String> customExecutorSource,
+      @JsonProperty("customExecutorResources") Optional<Resources> customExecutorResources,
       @JsonProperty("resources") Optional<Resources> resources,
       @JsonProperty("env") Optional<Map<String, String>> env,
       @JsonProperty("uris") Optional<List<String>> uris,
@@ -90,6 +93,7 @@ public class SingularityDeploy {
     this.customExecutorCmd = customExecutorCmd;
     this.customExecutorId = customExecutorId;
     this.customExecutorSource = customExecutorSource;
+    this.customExecutorResources = customExecutorResources;
 
     this.metadata = metadata;
     this.version = version;
@@ -190,6 +194,11 @@ public class SingularityDeploy {
   @ApiModelProperty(required=false, value="Custom Mesos executor source.")
   public Optional<String> getCustomExecutorSource() { return customExecutorSource; }
 
+  @ApiModelProperty(required=false, value="Resources to allocate for custom mesos executor")
+  public Optional<Resources> getCustomExecutorResources() {
+    return customExecutorResources;
+  }
+
   @ApiModelProperty(required=false, value="Resources required for this deploy.", dataType="com.hubspot.mesos.Resources")
   public Optional<Resources> getResources() {
     return resources;
@@ -272,6 +281,7 @@ public class SingularityDeploy {
         ", customExecutorCmd=" + customExecutorCmd +
         ", customExecutorId=" + customExecutorId +
         ", customExecutorSource=" + customExecutorSource +
+        ", customExecutorResources=" + customExecutorResources +
         ", resources=" + resources +
         ", command=" + command +
         ", arguments=" + arguments +

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeployBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeployBuilder.java
@@ -23,6 +23,8 @@ public class SingularityDeployBuilder {
   private Optional<String> customExecutorCmd;
   private Optional<String> customExecutorId;
   private Optional<String> customExecutorSource;
+  private Optional<Resources> customExecutorResources;
+
   private Optional<Resources> resources;
 
   private Optional<String> command;
@@ -54,6 +56,7 @@ public class SingularityDeployBuilder {
     this.customExecutorCmd = Optional.absent();
     this.customExecutorId = Optional.absent();
     this.customExecutorSource = Optional.absent();
+    this.customExecutorResources = Optional.absent();
     this.resources = Optional.absent();
     this.command = Optional.absent();
     this.arguments = Optional.absent();
@@ -72,7 +75,7 @@ public class SingularityDeployBuilder {
   }
 
   public SingularityDeploy build() {
-    return new SingularityDeploy(requestId, id, command, arguments, containerInfo, customExecutorCmd, customExecutorId, customExecutorSource, resources, env, uris, metadata, executorData, version, timestamp, deployHealthTimeoutSeconds, healthcheckUri, healthcheckIntervalSeconds,
+    return new SingularityDeploy(requestId, id, command, arguments, containerInfo, customExecutorCmd, customExecutorId, customExecutorSource, customExecutorResources, resources, env, uris, metadata, executorData, version, timestamp, deployHealthTimeoutSeconds, healthcheckUri, healthcheckIntervalSeconds,
         healthcheckTimeoutSeconds, serviceBasePath, loadBalancerGroups, considerHealthyAfterRunningForSeconds, loadBalancerOptions, skipHealthchecksOnDeploy);
   }
 
@@ -158,6 +161,15 @@ public class SingularityDeployBuilder {
 
   public SingularityDeployBuilder setCustomExecutorSource(Optional<String> customExecutorSource) {
     this.customExecutorSource = customExecutorSource;
+    return this;
+  }
+
+  public Optional<Resources> getCustomExecutorResources() {
+    return customExecutorResources;
+  }
+
+  public SingularityDeployBuilder setCustomExecutorResources(Optional<Resources> customExecutorResources) {
+    this.customExecutorResources = customExecutorResources;
     return this;
   }
 
@@ -299,6 +311,7 @@ public class SingularityDeployBuilder {
         ", customExecutorCmd=" + customExecutorCmd +
         ", customExecutorId=" + customExecutorId +
         ", customExecutorSource=" + customExecutorSource +
+        ", customExecutorResources=" + customExecutorResources +
         ", resources=" + resources +
         ", command=" + command +
         ", arguments=" + arguments +

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityMainModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityMainModule.java
@@ -3,6 +3,7 @@ package com.hubspot.singularity;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.inject.name.Names.named;
 
+import com.hubspot.singularity.config.CustomExecutorConfiguration;
 import com.hubspot.singularity.smtp.JadeTemplateLoader;
 import com.hubspot.singularity.smtp.MailTemplateHelpers;
 import com.hubspot.singularity.smtp.SingularityMailRecordCleaner;
@@ -205,6 +206,12 @@ public class SingularityMainModule implements Module {
   @Singleton
   public MesosConfiguration mesosConfiguration(final SingularityConfiguration config) {
     return config.getMesosConfiguration();
+  }
+
+  @Provides
+  @Singleton
+  public CustomExecutorConfiguration customExecutorConfiguration(final SingularityConfiguration config) {
+    return config.getCustomExecutorConfiguration();
   }
 
   @Provides

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/CustomExecutorConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/CustomExecutorConfiguration.java
@@ -1,0 +1,27 @@
+package com.hubspot.singularity.config;
+
+import javax.validation.constraints.Min;
+
+public class CustomExecutorConfiguration {
+  @Min(0)
+  private double numCpus = 0;
+
+  @Min(0)
+  private int memoryMb = 0;
+
+  public double getNumCpus() {
+    return numCpus;
+  }
+
+  public void setNumCpus(double numCpus) {
+    this.numCpus = numCpus;
+  }
+
+  public int getMemoryMb() {
+    return memoryMb;
+  }
+
+  public void setMemoryMb(int memoryMb) {
+    this.memoryMb = memoryMb;
+  }
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -152,6 +152,10 @@ public class SingularityConfiguration extends Configuration {
 
   private long threadpoolShutdownDelayInSeconds = 1;
 
+  @Valid
+  @JsonProperty("customExecutor")
+  private CustomExecutorConfiguration customExecutorConfiguration;
+
   @JsonProperty("zookeeper")
   @Valid
   private ZooKeeperConfiguration zooKeeperConfiguration;
@@ -656,4 +660,11 @@ public class SingularityConfiguration extends Configuration {
     this.zooKeeperConfiguration = zooKeeperConfiguration;
   }
 
+  public CustomExecutorConfiguration getCustomExecutorConfiguration() {
+    return customExecutorConfiguration;
+  }
+
+  public void setCustomExecutorConfiguration(CustomExecutorConfiguration customExecutorConfiguration) {
+    this.customExecutorConfiguration = customExecutorConfiguration;
+  }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -154,7 +154,8 @@ public class SingularityConfiguration extends Configuration {
 
   @Valid
   @JsonProperty("customExecutor")
-  private CustomExecutorConfiguration customExecutorConfiguration;
+  @NotNull
+  private CustomExecutorConfiguration customExecutorConfiguration = new CustomExecutorConfiguration();
 
   @JsonProperty("zookeeper")
   @Valid

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilderTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilderTest.java
@@ -40,6 +40,7 @@ import com.hubspot.singularity.SingularityRequest;
 import com.hubspot.singularity.SingularityRequestBuilder;
 import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.SingularityTaskRequest;
+import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.ExecutorIdGenerator;
 
 public class SingularityMesosTaskBuilderTest {
@@ -57,7 +58,7 @@ public class SingularityMesosTaskBuilderTest {
 
     when(idGenerator.getNextExecutorId()).then(new CreateFakeId());
 
-    builder = new SingularityMesosTaskBuilder(new ObjectMapper(), rackManager, idGenerator);
+    builder = new SingularityMesosTaskBuilder(new ObjectMapper(), rackManager, idGenerator, new SingularityConfiguration());
 
     resources = new Resources(1, 1, 0);
     offer = Offer.newBuilder()


### PR DESCRIPTION
This PR allows resources to be allocated specifically to the a custom executor, which should fix the `Failed to update resources for container (CONTAINER_GUID) of executor (EXECUTOR_ID) running task (TASK_ID) a on status update for terminal task, destroying container: Collect failed: No cpus resource given` issues we've been seeing.

The custom executor resources are defaulted to zero, so it shouldn't affect anyone unless they opt-in to this.

One last open question is whether or not we should enforce the same resource limits we have for tasks on the custom executor resources override in `SingularityDeploy`.

/cc @wsorenson 