### PR TITLE
logfetch fixes/features

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -86,7 +86,7 @@ For example, to tail the `service.log` file for all tasks for a request named `M
 
 - The path for the log file is relative to the base path for that task's sandbox. For example, to tail a file in `(sandbox path)/logs/access.log`, the argument to -l would be `logs/access.log`
 
-You can also provide the `-g` option which will provide the grep string to the singularity API and search the results. You cannot provide a full grep command as in some of the above examples, just a string to match on.
+You can also provide the `-g` option which will provide the grep string to the singularity API and search the results. This can be a string to match on or a full grep command as above.
 
 ##Options
 |Flags|Description|Default|
@@ -97,7 +97,7 @@ You can also provide the `-g` option which will provide the grep string to the s
 |-r , --request-id|Request Id to fetch logs for|
 |-d , --deploy-id|Deploy Id to fetch logs for (Must also specify requestId when using this option)|
 |-u, --singularity-uri-base|Base url for singularity (e.g. `localhost:8080/singularity/v2/api`)|Must be set!|
-|-g, --grep|Grep string for searching log files|
+|-g, --grep|Grep string or full command for searching output|
 |-l, --logfile|Log file path to tail (ie logs/access.log)|Must be set!|
 |-v, --verbose|Extra output about the task id associated with logs in the output|False|
 

--- a/scripts/logfetch/callbacks.py
+++ b/scripts/logfetch/callbacks.py
@@ -3,14 +3,17 @@ from termcolor import colored
 
 CALLBACK_FORMAT = '{0}/{1}'
 
-def generate_callback(request, destination, filename, chunk_size):
+def generate_callback(request, destination, filename, chunk_size, verbose):
   path = CALLBACK_FORMAT.format(destination, filename) if destination else filename
 
   def callback(response, **kwargs):
     with open(path, 'wb') as f:
       for chunk in response.iter_content(chunk_size):
         f.write(chunk)
-    sys.stderr.write(colored('Downloaded ', 'green') + colored(path, 'white') + '\n')
+      if verbose:
+        sys.stderr.write(colored('Downloaded ', 'green') + colored(path, 'white') + '\n')
+      else:
+        sys.stderr.write(colored('.', 'green'))
 
   return callback
 

--- a/scripts/logfetch/cat.py
+++ b/scripts/logfetch/cat.py
@@ -1,23 +1,12 @@
 import os
 import sys
+from termcolor import colored
 
-CAT_COMMAND_FORMAT = 'xargs -n {0} cat < {1}'
 def cat_files(args, all_logs):
     if all_logs:
-        catlist_filename = '{0}/.catlist'.format(args.dest)
-        create_catlist(args, all_logs, catlist_filename)
-        command = CAT_COMMAND_FORMAT.format(len(all_logs), catlist_filename)
-        sys.stdout.write(os.popen(command).read() + '\n')
+        for log in all_logs:
+            sys.stderr.write(colored(log, 'cyan') + '\n')
+            command = 'cat {0}'.format(log)
+            sys.stdout.write(os.popen(command).read() + '\n')
     else:
         sys.stderr.write(colored('No log files found\n', 'magenta'))
-
-def create_catlist(args, all_logs, catlist_filename):
-  catlist_file = open(catlist_filename, 'wb')
-  for log in all_logs:
-    catlist_file.write('{0}\n'.format(log))
-  catlist_file.close()
-
-def remove_catlist(catlist_filename):
-  if os.path.isfile(catlist_filename):
-    os.remove(catlist_filename)
-

--- a/scripts/logfetch/entrypoint.py
+++ b/scripts/logfetch/entrypoint.py
@@ -3,7 +3,7 @@ import ConfigParser
 import sys
 import os
 import pkg_resources
-from datetime import datetime
+from datetime import datetime, timedelta
 from termcolor import colored
 from fake_section_head import FakeSectionHead
 from live_logs import download_live_logs
@@ -63,12 +63,12 @@ def check_args(args):
   elif not args.requestId and not args.deployId and not args.taskId:
     exit('Must specify one of\n -t task-id\n -r request-id and -d deploy-id\n -r request-id')
 
-def convert_to_days(argument):
+def convert_to_date(argument):
     try:
-        val = int(argument)
+        val = datetime.now() - timedelta(days=int(argument))
     except:
       try:
-        val = (datetime.now() - datetime.strptime(argument, "%m-%d-%Y")).days
+        val = datetime.strptime(argument, "%m-%d-%Y")
       except:
         exit('Start/End days value must be either a number of days or a date in format "mm-dd-yyyy"')
     return val
@@ -113,12 +113,13 @@ def fetch():
   parser.add_argument("-e", "--end-days", dest="end_days", help="Search for logs no newer than this, can be an integer number of days or date in format 'mm-dd-yyyy' (defaults to None/today)")
   parser.add_argument("-l", "--log-type", dest="logtype", help="Logfile type to downlaod (ie 'access.log'), can be a glob (ie *.log)")
   parser.add_argument("-g", "--grep", dest="grep", help="Regex to grep for (normal grep syntax) or a full grep command")
+  parser.add_argument("-V", "--verbose", dest="verbose", help="Print more verbose output", action='store_true')
 
   args = parser.parse_args(remaining_argv)
 
   check_args(args)
-  args.start_days = convert_to_days(args.start_days)
-  args.end_days = convert_to_days(args.end_days)
+  args.start_days = convert_to_date(args.start_days)
+  args.end_days = convert_to_date(args.end_days)
 
   args.dest = os.path.expanduser(args.dest)
 
@@ -163,12 +164,13 @@ def cat():
   parser.add_argument("-s", "--start-days", dest="start_days", help="Search for logs no older than this, can be an integer number of days or date in format 'mm-dd-yyyy'")
   parser.add_argument("-e", "--end-days", dest="end_days", help="Search for logs no newer than this, can be an integer number of days or date in format 'mm-dd-yyyy' (defaults to None/today)")
   parser.add_argument("-l", "--logtype", dest="logtype", help="Logfile type to downlaod (ie 'access.log'), can be a glob (ie *.log)")
+  parser.add_argument("-V", "--verbose", dest="verbose", help="Print more verbose output", action='store_true')
 
   args = parser.parse_args(remaining_argv)
 
   check_args(args)
-  args.start_days = convert_to_days(args.start_days)
-  args.end_days = convert_to_days(args.end_days)
+  args.start_days = convert_to_date(args.start_days)
+  args.end_days = convert_to_date(args.end_days)
 
   args.dest = os.path.expanduser(args.dest)
 

--- a/scripts/logfetch/grep.py
+++ b/scripts/logfetch/grep.py
@@ -9,7 +9,7 @@ def grep_files(args, all_logs):
   if args.grep:
     if all_logs:
       for log in all_logs:
-        command = grep_command(args, all_logs, log)
+        command = grep_command(args, log)
         output = os.popen(command).read()
         if output is not None and output != '':
           sys.stderr.write(colored(log, 'cyan') + '\n')
@@ -19,7 +19,7 @@ def grep_files(args, all_logs):
     else:
       sys.stderr.write(colored('No logs found\n', 'magenta'))
 
-def grep_command(args, all_logs, filename):
+def grep_command(args, filename):
   if 'grep' in args.grep:
     return GREP_COMMAND_FORMAT.format(args.grep, filename)
   else:

--- a/scripts/logfetch/grep.py
+++ b/scripts/logfetch/grep.py
@@ -2,34 +2,25 @@ import os
 import sys
 from termcolor import colored
 
-GREP_COMMAND_FORMAT = 'while read file; do {0} "$file"; done < {1}'
+GREP_COMMAND_FORMAT = '{0} {1}'
 DEFAULT_GREP_COMMAND = 'grep --color=always \'{0}\''
 
 def grep_files(args, all_logs):
   if args.grep:
     if all_logs:
-      greplist_filename = '{0}/.greplist'.format(args.dest)
-      create_greplist(args, all_logs, greplist_filename)
-      command = grep_command(args, all_logs, greplist_filename)
-      sys.stderr.write(colored('Running "{0}" this might take a minute'.format(command), 'blue') + '\n')
-      sys.stdout.write(os.popen(command).read() + '\n')
-      remove_greplist(greplist_filename)
+      for log in all_logs:
+        command = grep_command(args, all_logs, log)
+        output = os.popen(command).read()
+        if output is not None and output != '':
+          sys.stderr.write(colored(log, 'cyan') + '\n')
+          sys.stdout.write(output)
+
       sys.stderr.write(colored('Finished grep, exiting', 'green') + '\n')
     else:
       sys.stderr.write(colored('No logs found\n', 'magenta'))
 
-def create_greplist(args, all_logs, greplist_filename):
-  greplist_file = open(greplist_filename, 'wb')
-  for log in all_logs:
-    greplist_file.write('{0}\n'.format(log))
-  greplist_file.close()
-
-def remove_greplist(greplist_filename):
-  if os.path.isfile(greplist_filename):
-    os.remove(greplist_filename)
-
-def grep_command(args, all_logs, greplist_filename):
+def grep_command(args, all_logs, filename):
   if 'grep' in args.grep:
-    return GREP_COMMAND_FORMAT.format(args.grep, greplist_filename)
+    return GREP_COMMAND_FORMAT.format(args.grep, filename)
   else:
-    return GREP_COMMAND_FORMAT.format(DEFAULT_GREP_COMMAND.format(args.grep), greplist_filename)
+    return GREP_COMMAND_FORMAT.format(DEFAULT_GREP_COMMAND.format(args.grep), filename)

--- a/scripts/logfetch/live_logs.py
+++ b/scripts/logfetch/live_logs.py
@@ -34,7 +34,7 @@ def download_live_logs(args):
 
       for log_file in logs_folder_files(args, task):
         logfile_name = '{0}-{1}'.format(task, log_file)
-        if (args.logtype and logfetch_base.log_matches(log_file, args.logtype)) or not args.logtype:
+        if not args.logtype or (args.logtype and logfetch_base.log_matches(log_file, args.logtype.replace('logs/', ''))):
           async_requests.append(
             grequests.AsyncRequest('GET',uri ,
               callback=generate_callback(uri, args.dest, logfile_name, args.chunk_size),

--- a/scripts/logfetch/live_logs.py
+++ b/scripts/logfetch/live_logs.py
@@ -19,38 +19,48 @@ def download_live_logs(args):
     metadata = files_json(args, task)
     if 'slaveHostname' in metadata:
       uri = DOWNLOAD_FILE_FORMAT.format(metadata['slaveHostname'])
+      if args.verbose:
+        sys.stderr.write(colored('Finding logs in base directory on {0}'.format(metadata['slaveHostname']), 'magenta') + '\n')
       for log_file in base_directory_files(args, task, metadata):
         logfile_name = '{0}-{1}'.format(task, log_file)
-        if (args.logtype and logfetch_base.log_matches(log_file, args.logtype)) or not args.logtype:
+        if not args.logtype or (args.logtype and logfetch_base.log_matches(log_file, args.logtype.replace('logs/', ''))):
           async_requests.append(
             grequests.AsyncRequest('GET',uri ,
-              callback=generate_callback(uri, args.dest, logfile_name, args.chunk_size),
+              callback=generate_callback(uri, args.dest, logfile_name, args.chunk_size, args.verbose),
               params={'path' : '{0}/{1}/{2}'.format(metadata['fullPathToRoot'], metadata['currentDirectory'], log_file)}
             )
           )
           if logfile_name.endswith('.gz'):
             zipped_files.append('{0}/{1}'.format(args.dest, logfile_name))
-          all_logs.append('{0}/{1}'.format(args.dest, logfile_name.replace('.gz', '.log')))
+          else:
+            all_logs.append('{0}/{1}'.format(args.dest, logfile_name.replace('.gz', '.log')))
+        elif args.logtype and args.verbose:
+          sys.stderr.write(colored('Excluding log {0}, doesn\'t match {1}'.format(log_file, args.logtype), 'magenta') + '\n')
 
+      if args.verbose:
+        sys.stderr.write(colored('Finding logs in logs directory on {0}'.format(metadata['slaveHostname']), 'magenta') + '\n')
       for log_file in logs_folder_files(args, task):
         logfile_name = '{0}-{1}'.format(task, log_file)
         if not args.logtype or (args.logtype and logfetch_base.log_matches(log_file, args.logtype.replace('logs/', ''))):
           async_requests.append(
             grequests.AsyncRequest('GET',uri ,
-              callback=generate_callback(uri, args.dest, logfile_name, args.chunk_size),
+              callback=generate_callback(uri, args.dest, logfile_name, args.chunk_size, args.verbose),
               params={'path' : '{0}/{1}/logs/{2}'.format(metadata['fullPathToRoot'], metadata['currentDirectory'], log_file)}
             )
           )
           if logfile_name.endswith('.gz'):
             zipped_files.append('{0}/{1}'.format(args.dest, logfile_name))
-          all_logs.append('{0}/{1}'.format(args.dest, logfile_name.replace('.gz', '.log')))
+          else:
+            all_logs.append('{0}/{1}'.format(args.dest, logfile_name.replace('.gz', '.log')))
+        elif args.logtype and args.verbose:
+          sys.stderr.write(colored('Excluding log {0}, doesn\'t match {1}'.format(log_file, args.logtype), 'magenta') + '\n')
 
   if async_requests:
     sys.stderr.write(colored('Starting live logs downloads\n', 'cyan'))
     grequests.map(async_requests, stream=True, size=args.num_parallel_fetches)
   if zipped_files:
-    sys.stderr.write(colored('Unpacking logs\n', 'cyan'))
-    logfetch_base.unpack_logs(zipped_files)
+    sys.stderr.write(colored('\nUnpacking logs\n', 'cyan'))
+    all_logs = all_logs + logfetch_base.unpack_logs(args, zipped_files)
   return all_logs
 
 def tasks_to_check(args):

--- a/scripts/logfetch/s3_logs.py
+++ b/scripts/logfetch/s3_logs.py
@@ -15,21 +15,28 @@ def download_s3_logs(args):
   sys.stderr.write(colored('Checking for S3 log files', 'cyan') + '\n')
   logs = logs_for_all_requests(args)
   async_requests = []
-  all_logs = []
+  zipped_files = []
   for log_file in logs:
     filename = log_file['key'].rsplit("/", 1)[1]
     if logfetch_base.is_in_date_range(args, time_from_filename(filename)):
       if not already_downloaded(args.dest, filename):
         async_requests.append(
-          grequests.AsyncRequest('GET', log_file['getUrl'], callback=generate_callback(log_file['getUrl'], args.dest, filename, args.chunk_size))
+          grequests.AsyncRequest('GET', log_file['getUrl'], callback=generate_callback(log_file['getUrl'], args.dest, filename, args.chunk_size, args.verbose))
         )
-      all_logs.append('{0}/{1}'.format(args.dest, filename.replace('.gz', '.log')))
+      else:
+        if args.verbose:
+          sys.stderr.write(colored('Log already downloaded {0}'.format(filename), 'magenta') + '\n')
+      zipped_files.append('{0}/{1}'.format(args.dest, filename))
+    else:
+      if args.verbose:
+        sys.stderr.write(colored('Excluding {0}, not in date range'.format(filename), 'magenta') + '\n')
   if async_requests:
-    sys.stderr.write(colored('Starting S3 Downloads', 'cyan'))
+    sys.stderr.write(colored('Starting S3 Downloads with {0} parallel fetches'.format(args.num_parallel_fetches), 'cyan'))
     grequests.map(async_requests, stream=True, size=args.num_parallel_fetches)
-  zipped_files = ['{0}/{1}'.format(args.dest, log_file['key'].rsplit("/", 1)[1]) for log_file in logs]
-  sys.stderr.write(colored('Unpacking S3 logs\n', 'cyan'))
-  logfetch_base.unpack_logs(zipped_files)
+  else:
+    sys.stderr.write(colored('No S3 logs to download', 'cyan'))
+  sys.stderr.write(colored('\nUnpacking S3 logs\n', 'cyan'))
+  all_logs = logfetch_base.unpack_logs(args, zipped_files)
   sys.stderr.write(colored('All S3 logs up to date', 'cyan') + '\n')
   return all_logs
 
@@ -45,11 +52,11 @@ def logs_for_all_requests(args):
     for task in tasks:
       s3_logs = get_json_response(s3_task_logs_uri(args, task))
       logs = logs + s3_logs if s3_logs else logs
-    sys.stderr.write(colored('Also searching s3 history...\n', 'magenta'))
+    sys.stderr.write(colored('Also searching s3 history...\n', 'cyan'))
     for request in logfetch_base.all_requests(args):
       s3_logs = get_json_response(s3_request_logs_uri(args, request))
       logs = logs + s3_logs if s3_logs else logs
-    return [dict(t) for t in set([tuple(l.items()) for l in logs])]
+    return [dict(t) for t in set([tuple(l.items()) for l in logs])] # remove any duplicates
 
 def time_from_filename(filename):
   time_string = re.search('(\d{13})', filename).group(1)

--- a/scripts/logfetch/tail.py
+++ b/scripts/logfetch/tail.py
@@ -1,8 +1,10 @@
+import os
 import sys
 import logfetch_base
 import requests
 import time
 import threading
+from grep import grep_command
 from termcolor import colored
 
 TAIL_LOG_FORMAT = '{0}/sandbox/{1}/read'
@@ -75,5 +77,22 @@ class LogStreamer(threading.Thread):
     response = requests.get(uri, params=params).json()
     prefix = '({0}) =>\n'.format(task) if args.verbose else ''
     if response['data'] != '':
+      if args.grep:
+        filename = '{0}/.grep{1}'.format(args.dest, self.Task)
+        self.create_grep_file(args, filename, response['data'])
+        output = os.popen(grep_command(args, filename)).read()
+        sys.stdout.write('{0}{1}'.format(colored(prefix, 'cyan'), output))
+        self.remove_grep_file(filename)
+      else:
         sys.stdout.write('{0}{1}'.format(colored(prefix, 'cyan'), response['data']))
     return offset + len(response['data'].encode('utf-8'))
+
+  def create_grep_file(self, args, filename, content):
+    grep_file = open(filename, 'wb')
+    grep_file.write(content)
+    grep_file.close()
+
+
+  def remove_grep_file(self, grep_file):
+    if os.path.isfile(grep_file):
+      os.remove(grep_file)

--- a/scripts/logfetch/tail.py
+++ b/scripts/logfetch/tail.py
@@ -84,12 +84,12 @@ class LogStreamer(threading.Thread):
         sys.stdout.write('{0}{1}'.format(colored(prefix, 'cyan'), output))
         self.remove_grep_file(filename)
       else:
-        sys.stdout.write('{0}{1}'.format(colored(prefix, 'cyan'), response['data']))
+        sys.stdout.write('{0}{1}'.format(colored(prefix, 'cyan'), response['data'].encode('utf-8')))
     return offset + len(response['data'].encode('utf-8'))
 
   def create_grep_file(self, args, filename, content):
     grep_file = open(filename, 'wb')
-    grep_file.write(content)
+    grep_file.write(content.encode('utf-8'))
     grep_file.close()
 
 


### PR DESCRIPTION
- rework how grep is done and print files names before matches
- fix -l flag for files in logs folder
- better date range comparing (actual datetime instead of # of days)
- add verbose mode for logfetch/logcat
- fix duplicate lines in logtail when grepping
- allow a full grep command input for logtail like in logfetch/logcat
- fix encoding issue that stops logtail