### PR TITLE
add s3 logs to request page

### DIFF
--- a/SingularityUI/app/collections/RequestTasksLogs.coffee
+++ b/SingularityUI/app/collections/RequestTasksLogs.coffee
@@ -1,0 +1,13 @@
+S3Log = require '../models/S3Log'
+
+Collection = require './collection'
+
+class RequestTasksLogs extends Collection
+
+    model: S3Log
+
+    url: => "#{ config.apiRoot }/logs/request/#{ @requestId }"
+
+    initialize: (models, {@requestId}) =>
+
+module.exports = RequestTasksLogs

--- a/SingularityUI/app/controllers/RequestDetail.coffee
+++ b/SingularityUI/app/controllers/RequestDetail.coffee
@@ -4,6 +4,7 @@ Request                = require '../models/Request'
 RequestDeployStatus    = require '../models/RequestDeployStatus'
 
 Tasks                  = require '../collections/Tasks'
+RequestTasksLogs       = require '../collections/RequestTasksLogs'
 RequestTasks           = require '../collections/RequestTasks'
 RequestHistoricalTasks = require '../collections/RequestHistoricalTasks'
 RequestDeployHistory   = require '../collections/RequestDeployHistory'
@@ -19,14 +20,12 @@ class RequestDetailController extends Controller
         header:             require '../templates/requestDetail/requestHeader'
         requestHistoryMsg:  require '../templates/requestDetail/requestHistoryMsg'
         stats:              require '../templates/requestDetail/requestStats'
-
-        activeTasks:    require '../templates/requestDetail/requestActiveTasks'
-        scheduledTasks: require '../templates/requestDetail/requestScheduledTasks'
-
-        # Subview templates
-        taskHistory:    require '../templates/requestDetail/requestHistoricalTasks'
-        deployHistory:  require '../templates/requestDetail/requestDeployHistory'
-        requestHistory: require '../templates/requestDetail/requestHistory'
+        activeTasks:        require '../templates/requestDetail/requestActiveTasks'
+        logs:               require '../templates/taskDetail/taskS3Logs'
+        scheduledTasks:     require '../templates/requestDetail/requestScheduledTasks'
+        taskHistory:        require '../templates/requestDetail/requestHistoricalTasks'
+        deployHistory:      require '../templates/requestDetail/requestDeployHistory'
+        requestHistory:     require '../templates/requestDetail/requestHistory'
 
     initialize: ({@requestId}) ->
         #
@@ -45,6 +44,8 @@ class RequestDetailController extends Controller
         @collections.scheduledTasks = new Tasks [],
             requestId: @requestId
             state:     'scheduled'
+
+        @collections.requestTasksLogs = new RequestTasksLogs [], {@requestId}
 
         @collections.requestHistory  = new RequestHistory         [], {@requestId}
         @collections.taskHistory     = new RequestHistoricalTasks [], {@requestId}
@@ -71,6 +72,10 @@ class RequestDetailController extends Controller
         @subviews.activeTasks = new SimpleSubview
             collection: @collections.activeTasks
             template:   @templates.activeTasks
+
+        @subviews.requestTasksLogs = new ExpandableTableSubview
+            collection: @collections.requestTasksLogs
+            template:   @templates.logs
 
         @subviews.scheduledTasks = new SimpleSubview
             collection:      @collections.scheduledTasks
@@ -135,5 +140,11 @@ class RequestDetailController extends Controller
             @collections.taskHistory.fetch().error    @ignore404
         if @collections.deployHistory.currentPage is 1
             @collections.deployHistory.fetch().error  @ignore404
+
+        if @collections.requestTasksLogs
+            @collections.requestTasksLogs.fetch().error =>
+                # It probably means S3 logs haven't been configured
+                app.caughtError()
+                delete @collections.s3Logs
 
 module.exports = RequestDetailController

--- a/SingularityUI/app/templates/requestDetail/requestBase.hbs
+++ b/SingularityUI/app/templates/requestDetail/requestBase.hbs
@@ -34,3 +34,7 @@
 <div class="col-md-12" id="request-history">
     
 </div>
+
+<div class="col-md-12" id="request-tasks-logs">
+
+</div>

--- a/SingularityUI/app/views/request.coffee
+++ b/SingularityUI/app/views/request.coffee
@@ -33,6 +33,7 @@ class RequestView extends View
         @$('#request-history-msg').html @subviews.requestHistoryMsg.$el
         @$('#stats').html               @subviews.stats.$el
         @$('#active-tasks').html        @subviews.activeTasks.$el
+        @$('#request-tasks-logs').html  @subviews.requestTasksLogs.$el
         @$('#scheduled-tasks').html     @subviews.scheduledTasks.$el
         @$('#task-history').html        @subviews.taskHistory.$el
         @$('#deploy-history').html      @subviews.deployHistory.$el


### PR DESCRIPTION
Adds a new table on the request page for all its tasks s3 logs.

we should merge in https://github.com/HubSpot/Singularity/pull/523 before rolling this out though as we'll run into that same issue here.

@tpetr 