### PR TITLE
fix bug in original custom executor resources implementation

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/mesos/Resources.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/Resources.java
@@ -13,6 +13,8 @@ public class Resources {
     return new Resources(a.getCpus() + b.getCpus(), a.getMemoryMb() + b.getMemoryMb(), a.getNumPorts() + b.getNumPorts());
   }
 
+  public static final Resources EMPTY_RESOURCES = new Resources(0, 0, 0);
+
   private final double cpus;
   private final double memoryMb;
   private final int numPorts;

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilderTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilderTest.java
@@ -76,7 +76,7 @@ public class SingularityMesosTaskBuilderTest {
     .setCommand(Optional.of("/bin/echo hi"))
     .build();
     final SingularityTaskRequest taskRequest = new SingularityTaskRequest(request, deploy, pendingTask);
-    final SingularityTask task = builder.buildTask(offer, null, taskRequest, resources);
+    final SingularityTask task = builder.buildTask(offer, null, taskRequest, resources, Optional.<Resources>absent());
 
     assertEquals("/bin/echo hi", task.getMesosTask().getCommand().getValue());
     assertEquals(0, task.getMesosTask().getCommand().getArgumentsCount());
@@ -91,7 +91,7 @@ public class SingularityMesosTaskBuilderTest {
     .setArguments(Optional.of(Collections.singletonList("wat")))
     .build();
     final SingularityTaskRequest taskRequest = new SingularityTaskRequest(request, deploy, pendingTask);
-    final SingularityTask task = builder.buildTask(offer, null, taskRequest, resources);
+    final SingularityTask task = builder.buildTask(offer, null, taskRequest, resources, Optional.<Resources>absent());
 
     assertEquals("/bin/echo", task.getMesosTask().getCommand().getValue());
     assertEquals(1, task.getMesosTask().getCommand().getArgumentsCount());
@@ -125,7 +125,7 @@ public class SingularityMesosTaskBuilderTest {
     .setArguments(Optional.of(Collections.singletonList("wat")))
     .build();
     final SingularityTaskRequest taskRequest = new SingularityTaskRequest(request, deploy, pendingTask);
-    final SingularityTask task = builder.buildTask(offer, Collections.singletonList(portsResource), taskRequest, resources);
+    final SingularityTask task = builder.buildTask(offer, Collections.singletonList(portsResource), taskRequest, resources, Optional.<Resources>absent());
 
     assertEquals("/bin/echo", task.getMesosTask().getCommand().getValue());
     assertEquals(1, task.getMesosTask().getCommand().getArgumentsCount());


### PR DESCRIPTION
my original implementation had a bug -- it was correctly carving out task + executor resources from the offer, but then incorrectly setting the task resources to that total amount. the executor amount was being tacked on at task launch time, which caused issues in QA.