### PR TITLE
Enforce task history updates by taskState type first.

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskHistoryUpdate.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskHistoryUpdate.java
@@ -61,8 +61,8 @@ public class SingularityTaskHistoryUpdate extends SingularityTaskIdHolder implem
   @Override
   public int compareTo(SingularityTaskHistoryUpdate o) {
     return ComparisonChain.start()
-        .compare(timestamp, o.getTimestamp())
         .compare(taskState.ordinal(), o.getTaskState().ordinal())
+        .compare(timestamp, o.getTimestamp())
         .compare(o.getTaskId().getId(), getTaskId().getId())
         .result();
   }


### PR DESCRIPTION
this trusts the lifecycle of TaskState over the ordering of clocks.