### PR TITLE
Better tailing error when a file has not been generated yet

### DIFF
--- a/SingularityUI/app/application.coffee
+++ b/SingularityUI/app/application.coffee
@@ -101,6 +101,20 @@ class Application
             return if @blurred and jqxhr.statusText is 'timeout'
 
             url = settings.url.replace(config.appRoot, '')
+            
+            try
+                serverMessage = JSON.parse(jqxhr.responseText).message or jqxhr.responseText
+            catch
+                serverMessage = jqxhr.responseText
+
+            serverMessage = _.escape serverMessage
+            
+            # Check if the file/directory doesn't exist yet so we
+            # can handle the error with somee style on tailing pages           
+            directoryPatt = new RegExp("does not have a directory yet")
+            hasNoDirectory = directoryPatt.test serverMessage
+            
+            return if jqxhr.status is 400 and hasNoDirectory
 
             if jqxhr.status is 502
                 Messenger().info
@@ -116,12 +130,6 @@ class Application
                     hideAfter: 20
             else
                 console.log jqxhr.responseText
-                try
-                    serverMessage = JSON.parse(jqxhr.responseText).message or jqxhr.responseText
-                catch
-                    serverMessage = jqxhr.responseText
-
-                serverMessage = _.escape serverMessage
 
                 Messenger().error
                     message:   "<p>An uncaught error occurred with your request. The server said:</p><pre>#{ serverMessage }</pre><p>The error has been saved to your JS console.</p>"

--- a/SingularityUI/app/application.coffee
+++ b/SingularityUI/app/application.coffee
@@ -101,20 +101,6 @@ class Application
             return if @blurred and jqxhr.statusText is 'timeout'
 
             url = settings.url.replace(config.appRoot, '')
-            
-            try
-                serverMessage = JSON.parse(jqxhr.responseText).message or jqxhr.responseText
-            catch
-                serverMessage = jqxhr.responseText
-
-            serverMessage = _.escape serverMessage
-            
-            # Check if the file/directory doesn't exist yet so we
-            # can handle the error with somee style on tailing pages           
-            directoryPatt = new RegExp("does not have a directory yet")
-            hasNoDirectory = directoryPatt.test serverMessage
-            
-            return if jqxhr.status is 400 and hasNoDirectory
 
             if jqxhr.status is 502
                 Messenger().info
@@ -130,6 +116,13 @@ class Application
                     hideAfter: 20
             else
                 console.log jqxhr.responseText
+
+                try
+                  serverMessage = JSON.parse(jqxhr.responseText).message or jqxhr.responseText
+                catch
+                  serverMessage = jqxhr.responseText
+
+                serverMessage = _.escape serverMessage
 
                 Messenger().error
                     message:   "<p>An uncaught error occurred with your request. The server said:</p><pre>#{ serverMessage }</pre><p>The error has been saved to your JS console.</p>"

--- a/SingularityUI/app/collections/LogLines.coffee
+++ b/SingularityUI/app/collections/LogLines.coffee
@@ -64,7 +64,16 @@ class LogLines extends Collection
                 length: @initialRequestLength
 
             @trigger 'initialdata'
-
+        .error (response) =>
+         
+   # If we get a 400, the file has likely not been generated
+            # yet, so we'll pass a message to the view
+            if response.status is 400              
+                directoryPatt = new RegExp("does not have a directory yet")
+                hasNoDirectory = directoryPatt.test response.responseText
+                if hasNoDirectory
+                    @trigger 'ajaxError', {status: 400, errorType: 'NoDirectory'}
+    
     fetchPrevious: ->
         @fetch data:
             offset: orZero @getMinOffset() - @state.get('currentRequestLength')

--- a/SingularityUI/app/collections/LogLines.coffee
+++ b/SingularityUI/app/collections/LogLines.coffee
@@ -65,10 +65,10 @@ class LogLines extends Collection
 
             @trigger 'initialdata'
         .error (response) =>
-         
-   # If we get a 400, the file has likely not been generated
+            # If we get a 400, the file has likely not been generated
             # yet, so we'll pass a message to the view
-            if response.status is 400              
+            if response.status is 400
+                app.caughtError() 
                 directoryPatt = new RegExp("does not have a directory yet")
                 hasNoDirectory = directoryPatt.test response.responseText
                 if hasNoDirectory

--- a/SingularityUI/app/templates/tail.hbs
+++ b/SingularityUI/app/templates/tail.hbs
@@ -38,10 +38,18 @@
     <div class="tail-fetching-start">
         fetching more lines <div class="page-loader small"></div>
     </div>
-    <div class="lines-wrapper"></div>
-
+    <div class="lines-wrapper">
+        {{#if ajaxError.status}}
+        <div class="lines-wrapper">
+            <div class="empty-table-message">
+                {{#ifEqual ajaxError.errorType 'NoDirectory'}}
+                    <p>This file has not been created yet. Hang tight, we're working on it.</p>
+                {{/ifEqual}}
+            </div>
+        </div>
+        {{/if}}
+    </div>
     <div class="tail-fetching-end">
         fetching more lines <div class="page-loader small"></div>
     </div>
 </div>
-


### PR DESCRIPTION
This will replace the more "harsh" error message:

![screenshot 2015-03-13 16 02 50](https://cloud.githubusercontent.com/assets/3275453/6646390/beaae2dc-c99a-11e4-9f5c-4b0c3b43f8e2.png)

With a "calmer" message: (open to wording tweaks)

![screenshot 2015-03-13 15 47 40](https://cloud.githubusercontent.com/assets/3275453/6646414/111fcf78-c99b-11e4-9713-c155e1548fa1.png)

Aside from just being less harsh, the additional purpose of this PR is to support a separate PR in the works that will redirect a user to a tailing file after they run a task, when that file may or may not have be generated by the time they arrive...so...this will provide them with a better waiting area if they are waiting on their file to load.


Right now this only handles a bad request (400) and more specifically, when a file/directory is not found. However, I've set things up so we could pass various types of error messages in the future.

How things are setup -
- If a 400 error occurs, we search the returned message to see if it contains "does not have a directory yet", and from there bypass the standard error message. (A more specific code returned from the request may be cleaner, but I'm working with what I have with this current setup, which isn't terrible.)
- In the collection, an event is triggered if we hit this error, with the relevant info passed along with it to the view which is listening, and that info is then passed in to the template to show/hide the message.
- Last an interval is set polling for the initial data to be loaded, at which point the interval and message are removed.

@tpetr 

