### PR TITLE
upgrade to new base_image

### DIFF
--- a/vagrant/Berksfile
+++ b/vagrant/Berksfile
@@ -1,3 +1,7 @@
 source 'https://supermarket.getchef.com'
 
-cookbook 'singularity', path: '../cookbook'
+cookbook 'singularity'
+
+cookbook 'mesos',
+         github: 'everpeace/cookbook-mesos',
+         ref: '85d4a8f5c441402844775d56b165919c99f8a546'

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -19,8 +19,8 @@ Vagrant.configure("2") do |config|
 
   config.vm.synced_folder "../", "/singularity", type: "nfs"
 
-  config.vm.box = "singularity-develop-0.21.0"
-  config.vm.box_url = "https://hubspot-vagrant-boxes.s3.amazonaws.com/singularity-develop-0.21.0"
+  config.vm.box = "singularity-develop-0.21.0-2"
+  config.vm.box_url = "https://hubspot-vagrant-boxes.s3.amazonaws.com/singularity-develop-0.21.0-2"
 
   config.vm.provider :virtualbox do |vb|
     vb.customize ["modifyvm", :id, "--memory", "1024"]
@@ -84,5 +84,7 @@ Vagrant.configure("2") do |config|
         }
       }
     end
+
+    build.vm.provision :shell, path: "provision_base.sh"
   end
 end

--- a/vagrant/provision-singularity.sh
+++ b/vagrant/provision-singularity.sh
@@ -69,14 +69,34 @@ enableCorsFilter: true
 EOF
 }
 
+function install_runnable_config {
+  mkdir -p /usr/share/mesos/logwatcher
+  mkdir -p /usr/share/mesos/s3
+  mkdir -p /usr/share/mesos/artifacts
+  cat > /etc/singularity.base.properties <<EOF
+root.log.directory=/etc/singularity
+logwatcher.metadata.directory=/usr/share/mesos/logwatcher
+s3uploader.metadata.directory=/usr/share/mesos/s3
+EOF
+  cat > /etc/singularity.executor.properties <<EOF
+executor.global.task.definition.directory=/usr/share/mesos
+executor.default.user=root
+executor.logrotate.to.directory=logs
+executor.s3.uploader.bucket=bucket
+executor.s3.uploader.pattern=%requestId/%Y/%m/%taskId_%index-%s%fileext
+executor.logrotate.command=/usr/sbin/logrotate
+EOF
+cat > /etc/singularity.s3base.yaml <<EOF
+artifactCacheDirectory: /usr/share/mesos/artifacts
+EOF
+  cat > /usr/local/bin/singularity-executor <<EOF
+#!/bin/bash
+exec java -Djava.library.path=/usr/local/lib -jar /singularity/SingularityExecutor/target/SingularityExecutor-*-shaded.jar
+EOF
+  chmod 755 /usr/local/bin/singularity-executor
+}
+
 function build_singularity {
-  # lame hack to install a recent mvn, thanks ubuntu...
-  if [ ! -f /usr/share/apache-maven-3.3.3/bin/mvn ]; then
-    wget -q http://apache.spinellicreations.com/maven/maven-3/3.3.3/binaries/apache-maven-3.3.3-bin.zip -O /tmp/apache-maven-3.3.3-bin.zip
-
-    unzip /tmp/apache-maven-3.3.3-bin.zip -d /usr/share/
-  fi
-
   cd /singularity
   sudo -u vagrant HOME=/home/vagrant /usr/share/apache-maven-3.3.3/bin/mvn clean package -DskipTests
 }
@@ -129,6 +149,7 @@ install_singularity_config
 build_singularity
 install_singularity
 migrate_db
+install_runnable_config
 start_singularity
 
 echo "The Singularity Web UI is available at http://vagrant-singularity:7099/singularity/"

--- a/vagrant/provision_base.sh
+++ b/vagrant/provision_base.sh
@@ -1,0 +1,40 @@
+#!/bin/bash -x
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Fail fast and fail hard.
+set -eo pipefail
+
+# Get the maven version right
+if [ ! -f /usr/share/apache-maven-3.3.3/bin/mvn ]; then
+  wget -q http://apache.spinellicreations.com/maven/maven-3/3.3.3/binaries/apache-maven-3.3.3-bin.zip -O /tmp/apache-maven-3.3.3-bin.zip
+  unzip /tmp/apache-maven-3.3.3-bin.zip -d /usr/share/
+fi
+
+if [ -f /usr/bin/mvn ]; then
+  rm -rf /usr/bin/mvn
+fi
+
+ln -s /usr/share/apache-maven-3.3.3/bin/mvn /usr/bin/mvn
+
+# Upgrade docker
+version=`docker -v`
+if [[ $version == *"1.6"* ]]; then
+  echo "Docker up to date"
+else
+  rm -rf `which docker`
+  wget -qO- https://get.docker.com/ | sh
+fi
+
+echo "ISOLATION=cgroups/cpu,cgroups/mem" >> /etc/default/mesos-slave


### PR DESCRIPTION
base_image:
- now relies on public version of singularity cookbook (/cc @eherot )
- upgrades maven after chef run (singularity cookbook does not support specifying a maven version)
- upgrade docker after chef run (singularity cookbook does not support specifying a docker version)
- run mesos-slave with cgroups isolation turned on as well

test:
- installs config such that the SingularityExecutor is usable right away
- don't need to upgrade maven in provision any more

This should fix the issue seen in #550 from the maven version. As of the last few runs I did not see the brunch error mentioned in #552 either

@tpetr 