### PR TITLE
don't 404 deleted requests, show a message instead

### DIFF
--- a/SingularityUI/app/controllers/RequestDetail.coffee
+++ b/SingularityUI/app/controllers/RequestDetail.coffee
@@ -16,9 +16,9 @@ SimpleSubview          = require '../views/simpleSubview'
 class RequestDetailController extends Controller
 
     templates:
-        header:         require '../templates/requestDetail/requestHeader'
-        taskHistoryMsg: require '../templates/requestDetail/taskHistoryMsg'
-        stats:          require '../templates/requestDetail/requestStats'
+        header:             require '../templates/requestDetail/requestHeader'
+        requestHistoryMsg:  require '../templates/requestDetail/requestHistoryMsg'
+        stats:              require '../templates/requestDetail/requestStats'
 
         activeTasks:    require '../templates/requestDetail/requestActiveTasks'
         scheduledTasks: require '../templates/requestDetail/requestScheduledTasks'
@@ -60,9 +60,9 @@ class RequestDetailController extends Controller
         # would have used header subview for this info,
         # but header expects a request model that
         # no longer exists if a request is deleted
-        @subviews.taskHistoryMsg = new SimpleSubview
+        @subviews.requestHistoryMsg = new SimpleSubview
             collection: @collections.requestHistory
-            template:   @templates.taskHistoryMsg
+            template:   @templates.requestHistoryMsg
 
         @subviews.stats = new SimpleSubview
             model:      @models.activeDeployStats
@@ -112,7 +112,7 @@ class RequestDetailController extends Controller
     refresh: ->
         @models.request.fetch().error =>
             # ignore 404 so we can still display info about
-            # deleted requests (show in `taskHistoryMsg`)
+            # deleted requests (show in `requestHistoryMsg`)
             @ignore404
             app.caughtError()
 

--- a/SingularityUI/app/styles/detailHeader.styl
+++ b/SingularityUI/app/styles/detailHeader.styl
@@ -52,6 +52,9 @@
         &[data-state='SYSTEM_COOLDOWN']
             color #BF5D36
         
+        &[data-state='DELETED']
+            color #ff0000
+        
         &:empty
             display none
 

--- a/SingularityUI/app/templates/requestDetail/requestBase.hbs
+++ b/SingularityUI/app/templates/requestDetail/requestBase.hbs
@@ -3,7 +3,7 @@
     <div class="page-loader centered cushy"></div>
 </div>
 
-<div class="col-md-12" id="task-history-msg">
+<div class="col-md-12" id="request-history-msg">
    
 </div>
 

--- a/SingularityUI/app/templates/requestDetail/requestBase.hbs
+++ b/SingularityUI/app/templates/requestDetail/requestBase.hbs
@@ -3,6 +3,10 @@
     <div class="page-loader centered cushy"></div>
 </div>
 
+<div class="col-md-12" id="task-history-msg">
+   
+</div>
+
 <div class="col-md-12" id="active-deploy">
     
 </div>

--- a/SingularityUI/app/templates/requestDetail/requestHistoryMsg.hbs
+++ b/SingularityUI/app/templates/requestDetail/requestHistoryMsg.hbs
@@ -17,7 +17,7 @@
         </div>
     </div>
     <div class='alert alert-warning'>
-        <strong>Note: </strong> This request was deleted {{timestampFromNow data.[0].createdAt}}. All active and scheduled tasks will not run again unless it is reposted to Singularity.
+        <strong>Note: </strong> This request was deleted {{timestampFromNow data.[0].createdAt}}, by {{data.[0].user}}. All active and scheduled tasks will not run again unless it is reposted to Singularity.
     </div>
 {{/ifEqual}}
 

--- a/SingularityUI/app/templates/requestDetail/requestHistoryMsg.hbs
+++ b/SingularityUI/app/templates/requestDetail/requestHistoryMsg.hbs
@@ -17,7 +17,7 @@
         </div>
     </div>
     <div class='alert alert-warning'>
-        <strong>Note: </strong> This request was deleted {{timestampFromNow data.[0].createdAt}}{{#if data.[0].user}}, by {{data.[0].user}} {{/if}}. All active and scheduled tasks will not run again unless it is reposted to Singularity.
+        <strong>Note: </strong>This request was deleted {{timestampFromNow data.[0].createdAt}}{{#if data.[0].user}}, by {{data.[0].user}}{{/if}}. All active and scheduled tasks will not run again unless it is reposted to Singularity.
     </div>
 {{/ifEqual}}
 

--- a/SingularityUI/app/templates/requestDetail/requestHistoryMsg.hbs
+++ b/SingularityUI/app/templates/requestDetail/requestHistoryMsg.hbs
@@ -17,7 +17,7 @@
         </div>
     </div>
     <div class='alert alert-warning'>
-        <strong>Note: </strong> This request was deleted {{timestampFromNow data.[0].createdAt}}, by {{data.[0].user}}. All active and scheduled tasks will not run again unless it is reposted to Singularity.
+        <strong>Note: </strong> This request was deleted {{timestampFromNow data.[0].createdAt}}{{#if data.[0].user}}, by {{data.[0].user}} {{/if}}. All active and scheduled tasks will not run again unless it is reposted to Singularity.
     </div>
 {{/ifEqual}}
 

--- a/SingularityUI/app/templates/requestDetail/taskHistoryMsg.hbs
+++ b/SingularityUI/app/templates/requestDetail/taskHistoryMsg.hbs
@@ -1,0 +1,23 @@
+{{! Part of requestBase }}
+
+{{#ifEqual data.[0].eventType 'DELETED'}}
+    <div class="row detail-header">
+        <div class="col-md-12">
+            <h4>
+                <span class="request-state" data-state="DELETED">
+                    Deleted
+                </span>
+                <span class="request-type">
+                    {{humanizeText data.[0].request.requestType }} 
+                </span>                
+            </h4>
+            <h2>
+                {{ data.[0].request.id }} 
+            </h2>
+        </div>
+    </div>
+    <div class='alert alert-warning'>
+        <strong>Note: </strong> This request was deleted {{timestampFromNow data.[0].createdAt}}. All active and scheduled tasks will not run again unless it is reposted to Singularity.
+    </div>
+{{/ifEqual}}
+

--- a/SingularityUI/app/views/request.coffee
+++ b/SingularityUI/app/views/request.coffee
@@ -29,14 +29,14 @@ class RequestView extends View
           config: config
 
         # Attach subview elements
-        @$('#header').html           @subviews.header.$el
-        @$('#task-history-msg').html @subviews.taskHistoryMsg.$el
-        @$('#stats').html            @subviews.stats.$el
-        @$('#active-tasks').html     @subviews.activeTasks.$el
-        @$('#scheduled-tasks').html  @subviews.scheduledTasks.$el
-        @$('#task-history').html     @subviews.taskHistory.$el
-        @$('#deploy-history').html   @subviews.deployHistory.$el
-        @$('#request-history').html  @subviews.requestHistory.$el
+        @$('#header').html              @subviews.header.$el
+        @$('#request-history-msg').html @subviews.requestHistoryMsg.$el
+        @$('#stats').html               @subviews.stats.$el
+        @$('#active-tasks').html        @subviews.activeTasks.$el
+        @$('#scheduled-tasks').html     @subviews.scheduledTasks.$el
+        @$('#task-history').html        @subviews.taskHistory.$el
+        @$('#deploy-history').html      @subviews.deployHistory.$el
+        @$('#request-history').html     @subviews.requestHistory.$el
 
     viewJson: (e) =>
         $target = $(e.currentTarget).parents 'tr'

--- a/SingularityUI/app/views/request.coffee
+++ b/SingularityUI/app/views/request.coffee
@@ -30,6 +30,7 @@ class RequestView extends View
 
         # Attach subview elements
         @$('#header').html           @subviews.header.$el
+        @$('#task-history-msg').html @subviews.taskHistoryMsg.$el
         @$('#stats').html            @subviews.stats.$el
         @$('#active-tasks').html     @subviews.activeTasks.$el
         @$('#scheduled-tasks').html  @subviews.scheduledTasks.$el


### PR DESCRIPTION
If a request no longer exists, instead of showing a 404, the request detail page will continue to show, and a message is displayed that it has been deleted. 

I copied the look of the existing state/request-type section for requests still running, but used a yellow alert instead. 

Thoughts?
@tpetr @wsorenson 

![screenshot 2015-04-23 17 00 55](https://cloud.githubusercontent.com/assets/3275453/7307524/73515fb2-e9db-11e4-8d2b-9df37f4daadd.png)

*Note - The header subview would have been a good section for this, but that expects a model that no longer exists for the request (hence the 404), and uses the simpleSubview so only expects a model or collection, so it seemed simpler to just add a new subview.*