### PR TITLE
remove invalid auto value that may be the root of issues on qa

### DIFF
--- a/SingularityUI/app/styles/table.styl
+++ b/SingularityUI/app/styles/table.styl
@@ -39,9 +39,7 @@
             a
                 position relative
                 overflow hidden
-                padding auto
-                padding-left 12px
-                padding-right 12px
+                padding 0 12px
                 display inline-block
                 background transparent
                 text-decoration none


### PR DESCRIPTION
Attempting to fix the padding issue with the action buttons that is occurring on QA by removing the invalid padding auto value.

![screenshot 2015-03-13 17 29 09](https://cloud.githubusercontent.com/assets/3275453/6647610/84f59f08-c9a6-11e4-97ee-6fd3082940b9.png)

@tpetr 
