### PR TITLE
handle invalid status code from singularity

### DIFF
--- a/scripts/logfetch/singularity_request.py
+++ b/scripts/logfetch/singularity_request.py
@@ -7,8 +7,8 @@ ERROR_STATUS_FORMAT = 'Singularity responded with an invalid status code ({0})'
 def get_json_response(uri, params={}):
   singularity_response = requests.get(uri, params=params)
   if singularity_response.status_code < 199 or singularity_response.status_code > 299:
-    sys.stderr.write(uri + '\n')
-    sys.stderr.write(str(params) + '\n')
+    sys.stderr.write('{0} params:{1}\n'.format(uri, str(params)))
     sys.stderr.write(colored(ERROR_STATUS_FORMAT.format(singularity_response.status_code), 'red') + '\n')
+    return {}
   return singularity_response.json()
 

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -10,7 +10,7 @@ requirements = [
 
 setup(
     name='singularity-logfetch',
-    version='0.10.0',
+    version='0.11.0',
     description='Singularity log fetching and searching',
     author="HubSpot",
     author_email='singularity-users@googlegroups.com',


### PR DESCRIPTION
don't error if singularity returns a bad status code, show a message, but keep going and search whatever tasks/logs can be found