### PR TITLE
add lb cleaning tasks listing

### DIFF
--- a/SingularityUI/app/models/Task.coffee
+++ b/SingularityUI/app/models/Task.coffee
@@ -14,6 +14,8 @@ class Task extends Model
     parse: (task) ->
         if task.offer?
             task.host = task.offer?.hostname?.split('.')[0]
+        else
+            task.host = task.host?.split('.')[0]
 
         if task.mesosTask?
             task.cpus     = _.find(task.mesosTask.resources, (resource) -> resource.name is 'cpus')?.scalar?.value ? ''

--- a/SingularityUI/app/templates/status.hbs
+++ b/SingularityUI/app/templates/status.hbs
@@ -111,7 +111,7 @@
                 <h2>Tasks</h2>
             </div>
             <div class="row">
-                <div class="col-md-3">
+                <div class="col-md-2">
                     <a class="big-number-link" href="{{appRoot}}/tasks">
                         <div class="well">
                             <div class="big-number">
@@ -121,7 +121,7 @@
                         </div>
                     </a>
                 </div>
-                <div class="col-md-3">
+                <div class="col-md-2">
                     <a class="big-number-link" href="{{appRoot}}/tasks/scheduled">
                         <div class="well">
                             <div class="big-number">
@@ -131,7 +131,7 @@
                         </div>
                     </a>
                 </div>
-                <div class="col-md-3">
+                <div class="col-md-2">
                     <a class="big-number-link" href="{{appRoot}}/tasks/scheduled">
                         <div class="well">
                             <div class="big-number">
@@ -141,12 +141,22 @@
                         </div>
                     </a>
                 </div>
-                <div class="col-md-3">
+                <div class="col-md-2">
                     <a class="big-number-link" href="{{appRoot}}/tasks/cleaning">
                         <div class="well">
                             <div class="big-number">
                                 <div class="number" data-state-attribute="cleaningTasks">{{ state.cleaningTasks }}</div>
                                 <div class="number-label">Cleaning</div>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-2">
+                    <a class="big-number-link" href="{{appRoot}}/tasks/lbcleanup">
+                        <div class="well">
+                            <div class="big-number">
+                                <div class="number" data-state-attribute="lbCleaningTasks">{{ state.lbCleanupTasks }}</div>
+                                <div class="number-label">LB Cleaning</div>
                             </div>
                         </div>
                     </a>

--- a/SingularityUI/app/templates/tasksTable/tasksBase.hbs
+++ b/SingularityUI/app/templates/tasksTable/tasksBase.hbs
@@ -7,6 +7,9 @@
             <li {{#ifEqual tasksFilter "scheduled"}}class="active"{{/ifEqual}}>
                 <a href="{{appRoot}}/tasks/scheduled">Scheduled</a>
             </li>
+            <li {{#ifEqual tasksFilter "lbcleanup"}}class="active"{{/ifEqual}}>
+                <a href="{{appRoot}}/tasks/lbcleanup">LB Cleaning</a>
+            </li>
             <li {{#ifEqual tasksFilter "cleaning"}}class="active"{{/ifEqual}}>
                 <a href="{{appRoot}}/tasks/cleaning">Cleaning</a>
             </li>

--- a/SingularityUI/app/templates/tasksTable/tasksBase.hbs
+++ b/SingularityUI/app/templates/tasksTable/tasksBase.hbs
@@ -7,11 +7,11 @@
             <li {{#ifEqual tasksFilter "scheduled"}}class="active"{{/ifEqual}}>
                 <a href="{{appRoot}}/tasks/scheduled">Scheduled</a>
             </li>
-            <li {{#ifEqual tasksFilter "lbcleanup"}}class="active"{{/ifEqual}}>
-                <a href="{{appRoot}}/tasks/lbcleanup">LB Cleaning</a>
-            </li>
             <li {{#ifEqual tasksFilter "cleaning"}}class="active"{{/ifEqual}}>
                 <a href="{{appRoot}}/tasks/cleaning">Cleaning</a>
+            </li>
+            <li {{#ifEqual tasksFilter "lbcleanup"}}class="active"{{/ifEqual}}>
+                <a href="{{appRoot}}/tasks/lbcleanup">LB Cleaning</a>
             </li>
             <li {{#ifEqual tasksFilter "decommissioning"}}class="active"{{/ifEqual}}>
                 <a href="{{appRoot}}/tasks/decommissioning">Decommissioning</a>

--- a/SingularityUI/app/templates/tasksTable/tasksLbCleaningBody.hbs
+++ b/SingularityUI/app/templates/tasksTable/tasksLbCleaningBody.hbs
@@ -1,0 +1,66 @@
+{{#unless rowsOnly}}
+    {{#if haveTasks}}
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th data-sort-attribute="id">
+                        Name
+                    </th>
+                    <th data-sort-attribute="startedAt">
+                        Started
+                    </th>
+                    <th data-sort-attribute="host">
+                        Host
+                    </th>
+                    <th data-sort-attribute="rackId">
+                        Rack
+                    </th>
+                    <th data-sort-attribute="instanceNo">
+                        Instance No
+                    </th>
+                    <th class="hidden-xs">
+                        {{! JSON Column }}
+                    </th>
+                </tr>
+            </thead>
+            <tbody>
+    {{/if}}
+{{/unless}}
+            {{#each tasks}}
+                <tr data-task-id="{{ id }}">
+                    <td class='keep-in-check'>
+                        <a title="{{ id }}" href="{{appRoot}}/task/{{ id }}">
+                            {{ id }}
+                        </a>
+                    </td>
+                    <td>
+                        {{timestampFromNow startedAt}}
+                    </td>
+                    <td>
+                        {{host}}
+                    </td>
+                    <td>
+                        {{rackId}}
+                    </td>
+                    <td>
+                        {{instanceNo}}
+                    </td>
+                    <td class="actions-column hidden-xs">
+                        <a data-task-id="{{ taskId.id }}" data-action="viewJSON" title="JSON">
+                            { }
+                        </a>
+                    </td>
+                </tr>
+            {{/each}}
+{{#unless rowsOnly}}
+    {{#if haveTasks}}
+        </tbody>
+    </table>
+    {{else}}
+        {{#if collectionSynced}}
+            <div class="empty-table-message"><p>No LB cleaning tasks</p></div>
+        {{else}}
+            <div class="page-loader centered cushy"></div>
+        {{/if}}
+    {{/if}}
+{{/unless}}

--- a/SingularityUI/app/views/tasks.coffee
+++ b/SingularityUI/app/views/tasks.coffee
@@ -14,6 +14,7 @@ class TasksView extends View
         active:          require '../templates/tasksTable/tasksActiveBody'
         scheduled:       require '../templates/tasksTable/tasksScheduledBody'
         cleaning:        require '../templates/tasksTable/tasksCleaningBody'
+        lbcleanup:      require '../templates/tasksTable/tasksLbCleaningBody'
         decommissioning: require '../templates/tasksTable/tasksDecommissioningBody'
 
     # For staged rendering


### PR DESCRIPTION
Adds a new listing page for LB cleaning tasks, and a link off the status page: 

![screenshot 2015-04-01 10 18 57](https://cloud.githubusercontent.com/assets/3275453/6942893/88a9c69a-d858-11e4-9e01-e5755dc29fd6.png)


![screenshot 2015-04-01 10 09 32](https://cloud.githubusercontent.com/assets/3275453/6942819/1035d97e-d858-11e4-9306-a3216154902c.png)

@tpetr 