### PR TITLE
Scheduled tasks property filter

### DIFF
--- a/SingularityUI/app/application.coffee
+++ b/SingularityUI/app/application.coffee
@@ -134,11 +134,11 @@ class Application
     showPageLoader: ->
         @$page.html "<div class='page-loader centered cushy'></div>"
 
-    appendPageLoader: ->
-        @$page.append "<div class='page-loader centered cushy'></div>"
+    showFixedPageLoader: ->
+        @$page.append "<div class='page-loader page-loader-fixed'></div>"
 
-    hidePageLoader: ->
-        @$page.find('.page-loader').remove()
+    hideFixedPageLoader: ->
+        @$page.find('.page-loader-fixed').remove()
 
     bootstrapController: (controller) ->
         @currentController = controller

--- a/SingularityUI/app/application.coffee
+++ b/SingularityUI/app/application.coffee
@@ -134,6 +134,12 @@ class Application
     showPageLoader: ->
         @$page.html "<div class='page-loader centered cushy'></div>"
 
+    appendPageLoader: ->
+        @$page.append "<div class='page-loader centered cushy'></div>"
+
+    hidePageLoader: ->
+        @$page.find('.page-loader').remove()
+
     bootstrapController: (controller) ->
         @currentController = controller
 

--- a/SingularityUI/app/collections/Tasks.coffee
+++ b/SingularityUI/app/collections/Tasks.coffee
@@ -18,10 +18,10 @@ class Tasks extends Collection
 
     url: ->
         requestFilter = if @requestId? then "/request/#{ @requestId }" else ''
-        propertyString = $.param 'property': @propertyFilterMap[@state] or [], true
+        propertyString = $.param 'property': @propertyFilterMap[@state] or @addPropertyString || [], true
         "#{ config.apiRoot }/tasks/#{ @state }#{ requestFilter }?#{ propertyString }"
 
-    initialize: (models = [], {@state, @requestId}) ->
+    initialize: (models = [], {@state, @requestId, @addPropertyString}) ->
         @comparator = @comparatorMap[@state]
 
 module.exports = Tasks

--- a/SingularityUI/app/collections/TasksPending.coffee
+++ b/SingularityUI/app/collections/TasksPending.coffee
@@ -1,0 +1,18 @@
+Collection = require './collection'
+
+Task = require '../models/TaskPending'
+
+class TasksPending extends Collection
+
+    model: Task
+
+    url: -> "#{ config.apiRoot }/tasks/scheduled/request/#{ @requestID }"
+
+    initialize: (models = [], { @requestID }) =>
+
+    getTaskByRuntime: (nextRunTime) =>
+        for model in @models
+            if model.get('pendingTask').pendingTaskId.nextRunAt is nextRunTime
+                return model
+
+module.exports = TasksPending

--- a/SingularityUI/app/controllers/TasksTable.coffee
+++ b/SingularityUI/app/controllers/TasksTable.coffee
@@ -11,7 +11,6 @@ TasksTableView = require '../views/tasks'
 class TasksTableController extends Controller
 
     initialize: ({@state, @searchFilter}) ->
-        # We want the view to handle the page loader for this one
         if @state is 'decommissioning'
             @collections.tasks = new Tasks [], state: 'active'
         else if @state is 'scheduled'
@@ -36,7 +35,6 @@ class TasksTableController extends Controller
         app.showView @view
 
     getPendingTask: (task) ->
-        ## NEED A LOADER
         app.appendPageLoader()
         @collections.tasksPending = new TasksPending [], {requestID: task.requestId}
         @collections.tasksPending.fetch().done =>

--- a/SingularityUI/app/controllers/TasksTable.coffee
+++ b/SingularityUI/app/controllers/TasksTable.coffee
@@ -1,6 +1,9 @@
 Controller = require './Controller'
 
+TaskPending = require '../models/TaskPending'
+
 Tasks = require '../collections/Tasks'
+TasksPending = require '../collections/TasksPending'
 Slaves = require '../collections/Slaves'
 
 TasksTableView = require '../views/tasks'
@@ -11,18 +14,35 @@ class TasksTableController extends Controller
         # We want the view to handle the page loader for this one
         if @state is 'decommissioning'
             @collections.tasks = new Tasks [], state: 'active'
+        else if @state is 'scheduled'
+            @collections.tasks = new Tasks [], {state: 'scheduled', addPropertyString: 'pendingTask'}
+            # @collections.tasks.setPropertyString('pendingTask')
+            
         else
             @collections.tasks = new Tasks [], {@state}
         @collections.slaves = new Slaves []
 
         @setView new TasksTableView _.extend {@state, @searchFilter},
             collection: @collections.tasks
+            pendingTasks: @collections.tasksPending
             attributes:
                 slaves: @collections.slaves
 
+        # Fetch a pending task's full details
+        @view.on 'getPendingTask', (task) => @getPendingTask(task)
+        
         @collections.slaves.fetch()
         @collections.tasks.fetch()
         app.showView @view
+
+    getPendingTask: (task) ->
+        ## NEED A LOADER
+        app.appendPageLoader()
+        @collections.tasksPending = new TasksPending [], {requestID: task.requestId}
+        @collections.tasksPending.fetch().done =>
+            utils.viewJSON @collections.tasksPending.getTaskByRuntime task.nextRunAt
+            app.hidePageLoader()
+
 
     refresh: ->
         # Don't refresh if user is scrolled down, viewing the table (arbitrary value)

--- a/SingularityUI/app/controllers/TasksTable.coffee
+++ b/SingularityUI/app/controllers/TasksTable.coffee
@@ -38,9 +38,13 @@ class TasksTableController extends Controller
         app.showFixedPageLoader()
         @collections.tasksPending = new TasksPending [], {requestID: task.requestId}
         @collections.tasksPending.fetch().done =>
-            utils.viewJSON @collections.tasksPending.getTaskByRuntime task.nextRunAt
-            # app.hideFixedPageLoader()
-
+            utils.viewJSON @collections.tasksPending.getTaskByRuntime(task.nextRunAt), (resp) =>
+                if resp.error
+                    Messenger().error
+                        message:   "<p>This task is no longer pending.</p>"
+                        hideAFter: 20
+                    @refresh()
+            app.hideFixedPageLoader()
 
     refresh: ->
         # Don't refresh if user is scrolled down, viewing the table (arbitrary value)

--- a/SingularityUI/app/controllers/TasksTable.coffee
+++ b/SingularityUI/app/controllers/TasksTable.coffee
@@ -35,11 +35,11 @@ class TasksTableController extends Controller
         app.showView @view
 
     getPendingTask: (task) ->
-        app.appendPageLoader()
+        app.showFixedPageLoader()
         @collections.tasksPending = new TasksPending [], {requestID: task.requestId}
         @collections.tasksPending.fetch().done =>
             utils.viewJSON @collections.tasksPending.getTaskByRuntime task.nextRunAt
-            app.hidePageLoader()
+            # app.hideFixedPageLoader()
 
 
     refresh: ->

--- a/SingularityUI/app/models/TaskPending.coffee
+++ b/SingularityUI/app/models/TaskPending.coffee
@@ -1,0 +1,9 @@
+Model = require './model'
+
+Request = require './Request'
+
+class TaskPending extends Model
+    # Won't be displayed in JSON dialog
+    ignoreAttributes: ['id', 'host', 'cpus', 'memoryMb']   	
+
+module.exports = TaskPending

--- a/SingularityUI/app/styles/loader.styl
+++ b/SingularityUI/app/styles/loader.styl
@@ -37,6 +37,11 @@
         margin-right 5px
 
 
+.page-loader-fixed
+    position: fixed
+    top: 50%
+    left: 50%
+    transform: translate(-50%, -50%)
 
 .page-loader-with-message
     text-align center

--- a/SingularityUI/app/templates/tasksTable/tasksScheduledBody.hbs
+++ b/SingularityUI/app/templates/tasksTable/tasksScheduledBody.hbs
@@ -36,7 +36,7 @@
                         <a data-task-id="{{ id }}" data-action="run-now" title="Run now">
                             <span class="glyphicon glyphicon-flash"></span>
                         </a>
-                        <a data-task-id="{{ id }}" data-action="viewJSON" title="JSON">
+                        <a data-task-id="{{ id }}" data-nextRunAt="{{ pendingTask.pendingTaskId.nextRunAt}}" data-request-id="{{ pendingTask.pendingTaskId.requestId }}" data-action="viewJSON" title="JSON">
                             { }
                         </a>
                     </td>

--- a/SingularityUI/app/templates/tasksTable/tasksScheduledBody.hbs
+++ b/SingularityUI/app/templates/tasksTable/tasksScheduledBody.hbs
@@ -9,10 +9,10 @@
                     <th data-sort-attribute="pendingTask.pendingTaskId.nextRunAt" class="hidden-xs">
                         Next run
                     </th>
-                    <th>
+                    <th data-sort-attribute="pendingTask.pendingTaskId.pendingType">
                         Pending Type
                     </th>
-                    <th>
+                    <th data-sort-attribute="pendingTask.pendingTaskId.deployId">
                         Deploy ID 
                     </th>
                     <th class="hidden-xs">

--- a/SingularityUI/app/templates/tasksTable/tasksScheduledBody.hbs
+++ b/SingularityUI/app/templates/tasksTable/tasksScheduledBody.hbs
@@ -9,6 +9,12 @@
                     <th data-sort-attribute="pendingTask.pendingTaskId.nextRunAt" class="hidden-xs">
                         Next run
                     </th>
+                    <th>
+                        Pending Type
+                    </th>
+                    <th>
+                        Deploy ID 
+                    </th>
                     <th class="hidden-xs">
                         {{! Actions column }}
                     </th>
@@ -20,9 +26,7 @@
             {{#each tasks}}
                 <tr data-task-id="{{ id }}">
                     <td>
-                        <span title="{{ id }}">
-                            {{ id }}
-                        </span>
+                        <a href="{{appRoot}}/request/{{pendingTask.pendingTaskId.requestId}}">{{ id }}</a>
                     </td>
                     <td class="hidden-xs">
                         {{timestampFromNow pendingTask.pendingTaskId.nextRunAt}}
@@ -31,6 +35,12 @@
                                 <span class="label label-danger">OVERDUE</span>
                             {{/ifTimestampInPast}}
                         {{/if}}
+                    </td>
+                    <td>
+                        {{humanizeText pendingTask.pendingTaskId.pendingType}}
+                    </td>
+                    <td>
+                        {{pendingTask.pendingTaskId.deployId}}
                     </td>
                     <td class="actions-column hidden-xs">
                         <a data-task-id="{{ id }}" data-action="run-now" title="Run now">

--- a/SingularityUI/app/utils.coffee
+++ b/SingularityUI/app/utils.coffee
@@ -1,7 +1,8 @@
 class Utils
     
-    @viewJSON: (model) ->
+    @viewJSON: (model, callback) ->
         if not model?
+            callback?({error: 'Invalid model given'})
             console.error 'Invalid model given'
             return
         

--- a/SingularityUI/app/views/tasks.coffee
+++ b/SingularityUI/app/views/tasks.coffee
@@ -210,8 +210,16 @@ class TasksView extends View
         app.router.navigate "/tasks/#{ @state }/#{ @searchFilter }", { replace: true }
 
     viewJson: (e) ->
-        id = $(e.target).parents('tr').data 'task-id'
-        utils.viewJSON @collection.get id
+        task =
+            taskId: $(e.target).data 'task-id'
+            requestId: $(e.target).data 'request-id'
+            nextRunAt: $(e.target).data 'nextrunat'
+
+        # need to make a fetch for scheduled tasks
+        if task.nextRunAt
+            @trigger 'getPendingTask', task
+        else
+            utils.viewJSON @collection.get task.taskId
 
     removeTask: (e) ->
         $row = $(e.target).parents 'tr'


### PR DESCRIPTION
This adds property filtering for scheduled (pending) tasks. However, the JSON button would not have enough data, so the JSON button will now fetch the full data about that scheduled task using the new endpoint mentioned: https://github.com/HubSpot/Singularity/issues/158

Also added to the table:  pending_type,  deploy_id, and a link out to the request.

@tpetr