### PR TITLE
tweaks to MesosUtils + Resources

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/mesos/MesosUtils.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/MesosUtils.java
@@ -56,7 +56,7 @@ public final class MesosUtils {
       }
     }
 
-    return null;
+    return Ranges.getDefaultInstance();
   }
 
   private static Ranges getRanges(TaskInfo taskInfo, String name) {
@@ -66,16 +66,8 @@ public final class MesosUtils {
   private static int getNumRanges(List<Resource> resources, String name) {
     int totalRanges = 0;
 
-
-    Ranges ranges = getRanges(resources, name);
-
-    if (ranges == null) {
-      return 0;
-    }
-
-    for (Range range : ranges.getRangeList()) {
-      long num = range.getEnd() - range.getBegin();
-      totalRanges += num;
+    for (Range range : getRanges(resources, name).getRangeList()) {
+      totalRanges += (range.getEnd() - range.getBegin()) + 1;
     }
 
     return totalRanges;
@@ -106,6 +98,8 @@ public final class MesosUtils {
     return ports;
   }
 
+  public static Resource getPortRangeResource(long begin, long end) { return newRange(PORTS, begin, end); }
+
   public static List<Long> getAllPorts(TaskInfo taskInfo) {
     final List<Long> ports = Lists.newArrayList();
 
@@ -129,7 +123,7 @@ public final class MesosUtils {
   public static Resource getPortsResource(int numPorts, List<Resource> resources) {
     Ranges ranges = getRanges(resources, PORTS);
 
-    Preconditions.checkState(ranges != null, "Ports %s should have existed in resources %s", PORTS, resources);
+    Preconditions.checkState(ranges.getRangeCount() > 0, "Ports %s should have existed in resources %s", PORTS, resources);
 
     Ranges.Builder rangesBldr = Ranges.newBuilder();
 
@@ -170,6 +164,10 @@ public final class MesosUtils {
 
   private static Resource newScalar(String name, double value) {
     return Resource.newBuilder().setName(name).setType(Value.Type.SCALAR).setScalar(Value.Scalar.newBuilder().setValue(value).build()).build();
+  }
+
+  private static Resource newRange(String name, long begin, long end) {
+    return Resource.newBuilder().setName(name).setType(Type.RANGES).setRanges(Ranges.newBuilder().addRange(Range.newBuilder().setBegin(begin).setEnd(end).build()).build()).build();
   }
 
   public static double getNumCpus(Offer offer) {
@@ -311,6 +309,10 @@ public final class MesosUtils {
     }
 
     return remaining;
+  }
+
+  public static Resources buildResourcesFromMesosResourceList(List<Resource> resources) {
+    return new Resources(getNumCpus(resources), getMemory(resources), getNumPorts(resources));
   }
 
   public static Path getTaskDirectoryPath(String taskId) {

--- a/SingularityBase/src/main/java/com/hubspot/mesos/Resources.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/Resources.java
@@ -33,4 +33,42 @@ public class Resources {
     return "Resources [cpus=" + cpus + ", memoryMb=" + memoryMb + ", numPorts=" + numPorts + "]";
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    Resources resources = (Resources) o;
+
+    if (Double.compare(resources.cpus, cpus) != 0) {
+      return false;
+    }
+
+    if (Double.compare(resources.memoryMb, memoryMb) != 0) {
+      return false;
+    }
+
+    if (numPorts != resources.numPorts) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result;
+    long temp;
+    temp = Double.doubleToLongBits(cpus);
+    result = (int) (temp ^ (temp >>> 32));
+    temp = Double.doubleToLongBits(memoryMb);
+    result = 31 * result + (int) (temp ^ (temp >>> 32));
+    result = 31 * result + numPorts;
+    return result;
+  }
 }

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/MesosUtilsTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/MesosUtilsTest.java
@@ -25,18 +25,10 @@ import com.hubspot.singularity.SingularityTaskId;
 
 public class MesosUtilsTest {
 
-  private void assertFound(int numPorts, Resource resource) {
-    int portsFound = 0;
-    for (Range r : resource.getRanges().getRangeList()) {
-      portsFound += (r.getEnd() - r.getBegin()) + 1;
-    }
-    Assert.assertEquals(numPorts, portsFound);
-  }
-
   private void test(int numPorts, String... ranges) {
     Resource resource = MesosUtils.getPortsResource(numPorts, buildOffer(ranges));
 
-    assertFound(numPorts, resource);
+    Assert.assertEquals(numPorts, MesosUtils.getNumPorts(Collections.singletonList(resource)));
   }
 
   @Test


### PR DESCRIPTION
- Return a empty `Ranges` instance instead of `null` in `getRanges()`
- Fix off-by-one error in `getNumRanges()`
- Add convenience methods for creating a port range resource (useful for unittests)
- Add `buildResourcesFromMesosResourceList()`, which converts `List<Resource>` into `Resources` (useful for unittests)
- add `equals()` and `hashCode()` to `Resources`

@wsorenson 