### PR TITLE
save run now command-line-input to localstorage per request

### DIFF
--- a/SingularityUI/app/models/Request.coffee
+++ b/SingularityUI/app/models/Request.coffee
@@ -11,6 +11,7 @@ class Request extends Model
 
     # When we show the JSON dialog, we will ignore these attributes
     ignoreAttributes: ['id', 'paused', 'deleted', 'hasActiveDeploy', 'canBeRunNow', 'canBeBounced', 'starred']
+    localStorageCommandLineInputKeyPrefix: 'runRequestCommandLineInput::'
 
     url: => "#{ config.apiRoot }/requests/request/#{ @get('id') }"
 
@@ -133,12 +134,14 @@ class Request extends Model
                 return if @data is false
                 
                 fileName = @data.filename.trim()
+                commandLineInput = @data.commandLineInput.trim()
 
                 if fileName.length is 0 and @data.autoTail is 'on'
                     $(window.noFilenameError).removeClass('hide')
                     return false
 
-                else                    
+                else
+                    localStorage.setItem(@localStorageCommandLineInputKeyPrefix + @id, commandLineInput) if commandLineInput?
                     localStorage.setItem('taskRunRedirectFilename', fileName) if filename?
                     localStorage.setItem('taskRunAutoTail', @data.autoTail)
                     @data.id = @get 'id'
@@ -146,8 +149,9 @@ class Request extends Model
                     @run( @data.commandLineInput ).done callback( @data )
                     return true
 
-            afterOpen: -> 
+            afterOpen: => 
                 $('#filename').val localStorage.getItem('taskRunRedirectFilename')
+                $('#commandLineInput').val localStorage.getItem(@localStorageCommandLineInputKeyPrefix + @id)
                 $('#autoTail').prop 'checked', (localStorage.getItem('taskRunAutoTail') is 'on')
 
             callback: (data) =>


### PR DESCRIPTION
When running a request, this will save the command line input to local storage. This is similar to the saving of the filename if redirecting to tailing (added with this branch), but this will save the input for each request individually. 

@tpetr 