### PR TITLE
match log type/name for s3 logs

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -32,10 +32,13 @@ Two commands exist for downloading logs.
 |-n --num-parallel-fetches|Max number of log fetches to make at once|5
 |-cs, --chunk-size|Chunk size for writing responses to file system|8192
 |-u, --singularity-uri-base|Base url for singularity (e.g. `localhost:8080/singularity/v2/api`)| Must be set!|
-|-s , --start-days|Search for logs no older than this many days|7
-|-e , --end-days|Search for logs no newer than this many days| None (today)
+|-s , --start-days|Search for logs no older than this, can be an integer number of days or date in format ‘mm-dd-yyyy’ |7
+|-e , --end-days|Search for logs no newer than this, can be an integer number of days or date in format ‘mm-dd-yyyy’| None (today)
+|-p, --file-pattern|Should match the executor.s3.uploader.pattern setting, determines if we can match on file name for s3 logs|`%requestId/%Y/%m/%taskId_%index-%s-%filename`|
+|-nn, --no-name-fetch-off|If a logtype matcher is specified, but the s3 log pattern does not include file name, don't download any s3 files| None (fetch all)|
 |-g, --grep|Grep string for searching log files(Only for `logfetch`)|
 |-l, --logtype|Glob matcher for type of log file to download| None (match all)|
+|-V, --verbose|More verbose output||
 
 ##Grep and Log Files
 When the `-g` option is set, the log fetcher will grep the downloaded files for the provided regex.

--- a/scripts/logfetch/entrypoint.py
+++ b/scripts/logfetch/entrypoint.py
@@ -21,6 +21,7 @@ DEFAULT_CHUNK_SIZE = 8192
 DEFAULT_DEST = os.path.expanduser('~/.logfetch_cache')
 DEFAULT_TASK_COUNT = 10
 DEFAULT_DAYS = 7
+DEFAULT_S3_PATTERN = '%requestId/%Y/%m/%taskId_%index-%s-%filename'
 
 def exit(reason, color='red'):
   sys.stderr.write(colored(reason, color) + '\n')
@@ -65,6 +66,9 @@ def check_args(args):
 
 def convert_to_date(argument):
     try:
+      if isinstance(argument, datetime):
+        return argument
+      else:
         val = datetime.now() - timedelta(days=int(argument))
     except:
       try:
@@ -87,8 +91,9 @@ def fetch():
     "chunk_size" : DEFAULT_CHUNK_SIZE,
     "dest" : DEFAULT_DEST,
     "task_count" : DEFAULT_TASK_COUNT,
-    "start_days" : DEFAULT_DAYS,
-    "end_days" : 0 #today
+    "start_days" : datetime.now() - timedelta(days=DEFAULT_DAYS),
+    "file_pattern" : DEFAULT_S3_PATTERN,
+    "end_days" : datetime.now()
   }
 
   try:
@@ -112,6 +117,8 @@ def fetch():
   parser.add_argument("-s", "--start-days", dest="start_days", help="Search for logs no older than this, can be an integer number of days or date in format 'mm-dd-yyyy'")
   parser.add_argument("-e", "--end-days", dest="end_days", help="Search for logs no newer than this, can be an integer number of days or date in format 'mm-dd-yyyy' (defaults to None/today)")
   parser.add_argument("-l", "--log-type", dest="logtype", help="Logfile type to downlaod (ie 'access.log'), can be a glob (ie *.log)")
+  parser.add_argument("-p", "--file-pattern", dest="file_pattern", help="S3 uploader file pattern")
+  parser.add_argument("-nn", "--no-name-fetch-off", dest="no_name_fetch_off", help="If a logtype matcher is specified, but the s3 log pattern does not include file name, don't download any s3 files", action="store_true")
   parser.add_argument("-g", "--grep", dest="grep", help="Regex to grep for (normal grep syntax) or a full grep command")
   parser.add_argument("-V", "--verbose", dest="verbose", help="Print more verbose output", action='store_true')
 
@@ -139,8 +146,9 @@ def cat():
     "chunk_size" : DEFAULT_CHUNK_SIZE,
     "dest" : DEFAULT_DEST,
     "task_count" : DEFAULT_TASK_COUNT,
-    "start_days" : DEFAULT_DAYS,
-    "end_days" : 0 #today
+    "start_days" : datetime.now() - timedelta(days=DEFAULT_DAYS),
+    "file_pattern" : DEFAULT_S3_PATTERN,
+    "end_days" : datetime.now()
   }
 
   try:
@@ -164,6 +172,8 @@ def cat():
   parser.add_argument("-s", "--start-days", dest="start_days", help="Search for logs no older than this, can be an integer number of days or date in format 'mm-dd-yyyy'")
   parser.add_argument("-e", "--end-days", dest="end_days", help="Search for logs no newer than this, can be an integer number of days or date in format 'mm-dd-yyyy' (defaults to None/today)")
   parser.add_argument("-l", "--logtype", dest="logtype", help="Logfile type to downlaod (ie 'access.log'), can be a glob (ie *.log)")
+  parser.add_argument("-p", "--file-pattern", dest="file_pattern", help="S3 uploader file pattern")
+  parser.add_argument("-nn", "--no-name-fetch-off", dest="no_name_fetch_off", help="If a logtype matcher is specified, but the s3 log pattern does not include file name, don't download any s3 files", action="store_true")
   parser.add_argument("-V", "--verbose", dest="verbose", help="Print more verbose output", action='store_true')
 
   args = parser.parse_args(remaining_argv)

--- a/scripts/logfetch/s3_logs.py
+++ b/scripts/logfetch/s3_logs.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import re
+import fnmatch
 import grequests
 import logfetch_base
 from termcolor import colored
@@ -11,6 +12,8 @@ TASK_FORMAT = '/task/{0}'
 S3LOGS_URI_FORMAT = '{0}/logs{1}'
 REQUEST_FORMAT = '/request/{0}'
 
+FILE_REGEX="\d{13}-([^-]*)-\d{8,20}\.gz"
+
 def download_s3_logs(args):
   sys.stderr.write(colored('Checking for S3 log files', 'cyan') + '\n')
   logs = logs_for_all_requests(args)
@@ -20,15 +23,19 @@ def download_s3_logs(args):
   for log_file in logs:
     filename = log_file['key'].rsplit("/", 1)[1]
     if logfetch_base.is_in_date_range(args, time_from_filename(filename)):
-      if not already_downloaded(args.dest, filename):
-        async_requests.append(
-          grequests.AsyncRequest('GET', log_file['getUrl'], callback=generate_callback(log_file['getUrl'], args.dest, filename, args.chunk_size, args.verbose))
-        )
+      if (not args.logtype) or is_old_log_format(filename) or log_matches(args, filename):
+        if not already_downloaded(args.dest, filename):
+          async_requests.append(
+            grequests.AsyncRequest('GET', log_file['getUrl'], callback=generate_callback(log_file['getUrl'], args.dest, filename, args.chunk_size, args.verbose))
+          )
+        else:
+          if args.verbose:
+            sys.stderr.write(colored('Log already downloaded {0}'.format(filename), 'magenta') + '\n')
+          all_logs.append('{0}/{1}'.format(args.dest, filename.replace('.gz', '.log')))
+        zipped_files.append('{0}/{1}'.format(args.dest, filename))
       else:
         if args.verbose:
-          sys.stderr.write(colored('Log already downloaded {0}'.format(filename), 'magenta') + '\n')
-        all_logs.append('{0}/{1}'.format(args.dest, filename.replace('.gz', '.log')))
-      zipped_files.append('{0}/{1}'.format(args.dest, filename))
+          sys.stderr.write(colored('Excluding {0} log does not match logtype argument {1}'.format(filename, args.logtype), 'magenta') + '\n')
     else:
       if args.verbose:
         sys.stderr.write(colored('Excluding {0}, not in date range'.format(filename), 'magenta') + '\n')
@@ -70,3 +77,10 @@ def s3_task_logs_uri(args, idString):
 def s3_request_logs_uri(args, idString):
   return S3LOGS_URI_FORMAT.format(logfetch_base.base_uri(args), REQUEST_FORMAT.format(idString))
 
+def is_old_log_format(filename):
+  m = re.search(FILE_REGEX, filename)
+  return not m
+
+def log_matches(args, filename):
+    m = re.search(FILE_REGEX, filename)
+    return fnmatch.fnmatch(args.logtype.replace('logs/', ''), m.group(1))

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -10,7 +10,7 @@ requirements = [
 
 setup(
     name='singularity-logfetch',
-    version='0.13.0',
+    version='0.15.0',
     description='Singularity log fetching and searching',
     author="HubSpot",
     author_email='singularity-users@googlegroups.com',


### PR DESCRIPTION
@tpetr should compliment the new logging and only download logs whose original name matches the `-l` glob
note: will continue to download all logs in the old format