### PR TITLE
Mailer missing values

### DIFF
--- a/SingularityService/src/main/resources/templates/task.jade
+++ b/SingularityService/src/main/resources/templates/task.jade
@@ -48,9 +48,9 @@ html
               | The task has been running for #{ runTime }. Consider checking whether this task is running correctly.
               ul
                 li This is a one-time notification about this task.
-                li It was expected to run again at #{ expectedNextRunTime }. 
+                li It was expected to run again at #{ expectedRunTime }. 
                 li This can be configured on a per-request basis with scheduledExpectedRuntimeMillis, otherwise it is calculated based on the schedule or historical average.
-                li The warning threshold is #{ warningThreshold } of expectedNextRunTime. (part of global configuration.)
+                li The warning threshold is #{ warningThreshold } of expectedRunTime. (part of global configuration.)
           if requestScheduled
             if !taskStateRunning
               if taskWillRetry

--- a/SingularityService/src/main/resources/templates/task.jade
+++ b/SingularityService/src/main/resources/templates/task.jade
@@ -48,7 +48,7 @@ html
               | The task has been running for #{ runTime }. Consider checking whether this task is running correctly.
               ul
                 li This is a one-time notification about this task.
-                li It was expected to run again at #{ expectedRunTime }. 
+                li It was expected to run for a maximum of #{ expectedRunTime }. 
                 li This can be configured on a per-request basis with scheduledExpectedRuntimeMillis, otherwise it is calculated based on the schedule or historical average.
                 li The warning threshold is #{ warningThreshold } of expectedRunTime. (part of global configuration.)
           if requestScheduled

--- a/SingularityService/src/main/resources/templates/task.jade
+++ b/SingularityService/src/main/resources/templates/task.jade
@@ -48,7 +48,7 @@ html
               | The task has been running for #{ runTime }. Consider checking whether this task is running correctly.
               ul
                 li This is a one-time notification about this task.
-                li It was expected to run for a maximum of #{ expectedRunTime }. 
+                li It was expected to run for a maximum of #{ expectedRunTime }.
                 li This can be configured on a per-request basis with scheduledExpectedRuntimeMillis, otherwise it is calculated based on the schedule or historical average.
                 li The warning threshold is #{ warningThreshold } of expectedRunTime. (part of global configuration.)
           if requestScheduled


### PR DESCRIPTION
Solves #557 

1) Wrong variable name was being used
2) Text doesn't properly express what the value is showing as you mentioned