### PR TITLE
Better tailing error when a file has not been generated yet

### DIFF
--- a/SingularityUI/app/application.coffee
+++ b/SingularityUI/app/application.coffee
@@ -101,6 +101,20 @@ class Application
             return if @blurred and jqxhr.statusText is 'timeout'
 
             url = settings.url.replace(config.appRoot, '')
+            
+            try
+                serverMessage = JSON.parse(jqxhr.responseText).message or jqxhr.responseText
+            catch
+                serverMessage = jqxhr.responseText
+
+            serverMessage = _.escape serverMessage
+            
+            # Check if the file/directory doesn't exist yet so we
+            # can handle the error with somee style on tailing pages           
+            directoryPatt = new RegExp("does not have a directory yet")
+            hasNoDirectory = directoryPatt.test serverMessage
+            
+            return if jqxhr.status is 400 and hasNoDirectory
 
             if jqxhr.status is 502
                 Messenger().info
@@ -116,12 +130,6 @@ class Application
                     hideAfter: 20
             else
                 console.log jqxhr.responseText
-                try
-                    serverMessage = JSON.parse(jqxhr.responseText).message or jqxhr.responseText
-                catch
-                    serverMessage = jqxhr.responseText
-
-                serverMessage = _.escape serverMessage
 
                 Messenger().error
                     message:   "<p>An uncaught error occurred with your request. The server said:</p><pre>#{ serverMessage }</pre><p>The error has been saved to your JS console.</p>"

--- a/SingularityUI/app/application.coffee
+++ b/SingularityUI/app/application.coffee
@@ -101,20 +101,6 @@ class Application
             return if @blurred and jqxhr.statusText is 'timeout'
 
             url = settings.url.replace(config.appRoot, '')
-            
-            try
-                serverMessage = JSON.parse(jqxhr.responseText).message or jqxhr.responseText
-            catch
-                serverMessage = jqxhr.responseText
-
-            serverMessage = _.escape serverMessage
-            
-            # Check if the file/directory doesn't exist yet so we
-            # can handle the error with somee style on tailing pages           
-            directoryPatt = new RegExp("does not have a directory yet")
-            hasNoDirectory = directoryPatt.test serverMessage
-            
-            return if jqxhr.status is 400 and hasNoDirectory
 
             if jqxhr.status is 502
                 Messenger().info
@@ -130,6 +116,13 @@ class Application
                     hideAfter: 20
             else
                 console.log jqxhr.responseText
+
+                try
+                  serverMessage = JSON.parse(jqxhr.responseText).message or jqxhr.responseText
+                catch
+                  serverMessage = jqxhr.responseText
+
+                serverMessage = _.escape serverMessage
 
                 Messenger().error
                     message:   "<p>An uncaught error occurred with your request. The server said:</p><pre>#{ serverMessage }</pre><p>The error has been saved to your JS console.</p>"

--- a/SingularityUI/app/collections/LogLines.coffee
+++ b/SingularityUI/app/collections/LogLines.coffee
@@ -64,7 +64,16 @@ class LogLines extends Collection
                 length: @initialRequestLength
 
             @trigger 'initialdata'
-
+        .error (response) =>
+         
+   # If we get a 400, the file has likely not been generated
+            # yet, so we'll pass a message to the view
+            if response.status is 400              
+                directoryPatt = new RegExp("does not have a directory yet")
+                hasNoDirectory = directoryPatt.test response.responseText
+                if hasNoDirectory
+                    @trigger 'ajaxError', {status: 400, errorType: 'NoDirectory'}
+    
     fetchPrevious: ->
         @fetch data:
             offset: orZero @getMinOffset() - @state.get('currentRequestLength')

--- a/SingularityUI/app/collections/LogLines.coffee
+++ b/SingularityUI/app/collections/LogLines.coffee
@@ -70,10 +70,7 @@ class LogLines extends Collection
             # yet, so we'll pass a message to the view
             if response.status in [400, 404, 500]
                 app.caughtError()
-                @ajaxError.set
-                    status: response.status
-                    responseText: response.responseText
-                    present: true
+                @ajaxError.setFromErrorResponse response
     
     fetchPrevious: ->
         @fetch data:

--- a/SingularityUI/app/collections/LogLines.coffee
+++ b/SingularityUI/app/collections/LogLines.coffee
@@ -65,10 +65,10 @@ class LogLines extends Collection
 
             @trigger 'initialdata'
         .error (response) =>
-         
-   # If we get a 400, the file has likely not been generated
+            # If we get a 400, the file has likely not been generated
             # yet, so we'll pass a message to the view
-            if response.status is 400              
+            if response.status is 400
+                app.caughtError() 
                 directoryPatt = new RegExp("does not have a directory yet")
                 hasNoDirectory = directoryPatt.test response.responseText
                 if hasNoDirectory

--- a/SingularityUI/app/controllers/Tail.coffee
+++ b/SingularityUI/app/controllers/Tail.coffee
@@ -2,18 +2,21 @@ Controller = require './Controller'
 
 LogLines = require '../collections/LogLines'
 TaskHistory = require '../models/TaskHistory'
+AjaxError = require '../models/AjaxError'
 
 TailView = require '../views/tail'
 
 class TailController extends Controller
 
     initialize: ({@taskId, @path, @offset}) ->
-        @collections.logLines = new LogLines [], {@taskId, @path}
+        @models.ajaxError = new AjaxError
+        @collections.logLines = new LogLines [], {@taskId, @path, ajaxError: @models.ajaxError}
         @models.taskHistory = new TaskHistory {@taskId}
     
         @setView new TailView _.extend {@taskId, @path, @offset},
             collection: @collections.logLines
             model: @models.taskHistory
+            ajaxError: @models.ajaxError
 
         app.showView @view
         if @offset?

--- a/SingularityUI/app/models/AjaxError.coffee
+++ b/SingularityUI/app/models/AjaxError.coffee
@@ -8,12 +8,16 @@ class AjaxError extends Model
     present: false
     shouldRefresh: false
 
-  parse: (data) ->
-    if data.responseText.match /Task .*? does not have a directory yet - check again soon/
-      data.message = "Hang tight, this task is still starting up!"
+  setFromErrorResponse: (error) =>
+    if error.responseText.match /Task .*? does not have a directory yet - check again soon/
+      message = "Hang tight, this task is still starting up!"
     else
-      data.message = data.responseText
+      message = error.responseText
 
-    data.shouldRefresh = data.status is 400
+    @set
+      status: error.status
+      shouldRefresh: error.status is 400
+      present: true
+      message: message
 
 module.exports = AjaxError

--- a/SingularityUI/app/models/AjaxError.coffee
+++ b/SingularityUI/app/models/AjaxError.coffee
@@ -1,0 +1,19 @@
+Model = require './model'
+
+# Used to POST new delays by the deploy form
+class AjaxError extends Model
+  defaults:
+    status: 0
+    message: '(no message)'
+    present: false
+    shouldRefresh: false
+
+  parse: (data) ->
+    if data.responseText.match /Task .*? does not have a directory yet - check again soon/
+      data.message = "Hang tight, this task is still starting up!"
+    else
+      data.message = data.responseText
+
+    data.shouldRefresh = data.status is 400
+
+module.exports = AjaxError

--- a/SingularityUI/app/templates/tail.hbs
+++ b/SingularityUI/app/templates/tail.hbs
@@ -38,10 +38,18 @@
     <div class="tail-fetching-start">
         fetching more lines <div class="page-loader small"></div>
     </div>
-    <div class="lines-wrapper"></div>
-
+    <div class="lines-wrapper">
+        {{#if ajaxError.status}}
+        <div class="lines-wrapper">
+            <div class="empty-table-message">
+                {{#ifEqual ajaxError.errorType 'NoDirectory'}}
+                    <p>This file has not been created yet. Hang tight, we're working on it.</p>
+                {{/ifEqual}}
+            </div>
+        </div>
+        {{/if}}
+    </div>
     <div class="tail-fetching-end">
         fetching more lines <div class="page-loader small"></div>
     </div>
 </div>
-

--- a/SingularityUI/app/templates/tail.hbs
+++ b/SingularityUI/app/templates/tail.hbs
@@ -39,12 +39,10 @@
         fetching more lines <div class="page-loader small"></div>
     </div>
     <div class="lines-wrapper">
-        {{#if ajaxError.status}}
+        {{#if ajaxError.present}}
         <div class="lines-wrapper">
             <div class="empty-table-message">
-                {{#ifEqual ajaxError.errorType 'NoDirectory'}}
-                    <p>This file has not been created yet. Hang tight, we're working on it.</p>
-                {{/ifEqual}}
+                <p>{{ajaxError.message}}</p>
             </div>
         </div>
         {{/if}}

--- a/SingularityUI/app/views/tail.coffee
+++ b/SingularityUI/app/views/tail.coffee
@@ -225,17 +225,5 @@ class TailView extends View
         @$('.line').removeClass('highlightLine')
         $(e.currentTarget).closest('.line').addClass('highlightLine')
 
-    # If we get a 400 we can render a nicer
-    # message that the file is being generated
-    handleAjaxError: (response) =>
-        @ajaxError =
-            status: true
-            errorType: response.errorType
-        
-        @dataInterval = setInterval =>
-            @collection.fetchInitialData()
-        , 2000
-
-        @render()
 
 module.exports = TailView

--- a/SingularityUI/app/views/tail.coffee
+++ b/SingularityUI/app/views/tail.coffee
@@ -30,19 +30,15 @@ class TailView extends View
             @$el.addClass 'fetching-data'
         @listenTo @collection, 'sync', =>
             @$el.removeClass 'fetching-data'
+
+        @listenTo @model, 'change:isStillRunning', => @stopTailing() unless @model.get 'isStillRunning'
+
+        @ajaxError = status: false
+        @listenTo @collection, 'ajaxError', @handleAjaxError
         
-        @listenTo @model, 'change:isStillRunning', => @stopTailing() unless @model.get 'isStillRunning'        
-
-    handleAjaxError: (response) =>
-        # ATM we get 404s if we request dirs and 500s if the file doesn't exist
-        if response.status in [404, 500]
-            app.caughtError()
-            @$el.html "<h1>Could not get request file.</h1>"
-
     render: =>
         breadcrumbs = utils.pathToBreadcrumbs @path
-
-        @$el.html @template {@taskId, @filename, breadcrumbs}
+        @$el.html @template {@taskId, @filename, breadcrumbs, @ajaxError}
 
         @$contents = @$ '.tail-contents'
         @$linesWrapper = @$contents.children('.lines-wrapper')
@@ -145,6 +141,10 @@ class TailView extends View
             , 0
 
     afterInitialData: =>
+        # Remove any `data is loading` message
+        clearInterval @dataInterval
+        @dumpContents()
+
         setTimeout =>
             @scrollToBottom()
         , 150
@@ -217,5 +217,17 @@ class TailView extends View
         @$('.line').removeClass('highlightLine')
         $(e.currentTarget).closest('.line').addClass('highlightLine')
 
+    # If we get a 400 we can render a nicer
+    # message that the file is being generated
+    handleAjaxError: (response) =>
+        @ajaxError =
+            status: true
+            errorType: response.errorType
+        
+        @dataInterval = setInterval =>
+            @collection.fetchInitialData()
+        , 2000
+
+        @render()
 
 module.exports = TailView


### PR DESCRIPTION
(reopening #480 against `master` instead of `hs_staging`)
- - -
This will replace the more "harsh" error message:

![screenshot 2015-03-13 16 02 50](https://cloud.githubusercontent.com/assets/3275453/6646390/beaae2dc-c99a-11e4-9f5c-4b0c3b43f8e2.png)

With a "calmer" message: (open to wording tweaks)

![screenshot 2015-03-13 15 47 40](https://cloud.githubusercontent.com/assets/3275453/6646414/111fcf78-c99b-11e4-9713-c155e1548fa1.png)

Aside from just being less harsh, the additional purpose of this PR is to support a separate PR in the works that will redirect a user to a tailing file after they run a task, when that file may or may not have be generated by the time they arrive...so...this will provide them with a better waiting area if they are waiting on their file to load.


Right now this only handles a bad request (400) and more specifically, when a file/directory is not found. However, I've set things up so we could pass various types of error messages in the future.

How things are setup -
- If a 400 error occurs, we search the returned message to see if it contains "does not have a directory yet", and from there bypass the standard error message. (A more specific code returned from the request may be cleaner, but I'm working with what I have with this current setup, which isn't terrible.)
- In the collection, an event is triggered if we hit this error, with the relevant info passed along with it to the view which is listening, and that info is then passed in to the template to show/hide the message.
- Last an interval is set polling for the initial data to be loaded, at which point the interval and message are removed.

@tpetr 