### PR TITLE
start tailing only after model and collection are fetched

### DIFF
--- a/SingularityUI/app/controllers/Tail.coffee
+++ b/SingularityUI/app/controllers/Tail.coffee
@@ -18,13 +18,9 @@ class TailController extends Controller
         app.showView @view
 
         if @offset?
-            $.when( @models.taskHistory.fetch(), @collections.logLines.fetchOffset(@offset) ).then =>
-                @view.afterInitialData()
+            $.when( @collections.logLines.fetchOffset(@offset), @refresh() ).then => @view.afterInitialOffsetData()
         else
-            $.when( @models.taskHistory.fetch(), @collections.logLines.fetchInitialData() ).then =>
-                @view.afterInitialData()
-        
-        @refresh()
+            $.when( @collections.logLines.fetchInitialData(), @refresh() ).then => @view.afterInitialData()
 
     refresh: ->
         @models.taskHistory.fetch()

--- a/SingularityUI/app/controllers/Tail.coffee
+++ b/SingularityUI/app/controllers/Tail.coffee
@@ -16,11 +16,14 @@ class TailController extends Controller
             model: @models.taskHistory
 
         app.showView @view
-        if @offset?
-            @collections.logLines.fetchOffset @offset
-        else
-            @collections.logLines.fetchInitialData()
 
+        if @offset?
+            $.when( @models.taskHistory.fetch(), @collections.logLines.fetchOffset(@offset) ).then =>
+                @view.afterInitialData()
+        else
+            $.when( @models.taskHistory.fetch(), @collections.logLines.fetchInitialData() ).then =>
+                @view.afterInitialData()
+        
         @refresh()
 
     refresh: ->

--- a/SingularityUI/app/views/tail.coffee
+++ b/SingularityUI/app/views/tail.coffee
@@ -17,9 +17,12 @@ class TailView extends View
     initialize: ({@taskId, @path, firstRequest, @offset}) ->
         @filename = _.last @path.split '/'
 
+        fetchDone = _.after 2, => @afterInitialData()
+        @model.once 'sync', => fetchDone()
+        @listenTo @collection, 'initialdata', fetchDone()
+
         @listenTo @collection, 'reset',       @dumpContents
         @listenTo @collection, 'sync',        @renderLines
-        @listenTo @collection, 'initialdata', @afterInitialData
         @listenTo @collection, 'initialOffsetData', @afterInitialOffsetData
 
         @listenTo @collection.state, 'change:moreToFetch', @showOrHideMoreToFetchSpinners

--- a/SingularityUI/app/views/tail.coffee
+++ b/SingularityUI/app/views/tail.coffee
@@ -17,10 +17,6 @@ class TailView extends View
     initialize: ({@taskId, @path, firstRequest, @offset}) ->
         @filename = _.last @path.split '/'
 
-        fetchDone = _.after 2, => @afterInitialData()
-        @model.once 'sync', => fetchDone()
-        @listenTo @collection, 'initialdata', fetchDone()
-
         @listenTo @collection, 'reset',       @dumpContents
         @listenTo @collection, 'sync',        @renderLines
         @listenTo @collection, 'initialOffsetData', @afterInitialOffsetData


### PR DESCRIPTION
Right now, on initial load of the tailing log file view, `startTailing` can run before the model is fetched, which leads to tailing not being started (as `isStillRunning` returns false). This change will require both the collection and model to be fetched before tailing starts.

@tpetr 