### PR TITLE
allow for deploys to override app folder cleanup

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/deploy/ExecutorData.java
+++ b/SingularityBase/src/main/java/com/hubspot/deploy/ExecutorData.java
@@ -24,13 +24,15 @@ public class ExecutorData {
   private final Map<String, String> loggingExtraFields;
   private final Optional<Long> sigKillProcessesAfterMillis;
   private final Optional<Integer> maxTaskThreads;
+  private final Optional<Boolean> preserveTaskSandboxAfterFinish;
 
   @JsonCreator
   public ExecutorData(@JsonProperty("cmd") String cmd, @JsonProperty("embeddedArtifacts") List<EmbeddedArtifact> embeddedArtifacts, @JsonProperty("externalArtifacts") List<ExternalArtifact> externalArtifacts,
       @JsonProperty("s3Artifacts") List<S3Artifact> s3Artifacts, @JsonProperty("successfulExitCodes") List<Integer> successfulExitCodes, @JsonProperty("user") Optional<String> user,
       @JsonProperty("runningSentinel") Optional<String> runningSentinel, @JsonProperty("extraCmdLineArgs") List<String> extraCmdLineArgs, @JsonProperty("loggingTag") Optional<String> loggingTag,
       @JsonProperty("loggingExtraFields") Map<String, String> loggingExtraFields, @JsonProperty("sigKillProcessesAfterMillis") Optional<Long> sigKillProcessesAfterMillis,
-      @JsonProperty("maxTaskThreads") Optional<Integer> maxTaskThreads) {
+      @JsonProperty("maxTaskThreads") Optional<Integer> maxTaskThreads,
+      @JsonProperty("preserveTaskSandboxAfterFinish") Optional<Boolean> preserveTaskSandboxAfterFinish) {
     this.cmd = cmd;
     this.embeddedArtifacts = JavaUtils.nonNullImmutable(embeddedArtifacts);
     this.externalArtifacts = JavaUtils.nonNullImmutable(externalArtifacts);
@@ -43,10 +45,11 @@ public class ExecutorData {
     this.loggingExtraFields = JavaUtils.nonNullImmutable(loggingExtraFields);
     this.sigKillProcessesAfterMillis = sigKillProcessesAfterMillis;
     this.maxTaskThreads = maxTaskThreads;
+    this.preserveTaskSandboxAfterFinish = preserveTaskSandboxAfterFinish;
   }
 
   public ExecutorDataBuilder toBuilder() {
-    return new ExecutorDataBuilder(cmd, embeddedArtifacts, externalArtifacts, s3Artifacts, successfulExitCodes, runningSentinel, user, extraCmdLineArgs, loggingTag, loggingExtraFields, sigKillProcessesAfterMillis, maxTaskThreads);
+    return new ExecutorDataBuilder(cmd, embeddedArtifacts, externalArtifacts, s3Artifacts, successfulExitCodes, runningSentinel, user, extraCmdLineArgs, loggingTag, loggingExtraFields, sigKillProcessesAfterMillis, maxTaskThreads, preserveTaskSandboxAfterFinish);
   }
 
   public String getCmd() {
@@ -97,11 +100,15 @@ public class ExecutorData {
     return maxTaskThreads;
   }
 
+  public Optional<Boolean> getPreserveTaskSandboxAfterFinish() {
+    return preserveTaskSandboxAfterFinish;
+  }
+
   @Override
   public String toString() {
     return "ExecutorData [cmd=" + cmd + ", embeddedArtifacts=" + embeddedArtifacts + ", externalArtifacts=" + externalArtifacts + ", s3Artifacts=" + s3Artifacts + ", successfulExitCodes="
         + successfulExitCodes + ", runningSentinel=" + runningSentinel + ", user=" + user + ", extraCmdLineArgs=" + extraCmdLineArgs + ", loggingTag=" + loggingTag + ", loggingExtraFields="
-        + loggingExtraFields + ", sigKillProcessesAfterMillis=" + sigKillProcessesAfterMillis + ", maxTaskThreads=" + maxTaskThreads + "]";
+        + loggingExtraFields + ", sigKillProcessesAfterMillis=" + sigKillProcessesAfterMillis + ", maxTaskThreads=" + maxTaskThreads + ", preserveTaskSandboxAfterFinish=" + preserveTaskSandboxAfterFinish + "]";
   }
 
 }

--- a/SingularityBase/src/main/java/com/hubspot/deploy/ExecutorDataBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/deploy/ExecutorDataBuilder.java
@@ -19,9 +19,10 @@ public class ExecutorDataBuilder {
   private Map<String, String> loggingExtraFields;
   private Optional<Long> sigKillProcessesAfterMillis;
   private Optional<Integer> maxTaskThreads;
+  private Optional<Boolean> preserveTaskSandboxAfterFinish;
 
   public ExecutorDataBuilder(String cmd, List<EmbeddedArtifact> embeddedArtifacts, List<ExternalArtifact> externalArtifacts, List<S3Artifact> s3Artifacts, List<Integer> successfulExitCodes, Optional<String> runningSentinel,
-      Optional<String> user, List<String> extraCmdLineArgs, Optional<String> loggingTag, Map<String, String> loggingExtraFields, Optional<Long> sigKillProcessesAfterMillis, Optional<Integer> maxTaskThreads) {
+      Optional<String> user, List<String> extraCmdLineArgs, Optional<String> loggingTag, Map<String, String> loggingExtraFields, Optional<Long> sigKillProcessesAfterMillis, Optional<Integer> maxTaskThreads, Optional<Boolean> preserveTaskSandboxAfterFinish) {
     this.cmd = cmd;
     this.embeddedArtifacts = embeddedArtifacts;
     this.externalArtifacts = externalArtifacts;
@@ -34,6 +35,7 @@ public class ExecutorDataBuilder {
     this.loggingExtraFields = loggingExtraFields;
     this.sigKillProcessesAfterMillis = sigKillProcessesAfterMillis;
     this.maxTaskThreads = maxTaskThreads;
+    this.preserveTaskSandboxAfterFinish = preserveTaskSandboxAfterFinish;
   }
 
   public ExecutorDataBuilder() {
@@ -41,7 +43,7 @@ public class ExecutorDataBuilder {
   }
 
   public ExecutorData build() {
-    return new ExecutorData(cmd, embeddedArtifacts, externalArtifacts, s3Artifacts, successfulExitCodes, user, runningSentinel, extraCmdLineArgs, loggingTag, loggingExtraFields, sigKillProcessesAfterMillis, maxTaskThreads);
+    return new ExecutorData(cmd, embeddedArtifacts, externalArtifacts, s3Artifacts, successfulExitCodes, user, runningSentinel, extraCmdLineArgs, loggingTag, loggingExtraFields, sigKillProcessesAfterMillis, maxTaskThreads, preserveTaskSandboxAfterFinish);
   }
 
   public Optional<String> getLoggingTag() {
@@ -152,11 +154,21 @@ public class ExecutorDataBuilder {
     return this;
   }
 
+  public Optional<Boolean> getPreserveTaskSandboxAfterFinish() {
+    return preserveTaskSandboxAfterFinish;
+  }
+
+  public ExecutorDataBuilder setPreserveTaskSandboxAfterFinish(Optional<Boolean> preserveTaskSandboxAfterFinish) {
+    this.preserveTaskSandboxAfterFinish = preserveTaskSandboxAfterFinish;
+    return this;
+  }
+
   @Override
   public String toString() {
     return "ExecutorDataBuilder [cmd=" + cmd + ", embeddedArtifacts=" + embeddedArtifacts + ", externalArtifacts=" + externalArtifacts + ", s3Artifacts=" + s3Artifacts + ", successfulExitCodes="
         + successfulExitCodes + ", runningSentinel=" + runningSentinel + ", user=" + user + ", extraCmdLineArgs=" + extraCmdLineArgs + ", loggingTag=" + loggingTag + ", loggingExtraFields="
-        + loggingExtraFields + ", sigKillProcessesAfterMillis=" + sigKillProcessesAfterMillis + ", maxTaskThreads=" + maxTaskThreads + "]";
+        + loggingExtraFields + ", sigKillProcessesAfterMillis=" + sigKillProcessesAfterMillis + ", maxTaskThreads=" + maxTaskThreads + ", preserveTaskSandboxAfterFinish=" + preserveTaskSandboxAfterFinish + "]";
+
   }
 
 }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTask.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTask.java
@@ -57,7 +57,7 @@ public class SingularityExecutorTask {
   public void cleanup(TaskState state) {
     ExtendedTaskState extendedTaskState = ExtendedTaskState.fromTaskState(state);
 
-    boolean cleanupAppTaskDirectory = !extendedTaskState.isFailed();
+    boolean cleanupAppTaskDirectory = !extendedTaskState.isFailed() && !taskDefinition.getExecutorData().getPreserveTaskSandboxAfterFinish().or(Boolean.FALSE);
 
     taskCleanup.cleanup(cleanupAppTaskDirectory);
   }

--- a/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/SingularityExecutorCleanup.java
+++ b/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/SingularityExecutorCleanup.java
@@ -177,7 +177,7 @@ public class SingularityExecutorCleanup {
 
     SingularityExecutorTaskCleanup taskCleanup = new SingularityExecutorTaskCleanup(logManager, executorConfiguration, taskDefinition, LOG);
 
-    boolean cleanupTaskAppDirectory = true;
+    boolean cleanupTaskAppDirectory = !taskDefinition.getExecutorData().getPreserveTaskSandboxAfterFinish().or(Boolean.FALSE);
 
     if (taskHistory.isPresent()) {
       final Optional<SingularityTaskHistoryUpdate> lastUpdate = JavaUtils.getLast(taskHistory.get().getTaskUpdates());


### PR DESCRIPTION
(reopening #476 against `master` instead of `hs_staging`)
- - -
This PR allows deploys to skip the automatic cleanup that the SingularityExecutor and SingularityExecutorCleanup processes perform on successful tasks. This will not, however, prevent Mesos eventually GC-ing the task sandbox.