### PR TITLE
stop tailing when task has finished

### DIFF
--- a/SingularityUI/app/controllers/Tail.coffee
+++ b/SingularityUI/app/controllers/Tail.coffee
@@ -16,8 +16,11 @@ class TailController extends Controller
             model: @models.taskHistory
 
         app.showView @view
+        @refresh()
 
+    refresh: ->
         @collections.logLines.fetchInitialData()
         @models.taskHistory.fetch()
+
 
 module.exports = TailController

--- a/SingularityUI/app/controllers/Tail.coffee
+++ b/SingularityUI/app/controllers/Tail.coffee
@@ -1,6 +1,7 @@
 Controller = require './Controller'
 
 LogLines = require '../collections/LogLines'
+TaskHistory = require '../models/TaskHistory'
 
 TailView = require '../views/tail'
 
@@ -8,12 +9,15 @@ class TailController extends Controller
 
     initialize: ({@taskId, @path}) ->
         @collections.logLines = new LogLines [], {@taskId, @path}
-        
+        @models.taskHistory = new TaskHistory {@taskId}
+    
         @setView new TailView _.extend {@taskId, @path},
             collection: @collections.logLines
+            model: @models.taskHistory
 
         app.showView @view
 
         @collections.logLines.fetchInitialData()
+        @models.taskHistory.fetch()
 
 module.exports = TailController


### PR DESCRIPTION
right now the log tailing view will periodically hit Singularity for more data indefinitely, but when a task completes, it's a pretty safe bet that we're never going to get any more data from it. we should only auto-tail a task if it hasn't hit a terminal task state.

@tpetr 