### PR TITLE
Service.log never complete

### DIFF
--- a/SingularityUI/app/views/tail.coffee
+++ b/SingularityUI/app/views/tail.coffee
@@ -1,5 +1,7 @@
 View = require './view'
 
+TERMINAL_TASK_STATES = ['TASK_KILLED', 'TASK_LOST', 'TASK_FAILED', 'TASK_FINISHED']
+
 class TailView extends View
 
     pollingTimeout: 3000
@@ -58,8 +60,6 @@ class TailView extends View
         $('#global-zeroclipboard-html-bridge').css 'top', '1px'
 
     renderLines: ->
-        [..., task] = @model.get('taskUpdates')
-        console.log(task.taskState)
         # So we want to either prepend (fetchPrevious) or append (fetchNext) the lines
         # Well, or just render them if we're starting fresh
         $firstLine = @$linesWrapper.find '.line:first-child'
@@ -178,8 +178,8 @@ class TailView extends View
         @$el.addClass 'tailing'
 
     stopTailing: ->
-        return if @isTailing isnt true
-
+        [..., task] = @model.get('taskUpdates')
+        return if @isTailing isnt true and task.taskState in TERMINAL_TASK_STATES
         @isTailing = false
         clearInterval @tailInterval
         @$el.removeClass 'tailing'

--- a/SingularityUI/app/views/tail.coffee
+++ b/SingularityUI/app/views/tail.coffee
@@ -180,6 +180,7 @@ class TailView extends View
     stopTailing: ->
         [..., task] = @model.get('taskUpdates')
         return if @isTailing isnt true and task.taskState in TERMINAL_TASK_STATES
+
         @isTailing = false
         clearInterval @tailInterval
         @$el.removeClass 'tailing'

--- a/SingularityUI/app/views/tail.coffee
+++ b/SingularityUI/app/views/tail.coffee
@@ -58,6 +58,8 @@ class TailView extends View
         $('#global-zeroclipboard-html-bridge').css 'top', '1px'
 
     renderLines: ->
+        [..., task] = @model.get('taskUpdates')
+        console.log(task.taskState)
         # So we want to either prepend (fetchPrevious) or append (fetchNext) the lines
         # Well, or just render them if we're starting fresh
         $firstLine = @$linesWrapper.find '.line:first-child'

--- a/SingularityUI/app/views/tail.coffee
+++ b/SingularityUI/app/views/tail.coffee
@@ -178,7 +178,7 @@ class TailView extends View
         @$el.addClass 'tailing'
 
     stopTailing: ->
-        [..., task] = @model.get('taskUpdates')
+        task = @model.get('taskUpdates')[..].pop()
         return if @isTailing isnt true and task.taskState in TERMINAL_TASK_STATES
 
         @isTailing = false


### PR DESCRIPTION
resolves issue w/ browser tailing ending too soon by checking terminal states.

>If I have a job, and I wanna monitor it's progress-- I click into the service.log and I see it chugging along, but as it finishes, it's very likely that I won't see the last few seconds worth of logs which can be the difference between success or fail and why it fails, so then to figure that out, I need to click back out and then into tail-of-finished-service.log.
It's not a huge issue, but a minor annoyance that adds up over time. Would be awesome if I could monitor the progress all the way to the bitter end.

