### PR TITLE
optionally include stacktrace for abort email

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityAbort.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityAbort.java
@@ -54,7 +54,7 @@ public class SingularityAbort implements ConnectionStateListener {
   public void stateChanged(CuratorFramework client, ConnectionState newState) {
     if (newState == ConnectionState.LOST) {
       LOG.error("Aborting due to new connection state received from ZooKeeper: {}", newState);
-      abort(AbortReason.LOST_ZK_CONNECTION);
+      abort(AbortReason.LOST_ZK_CONNECTION, Optional.<Throwable>absent());
     }
   }
 
@@ -62,10 +62,10 @@ public class SingularityAbort implements ConnectionStateListener {
     LOST_ZK_CONNECTION, LOST_LEADERSHIP, UNRECOVERABLE_ERROR, TEST_ABORT, MESOS_ERROR;
   }
 
-  public void abort(AbortReason abortReason) {
+  public void abort(AbortReason abortReason, Optional<Throwable> throwable) {
     if (!aborting.getAndSet(true)) {
       try {
-        sendAbortNotification(abortReason);
+        sendAbortNotification(abortReason, throwable);
         flushLogs();
       } finally {
         exit();
@@ -89,17 +89,17 @@ public class SingularityAbort implements ConnectionStateListener {
     }
   }
 
-  private void sendAbortNotification(AbortReason abortReason) {
+  private void sendAbortNotification(AbortReason abortReason, Optional<Throwable> throwable) {
     final String message = String.format("Singularity on %s is aborting due to %s", hostAndPort.getHostText(), abortReason);
 
     LOG.error(message);
 
-    sendAbortMail(message);
+    sendAbortMail(message, throwable);
 
     exceptionNotifier.notify(message);
   }
 
-  private void sendAbortMail(final String message) {
+  private void sendAbortMail(final String message, final Optional<Throwable> throwable) {
     if (!maybeSmtpConfiguration.isPresent()) {
       LOG.warn("Couldn't send abort mail because no SMTP configuration is present");
       return;
@@ -112,7 +112,9 @@ public class SingularityAbort implements ConnectionStateListener {
       return;
     }
 
-    smtpSender.queueMail(maybeSmtpConfiguration.get().getAdmins(), ImmutableList.<String> of(), message, "");
+    final String body = throwable.isPresent() ? throwable.get().toString() : "(no stack trace)";
+
+    smtpSender.queueMail(maybeSmtpConfiguration.get().getAdmins(), ImmutableList.<String> of(), message, body);
   }
 
   private void flushLogs() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityLeaderController.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityLeaderController.java
@@ -84,11 +84,11 @@ public class SingularityLeaderController implements Managed, LeaderLatchListener
       } catch (Throwable t) {
         LOG.error("While starting driver", t);
         exceptionNotifier.notify(t);
-        abort.abort(AbortReason.UNRECOVERABLE_ERROR);
+        abort.abort(AbortReason.UNRECOVERABLE_ERROR, Optional.of(t));
       }
 
       if (driverManager.getCurrentStatus() != Protos.Status.DRIVER_RUNNING) {
-        abort.abort(AbortReason.UNRECOVERABLE_ERROR);
+        abort.abort(AbortReason.UNRECOVERABLE_ERROR, Optional.<Throwable>absent());
       }
     }
   }
@@ -124,7 +124,7 @@ public class SingularityLeaderController implements Managed, LeaderLatchListener
         LOG.error("While stopping driver", t);
         exceptionNotifier.notify(t);
       } finally {
-        abort.abort(AbortReason.LOST_LEADERSHIP);
+        abort.abort(AbortReason.LOST_LEADERSHIP, Optional.<Throwable>absent());
       }
     }
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerDelegator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerDelegator.java
@@ -94,7 +94,7 @@ public class SingularityMesosSchedulerDelegator implements Scheduler {
 
     exceptionNotifier.notify(t);
 
-    abort.abort(AbortReason.UNRECOVERABLE_ERROR);
+    abort.abort(AbortReason.UNRECOVERABLE_ERROR, Optional.of(t));
   }
 
   private void startup(SchedulerDriver driver, MasterInfo masterInfo) throws Exception {
@@ -308,7 +308,7 @@ public class SingularityMesosSchedulerDelegator implements Scheduler {
 
       LOG.error("Aborting due to error: {}", message);
 
-      abort.abort(AbortReason.MESOS_ERROR);
+      abort.abort(AbortReason.MESOS_ERROR, Optional.<Throwable>absent());
     } catch (Throwable t) {
       handleUncaughtSchedulerException(t);
     } finally {

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/TestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/TestResource.java
@@ -6,6 +6,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 
+import com.google.common.base.Optional;
 import com.wordnik.swagger.annotations.Api;
 import com.wordnik.swagger.annotations.ApiOperation;
 import org.apache.mesos.Protos.TaskID;
@@ -83,7 +84,7 @@ public class TestResource {
   public void abort() {
     checkForbidden(configuration.isAllowTestResourceCalls(), "Test resource calls are disabled (set isAllowTestResourceCalls to true in configuration)");
 
-    abort.abort(AbortReason.TEST_ABORT);
+    abort.abort(AbortReason.TEST_ABORT, Optional.<Throwable>absent());
   }
 
   @POST

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityHealthcheckAsyncHandler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityHealthcheckAsyncHandler.java
@@ -93,7 +93,7 @@ public class SingularityHealthcheckAsyncHandler extends AsyncCompletionHandler<R
       LOG.error("Caught throwable while re-enqueuing health check for {}, aborting", task.getTaskId(), t);
       exceptionNotifier.notify(t);
 
-      abort.abort(AbortReason.UNRECOVERABLE_ERROR);
+      abort.abort(AbortReason.UNRECOVERABLE_ERROR, Optional.of(t));
     }
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderOnlyPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderOnlyPoller.java
@@ -111,7 +111,7 @@ public abstract class SingularityLeaderOnlyPoller implements Managed {
       LOG.error("Caught an exception while running {}", getClass().getSimpleName(), t);
       exceptionNotifier.notify(t);
       if (abortsOnError()) {
-        abort.abort(AbortReason.UNRECOVERABLE_ERROR);
+        abort.abort(AbortReason.UNRECOVERABLE_ERROR, Optional.of(t));
       }
     } finally {
       if (lockHolder.isPresent()) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityNewTaskChecker.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityNewTaskChecker.java
@@ -183,7 +183,7 @@ public class SingularityNewTaskChecker implements Managed {
     } catch (Throwable t) {
       LOG.error("Uncaught throwable re-enqueuing task check for task {}, aborting", task, t);
       exceptionNotifier.notify(t);
-      abort.abort(AbortReason.UNRECOVERABLE_ERROR);
+      abort.abort(AbortReason.UNRECOVERABLE_ERROR, Optional.of(t));
     }
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityTaskReconciliation.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityTaskReconciliation.java
@@ -128,7 +128,7 @@ public class SingularityTaskReconciliation implements Managed {
         } catch (Throwable t) {
           LOG.error("While checking for reconciliation tasks", t);
           exceptionNotifier.notify(t);
-          abort.abort(AbortReason.UNRECOVERABLE_ERROR);
+          abort.abort(AbortReason.UNRECOVERABLE_ERROR, Optional.of(t));
         }
       }
     }, configuration.getCheckReconcileWhenRunningEveryMillis(), TimeUnit.MILLISECONDS);


### PR DESCRIPTION
This PR updates the abort email to optionally include a stacktrace, which is useful for quick debugging.