### PR TITLE
don't continually bounce the view to the bottom of the log while tailing if you've scrolled up

### DIFF
--- a/SingularityUI/app/controllers/Tail.coffee
+++ b/SingularityUI/app/controllers/Tail.coffee
@@ -16,10 +16,10 @@ class TailController extends Controller
             model: @models.taskHistory
 
         app.showView @view
+        @collections.logLines.fetchInitialData()
         @refresh()
 
     refresh: ->
-        @collections.logLines.fetchInitialData()
         @models.taskHistory.fetch()
 
 


### PR DESCRIPTION
@tpetr - the data was being refetched during the global refresh, causing the view to start tailing again, moved it out to only during initialization. 