### PR TITLE
check for no data in beforeClose

### DIFF
--- a/SingularityUI/app/controllers/RequestDetail.coffee
+++ b/SingularityUI/app/controllers/RequestDetail.coffee
@@ -96,8 +96,6 @@ class RequestDetailController extends Controller
         #
         @setView new RequestDetailView _.extend {@requestId, @subviews},
             model: @models.request
-            history: @collections.taskHistory
-            activeTasks: @collections.activeTasks
 
         @refresh()
 

--- a/SingularityUI/app/lib/AutoTailer.coffee
+++ b/SingularityUI/app/lib/AutoTailer.coffee
@@ -1,0 +1,104 @@
+RequestHistoricalTasks = require '../collections/RequestHistoricalTasks'
+
+TaskFiles = require '../collections/TaskFiles'
+RequestTasks = require '../collections/RequestTasks'
+
+autoTailWaitingTemplate = require 'templates/vex/autoTailingWaiting'
+autoTailFailureTemplate = require 'templates/vex/autoTailingFailure'
+
+interval = (a, b) -> setInterval(b, a)  # f u javascript
+timeout = (a, b) -> setTimeout(b, a)
+
+AUTO_TAIL_TIMEOUT = 5 * 60 * 1000
+
+
+class AutoTailer extends Backbone.View
+
+    initialize: ({@requestId, @autoTailFilename, @autoTailTimestamp}) ->
+        
+        @history     = new RequestHistoricalTasks [], {@requestId}
+
+        @activeTasks = new RequestTasks [],
+            requestId: @requestId
+            state:    'active'
+
+        @activeTasks.fetch().error    @ignore404
+
+        if @history.currentPage is 1
+            @history.fetch().error    @ignore404
+
+
+    # Start polling for task changes, and check
+    # Task History changes in case we need 
+    # to back out of the file redirect 
+    startAutoTailPolling: ->
+        @showAutoTailWaitingDialog()
+        @stopAutoTailPolling()
+
+        @listenTo @history, 'reset', @handleHistoryReset
+        @listenToOnce @activeTasks, 'add', @handleActiveTasksAdd
+
+        @autoTailPollInterval = interval 2000, =>
+            if @autoTailTaskFiles
+                @autoTailTaskFiles.fetch().error -> app.caughtError()  # we don't care about errors in this situation
+            else
+                @history.fetch()
+                @activeTasks.fetch()
+
+        @autoTailTimeout = timeout 60000, =>
+            @stopAutoTailPolling()
+            vex.close()
+            vex.dialog.alert
+                message: autoTailFailureTemplate
+                    autoTailFilename: @autoTailFilename
+                    timeout: Math.floor(AUTO_TAIL_TIMEOUT / 60000)
+                buttons: [
+                    $.extend _.clone(vex.dialog.buttons.YES), text: 'OK'
+                ]
+
+    handleHistoryReset: (tasks) =>
+        timestamp = @autoTailTimestamp
+        matchingTask = tasks.find (task) -> task.get('taskId').startedAt > timestamp
+        if matchingTask
+            $('.auto-tail-checklist').addClass 'waiting-for-file'
+            @stopListening @activeTasks, 'add'
+            @autoTailTaskFiles = new TaskFiles [], taskId: matchingTask.get('id')
+
+    handleActiveTasksAdd: (task) =>
+        $('.auto-tail-checklist').addClass 'waiting-for-file'
+        @autoTailTaskId = task.get('id')
+        @autoTailTaskFiles = new TaskFiles [], taskId: @autoTailTaskId
+        @listenTo @autoTailTaskFiles, 'add', @handleTaskFilesAdd
+
+    handleTaskFilesAdd: =>
+        if @autoTailTaskFiles.findWhere({name: @autoTailFilename})
+            @stopAutoTailPolling()
+            @stopListening @history, 'reset', @handleHistoryReset
+            app.router.navigate "#task/#{@autoTailTaskId}/tail/#{@autoTailTaskId}/#{@autoTailFilename}", trigger: true
+            vex.close()
+
+    stopAutoTailPolling: ->
+        if @autoTailPollInterval
+            clearInterval @autoTailPollInterval
+        if @autoTailTimeout
+            clearTimeout @autoTailTimeout
+        @stopListening @activeTasks, 'add', @handleActiveTasksAdd
+        @stopListening @history, 'reset', @handleHistoryReset
+        if @autoTailTaskFiles
+            @stopListening @autoTailTaskFiles, 'add', @handleTaskFilesAdd
+        @autoTailTaskFiles = null
+
+    ## Prompt for cancelling the redirect after it's been initiated
+    showAutoTailWaitingDialog: ->
+        vex.dialog.alert
+            overlayClosesOnClick: false
+            message: autoTailWaitingTemplate 
+                autoTailFilename: @autoTailFilename
+            buttons: [
+                $.extend _.clone(vex.dialog.buttons.NO), text: 'Close'
+            ]
+            callback: (data) =>
+                @stopAutoTailPolling()
+
+
+module.exports = AutoTailer

--- a/SingularityUI/app/models/Request.coffee
+++ b/SingularityUI/app/models/Request.coffee
@@ -130,6 +130,8 @@ class Request extends Model
             ]
 
             beforeClose: =>
+                return if @data is false
+                
                 fileName = @data.filename.trim()
 
                 if fileName.length is 0 and @data.autoTail is 'on'
@@ -149,7 +151,6 @@ class Request extends Model
                 $('#autoTail').prop 'checked', (localStorage.getItem('taskRunAutoTail') is 'on')
 
             callback: (data) =>
-                return if data is false
                 @data = data
 
     promptRemove: (callback) =>

--- a/SingularityUI/app/views/requests.coffee
+++ b/SingularityUI/app/views/requests.coffee
@@ -1,4 +1,6 @@
 View = require './view'
+AutoTailer = require '../lib/AutoTailer'
+Request = require '../models/Request'
 
 class RequestsView extends View
 
@@ -314,9 +316,27 @@ class RequestsView extends View
         $row = $(e.target).parents 'tr'
         id = $row.data('request-id')
 
-        @collection.get(id).promptRun =>
-            $row.addClass 'flash'
-            setTimeout (=> $row.removeClass 'flash'), 500
+        request = new Request id: id
+
+        request.promptRun (data) =>   
+
+            # If user wants to redirect to a file after the task starts
+            if data.autoTail is 'on'
+                autoTailer = new AutoTailer({
+                    requestId: id
+                    autoTailFilename: data.filename
+                    autoTailTimestamp: +new Date()
+                })
+
+                autoTailer.startAutoTailPolling()
+
+            else
+                $row.addClass 'flash'
+                setTimeout (=> $row.removeClass 'flash'), 500
+
+                @trigger 'refreshrequest'
+                setTimeout ( => @trigger 'refreshrequest'), 2500
+
 
     toggleStar: (e) ->
         $target = $(e.currentTarget)


### PR DESCRIPTION
I noticed in QA that you will get an error when trying to cancel out of the updated run-now prompt; because we added the beforeClose method, we need to test if the data is empty in that method, since it’s called after the callback. @tpetr 