### PR TITLE
temporarily work around brunch/chokidar issue with a custom npm-shrinkwrap.json

### DIFF
--- a/SingularityUI/npm-shrinkwrap.json
+++ b/SingularityUI/npm-shrinkwrap.json
@@ -1,0 +1,2901 @@
+{
+  "name": "SingularityUI",
+  "version": "0.3.0",
+  "dependencies": {
+    "bower": {
+      "version": "1.4.1",
+      "from": "bower@^1.3.8",
+      "resolved": "http://registry.npmjs.org/bower/-/bower-1.4.1.tgz",
+      "dependencies": {
+        "abbrev": {
+          "version": "1.0.5",
+          "from": "abbrev@^1.0.5",
+          "resolved": "http://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+        },
+        "archy": {
+          "version": "1.0.0",
+          "from": "archy@1.0.0"
+        },
+        "bower-config": {
+          "version": "0.6.1",
+          "from": "bower-config@^0.6.1",
+          "resolved": "http://registry.npmjs.org/bower-config/-/bower-config-0.6.1.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "2.0.3",
+              "from": "graceful-fs@~2.0.0",
+              "resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+            },
+            "mout": {
+              "version": "0.9.1",
+              "from": "mout@~0.9.0",
+              "resolved": "http://registry.npmjs.org/mout/-/mout-0.9.1.tgz"
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "from": "optimist@~0.6.0",
+              "resolved": "http://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "wordwrap@~0.0.2"
+                },
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "minimist@~0.0.1",
+                  "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                }
+              }
+            },
+            "osenv": {
+              "version": "0.0.3",
+              "from": "osenv@0.0.3"
+            }
+          }
+        },
+        "bower-endpoint-parser": {
+          "version": "0.2.2",
+          "from": "bower-endpoint-parser@^0.2.2",
+          "resolved": "http://registry.npmjs.org/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz"
+        },
+        "bower-json": {
+          "version": "0.4.0",
+          "from": "bower-json@^0.4.0",
+          "resolved": "http://registry.npmjs.org/bower-json/-/bower-json-0.4.0.tgz",
+          "dependencies": {
+            "deep-extend": {
+              "version": "0.2.11",
+              "from": "deep-extend@~0.2.5",
+              "resolved": "http://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+            },
+            "graceful-fs": {
+              "version": "2.0.3",
+              "from": "graceful-fs@~2.0.0",
+              "resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+            },
+            "intersect": {
+              "version": "0.0.3",
+              "from": "intersect@~0.0.3",
+              "resolved": "http://registry.npmjs.org/intersect/-/intersect-0.0.3.tgz"
+            }
+          }
+        },
+        "bower-logger": {
+          "version": "0.2.2",
+          "from": "bower-logger@^0.2.2",
+          "resolved": "http://registry.npmjs.org/bower-logger/-/bower-logger-0.2.2.tgz"
+        },
+        "bower-registry-client": {
+          "version": "0.3.0",
+          "from": "bower-registry-client@^0.3.0",
+          "resolved": "http://registry.npmjs.org/bower-registry-client/-/bower-registry-client-0.3.0.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "async@~0.2.8",
+              "resolved": "http://registry.npmjs.org/async/-/async-0.2.10.tgz"
+            },
+            "graceful-fs": {
+              "version": "2.0.3",
+              "from": "graceful-fs@~2.0.0",
+              "resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+            },
+            "lru-cache": {
+              "version": "2.3.1",
+              "from": "lru-cache@~2.3.0",
+              "resolved": "http://registry.npmjs.org/lru-cache/-/lru-cache-2.3.1.tgz"
+            },
+            "request": {
+              "version": "2.51.0",
+              "from": "request@~2.51.0",
+              "resolved": "http://registry.npmjs.org/request/-/request-2.51.0.tgz",
+              "dependencies": {
+                "bl": {
+                  "version": "0.9.4",
+                  "from": "bl@~0.9.0",
+                  "resolved": "http://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@~1.0.26",
+                      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@~0.10.x",
+                          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.1"
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.8.0",
+                  "from": "caseless@~0.8.0",
+                  "resolved": "http://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
+                },
+                "forever-agent": {
+                  "version": "0.5.2",
+                  "from": "forever-agent@~0.5.0",
+                  "resolved": "http://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                },
+                "form-data": {
+                  "version": "0.2.0",
+                  "from": "form-data@~0.2.0",
+                  "resolved": "http://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.9.0",
+                      "from": "async@~0.9.0",
+                      "resolved": "http://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                    },
+                    "mime-types": {
+                      "version": "2.0.10",
+                      "from": "mime-types@~2.0.3",
+                      "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.8.0",
+                          "from": "mime-db@~1.8.0",
+                          "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.0",
+                  "from": "json-stringify-safe@~5.0.0",
+                  "resolved": "http://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                },
+                "mime-types": {
+                  "version": "1.0.2",
+                  "from": "mime-types@~1.0.1",
+                  "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                },
+                "node-uuid": {
+                  "version": "1.4.3",
+                  "from": "node-uuid@~1.4.0",
+                  "resolved": "http://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                },
+                "qs": {
+                  "version": "2.3.3",
+                  "from": "qs@~2.3.1",
+                  "resolved": "http://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.0",
+                  "from": "tunnel-agent@~0.4.0",
+                  "resolved": "http://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                },
+                "tough-cookie": {
+                  "version": "0.12.1",
+                  "from": "tough-cookie@>=0.12.0",
+                  "resolved": "http://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                  "dependencies": {
+                    "punycode": {
+                      "version": "1.3.2",
+                      "from": "punycode@>=0.2.0",
+                      "resolved": "http://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "0.10.1",
+                  "from": "http-signature@~0.10.0",
+                  "resolved": "http://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@^0.1.5",
+                      "resolved": "http://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11",
+                      "resolved": "http://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "ctype@0.5.3",
+                      "resolved": "http://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.5.0",
+                  "from": "oauth-sign@~0.5.0",
+                  "resolved": "http://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
+                },
+                "hawk": {
+                  "version": "1.1.1",
+                  "from": "hawk@1.1.1",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "0.9.1",
+                      "from": "hoek@0.9.x",
+                      "resolved": "http://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                    },
+                    "boom": {
+                      "version": "0.4.2",
+                      "from": "boom@0.4.x",
+                      "resolved": "http://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "0.2.2",
+                      "from": "cryptiles@0.2.x",
+                      "resolved": "http://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                    },
+                    "sntp": {
+                      "version": "0.2.4",
+                      "from": "sntp@0.2.x",
+                      "resolved": "http://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "from": "aws-sign2@~0.5.0",
+                  "resolved": "http://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                },
+                "stringstream": {
+                  "version": "0.0.4",
+                  "from": "stringstream@~0.0.4",
+                  "resolved": "http://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                },
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "from": "combined-stream@~0.0.5",
+                  "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "from": "delayed-stream@0.0.5",
+                      "resolved": "http://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "request-replay": {
+              "version": "0.2.0",
+              "from": "request-replay@~0.2.0",
+              "resolved": "http://registry.npmjs.org/request-replay/-/request-replay-0.2.0.tgz"
+            },
+            "rimraf": {
+              "version": "2.2.8",
+              "from": "rimraf@~2.2.0",
+              "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+            },
+            "mkdirp": {
+              "version": "0.3.5",
+              "from": "mkdirp@~0.3.5"
+            }
+          }
+        },
+        "cardinal": {
+          "version": "0.4.4",
+          "from": "cardinal@0.4.4",
+          "dependencies": {
+            "redeyed": {
+              "version": "0.4.4",
+              "from": "redeyed@~0.4.0",
+              "resolved": "http://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
+              "dependencies": {
+                "esprima": {
+                  "version": "1.0.4",
+                  "from": "esprima@~1.0.4",
+                  "resolved": "http://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+                }
+              }
+            },
+            "ansicolors": {
+              "version": "0.2.1",
+              "from": "ansicolors@~0.2.1",
+              "resolved": "http://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz"
+            }
+          }
+        },
+        "chalk": {
+          "version": "1.0.0",
+          "from": "chalk@^1.0.0",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.0.1",
+              "from": "ansi-styles@^2.0.1"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "escape-string-regexp@^1.0.2",
+              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+            },
+            "has-ansi": {
+              "version": "1.0.3",
+              "from": "has-ansi@^1.0.3",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "from": "ansi-regex@^1.0.0",
+                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                },
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@^4.0.1",
+                  "resolved": "http://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "2.0.1",
+              "from": "strip-ansi@^2.0.1",
+              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "from": "ansi-regex@^1.0.0",
+                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "1.3.1",
+              "from": "supports-color@^1.3.0"
+            }
+          }
+        },
+        "chmodr": {
+          "version": "0.1.0",
+          "from": "chmodr@0.1.0"
+        },
+        "configstore": {
+          "version": "0.3.2",
+          "from": "configstore@^0.3.2",
+          "resolved": "http://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
+          "dependencies": {
+            "js-yaml": {
+              "version": "3.2.7",
+              "from": "js-yaml@^3.1.0",
+              "resolved": "http://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
+              "dependencies": {
+                "argparse": {
+                  "version": "1.0.2",
+                  "from": "argparse@~ 1.0.0",
+                  "dependencies": {
+                    "lodash": {
+                      "version": "3.6.0",
+                      "from": "lodash@>= 3.2.0 < 4.0.0",
+                      "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
+                    },
+                    "sprintf-js": {
+                      "version": "1.0.2",
+                      "from": "sprintf-js@~1.0.2",
+                      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
+                    }
+                  }
+                },
+                "esprima": {
+                  "version": "2.0.0",
+                  "from": "esprima@~ 2.0.0",
+                  "resolved": "http://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@^2.0.0",
+              "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "osenv": {
+              "version": "0.1.0",
+              "from": "osenv@^0.1.0",
+              "resolved": "http://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz"
+            },
+            "uuid": {
+              "version": "2.0.1",
+              "from": "uuid@^2.0.1",
+              "resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
+            },
+            "xdg-basedir": {
+              "version": "1.0.1",
+              "from": "xdg-basedir@^1.0.0",
+              "resolved": "http://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz"
+            }
+          }
+        },
+        "decompress-zip": {
+          "version": "0.1.0",
+          "from": "decompress-zip@^0.1.0",
+          "resolved": "http://registry.npmjs.org/decompress-zip/-/decompress-zip-0.1.0.tgz",
+          "dependencies": {
+            "binary": {
+              "version": "0.3.0",
+              "from": "binary@^0.3.0",
+              "resolved": "http://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+              "dependencies": {
+                "chainsaw": {
+                  "version": "0.1.0",
+                  "from": "chainsaw@~0.1.0",
+                  "resolved": "http://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+                  "dependencies": {
+                    "traverse": {
+                      "version": "0.3.9",
+                      "from": "traverse@>=0.3.0 <0.4",
+                      "resolved": "http://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
+                    }
+                  }
+                },
+                "buffers": {
+                  "version": "0.1.1",
+                  "from": "buffers@~0.1.1",
+                  "resolved": "http://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
+                }
+              }
+            },
+            "mkpath": {
+              "version": "0.1.0",
+              "from": "mkpath@^0.1.0",
+              "resolved": "http://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz"
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "readable-stream@^1.1.8",
+              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1"
+                }
+              }
+            },
+            "touch": {
+              "version": "0.0.3",
+              "from": "touch@0.0.3",
+              "dependencies": {
+                "nopt": {
+                  "version": "1.0.10",
+                  "from": "nopt@~1.0.10",
+                  "resolved": "http://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz"
+                }
+              }
+            }
+          }
+        },
+        "fstream": {
+          "version": "1.0.4",
+          "from": "fstream@^1.0.3",
+          "resolved": "http://registry.npmjs.org/fstream/-/fstream-1.0.4.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@~2.0.0"
+            }
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.2",
+          "from": "fstream-ignore@^1.0.2",
+          "resolved": "http://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.2.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@2"
+            },
+            "minimatch": {
+              "version": "2.0.4",
+              "from": "minimatch@^2.0.1",
+              "resolved": "http://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "from": "brace-expansion@^1.0.0",
+                  "resolved": "http://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "balanced-match@^0.2.0",
+                      "resolved": "http://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "github": {
+          "version": "0.2.3",
+          "from": "github@^0.2.3"
+        },
+        "glob": {
+          "version": "4.5.3",
+          "from": "glob@^4.3.2",
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.4",
+              "from": "inflight@^1.0.4",
+              "resolved": "http://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@1",
+                  "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@2"
+            },
+            "minimatch": {
+              "version": "2.0.4",
+              "from": "minimatch@^2.0.1",
+              "resolved": "http://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "from": "brace-expansion@^1.0.0",
+                  "resolved": "http://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "balanced-match@^0.2.0",
+                      "resolved": "http://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.1",
+              "from": "once@^1.3.0",
+              "resolved": "http://registry.npmjs.org/once/-/once-1.3.1.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@1",
+                  "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "graceful-fs": {
+          "version": "3.0.6",
+          "from": "graceful-fs@^3.0.5"
+        },
+        "handlebars": {
+          "version": "2.0.0",
+          "from": "handlebars@^2.0.0",
+          "resolved": "http://registry.npmjs.org/handlebars/-/handlebars-2.0.0.tgz",
+          "dependencies": {
+            "optimist": {
+              "version": "0.3.7",
+              "from": "optimist@~0.3",
+              "resolved": "http://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "wordwrap@~0.0.2"
+                }
+              }
+            },
+            "uglify-js": {
+              "version": "2.3.6",
+              "from": "uglify-js@~2.3",
+              "resolved": "http://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@~0.2.6",
+                  "resolved": "http://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
+                "source-map": {
+                  "version": "0.1.43",
+                  "from": "source-map@~0.1.7",
+                  "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "http://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "inquirer": {
+          "version": "0.8.0",
+          "from": "inquirer@0.8.0",
+          "dependencies": {
+            "ansi-regex": {
+              "version": "1.1.1",
+              "from": "ansi-regex@^1.1.0",
+              "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+            },
+            "chalk": {
+              "version": "0.5.1",
+              "from": "chalk@^0.5.0",
+              "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "1.1.0",
+                  "from": "ansi-styles@^1.1.0",
+                  "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@^1.0.0",
+                  "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "0.1.0",
+                  "from": "has-ansi@^0.1.0",
+                  "resolved": "http://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "0.2.1",
+                      "from": "ansi-regex@^0.2.1",
+                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "0.3.0",
+                  "from": "strip-ansi@^0.3.0",
+                  "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "0.2.1",
+                      "from": "ansi-regex@^0.2.1",
+                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "0.2.0",
+                  "from": "supports-color@^0.2.0",
+                  "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+                }
+              }
+            },
+            "cli-color": {
+              "version": "0.3.3",
+              "from": "cli-color@~0.3.2",
+              "resolved": "http://registry.npmjs.org/cli-color/-/cli-color-0.3.3.tgz",
+              "dependencies": {
+                "d": {
+                  "version": "0.1.1",
+                  "from": "d@~0.1.1",
+                  "resolved": "http://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                },
+                "es5-ext": {
+                  "version": "0.10.6",
+                  "from": "es5-ext@~0.10.6",
+                  "resolved": "http://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
+                  "dependencies": {
+                    "es6-iterator": {
+                      "version": "0.1.3",
+                      "from": "es6-iterator@~0.1.3",
+                      "resolved": "http://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
+                    },
+                    "es6-symbol": {
+                      "version": "2.0.1",
+                      "from": "es6-symbol@~2.0.1",
+                      "resolved": "http://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                    }
+                  }
+                },
+                "memoizee": {
+                  "version": "0.3.8",
+                  "from": "memoizee@~0.3.8",
+                  "resolved": "http://registry.npmjs.org/memoizee/-/memoizee-0.3.8.tgz",
+                  "dependencies": {
+                    "es6-weak-map": {
+                      "version": "0.1.2",
+                      "from": "es6-weak-map@~0.1.2",
+                      "resolved": "http://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.2.tgz",
+                      "dependencies": {
+                        "es6-iterator": {
+                          "version": "0.1.3",
+                          "from": "es6-iterator@~0.1.1",
+                          "resolved": "http://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                          "dependencies": {
+                            "es6-symbol": {
+                              "version": "2.0.1",
+                              "from": "es6-symbol@~2.0.1",
+                              "resolved": "http://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                            }
+                          }
+                        },
+                        "es6-symbol": {
+                          "version": "0.1.1",
+                          "from": "es6-symbol@0.1.x",
+                          "resolved": "http://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
+                        }
+                      }
+                    },
+                    "event-emitter": {
+                      "version": "0.3.3",
+                      "from": "event-emitter@~0.3.1",
+                      "resolved": "http://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
+                    },
+                    "lru-queue": {
+                      "version": "0.1.0",
+                      "from": "lru-queue@0.1",
+                      "resolved": "http://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
+                    },
+                    "next-tick": {
+                      "version": "0.2.2",
+                      "from": "next-tick@~0.2.2",
+                      "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
+                    }
+                  }
+                },
+                "timers-ext": {
+                  "version": "0.1.0",
+                  "from": "timers-ext@0.1",
+                  "resolved": "http://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
+                  "dependencies": {
+                    "next-tick": {
+                      "version": "0.2.2",
+                      "from": "next-tick@~0.2.2",
+                      "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "figures": {
+              "version": "1.3.5",
+              "from": "figures@^1.3.2",
+              "resolved": "http://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
+            },
+            "lodash": {
+              "version": "2.4.1",
+              "from": "lodash@~2.4.1",
+              "resolved": "http://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+            },
+            "mute-stream": {
+              "version": "0.0.4",
+              "from": "mute-stream@~0.0.4"
+            },
+            "readline2": {
+              "version": "0.1.1",
+              "from": "readline2@~0.1.0",
+              "resolved": "http://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+              "dependencies": {
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@^2.0.1",
+                  "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz"
+                }
+              }
+            },
+            "rx": {
+              "version": "2.5.1",
+              "from": "rx@^2.2.27",
+              "resolved": "http://registry.npmjs.org/rx/-/rx-2.5.1.tgz"
+            },
+            "through": {
+              "version": "2.3.7",
+              "from": "through@~2.3.4",
+              "resolved": "http://registry.npmjs.org/through/-/through-2.3.7.tgz"
+            }
+          }
+        },
+        "insight": {
+          "version": "0.5.3",
+          "from": "insight@^0.5.0",
+          "resolved": "http://registry.npmjs.org/insight/-/insight-0.5.3.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.9.0",
+              "from": "async@^0.9.0",
+              "resolved": "http://registry.npmjs.org/async/-/async-0.9.0.tgz"
+            },
+            "lodash.debounce": {
+              "version": "3.0.3",
+              "from": "lodash.debounce@^3.0.1",
+              "resolved": "http://registry.npmjs.org/lodash.debounce/-/lodash.debounce-3.0.3.tgz",
+              "dependencies": {
+                "lodash.isnative": {
+                  "version": "3.0.1",
+                  "from": "lodash.isnative@^3.0.0"
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@^2.0.0",
+              "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "os-name": {
+              "version": "1.0.3",
+              "from": "os-name@^1.0.0",
+              "resolved": "http://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
+              "dependencies": {
+                "osx-release": {
+                  "version": "1.0.0",
+                  "from": "osx-release@^1.0.0",
+                  "resolved": "http://registry.npmjs.org/osx-release/-/osx-release-1.0.0.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "1.1.1",
+                      "from": "minimist@^1.1.0",
+                      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                    }
+                  }
+                },
+                "win-release": {
+                  "version": "1.0.0",
+                  "from": "win-release@^1.0.0",
+                  "resolved": "http://registry.npmjs.org/win-release/-/win-release-1.0.0.tgz"
+                }
+              }
+            },
+            "tough-cookie": {
+              "version": "0.12.1",
+              "from": "tough-cookie@^0.12.1",
+              "resolved": "http://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+              "dependencies": {
+                "punycode": {
+                  "version": "1.3.2",
+                  "from": "punycode@>=0.2.0",
+                  "resolved": "http://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "is-root": {
+          "version": "1.0.0",
+          "from": "is-root@^1.0.0",
+          "resolved": "http://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz"
+        },
+        "junk": {
+          "version": "1.0.1",
+          "from": "junk@^1.0.0",
+          "resolved": "http://registry.npmjs.org/junk/-/junk-1.0.1.tgz"
+        },
+        "lockfile": {
+          "version": "1.0.0",
+          "from": "lockfile@^1.0.0",
+          "resolved": "http://registry.npmjs.org/lockfile/-/lockfile-1.0.0.tgz"
+        },
+        "lru-cache": {
+          "version": "2.5.0",
+          "from": "lru-cache@2",
+          "resolved": "http://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "from": "mkdirp@0.5.0",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8"
+            }
+          }
+        },
+        "mout": {
+          "version": "0.11.0",
+          "from": "mout@^0.11.0",
+          "resolved": "http://registry.npmjs.org/mout/-/mout-0.11.0.tgz"
+        },
+        "nopt": {
+          "version": "3.0.1",
+          "from": "nopt@^3.0.1",
+          "resolved": "http://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz"
+        },
+        "opn": {
+          "version": "1.0.1",
+          "from": "opn@^1.0.1",
+          "resolved": "http://registry.npmjs.org/opn/-/opn-1.0.1.tgz"
+        },
+        "p-throttler": {
+          "version": "0.1.1",
+          "from": "p-throttler@0.1.1",
+          "dependencies": {
+            "q": {
+              "version": "0.9.7",
+              "from": "q@~0.9.2",
+              "resolved": "http://registry.npmjs.org/q/-/q-0.9.7.tgz"
+            }
+          }
+        },
+        "promptly": {
+          "version": "0.2.0",
+          "from": "promptly@0.2.0",
+          "dependencies": {
+            "read": {
+              "version": "1.0.5",
+              "from": "read@~1.0.4",
+              "resolved": "http://registry.npmjs.org/read/-/read-1.0.5.tgz",
+              "dependencies": {
+                "mute-stream": {
+                  "version": "0.0.4",
+                  "from": "mute-stream@~0.0.4"
+                }
+              }
+            }
+          }
+        },
+        "q": {
+          "version": "1.2.0",
+          "from": "q@^1.1.2",
+          "resolved": "http://registry.npmjs.org/q/-/q-1.2.0.tgz"
+        },
+        "request": {
+          "version": "2.53.0",
+          "from": "request@2.53.0",
+          "dependencies": {
+            "bl": {
+              "version": "0.9.4",
+              "from": "bl@~0.9.0",
+              "resolved": "http://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@~1.0.26",
+                  "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@~0.10.x",
+                      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@~2.0.1"
+                    }
+                  }
+                }
+              }
+            },
+            "caseless": {
+              "version": "0.9.0",
+              "from": "caseless@~0.9.0",
+              "resolved": "http://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
+            },
+            "forever-agent": {
+              "version": "0.5.2",
+              "from": "forever-agent@~0.5.0",
+              "resolved": "http://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+            },
+            "form-data": {
+              "version": "0.2.0",
+              "from": "form-data@~0.2.0",
+              "resolved": "http://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.9.0",
+                  "from": "async@~0.9.0",
+                  "resolved": "http://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                }
+              }
+            },
+            "json-stringify-safe": {
+              "version": "5.0.0",
+              "from": "json-stringify-safe@~5.0.0",
+              "resolved": "http://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+            },
+            "mime-types": {
+              "version": "2.0.10",
+              "from": "mime-types@~2.0.1",
+              "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.8.0",
+                  "from": "mime-db@~1.8.0",
+                  "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
+                }
+              }
+            },
+            "node-uuid": {
+              "version": "1.4.3",
+              "from": "node-uuid@~1.4.0",
+              "resolved": "http://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+            },
+            "qs": {
+              "version": "2.3.3",
+              "from": "qs@~2.3.1",
+              "resolved": "http://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+            },
+            "tunnel-agent": {
+              "version": "0.4.0",
+              "from": "tunnel-agent@~0.4.0",
+              "resolved": "http://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+            },
+            "tough-cookie": {
+              "version": "0.12.1",
+              "from": "tough-cookie@>=0.12.0",
+              "resolved": "http://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+              "dependencies": {
+                "punycode": {
+                  "version": "1.3.2",
+                  "from": "punycode@>=0.2.0",
+                  "resolved": "http://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                }
+              }
+            },
+            "http-signature": {
+              "version": "0.10.1",
+              "from": "http-signature@~0.10.0",
+              "resolved": "http://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.1.5",
+                  "from": "assert-plus@^0.1.5",
+                  "resolved": "http://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                },
+                "asn1": {
+                  "version": "0.1.11",
+                  "from": "asn1@0.1.11",
+                  "resolved": "http://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                },
+                "ctype": {
+                  "version": "0.5.3",
+                  "from": "ctype@0.5.3",
+                  "resolved": "http://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.6.0",
+              "from": "oauth-sign@~0.6.0",
+              "resolved": "http://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
+            },
+            "hawk": {
+              "version": "2.3.1",
+              "from": "hawk@~2.3.0",
+              "resolved": "http://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+              "dependencies": {
+                "hoek": {
+                  "version": "2.12.0",
+                  "from": "hoek@2.x.x",
+                  "resolved": "http://registry.npmjs.org/hoek/-/hoek-2.12.0.tgz"
+                },
+                "boom": {
+                  "version": "2.7.0",
+                  "from": "boom@2.x.x",
+                  "resolved": "http://registry.npmjs.org/boom/-/boom-2.7.0.tgz"
+                },
+                "cryptiles": {
+                  "version": "2.0.4",
+                  "from": "cryptiles@2.x.x",
+                  "resolved": "http://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "from": "sntp@1.x.x",
+                  "resolved": "http://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                }
+              }
+            },
+            "aws-sign2": {
+              "version": "0.5.0",
+              "from": "aws-sign2@~0.5.0",
+              "resolved": "http://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+            },
+            "stringstream": {
+              "version": "0.0.4",
+              "from": "stringstream@~0.0.4",
+              "resolved": "http://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+            },
+            "combined-stream": {
+              "version": "0.0.7",
+              "from": "combined-stream@~0.0.5",
+              "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "0.0.5",
+                  "from": "delayed-stream@0.0.5",
+                  "resolved": "http://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                }
+              }
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "from": "isstream@~0.1.1",
+              "resolved": "http://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+            }
+          }
+        },
+        "request-progress": {
+          "version": "0.3.1",
+          "from": "request-progress@0.3.1",
+          "dependencies": {
+            "throttleit": {
+              "version": "0.0.2",
+              "from": "throttleit@~0.0.2",
+              "resolved": "http://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
+            }
+          }
+        },
+        "retry": {
+          "version": "0.6.1",
+          "from": "retry@0.6.1"
+        },
+        "rimraf": {
+          "version": "2.3.2",
+          "from": "rimraf@^2.2.8"
+        },
+        "semver": {
+          "version": "2.3.2",
+          "from": "semver@^2.3.0",
+          "resolved": "http://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
+        },
+        "shell-quote": {
+          "version": "1.4.3",
+          "from": "shell-quote@^1.4.2",
+          "resolved": "http://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
+          "dependencies": {
+            "jsonify": {
+              "version": "0.0.0",
+              "from": "jsonify@~0.0.0",
+              "resolved": "http://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+            },
+            "array-filter": {
+              "version": "0.0.1",
+              "from": "array-filter@~0.0.0",
+              "resolved": "http://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
+            },
+            "array-reduce": {
+              "version": "0.0.0",
+              "from": "array-reduce@~0.0.0",
+              "resolved": "http://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
+            },
+            "array-map": {
+              "version": "0.0.0",
+              "from": "array-map@~0.0.0",
+              "resolved": "http://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
+            }
+          }
+        },
+        "stringify-object": {
+          "version": "1.0.1",
+          "from": "stringify-object@^1.0.0",
+          "resolved": "http://registry.npmjs.org/stringify-object/-/stringify-object-1.0.1.tgz"
+        },
+        "tar-fs": {
+          "version": "1.5.0",
+          "from": "tar-fs@^1.4.1",
+          "resolved": "http://registry.npmjs.org/tar-fs/-/tar-fs-1.5.0.tgz",
+          "dependencies": {
+            "pump": {
+              "version": "1.0.0",
+              "from": "pump@^1.0.0",
+              "resolved": "http://registry.npmjs.org/pump/-/pump-1.0.0.tgz",
+              "dependencies": {
+                "end-of-stream": {
+                  "version": "1.1.0",
+                  "from": "end-of-stream@^1.1.0",
+                  "resolved": "http://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz"
+                },
+                "once": {
+                  "version": "1.3.1",
+                  "from": "once@^1.3.1",
+                  "resolved": "http://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@1",
+                      "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "tar-stream": {
+              "version": "1.1.3",
+              "from": "tar-stream@^1.1.2",
+              "dependencies": {
+                "bl": {
+                  "version": "0.9.4",
+                  "from": "bl@^0.9.0",
+                  "resolved": "http://registry.npmjs.org/bl/-/bl-0.9.4.tgz"
+                },
+                "end-of-stream": {
+                  "version": "1.1.0",
+                  "from": "end-of-stream@^1.0.0",
+                  "resolved": "http://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                  "dependencies": {
+                    "once": {
+                      "version": "1.3.1",
+                      "from": "once@~1.3.0",
+                      "resolved": "http://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@1",
+                          "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@~1.0.33",
+                  "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@~0.10.x",
+                      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@~2.0.1"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.0",
+                  "from": "xtend@^4.0.0",
+                  "resolved": "http://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "tmp": {
+          "version": "0.0.24",
+          "from": "tmp@0.0.24",
+          "resolved": "http://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz"
+        },
+        "update-notifier": {
+          "version": "0.3.1",
+          "from": "update-notifier@^0.3.0",
+          "resolved": "http://registry.npmjs.org/update-notifier/-/update-notifier-0.3.1.tgz",
+          "dependencies": {
+            "is-npm": {
+              "version": "1.0.0",
+              "from": "is-npm@^1.0.0",
+              "resolved": "http://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz"
+            },
+            "latest-version": {
+              "version": "1.0.0",
+              "from": "latest-version@^1.0.0",
+              "resolved": "http://registry.npmjs.org/latest-version/-/latest-version-1.0.0.tgz",
+              "dependencies": {
+                "package-json": {
+                  "version": "1.1.0",
+                  "from": "package-json@^1.0.0",
+                  "resolved": "http://registry.npmjs.org/package-json/-/package-json-1.1.0.tgz",
+                  "dependencies": {
+                    "got": {
+                      "version": "2.7.2",
+                      "from": "got@^2.4.0",
+                      "resolved": "http://registry.npmjs.org/got/-/got-2.7.2.tgz",
+                      "dependencies": {
+                        "duplexify": {
+                          "version": "3.2.0",
+                          "from": "duplexify@^3.2.0",
+                          "resolved": "http://registry.npmjs.org/duplexify/-/duplexify-3.2.0.tgz",
+                          "dependencies": {
+                            "end-of-stream": {
+                              "version": "1.0.0",
+                              "from": "end-of-stream@1.0.0",
+                              "dependencies": {
+                                "once": {
+                                  "version": "1.3.1",
+                                  "from": "once@~1.3.0",
+                                  "resolved": "http://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.1",
+                                      "from": "wrappy@1",
+                                      "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "readable-stream": {
+                              "version": "1.0.33",
+                              "from": "readable-stream@^1.0.27-1",
+                              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.1",
+                                  "from": "core-util-is@~1.0.0",
+                                  "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                },
+                                "isarray": {
+                                  "version": "0.0.1",
+                                  "from": "isarray@0.0.1",
+                                  "resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.31",
+                                  "from": "string_decoder@~0.10.x",
+                                  "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@~2.0.1"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "infinity-agent": {
+                          "version": "1.0.2",
+                          "from": "infinity-agent@^1.0.0",
+                          "resolved": "http://registry.npmjs.org/infinity-agent/-/infinity-agent-1.0.2.tgz"
+                        },
+                        "is-stream": {
+                          "version": "1.0.1",
+                          "from": "is-stream@^1.0.0",
+                          "resolved": "http://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz"
+                        },
+                        "lowercase-keys": {
+                          "version": "1.0.0",
+                          "from": "lowercase-keys@^1.0.0",
+                          "resolved": "http://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
+                        },
+                        "nested-error-stacks": {
+                          "version": "1.0.0",
+                          "from": "nested-error-stacks@^1.0.0",
+                          "resolved": "http://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.0.tgz"
+                        },
+                        "object-assign": {
+                          "version": "2.0.0",
+                          "from": "object-assign@^2.0.0",
+                          "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+                        },
+                        "prepend-http": {
+                          "version": "1.0.1",
+                          "from": "prepend-http@^1.0.0",
+                          "resolved": "http://registry.npmjs.org/prepend-http/-/prepend-http-1.0.1.tgz"
+                        },
+                        "read-all-stream": {
+                          "version": "2.1.2",
+                          "from": "read-all-stream@^2.0.0",
+                          "dependencies": {
+                            "readable-stream": {
+                              "version": "1.1.13",
+                              "from": "readable-stream@~1.1.13",
+                              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.1",
+                                  "from": "core-util-is@~1.0.0",
+                                  "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                },
+                                "isarray": {
+                                  "version": "0.0.1",
+                                  "from": "isarray@0.0.1",
+                                  "resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.31",
+                                  "from": "string_decoder@~0.10.x",
+                                  "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@~2.0.1"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "statuses": {
+                          "version": "1.2.1",
+                          "from": "statuses@^1.2.1"
+                        },
+                        "timed-out": {
+                          "version": "2.0.0",
+                          "from": "timed-out@^2.0.0",
+                          "resolved": "http://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "registry-url": {
+                      "version": "3.0.3",
+                      "from": "registry-url@^3.0.0",
+                      "resolved": "http://registry.npmjs.org/registry-url/-/registry-url-3.0.3.tgz",
+                      "dependencies": {
+                        "rc": {
+                          "version": "1.0.1",
+                          "from": "rc@^1.0.1",
+                          "resolved": "http://registry.npmjs.org/rc/-/rc-1.0.1.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.10",
+                              "from": "minimist@~0.0.7",
+                              "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                            },
+                            "deep-extend": {
+                              "version": "0.2.11",
+                              "from": "deep-extend@~0.2.5",
+                              "resolved": "http://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+                            },
+                            "strip-json-comments": {
+                              "version": "0.1.3",
+                              "from": "strip-json-comments@0.1.x",
+                              "resolved": "http://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+                            },
+                            "ini": {
+                              "version": "1.3.3",
+                              "from": "ini@~1.3.0",
+                              "resolved": "http://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "semver-diff": {
+              "version": "2.0.0",
+              "from": "semver-diff@^2.0.0",
+              "resolved": "http://registry.npmjs.org/semver-diff/-/semver-diff-2.0.0.tgz",
+              "dependencies": {
+                "semver": {
+                  "version": "4.3.3",
+                  "from": "semver@^4.0.0"
+                }
+              }
+            },
+            "string-length": {
+              "version": "1.0.0",
+              "from": "string-length@^1.0.0",
+              "resolved": "http://registry.npmjs.org/string-length/-/string-length-1.0.0.tgz",
+              "dependencies": {
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@^2.0.0",
+                  "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.0.0",
+                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "user-home": {
+          "version": "1.1.1",
+          "from": "user-home@^1.1.0",
+          "resolved": "http://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+        },
+        "which": {
+          "version": "1.0.9",
+          "from": "which@^1.0.8",
+          "resolved": "http://registry.npmjs.org/which/-/which-1.0.9.tgz"
+        }
+      }
+    },
+    "brunch": {
+      "version": "1.8.0",
+      "from": "brunch@1.8.0",
+      "dependencies": {
+        "anymatch": {
+          "version": "1.1.0",
+          "from": "anymatch@~1.1.0",
+          "dependencies": {
+            "minimatch": {
+              "version": "1.0.0",
+              "from": "minimatch@~1.0.0",
+              "resolved": "http://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.0",
+                  "from": "lru-cache@2",
+                  "resolved": "http://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@~1.0.0",
+                  "resolved": "http://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "anysort": {
+          "version": "1.0.0",
+          "from": "anysort@~1.0.0",
+          "resolved": "http://registry.npmjs.org/anysort/-/anysort-1.0.0.tgz",
+          "dependencies": {
+            "anymatch": {
+              "version": "1.0.0",
+              "from": "anymatch@~1.0.0",
+              "resolved": "http://registry.npmjs.org/anymatch/-/anymatch-1.0.0.tgz",
+              "dependencies": {
+                "minimatch": {
+                  "version": "1.0.0",
+                  "from": "minimatch@~1.0.0",
+                  "resolved": "http://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "from": "lru-cache@2",
+                      "resolved": "http://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@~1.0.0",
+                      "resolved": "http://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "async-each": {
+          "version": "0.1.6",
+          "from": "async-each@~0.1.2",
+          "resolved": "http://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+        },
+        "async-waterfall": {
+          "version": "0.1.5",
+          "from": "async-waterfall@~0.1.2",
+          "resolved": "http://registry.npmjs.org/async-waterfall/-/async-waterfall-0.1.5.tgz"
+        },
+        "chokidar": {
+          "version": "0.12.6",
+          "from": "chokidar@~1.0.0",
+          "dependencies": {
+            "arrify": {
+              "version": "1.0.0",
+              "from": "arrify@^1.0.0",
+              "resolved": "http://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
+            },
+            "glob-parent": {
+              "version": "1.2.0",
+              "from": "glob-parent@^1.0.0"
+            },
+            "is-binary-path": {
+              "version": "1.0.0",
+              "from": "is-binary-path@^1.0.0",
+              "dependencies": {
+                "binary-extensions": {
+                  "version": "1.3.0",
+                  "from": "binary-extensions@^1.0.0"
+                }
+              }
+            },
+            "is-glob": {
+              "version": "1.1.3",
+              "from": "is-glob@^1.1.3"
+            },
+            "readdirp": {
+              "version": "1.3.0",
+              "from": "readdirp@^1.3.0",
+              "resolved": "http://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "2.0.3",
+                  "from": "graceful-fs@~2.0.0",
+                  "resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+                },
+                "minimatch": {
+                  "version": "0.2.14",
+                  "from": "minimatch@~0.2.12",
+                  "resolved": "http://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "from": "lru-cache@2",
+                      "resolved": "http://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@~1.0.0",
+                      "resolved": "http://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@~1.0.26-2",
+                  "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@~0.10.x",
+                      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@~2.0.1"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "coffee-script": {
+          "version": "1.9.1",
+          "from": "coffee-script@~1.9.0"
+        },
+        "commander": {
+          "version": "2.7.1",
+          "from": "commander@~2.7.1",
+          "dependencies": {
+            "graceful-readlink": {
+              "version": "1.0.1",
+              "from": "graceful-readlink@>= 1.0.0",
+              "resolved": "http://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+            }
+          }
+        },
+        "commonjs-require-definition": {
+          "version": "0.2.0",
+          "from": "commonjs-require-definition@~0.2.0",
+          "resolved": "http://registry.npmjs.org/commonjs-require-definition/-/commonjs-require-definition-0.2.0.tgz"
+        },
+        "debug": {
+          "version": "2.1.3",
+          "from": "debug@~2.1.1",
+          "resolved": "http://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.0",
+              "from": "ms@0.7.0",
+              "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
+            }
+          }
+        },
+        "deppack": {
+          "version": "0.0.82",
+          "from": "deppack@~0.0.8",
+          "resolved": "http://registry.npmjs.org/deppack/-/deppack-0.0.82.tgz",
+          "dependencies": {
+            "detective": {
+              "version": "4.0.0",
+              "from": "detective@~4.0.0",
+              "resolved": "http://registry.npmjs.org/detective/-/detective-4.0.0.tgz",
+              "dependencies": {
+                "acorn": {
+                  "version": "0.9.0",
+                  "from": "acorn@~0.9.0",
+                  "resolved": "http://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
+                },
+                "defined": {
+                  "version": "0.0.0",
+                  "from": "defined@0.0.0"
+                },
+                "escodegen": {
+                  "version": "1.6.1",
+                  "from": "escodegen@^1.4.1",
+                  "resolved": "http://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
+                  "dependencies": {
+                    "estraverse": {
+                      "version": "1.9.3",
+                      "from": "estraverse@^1.9.1",
+                      "resolved": "http://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
+                    },
+                    "esutils": {
+                      "version": "1.1.6",
+                      "from": "esutils@^1.1.6",
+                      "resolved": "http://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
+                    },
+                    "esprima": {
+                      "version": "1.2.5",
+                      "from": "esprima@^1.2.2"
+                    },
+                    "optionator": {
+                      "version": "0.5.0",
+                      "from": "optionator@^0.5.0",
+                      "resolved": "http://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+                      "dependencies": {
+                        "prelude-ls": {
+                          "version": "1.1.1",
+                          "from": "prelude-ls@~1.1.1",
+                          "resolved": "http://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
+                        },
+                        "deep-is": {
+                          "version": "0.1.3",
+                          "from": "deep-is@~0.1.2",
+                          "resolved": "http://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+                        },
+                        "wordwrap": {
+                          "version": "0.0.2",
+                          "from": "wordwrap@~0.0.2"
+                        },
+                        "type-check": {
+                          "version": "0.3.1",
+                          "from": "type-check@~0.3.1",
+                          "resolved": "http://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
+                        },
+                        "levn": {
+                          "version": "0.2.5",
+                          "from": "levn@~0.2.5",
+                          "resolved": "http://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
+                        },
+                        "fast-levenshtein": {
+                          "version": "1.0.6",
+                          "from": "fast-levenshtein@~1.0.0",
+                          "resolved": "http://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
+                        }
+                      }
+                    },
+                    "source-map": {
+                      "version": "0.1.43",
+                      "from": "source-map@~0.1.40",
+                      "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "0.1.0",
+                          "from": "amdefine@>=0.0.4",
+                          "resolved": "http://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "browser-resolve": {
+              "version": "1.7.2",
+              "from": "browser-resolve@~1.7.2",
+              "resolved": "http://registry.npmjs.org/browser-resolve/-/browser-resolve-1.7.2.tgz",
+              "dependencies": {
+                "resolve": {
+                  "version": "1.1.5",
+                  "from": "resolve@1.1.5"
+                }
+              }
+            }
+          }
+        },
+        "fcache": {
+          "version": "0.1.1",
+          "from": "fcache@~0.1.0",
+          "resolved": "http://registry.npmjs.org/fcache/-/fcache-0.1.1.tgz"
+        },
+        "init-skeleton": {
+          "version": "0.4.0",
+          "from": "init-skeleton@~0.4.0",
+          "resolved": "http://registry.npmjs.org/init-skeleton/-/init-skeleton-0.4.0.tgz",
+          "dependencies": {
+            "rimraf": {
+              "version": "2.3.2",
+              "from": "rimraf@~2.3.2",
+              "dependencies": {
+                "glob": {
+                  "version": "4.5.3",
+                  "from": "glob@^4.4.2",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "inflight@^1.0.4",
+                      "resolved": "http://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@1",
+                          "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@2"
+                    },
+                    "minimatch": {
+                      "version": "2.0.4",
+                      "from": "minimatch@^2.0.1",
+                      "resolved": "http://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.0",
+                          "from": "brace-expansion@^1.0.0",
+                          "resolved": "http://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.0",
+                              "from": "balanced-match@^0.2.0",
+                              "resolved": "http://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.1",
+                      "from": "once@^1.3.0",
+                      "resolved": "http://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@1",
+                          "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "ncp": {
+              "version": "2.0.0",
+              "from": "ncp@~2.0.0",
+              "resolved": "http://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz"
+            }
+          }
+        },
+        "loggy": {
+          "version": "0.2.0",
+          "from": "loggy@~0.2.0",
+          "resolved": "http://registry.npmjs.org/loggy/-/loggy-0.2.0.tgz",
+          "dependencies": {
+            "ansi-color": {
+              "version": "0.2.1",
+              "from": "ansi-color@~0.2.1",
+              "resolved": "http://registry.npmjs.org/ansi-color/-/ansi-color-0.2.1.tgz"
+            },
+            "growl": {
+              "version": "1.7.0",
+              "from": "growl@~1.7.0",
+              "resolved": "http://registry.npmjs.org/growl/-/growl-1.7.0.tgz"
+            },
+            "date-utils": {
+              "version": "1.2.16",
+              "from": "date-utils@~1.2.12",
+              "resolved": "http://registry.npmjs.org/date-utils/-/date-utils-1.2.16.tgz"
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "from": "mkdirp@~0.5.0",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8"
+            }
+          }
+        },
+        "pushserve": {
+          "version": "0.1.6",
+          "from": "pushserve@~0.1.6",
+          "resolved": "http://registry.npmjs.org/pushserve/-/pushserve-0.1.6.tgz",
+          "dependencies": {
+            "express": {
+              "version": "3.3.8",
+              "from": "express@~3.3.0",
+              "resolved": "http://registry.npmjs.org/express/-/express-3.3.8.tgz",
+              "dependencies": {
+                "connect": {
+                  "version": "2.8.8",
+                  "from": "connect@2.8.8",
+                  "dependencies": {
+                    "qs": {
+                      "version": "0.6.5",
+                      "from": "qs@0.6.5"
+                    },
+                    "formidable": {
+                      "version": "1.0.14",
+                      "from": "formidable@1.0.14"
+                    },
+                    "bytes": {
+                      "version": "0.2.0",
+                      "from": "bytes@0.2.0"
+                    },
+                    "pause": {
+                      "version": "0.0.1",
+                      "from": "pause@0.0.1",
+                      "resolved": "http://registry.npmjs.org/pause/-/pause-0.0.1.tgz"
+                    },
+                    "uid2": {
+                      "version": "0.0.2",
+                      "from": "uid2@0.0.2"
+                    }
+                  }
+                },
+                "commander": {
+                  "version": "1.2.0",
+                  "from": "commander@1.2.0",
+                  "dependencies": {
+                    "keypress": {
+                      "version": "0.1.0",
+                      "from": "keypress@0.1.x",
+                      "resolved": "http://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz"
+                    }
+                  }
+                },
+                "range-parser": {
+                  "version": "0.0.4",
+                  "from": "range-parser@0.0.4"
+                },
+                "mkdirp": {
+                  "version": "0.3.5",
+                  "from": "mkdirp@0.3.5"
+                },
+                "cookie": {
+                  "version": "0.1.0",
+                  "from": "cookie@0.1.0"
+                },
+                "buffer-crc32": {
+                  "version": "0.2.1",
+                  "from": "buffer-crc32@0.2.1"
+                },
+                "fresh": {
+                  "version": "0.2.0",
+                  "from": "fresh@0.2.0"
+                },
+                "methods": {
+                  "version": "0.0.1",
+                  "from": "methods@0.0.1",
+                  "resolved": "http://registry.npmjs.org/methods/-/methods-0.0.1.tgz"
+                },
+                "send": {
+                  "version": "0.1.4",
+                  "from": "send@0.1.4",
+                  "dependencies": {
+                    "mime": {
+                      "version": "1.2.11",
+                      "from": "mime@~1.2.9",
+                      "resolved": "http://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                    }
+                  }
+                },
+                "cookie-signature": {
+                  "version": "1.0.1",
+                  "from": "cookie-signature@1.0.1"
+                }
+              }
+            },
+            "commander": {
+              "version": "2.0.0",
+              "from": "commander@~2.0.0",
+              "resolved": "http://registry.npmjs.org/commander/-/commander-2.0.0.tgz"
+            },
+            "connect-slashes": {
+              "version": "0.0.11",
+              "from": "connect-slashes@~0.0.9",
+              "resolved": "http://registry.npmjs.org/connect-slashes/-/connect-slashes-0.0.11.tgz"
+            }
+          }
+        },
+        "quickly-copy-file": {
+          "version": "0.1.0",
+          "from": "quickly-copy-file@~0.1.0",
+          "resolved": "http://registry.npmjs.org/quickly-copy-file/-/quickly-copy-file-0.1.0.tgz"
+        },
+        "read-components": {
+          "version": "0.6.1",
+          "from": "read-components@~0.6.0",
+          "resolved": "http://registry.npmjs.org/read-components/-/read-components-0.6.1.tgz",
+          "dependencies": {
+            "component-builder": {
+              "version": "0.10.1",
+              "from": "component-builder@~0.10.0",
+              "resolved": "http://registry.npmjs.org/component-builder/-/component-builder-0.10.1.tgz",
+              "dependencies": {
+                "component-require": {
+                  "version": "0.3.1",
+                  "from": "component-require@0.3.1"
+                },
+                "batch": {
+                  "version": "0.2.1",
+                  "from": "batch@0.2.1"
+                },
+                "mkdirp": {
+                  "version": "0.3.4",
+                  "from": "mkdirp@0.3.4"
+                },
+                "cp": {
+                  "version": "0.1.1",
+                  "from": "cp@~0.1.0",
+                  "resolved": "http://registry.npmjs.org/cp/-/cp-0.1.1.tgz"
+                },
+                "string-to-js": {
+                  "version": "0.0.1",
+                  "from": "string-to-js@0.0.1"
+                }
+              }
+            }
+          }
+        },
+        "source-map": {
+          "version": "0.3.0",
+          "from": "source-map@~0.3.0",
+          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
+          "dependencies": {
+            "amdefine": {
+              "version": "0.1.0",
+              "from": "amdefine@>=0.0.4",
+              "resolved": "http://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "clean-css-brunch": {
+      "version": "1.7.2",
+      "from": "clean-css-brunch@>= 1.0 < 1.8",
+      "resolved": "http://registry.npmjs.org/clean-css-brunch/-/clean-css-brunch-1.7.2.tgz",
+      "dependencies": {
+        "clean-css": {
+          "version": "3.1.9",
+          "from": "clean-css@~3.1.5",
+          "resolved": "http://registry.npmjs.org/clean-css/-/clean-css-3.1.9.tgz",
+          "dependencies": {
+            "commander": {
+              "version": "2.6.0",
+              "from": "commander@2.6.x",
+              "resolved": "http://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
+            },
+            "source-map": {
+              "version": "0.1.43",
+              "from": "source-map@>=0.1.43 <0.2",
+              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "http://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "coffee-script-brunch": {
+      "version": "1.7.3",
+      "from": "coffee-script-brunch@>= 1.0 < 1.8",
+      "resolved": "http://registry.npmjs.org/coffee-script-brunch/-/coffee-script-brunch-1.7.3.tgz",
+      "dependencies": {
+        "coffee-script": {
+          "version": "1.6.3",
+          "from": "coffee-script@~1.6.3",
+          "resolved": "http://registry.npmjs.org/coffee-script/-/coffee-script-1.6.3.tgz"
+        }
+      }
+    },
+    "css-brunch": {
+      "version": "1.7.0",
+      "from": "css-brunch@>= 1.0 < 1.8",
+      "resolved": "http://registry.npmjs.org/css-brunch/-/css-brunch-1.7.0.tgz"
+    },
+    "handlebars-brunch": {
+      "version": "1.9.1",
+      "from": "handlebars-brunch@^1.9.1",
+      "resolved": "http://registry.npmjs.org/handlebars-brunch/-/handlebars-brunch-1.9.1.tgz",
+      "dependencies": {
+        "handlebars": {
+          "version": "2.0.0",
+          "from": "handlebars@^2.0.0",
+          "resolved": "http://registry.npmjs.org/handlebars/-/handlebars-2.0.0.tgz",
+          "dependencies": {
+            "optimist": {
+              "version": "0.3.7",
+              "from": "optimist@~0.3",
+              "resolved": "http://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "wordwrap@~0.0.2"
+                }
+              }
+            },
+            "uglify-js": {
+              "version": "2.3.6",
+              "from": "uglify-js@~2.3",
+              "resolved": "http://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@~0.2.6",
+                  "resolved": "http://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
+                "source-map": {
+                  "version": "0.1.43",
+                  "from": "source-map@~0.1.7",
+                  "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "http://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "umd-wrapper": {
+          "version": "0.1.0",
+          "from": "umd-wrapper@~0.1.0",
+          "resolved": "http://registry.npmjs.org/umd-wrapper/-/umd-wrapper-0.1.0.tgz"
+        }
+      }
+    },
+    "javascript-brunch": {
+      "version": "1.7.1",
+      "from": "javascript-brunch@>= 1.0 < 1.8",
+      "resolved": "http://registry.npmjs.org/javascript-brunch/-/javascript-brunch-1.7.1.tgz",
+      "dependencies": {
+        "esprima": {
+          "version": "1.0.4",
+          "from": "esprima@~1.0.4",
+          "resolved": "http://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+        }
+      }
+    },
+    "less-brunch": {
+      "version": "1.8.1",
+      "from": "less-brunch@^1.7.2",
+      "resolved": "http://registry.npmjs.org/less-brunch/-/less-brunch-1.8.1.tgz",
+      "dependencies": {
+        "less": {
+          "version": "2.5.0",
+          "from": "less@^2.2.0",
+          "resolved": "http://registry.npmjs.org/less/-/less-2.5.0.tgz",
+          "dependencies": {
+            "errno": {
+              "version": "0.1.2",
+              "from": "errno@^0.1.1",
+              "resolved": "http://registry.npmjs.org/errno/-/errno-0.1.2.tgz",
+              "dependencies": {
+                "prr": {
+                  "version": "0.0.0",
+                  "from": "prr@~0.0.0",
+                  "resolved": "http://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "3.0.6",
+              "from": "graceful-fs@^3.0.5"
+            },
+            "image-size": {
+              "version": "0.3.5",
+              "from": "image-size@~0.3.5",
+              "resolved": "http://registry.npmjs.org/image-size/-/image-size-0.3.5.tgz"
+            },
+            "mime": {
+              "version": "1.3.4",
+              "from": "mime@^1.2.11",
+              "resolved": "http://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+            },
+            "mkdirp": {
+              "version": "0.5.0",
+              "from": "mkdirp@^0.5.0",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8"
+                }
+              }
+            },
+            "promise": {
+              "version": "6.1.0",
+              "from": "promise@^6.0.1",
+              "resolved": "http://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
+              "dependencies": {
+                "asap": {
+                  "version": "1.0.0",
+                  "from": "asap@~1.0.0",
+                  "resolved": "http://registry.npmjs.org/asap/-/asap-1.0.0.tgz"
+                }
+              }
+            },
+            "request": {
+              "version": "2.55.0",
+              "from": "request@^2.51.0",
+              "resolved": "http://registry.npmjs.org/request/-/request-2.55.0.tgz",
+              "dependencies": {
+                "bl": {
+                  "version": "0.9.4",
+                  "from": "bl@~0.9.0",
+                  "resolved": "http://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@~1.0.26",
+                      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@~0.10.x",
+                          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.1"
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.9.0",
+                  "from": "caseless@~0.9.0",
+                  "resolved": "http://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
+                },
+                "forever-agent": {
+                  "version": "0.6.1",
+                  "from": "forever-agent@~0.6.0"
+                },
+                "form-data": {
+                  "version": "0.2.0",
+                  "from": "form-data@~0.2.0",
+                  "resolved": "http://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.9.0",
+                      "from": "async@~0.9.0",
+                      "resolved": "http://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                    }
+                  }
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.0",
+                  "from": "json-stringify-safe@~5.0.0",
+                  "resolved": "http://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                },
+                "mime-types": {
+                  "version": "2.0.10",
+                  "from": "mime-types@~2.0.1",
+                  "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.8.0",
+                      "from": "mime-db@~1.8.0",
+                      "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
+                    }
+                  }
+                },
+                "node-uuid": {
+                  "version": "1.4.3",
+                  "from": "node-uuid@~1.4.0",
+                  "resolved": "http://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                },
+                "qs": {
+                  "version": "2.4.1",
+                  "from": "qs@~2.4.0",
+                  "resolved": "http://registry.npmjs.org/qs/-/qs-2.4.1.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.0",
+                  "from": "tunnel-agent@~0.4.0",
+                  "resolved": "http://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                },
+                "tough-cookie": {
+                  "version": "0.12.1",
+                  "from": "tough-cookie@>=0.12.0",
+                  "resolved": "http://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                  "dependencies": {
+                    "punycode": {
+                      "version": "1.3.2",
+                      "from": "punycode@>=0.2.0",
+                      "resolved": "http://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "0.10.1",
+                  "from": "http-signature@~0.10.0",
+                  "resolved": "http://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@^0.1.5",
+                      "resolved": "http://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11",
+                      "resolved": "http://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "ctype@0.5.3",
+                      "resolved": "http://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.6.0",
+                  "from": "oauth-sign@~0.6.0",
+                  "resolved": "http://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
+                },
+                "hawk": {
+                  "version": "2.3.1",
+                  "from": "hawk@~2.3.0",
+                  "resolved": "http://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "2.12.0",
+                      "from": "hoek@2.x.x",
+                      "resolved": "http://registry.npmjs.org/hoek/-/hoek-2.12.0.tgz"
+                    },
+                    "boom": {
+                      "version": "2.7.0",
+                      "from": "boom@2.x.x",
+                      "resolved": "http://registry.npmjs.org/boom/-/boom-2.7.0.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.4",
+                      "from": "cryptiles@2.x.x",
+                      "resolved": "http://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "from": "sntp@1.x.x",
+                      "resolved": "http://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "from": "aws-sign2@~0.5.0",
+                  "resolved": "http://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                },
+                "stringstream": {
+                  "version": "0.0.4",
+                  "from": "stringstream@~0.0.4",
+                  "resolved": "http://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                },
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "from": "combined-stream@~0.0.5",
+                  "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "from": "delayed-stream@0.0.5",
+                      "resolved": "http://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    }
+                  }
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "from": "isstream@~0.1.1",
+                  "resolved": "http://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                },
+                "har-validator": {
+                  "version": "1.6.1",
+                  "from": "har-validator@^1.4.0",
+                  "resolved": "http://registry.npmjs.org/har-validator/-/har-validator-1.6.1.tgz",
+                  "dependencies": {
+                    "bluebird": {
+                      "version": "2.9.24",
+                      "from": "bluebird@^2.9.21",
+                      "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.9.24.tgz"
+                    },
+                    "chalk": {
+                      "version": "1.0.0",
+                      "from": "chalk@^1.0.0",
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.0.1",
+                          "from": "ansi-styles@^2.0.1"
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.3",
+                          "from": "escape-string-regexp@^1.0.2",
+                          "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                        },
+                        "has-ansi": {
+                          "version": "1.0.3",
+                          "from": "has-ansi@^1.0.3",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "1.1.1",
+                              "from": "ansi-regex@^1.1.0",
+                              "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                            },
+                            "get-stdin": {
+                              "version": "4.0.1",
+                              "from": "get-stdin@^4.0.1",
+                              "resolved": "http://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "2.0.1",
+                          "from": "strip-ansi@^2.0.1",
+                          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "1.1.1",
+                              "from": "ansi-regex@^1.0.0",
+                              "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "1.3.1",
+                          "from": "supports-color@^1.3.0"
+                        }
+                      }
+                    },
+                    "commander": {
+                      "version": "2.7.1",
+                      "from": "commander@^2.7.1",
+                      "dependencies": {
+                        "graceful-readlink": {
+                          "version": "1.0.1",
+                          "from": "graceful-readlink@>= 1.0.0",
+                          "resolved": "http://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "is-my-json-valid": {
+                      "version": "2.10.1",
+                      "from": "is-my-json-valid@^2.10.0",
+                      "dependencies": {
+                        "generate-function": {
+                          "version": "2.0.0",
+                          "from": "generate-function@^2.0.0",
+                          "resolved": "http://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                        },
+                        "generate-object-property": {
+                          "version": "1.1.1",
+                          "from": "generate-object-property@^1.1.0",
+                          "resolved": "http://registry.npmjs.org/generate-object-property/-/generate-object-property-1.1.1.tgz",
+                          "dependencies": {
+                            "is-property": {
+                              "version": "1.0.2",
+                              "from": "is-property@^1.0.0",
+                              "resolved": "http://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "jsonpointer": {
+                          "version": "1.1.0",
+                          "from": "jsonpointer@^1.1.0",
+                          "resolved": "http://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
+                        },
+                        "xtend": {
+                          "version": "4.0.0",
+                          "from": "xtend@^4.0.0",
+                          "resolved": "http://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.4.2",
+              "from": "source-map@^0.4.2",
+              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "http://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "progeny": {
+          "version": "0.5.2",
+          "from": "progeny@^0.5.0",
+          "resolved": "http://registry.npmjs.org/progeny/-/progeny-0.5.2.tgz",
+          "dependencies": {
+            "async-each": {
+              "version": "0.1.6",
+              "from": "async-each@~0.1.4",
+              "resolved": "http://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+            },
+            "fs-mode": {
+              "version": "1.0.1",
+              "from": "fs-mode@^1.0.1",
+              "resolved": "http://registry.npmjs.org/fs-mode/-/fs-mode-1.0.1.tgz",
+              "dependencies": {
+                "cbify": {
+                  "version": "1.0.0",
+                  "from": "cbify@^1.0.0",
+                  "resolved": "http://registry.npmjs.org/cbify/-/cbify-1.0.0.tgz",
+                  "dependencies": {
+                    "fn-args": {
+                      "version": "1.0.0",
+                      "from": "fn-args@^1.0.0",
+                      "resolved": "http://registry.npmjs.org/fn-args/-/fn-args-1.0.0.tgz"
+                    },
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@^1.0.1",
+                      "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "stylus-brunch": {
+      "version": "1.7.0",
+      "from": "stylus-brunch@>= 1.0 < 1.8",
+      "resolved": "http://registry.npmjs.org/stylus-brunch/-/stylus-brunch-1.7.0.tgz",
+      "dependencies": {
+        "stylus": {
+          "version": "0.50.0",
+          "from": "stylus@0.x",
+          "resolved": "http://registry.npmjs.org/stylus/-/stylus-0.50.0.tgz",
+          "dependencies": {
+            "css-parse": {
+              "version": "1.7.0",
+              "from": "css-parse@1.7.x",
+              "resolved": "http://registry.npmjs.org/css-parse/-/css-parse-1.7.0.tgz"
+            },
+            "mkdirp": {
+              "version": "0.3.5",
+              "from": "mkdirp@0.3.x"
+            },
+            "debug": {
+              "version": "2.1.3",
+              "from": "debug@*",
+              "resolved": "http://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.0",
+                  "from": "ms@0.7.0",
+                  "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
+                }
+              }
+            },
+            "sax": {
+              "version": "0.5.8",
+              "from": "sax@0.5.x",
+              "resolved": "http://registry.npmjs.org/sax/-/sax-0.5.8.tgz"
+            },
+            "glob": {
+              "version": "3.2.11",
+              "from": "glob@3.2.x",
+              "resolved": "http://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@2"
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "from": "minimatch@0.3",
+                  "resolved": "http://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "from": "lru-cache@2",
+                      "resolved": "http://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@~1.0.0",
+                      "resolved": "http://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.1.43",
+              "from": "source-map@0.1.x",
+              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "http://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "nib": {
+          "version": "1.0.4",
+          "from": "nib@~1.0.0",
+          "resolved": "http://registry.npmjs.org/nib/-/nib-1.0.4.tgz",
+          "dependencies": {
+            "stylus": {
+              "version": "0.45.1",
+              "from": "stylus@0.45.x",
+              "resolved": "http://registry.npmjs.org/stylus/-/stylus-0.45.1.tgz",
+              "dependencies": {
+                "css-parse": {
+                  "version": "1.7.0",
+                  "from": "css-parse@1.7.x",
+                  "resolved": "http://registry.npmjs.org/css-parse/-/css-parse-1.7.0.tgz"
+                },
+                "mkdirp": {
+                  "version": "0.3.5",
+                  "from": "mkdirp@0.3.x"
+                },
+                "debug": {
+                  "version": "2.1.3",
+                  "from": "debug@*",
+                  "resolved": "http://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.0",
+                      "from": "ms@0.7.0",
+                      "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
+                    }
+                  }
+                },
+                "sax": {
+                  "version": "0.5.8",
+                  "from": "sax@0.5.x",
+                  "resolved": "http://registry.npmjs.org/sax/-/sax-0.5.8.tgz"
+                },
+                "glob": {
+                  "version": "3.2.11",
+                  "from": "glob@3.2.x",
+                  "resolved": "http://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@2"
+                    },
+                    "minimatch": {
+                      "version": "0.3.0",
+                      "from": "minimatch@0.3",
+                      "resolved": "http://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "from": "lru-cache@2",
+                          "resolved": "http://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "from": "sigmund@~1.0.0",
+                          "resolved": "http://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "node-sprite": {
+          "version": "0.1.1",
+          "from": "node-sprite@0.1.1",
+          "dependencies": {
+            "coffee-script": {
+              "version": "1.3.3",
+              "from": "coffee-script@1.3.3"
+            },
+            "underscore": {
+              "version": "1.3.1",
+              "from": "underscore@1.3.1"
+            },
+            "imagemagick": {
+              "version": "0.1.2",
+              "from": "http://github.com/naltatis/node-imagemagick/tarball/master",
+              "resolved": "http://github.com/naltatis/node-imagemagick/tarball/master"
+            },
+            "seq": {
+              "version": "0.3.5",
+              "from": "seq@0.3.5",
+              "dependencies": {
+                "chainsaw": {
+                  "version": "0.0.9",
+                  "from": "chainsaw@>=0.0.7 <0.1",
+                  "resolved": "http://registry.npmjs.org/chainsaw/-/chainsaw-0.0.9.tgz",
+                  "dependencies": {
+                    "traverse": {
+                      "version": "0.3.9",
+                      "from": "traverse@>=0.3.0 <0.4",
+                      "resolved": "http://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
+                    }
+                  }
+                },
+                "hashish": {
+                  "version": "0.0.4",
+                  "from": "hashish@>=0.0.2 <0.1",
+                  "resolved": "http://registry.npmjs.org/hashish/-/hashish-0.0.4.tgz",
+                  "dependencies": {
+                    "traverse": {
+                      "version": "0.6.6",
+                      "from": "traverse@>=0.2.4",
+                      "resolved": "http://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "watch": {
+              "version": "0.5.1",
+              "from": "watch@0.5.1"
+            }
+          }
+        },
+        "progeny": {
+          "version": "0.1.3",
+          "from": "progeny@~0.1.1",
+          "resolved": "http://registry.npmjs.org/progeny/-/progeny-0.1.3.tgz",
+          "dependencies": {
+            "async-each": {
+              "version": "0.1.6",
+              "from": "async-each@~0.1.3",
+              "resolved": "http://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+            }
+          }
+        }
+      }
+    },
+    "uglify-js-brunch": {
+      "version": "1.7.8",
+      "from": "uglify-js-brunch@>= 1.0 < 1.8",
+      "resolved": "http://registry.npmjs.org/uglify-js-brunch/-/uglify-js-brunch-1.7.8.tgz",
+      "dependencies": {
+        "uglify-js": {
+          "version": "2.4.19",
+          "from": "uglify-js@~2.4.7",
+          "resolved": "http://registry.npmjs.org/uglify-js/-/uglify-js-2.4.19.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "async@~0.2.6",
+              "resolved": "http://registry.npmjs.org/async/-/async-0.2.10.tgz"
+            },
+            "source-map": {
+              "version": "0.1.34",
+              "from": "source-map@0.1.34",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "http://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            },
+            "yargs": {
+              "version": "3.5.4",
+              "from": "yargs@~3.5.4",
+              "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+              "dependencies": {
+                "camelcase": {
+                  "version": "1.0.2",
+                  "from": "camelcase@^1.0.2",
+                  "resolved": "http://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
+                },
+                "decamelize": {
+                  "version": "1.0.0",
+                  "from": "decamelize@^1.0.0",
+                  "resolved": "http://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
+                },
+                "window-size": {
+                  "version": "0.1.0",
+                  "from": "window-size@0.1.0"
+                },
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "wordwrap@0.0.2"
+                }
+              }
+            },
+            "uglify-to-browserify": {
+              "version": "1.0.2",
+              "from": "uglify-to-browserify@~1.0.0",
+              "resolved": "http://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a `npm-shinkwrap.json` file which locks down all of our dependencies (something we probably should have done already), but with `chokidar` overridden to `0.12.6` instead of `1.0.0` (see https://github.com/brunch/brunch/issues/956).

/cc @timmfin @benrlodge 