### PR TITLE
fix global suppress refresh bug

### DIFF
--- a/SingularityUI/app/application.coffee
+++ b/SingularityUI/app/application.coffee
@@ -66,7 +66,7 @@ class Application
         setInterval @globalRefresh, @globalRefreshTime
 
     globalRefresh: =>
-        return if localStorage.getItem 'suppressRefresh'
+        return if localStorage.getItem('suppressRefresh') is 'true'
         if @blurred
             clearInterval @globalRefreshInterval
             return


### PR DESCRIPTION
the global refresh check was only looking if the suppressRefresh key
existed, not its value. @tpetr 