### PR TITLE
Add task detail

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/views/IndexView.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/views/IndexView.java
@@ -26,6 +26,10 @@ public class IndexView extends View {
   private final Integer slaveHttpPort;
   private final Integer slaveHttpsPort;
 
+  private final long defaultHealthcheckIntervalSeconds;
+  private final long defaultHealthcheckTimeoutSeconds;
+  private final long defaultDeployHealthTimeoutSeconds;
+
   public IndexView(String singularityUriBase, String appRoot, SingularityConfiguration configuration) {
     super("index.mustache");
 
@@ -50,6 +54,10 @@ public class IndexView extends View {
     this.hideNewRequestButton = configuration.getUiConfiguration().isHideNewRequestButton();
 
     this.navColor = configuration.getUiConfiguration().getNavColor();
+
+    this.defaultHealthcheckIntervalSeconds = configuration.getHealthcheckIntervalSeconds();
+    this.defaultHealthcheckTimeoutSeconds = configuration.getHealthcheckTimeoutSeconds();
+    this.defaultDeployHealthTimeoutSeconds = configuration.getDeployHealthyBySeconds();
   }
 
   public String getAppRoot() {
@@ -98,6 +106,18 @@ public class IndexView extends View {
 
   public Boolean getHideNewRequestButton() {
     return hideNewRequestButton;
+  }
+
+  public long getDefaultHealthcheckIntervalSeconds() {
+    return defaultHealthcheckIntervalSeconds;
+  }
+
+  public long getDefaultHealthcheckTimeoutSeconds() {
+    return defaultHealthcheckTimeoutSeconds;
+  }
+
+  public long getDefaultDeployHealthTimeoutSeconds() {
+    return defaultDeployHealthTimeoutSeconds;
   }
 
   @Override

--- a/SingularityUI/app/assets/_index.mustache
+++ b/SingularityUI/app/assets/_index.mustache
@@ -27,6 +27,9 @@
             hideNewRequestButton: {{{hideNewRequestButton}}},
             defaultCpus: {{{defaultCpus}}},
             defaultMemory: {{{defaultMemory}}},
+            defaultHealthcheckIntervalSeconds: {{{defaultHealthcheckIntervalSeconds}}},
+            defaultHealthcheckTimeoutSeconds: {{{defaultHealthcheckTimeoutSeconds}}},
+            defaultDeployHealthTimeoutSeconds: {{{defaultDeployHealthTimeoutSeconds}}},
             slaveHttpPort: {{{slaveHttpPort}}},
             {{#slaveHttpsPort}}
             slaveHttpsPort: {{{slaveHttpsPort}}}

--- a/SingularityUI/app/collections/Deploys.coffee
+++ b/SingularityUI/app/collections/Deploys.coffee
@@ -1,0 +1,16 @@
+Collection = require './collection'
+
+Deploy = require '../models/Deploy'
+
+class Deploys extends Collection
+
+    model: Deploy
+
+    initialize: ({ @state }) ->
+        @state = if not @state?  then '' else @state
+
+    url: ->
+        "#{ config.apiRoot }/deploys/#{ @state }"
+        
+module.exports = Deploys
+

--- a/SingularityUI/app/controllers/TaskDetail.coffee
+++ b/SingularityUI/app/controllers/TaskDetail.coffee
@@ -6,6 +6,7 @@ TaskResourceUsage = require '../models/TaskResourceUsage'
 TaskS3Logs = require '../collections/TaskS3Logs'
 TaskFiles = require '../collections/TaskFiles'
 TaskCleanups = require '../collections/TaskCleanups'
+Deploys = require '../collections/Deploys'
 
 FileBrowserSubview = require '../views/fileBrowserSubview'
 ExpandableTableSubview = require '../views/expandableTableSubview'
@@ -43,12 +44,15 @@ class TaskDetailController extends Controller
 
         @collections.taskCleanups = new TaskCleanups
 
+        # For notifications at the task level
+        @collections.deploys = new Deploys {state: 'pending'}
         #
         # Subviews
         #
         @subviews.overview = new OverviewSubview
             collection: @collections.taskCleanups
             model:      @models.task
+            deploys:    @collections.deploys
             template:   @templates.overview
 
         @subviews.history = new SimpleSubview
@@ -117,6 +121,8 @@ class TaskDetailController extends Controller
         @resourcesFetched = false
 
         @collections.taskCleanups.fetch()
+
+        @collections.deploys.fetch()
 
         @models.task.fetch()
             .done =>

--- a/SingularityUI/app/handlebarsHelpers.coffee
+++ b/SingularityUI/app/handlebarsHelpers.coffee
@@ -76,6 +76,11 @@ Handlebars.registerHelper 'timestampFormatted', (timestamp) ->
     timeObject = moment timestamp
     timeObject.format 'lll'
 
+Handlebars.registerHelper 'timestampFormattedWithSeconds', (timestamp) ->
+    return '' if not timestamp
+    timeObject = moment timestamp
+    timeObject.format 'lll:ss'
+
 # 'DRIVER_NOT_RUNNING' => 'Driver not running'
 Handlebars.registerHelper 'humanizeText', (text) ->
     return '' if not text

--- a/SingularityUI/app/models/TaskHistory.coffee
+++ b/SingularityUI/app/models/TaskHistory.coffee
@@ -56,6 +56,7 @@ class TaskHistory extends Model
 
 
         taskHistory.isCleaning = _.last( taskHistory.taskUpdates ).taskState is 'TASK_CLEANING'
+        taskHistory.showRecentHealthchecksOnly = true
 
 
         taskHistory

--- a/SingularityUI/app/models/TaskHistory.coffee
+++ b/SingularityUI/app/models/TaskHistory.coffee
@@ -57,8 +57,6 @@ class TaskHistory extends Model
 
 
         taskHistory.isCleaning = _.last( taskHistory.taskUpdates ).taskState is 'TASK_CLEANING'
-        taskHistory.showRecentHealthchecksOnly = true
-
 
         taskHistory
 

--- a/SingularityUI/app/models/TaskHistory.coffee
+++ b/SingularityUI/app/models/TaskHistory.coffee
@@ -15,7 +15,8 @@ class TaskHistory extends Model
     initialize: ({ @taskId }) ->
 
     parse: (taskHistory) ->
-        _.sortBy taskHistory.taskUpdates, (t) -> t.timestamp
+        taskHistory.taskUpdates = _.sortBy taskHistory.taskUpdates, (t) -> t.timestamp
+        taskHistory.healthcheckResults = (_.sortBy taskHistory.healthcheckResults, (t) -> t.timestamp).reverse()
 
         taskHistory.task?.mesosTask?.executor?.command?.environment?.variables = _.sortBy taskHistory.task.mesosTask.executor.command.environment.variables, "name"
 

--- a/SingularityUI/app/styles/main.styl
+++ b/SingularityUI/app/styles/main.styl
@@ -66,6 +66,15 @@ code
     background rgba(0, 0, 0, .05)
     color rgba(0, 0, 0, .75)
 
+.healthcheck-message
+    white-space pre-line
+
+.healthcheck-link
+    font-weight bolder
+
+.healthcheck-number
+    font-weight bolder
+
 .flash-background
     background: #fbfbfb
 

--- a/SingularityUI/app/templates/taskDetail/taskBase.hbs
+++ b/SingularityUI/app/templates/taskDetail/taskBase.hbs
@@ -19,10 +19,6 @@
     <div id='lb-updates' class='col-md-12'>
         
     </div>
-
-    <div id='health-checks' class='col-md-12'>
-        
-    </div>
     
     <div id='info' class='col-md-12'>
         
@@ -33,6 +29,10 @@
     </div>
 
     <div id='environment' class='col-md-12'>
+        
+    </div>
+
+    <div id='health-checks' class='col-md-12'>
         
     </div>
 </div>

--- a/SingularityUI/app/templates/taskDetail/taskHealthChecks.hbs
+++ b/SingularityUI/app/templates/taskDetail/taskHealthChecks.hbs
@@ -10,7 +10,7 @@
                         <tr>
                             <th>Timestamp</th>
                             <th>Duration</th>
-                            <th>HTTP Status</th>
+                            <th>Status</th>
                             <th>Response</th>
                         </tr>
                     </thead>
@@ -24,7 +24,15 @@
                                    {{durationMillis}}{{#if durationMillis}}ms{{/if}}
                                 </td>
                                 <td>
-                                   {{statusCode}}
+                                    {{#if statusCode}}
+                                        {{#ifEqual statusCode 200}}
+                                            <span class="label label-success">HTTP {{statusCode}}</span>
+                                        {{else}}
+                                            <span class="label label-danger">HTTP {{statusCode}}</span>
+                                        {{/ifEqual}}
+                                    {{else}}
+                                        <span class="label label-warning">No Response</span>
+                                    {{/if}}
                                 </td>
                                 <td> 
                                     {{#if errorMessage}}{{errorMessage}}{{else}}{{responseBody}}{{/if}}

--- a/SingularityUI/app/templates/taskDetail/taskHealthChecks.hbs
+++ b/SingularityUI/app/templates/taskDetail/taskHealthChecks.hbs
@@ -11,7 +11,7 @@
                             <th>Timestamp</th>
                             <th>Duration</th>
                             <th>HTTP Status</th>
-                            <th>Message</th>
+                            <th>Response</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -27,7 +27,7 @@
                                    {{statusCode}}
                                 </td>
                                 <td> 
-                                    {{errorMessage}}
+                                    {{#if errorMessage}}{{errorMessage}}{{else}}{{responseBody}}{{/if}}
                                 </td>
                                 <td class="actions-column">
                                     <a data-index="{{@index}}" data-key="healthcheckResults" data-action="viewJsonProperty" title="JSON">

--- a/SingularityUI/app/templates/taskDetail/taskHealthChecks.hbs
+++ b/SingularityUI/app/templates/taskDetail/taskHealthChecks.hbs
@@ -1,16 +1,20 @@
 {{#if synced}}
     {{#if data.task.taskRequest.deploy.healthcheckUri}}
         <div class="page-header">
-            <h2>Healthchecks</h2>
+            <h2>
+                Healthchecks
+                <small>
+                    <a data-action="expandToggle">
+                        {{#if expanded}}
+                            collapse
+                        {{else}}
+                            view
+                        {{/if}}
+                    </a>
+                </small>
+            </h2>
         </div>
-        {{#ifGT data.healthcheckResults.length 1}}
-            <div class="checkbox">
-                <label>
-                    <input id="toggle-Healthchecks" {{#if data.showRecentHealthchecksOnly}}{{else}}checked="checked"{{/if}} type="checkbox"> 
-                    <strong>Show all Healthchecks </strong>
-                </label>
-            </div>
-        {{/ifGT}}
+        <div class='{{#unless expanded}}hide{{/unless}}'>
         <div class="well">
             Beginning on <span class="healthcheck-number">Task running</span>, hit <a class="healthcheck-link" target="_blank" href="http://{{data.task.offer.hostname}}:{{data.ports.[0]}}{{data.task.taskRequest.deploy.healthcheckUri}}">{{data.task.taskRequest.deploy.healthcheckUri}}</a> with a <span class="healthcheck-number">{{#if data.task.taskRequest.deploy.healthcheckTimeoutSeconds}}{{data.task.taskRequest.deploy.healthcheckTimeoutSeconds}}{{else}}{{config.defaultHealthcheckTimeoutSeconds}}{{/if}}</span> second timeout every <span class="healthcheck-number">{{#if data.task.taskRequest.deploy.healthcheckIntervalSeconds}}{{data.task.taskRequest.deploy.healthcheckIntervalSeconds}}{{else}}{{config.defaultHealthcheckIntervalSeconds}}{{/if}}</span> second(s) until <span class="healthcheck-number">HTTP 200</span> is received, or <span class="healthcheck-number">{{#if data.task.taskRequest.deploy.deployHealthTimeoutSeconds}}{{data.task.taskRequest.deploy.deployHealthTimeoutSeconds}}{{else}}{{config.defaultDeployHealthTimeoutSeconds}}{{/if}}</span> seconds have elapsed.
         </div>
@@ -27,7 +31,7 @@
                     </thead>
                     <tbody>
                         {{#each data.healthcheckResults}}
-                            <tr {{#if ../data.showRecentHealthchecksOnly}}{{#ifNotEqual @index 0}} style='display:none' {{/ifNotEqual}}{{/if}}>
+                            <tr>
                                 <td>
                                    {{timestampFormattedWithSeconds timestamp}}
                                 </td>
@@ -68,6 +72,7 @@
                 Healthchecks are disabled for this deploy
             </div>
         {{/if}}
+        </div>
     {{/if}}
 {{else}}
     <div class="page-loader centered cushy"></div>

--- a/SingularityUI/app/templates/taskDetail/taskHealthChecks.hbs
+++ b/SingularityUI/app/templates/taskDetail/taskHealthChecks.hbs
@@ -3,6 +3,14 @@
         <div class="page-header">
             <h2>Healthchecks</h2>
         </div>
+        {{#ifGT data.healthcheckResults.length 1}}
+            <div class="checkbox">
+                <label>
+                    <input id="toggle-Healthchecks" {{#if data.showRecentHealthchecksOnly}}{{else}}checked="checked"{{/if}} type="checkbox"> 
+                    <strong>Show all Healthchecks </strong>
+                </label>
+            </div>
+        {{/ifGT}}
         <div class="well">
             Beginning on <span class="healthcheck-number">Task running</span>, hit <a class="healthcheck-link" target="_blank" href="http://{{data.task.offer.hostname}}:{{data.ports.[0]}}{{data.task.taskRequest.deploy.healthcheckUri}}">{{data.task.taskRequest.deploy.healthcheckUri}}</a> with a <span class="healthcheck-number">{{#if data.task.taskRequest.deploy.healthcheckTimeoutSeconds}}{{data.task.taskRequest.deploy.healthcheckTimeoutSeconds}}{{else}}{{config.defaultHealthcheckTimeoutSeconds}}{{/if}}</span> second timeout every <span class="healthcheck-number">{{#if data.task.taskRequest.deploy.healthcheckIntervalSeconds}}{{data.task.taskRequest.deploy.healthcheckIntervalSeconds}}{{else}}{{config.defaultHealthcheckIntervalSeconds}}{{/if}}</span> second(s) until <span class="healthcheck-number">HTTP 200</span> is received, or <span class="healthcheck-number">{{#if data.task.taskRequest.deploy.deployHealthTimeoutSeconds}}{{data.task.taskRequest.deploy.deployHealthTimeoutSeconds}}{{else}}{{config.defaultDeployHealthTimeoutSeconds}}{{/if}}</span> seconds have elapsed.
         </div>
@@ -19,7 +27,7 @@
                     </thead>
                     <tbody>
                         {{#each data.healthcheckResults}}
-                            <tr>
+                            <tr {{#if ../data.showRecentHealthchecksOnly}}{{#ifNotEqual @index 0}} style='display:none' {{/ifNotEqual}}{{/if}}>
                                 <td>
                                    {{timestampFormattedWithSeconds timestamp}}
                                 </td>

--- a/SingularityUI/app/templates/taskDetail/taskHealthChecks.hbs
+++ b/SingularityUI/app/templates/taskDetail/taskHealthChecks.hbs
@@ -3,6 +3,9 @@
         <div class="page-header">
             <h2>Healthchecks</h2>
         </div>
+        <div class="well">
+            Beginning on <span class="healthcheck-number">Task running</span>, hit <a class="healthcheck-link" target="_blank" href="http://{{data.task.offer.hostname}}:{{data.ports.[0]}}{{data.task.taskRequest.deploy.healthcheckUri}}">{{data.task.taskRequest.deploy.healthcheckUri}}</a> with a <span class="healthcheck-number">{{#if data.task.taskRequest.deploy.healthcheckTimeoutSeconds}}{{data.task.taskRequest.deploy.healthcheckTimeoutSeconds}}{{else}}{{config.defaultHealthcheckTimeoutSeconds}}{{/if}}</span> second timeout every <span class="healthcheck-number">{{#if data.task.taskRequest.deploy.healthcheckIntervalSeconds}}{{data.task.taskRequest.deploy.healthcheckIntervalSeconds}}{{else}}{{config.defaultHealthcheckIntervalSeconds}}{{/if}}</span> second(s) until <span class="healthcheck-number">HTTP 200</span> is received, or <span class="healthcheck-number">{{#if data.task.taskRequest.deploy.deployHealthTimeoutSeconds}}{{data.task.taskRequest.deploy.deployHealthTimeoutSeconds}}{{else}}{{config.defaultDeployHealthTimeoutSeconds}}{{/if}}</span> seconds have elapsed.
+        </div>
         {{#ifGT data.healthcheckResults.length 0}}
             <div class="table-container">
                 <table class="table table-striped">
@@ -11,14 +14,14 @@
                             <th>Timestamp</th>
                             <th>Duration</th>
                             <th>Status</th>
-                            <th>Response</th>
+                            <th>Message</th>
                         </tr>
                     </thead>
                     <tbody>
                         {{#each data.healthcheckResults}}
                             <tr>
                                 <td>
-                                   {{timestampFormatted timestamp}}
+                                   {{timestampFormattedWithSeconds timestamp}}
                                 </td>
                                 <td>
                                    {{durationMillis}}{{#if durationMillis}}ms{{/if}}
@@ -34,8 +37,8 @@
                                         <span class="label label-warning">No Response</span>
                                     {{/if}}
                                 </td>
-                                <td> 
-                                    {{#if errorMessage}}{{errorMessage}}{{else}}{{responseBody}}{{/if}}
+                                <td>
+                                    <pre class="healthcheck-message">{{#if errorMessage}}{{errorMessage}}{{else}}{{responseBody}}{{/if}}</pre>
                                 </td>
                                 <td class="actions-column">
                                     <a data-index="{{@index}}" data-key="healthcheckResults" data-action="viewJsonProperty" title="JSON">

--- a/SingularityUI/app/templates/taskDetail/taskOverview.hbs
+++ b/SingularityUI/app/templates/taskDetail/taskOverview.hbs
@@ -69,3 +69,60 @@
         </div>
     {{/withLast}}
 {{/if}}
+
+{{#if isDeployPending}}
+    {{#ifGT data.healthcheckResults.length 0}}
+        <div class="well text-muted">
+            <h4>Current Healthcheck</h4>
+            <div class="table-container">
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>Timestamp</th>
+                            <th>Duration</th>
+                            <th>Status</th>
+                            <th>Message</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {{#each data.healthcheckResults}}
+                            {{#ifLT @index 1}}
+                                <tr>
+                                    <td>
+                                       {{timestampFormattedWithSeconds timestamp}}
+                                    </td>
+                                    <td>
+                                       {{durationMillis}}{{#if durationMillis}}ms{{/if}}
+                                    </td>
+                                    <td>
+                                        {{#if statusCode}}
+                                            {{#ifEqual statusCode 200}}
+                                                <span class="label label-success">HTTP {{statusCode}}</span>
+                                            {{else}}
+                                                <span class="label label-danger">HTTP {{statusCode}}</span>
+                                            {{/ifEqual}}
+                                        {{else}}
+                                            <span class="label label-warning">No Response</span>
+                                        {{/if}}
+                                    </td>
+                                    <td>
+                                        <pre class="healthcheck-message">{{#if errorMessage}}{{errorMessage}}{{else}}{{responseBody}}{{/if}}</pre>
+                                    </td>
+                                    <td class="actions-column">
+                                        <a data-index="{{@index}}" data-key="healthcheckResults" data-action="viewJsonProperty" title="JSON">
+                                            { }
+                                        </a>
+                                    </td>
+                                </tr>
+                            {{/ifLT}}
+                        {{/each}}
+                    </tbody>
+                </table>
+            </div>
+            <a href="#health-checks" data-action="viewHealthchecks">View full healthcheck history</a>
+        </div>
+    {{/ifGT}}
+{{/if}}
+
+
+

--- a/SingularityUI/app/templates/taskDetail/taskOverview.hbs
+++ b/SingularityUI/app/templates/taskDetail/taskOverview.hbs
@@ -71,9 +71,9 @@
 {{/if}}
 
 {{#if isDeployPending}}
-    {{#ifGT data.healthcheckResults.length 0}}
-        <div class="well text-muted">
-            <h4>Current Healthcheck</h4>
+    <div class="well text-muted">
+        <h4>Current Healthcheck</h4>
+        {{#ifGT data.healthcheckResults.length 0}}
             <div class="table-container">
                 <table class="table">
                     <thead>
@@ -85,43 +85,43 @@
                         </tr>
                     </thead>
                     <tbody>
-                        {{#each data.healthcheckResults}}
-                            {{#ifLT @index 1}}
-                                <tr>
-                                    <td>
-                                       {{timestampFormattedWithSeconds timestamp}}
-                                    </td>
-                                    <td>
-                                       {{durationMillis}}{{#if durationMillis}}ms{{/if}}
-                                    </td>
-                                    <td>
-                                        {{#if statusCode}}
-                                            {{#ifEqual statusCode 200}}
-                                                <span class="label label-success">HTTP {{statusCode}}</span>
-                                            {{else}}
-                                                <span class="label label-danger">HTTP {{statusCode}}</span>
-                                            {{/ifEqual}}
-                                        {{else}}
-                                            <span class="label label-warning">No Response</span>
-                                        {{/if}}
-                                    </td>
-                                    <td>
-                                        <pre class="healthcheck-message">{{#if errorMessage}}{{errorMessage}}{{else}}{{responseBody}}{{/if}}</pre>
-                                    </td>
-                                    <td class="actions-column">
-                                        <a data-index="{{@index}}" data-key="healthcheckResults" data-action="viewJsonProperty" title="JSON">
-                                            { }
-                                        </a>
-                                    </td>
-                                </tr>
-                            {{/ifLT}}
-                        {{/each}}
+                    {{#with healthCheck}}
+                        <tr>
+                            <td>
+                               {{timestampFormattedWithSeconds timestamp}}
+                            </td>
+                            <td>
+                               {{durationMillis}}{{#if durationMillis}}ms{{/if}}
+                            </td>
+                            <td>
+                                {{#if statusCode}}
+                                    {{#ifEqual statusCode 200}}
+                                        <span class="label label-success">HTTP {{statusCode}}</span>
+                                    {{else}}
+                                        <span class="label label-danger">HTTP {{statusCode}}</span>
+                                    {{/ifEqual}}
+                                {{else}}
+                                    <span class="label label-warning">No Response</span>
+                                {{/if}}
+                            </td>
+                            <td>
+                                <pre class="healthcheck-message">{{#if errorMessage}}{{errorMessage}}{{else}}{{responseBody}}{{/if}}</pre>
+                            </td>
+                            <td class="actions-column">
+                                <a data-index="{{@index}}" data-key="healthcheckResults" data-action="viewJsonProperty" title="JSON">
+                                    { }
+                                </a>
+                            </td>
+                        </tr>
+                       {{/with}}
                     </tbody>
                 </table>
             </div>
-            <a href="#health-checks" data-action="viewHealthchecks">View full healthcheck history</a>
-        </div>
-    {{/ifGT}}
+            <a href="#health-checks" data-action="viewHealthchecks">View full healthcheck history</a>    
+        {{else}}
+            <p>Deploy for this task is pending. Healthchecks not run yet.</p>
+        {{/ifGT}}
+    </div>
 {{/if}}
 
 

--- a/SingularityUI/app/views/simpleSubview.coffee
+++ b/SingularityUI/app/views/simpleSubview.coffee
@@ -49,4 +49,8 @@ class SimpleSubview extends View
         @expanded = not @expanded
         @render()
 
+    expandToggleIfClosed: ->
+        return if @expanded
+        @expandToggle()
+
 module.exports = SimpleSubview

--- a/SingularityUI/app/views/task.coffee
+++ b/SingularityUI/app/views/task.coffee
@@ -9,6 +9,7 @@ class TaskView extends View
             'click [data-action="viewObjectJSON"]': 'viewJson'
             'click [data-action="viewJsonProperty"]': 'viewJsonProperty'
             'click [data-action="remove"]': 'killTask'
+            'click #toggle-Healthchecks' : 'toggleHealthchecks'
     initialize: ({@taskId}) ->
 
     render: ->
@@ -52,6 +53,8 @@ class TaskView extends View
         taskModel.promptKill =>
             setTimeout (=> @trigger 'refreshrequest'), 1000
 
+    toggleHealthchecks: ->
+        @model.set 'showRecentHealthchecksOnly', !@model.get 'showRecentHealthchecksOnly'
 
 
 module.exports = TaskView

--- a/SingularityUI/app/views/task.coffee
+++ b/SingularityUI/app/views/task.coffee
@@ -8,9 +8,10 @@ class TaskView extends View
         _.extend super,
             'click [data-action="viewObjectJSON"]': 'viewJson'
             'click [data-action="viewJsonProperty"]': 'viewJsonProperty'
-            'click [data-action="remove"]': 'killTask'
-            'click #toggle-Healthchecks' : 'toggleHealthchecks'
+            'click [data-action="remove"]': 'killTask'           
+    
     initialize: ({@taskId}) ->
+        @subviews.overview.on 'toggleHealthchecks', @toggleHealthchecks
 
     render: ->
         @$el.html @baseTemplate
@@ -25,6 +26,9 @@ class TaskView extends View
         @$('#info').html            @subviews.info.$el
         @$('#resources').html       @subviews.resourceUsage.$el
         @$('#environment').html     @subviews.environment.$el
+
+    toggleHealthchecks: =>
+        @subviews.healthChecks.expandToggleIfClosed()
 
     viewJson: (event) ->
         utils.viewJSON @model
@@ -52,9 +56,6 @@ class TaskView extends View
         taskModel = new Task id: @taskId
         taskModel.promptKill =>
             setTimeout (=> @trigger 'refreshrequest'), 1000
-
-    toggleHealthchecks: ->
-        @model.set 'showRecentHealthchecksOnly', !@model.get 'showRecentHealthchecksOnly'
 
 
 module.exports = TaskView

--- a/SingularityUI/app/views/taskOverviewSubview.coffee
+++ b/SingularityUI/app/views/taskOverviewSubview.coffee
@@ -46,6 +46,7 @@ class taskOverviewSubview extends View
         config:           config
         data:             @model.toJSON()
         isDeployPending:  @isDeployPending
+        healthCheck:      @model.get('healthcheckResults')[0]
         synced:           @model.synced and @collection.synced and @deploys.synced
 
     # If we have a deploy pending for this task,

--- a/SingularityUI/app/views/taskOverviewSubview.coffee
+++ b/SingularityUI/app/views/taskOverviewSubview.coffee
@@ -11,13 +11,16 @@ class taskOverviewSubview extends View
     events: ->
         _.extend super,
             'click [data-action="remove"]': 'promptKillTask'
+            'click [data-action="viewHealthchecks"]': 'triggerToggleHealthchecks'
 
+    initialize: ({@collection, @model, @template, @deploys}) ->
 
-    initialize: ({@collection, @model, @template}) ->
         @taskModel = new Task id: @model.taskId
+        @shouldPollHealthchecks = true
 
         for eventName in ['sync', 'add', 'remove', 'change']
             @listenTo @model, eventName, @render
+            @listenTo @deploys, eventName, @render
 
         # copy latest task cleanup object over to the task model whenever things change
         for eventName in ['add', 'reset']
@@ -35,13 +38,39 @@ class taskOverviewSubview extends View
 
 
     render: ->
-        return if not @model.synced and @model.isEmpty?()
+        return if not @model.synced or not @deploys.synced
+        @checkForPendingDeploy() if not @isDeployPending and @shouldPollHealthchecks
         @$el.html @template @renderData()
 
     renderData: ->
-        config:    config
-        data:      @model.toJSON()
-        synced:    @model.synced and @collection.synced
+        config:           config
+        data:             @model.toJSON()
+        isDeployPending:  @isDeployPending
+        synced:           @model.synced and @collection.synced and @deploys.synced
+
+    # If we have a deploy pending for this task,
+    # we start polling until we get a healthcheck to show
+    checkForPendingDeploy: ->
+        @isDeployPending = false
+        for deploy in @deploys.toJSON()
+            if deploy.deployMarker.deployId is @model.get('task').taskId.deployId
+                @isDeployPending = true
+                @pollForHealthchecks()
+                break
+
+    # Poll for Healthchecks if the task 
+    # is part of a pending deploy
+    pollForHealthchecks: =>
+        do fetchModel = =>
+            @model.fetch().done =>
+                if @model.get('healthcheckResults').length > 0
+                    @render()
+                    return @shouldPollHealthchecks = false
+                    
+                setTimeout ( => fetchModel() ), 1500
+                   
+    triggerToggleHealthchecks: ->
+        @trigger 'toggleHealthchecks'
 
     # Choose prompt based on if we plan to 
     # gracefully kill (sigterm), or force kill (kill-9)


### PR DESCRIPTION
- Moves healthchecks table to bottom of task detail page, collapsed by default
- Reordered healthchecks table to newest --> oldest, instead of oldest --> newest
- When the deploy associated with the task is PENDING (meaning a deploy is in progress), additionally display the current healthcheck at the top of the task detail page (underneath the well) with a link to the full healthcheck history

@tpetr - this was opened from hs_staging (otherwise I'd open against master)