### PR TITLE
Task state labels

### DIFF
--- a/SingularityUI/app/handlebarsHelpers.coffee
+++ b/SingularityUI/app/handlebarsHelpers.coffee
@@ -107,7 +107,15 @@ Handlebars.registerHelper 'usernameFromEmail', (email) ->
 Handlebars.registerHelper 'substituteTaskId', (value, taskId) ->
     value.replace('$TASK_ID', taskId)
 
-Handlebars.registerHelper 'labelClassForTaskState', (value, taskId) ->
-    value.replace('$TASK_ID', taskId)
-
-Handlebars.logger.level = 0;
+Handlebars.registerHelper 'getLabelClass', (state) ->
+    switch state
+        when 'TASK_STARTING', 'TASK_CLEANING'
+            'warning'
+        when 'TASK_STAGING', 'TASK_LAUNCHED', 'TASK_RUNNING'
+            'info'
+        when 'TASK_FINISHED'
+            'success'
+        when 'TASK_KILLED', 'TASK_LOST', 'TASK_FAILED', 'TASK_LOST_WHILE_DOWN'
+            'danger'
+        else
+            'default'

--- a/SingularityUI/app/handlebarsHelpers.coffee
+++ b/SingularityUI/app/handlebarsHelpers.coffee
@@ -106,3 +106,8 @@ Handlebars.registerHelper 'usernameFromEmail', (email) ->
 
 Handlebars.registerHelper 'substituteTaskId', (value, taskId) ->
     value.replace('$TASK_ID', taskId)
+
+Handlebars.registerHelper 'labelClassForTaskState', (value, taskId) ->
+    value.replace('$TASK_ID', taskId)
+
+Handlebars.logger.level = 0;

--- a/SingularityUI/app/templates/requestDetail/requestActiveTasks.hbs
+++ b/SingularityUI/app/templates/requestDetail/requestActiveTasks.hbs
@@ -25,7 +25,7 @@
                         </span>
                     </td>
                     <td class="hidden-sm hidden-xs">
-                        {{humanizeText lastTaskState}}
+                        <span class="label label-{{getLabelClass lastTaskState}}">{{humanizeText lastTaskState}}</span>
                     </td>
                     <td class="hidden-sm hidden-xs">
                         {{ taskId.deployId }}

--- a/SingularityUI/app/templates/requestDetail/requestHistoricalTasks.hbs
+++ b/SingularityUI/app/templates/requestDetail/requestHistoricalTasks.hbs
@@ -37,7 +37,6 @@
                             </span>
                         </td>
                         <td class="hidden-sm hidden-xs">
-                            {{log lastTaskState}}
                             <span class="label label-{{getLabelClass lastTaskState}}">{{humanizeText lastTaskState}}</span>
                         </td>
                         <td class="hidden-sm hidden-xs">
@@ -49,7 +48,6 @@
                         <td class="hidden-xs">
                             {{timestampFromNow updatedAt}}
                         </td>
-                        {{log ../../config.finishedTaskLogPath}}
                         <td class="hidden-xs actions-column">
                             <a href="{{ appRoot }}/task/{{ taskId.id }}/tail/{{ substituteTaskId ../../config.finishedTaskLogPath taskId.id }}" title="Log">
                                 ...

--- a/SingularityUI/app/templates/requestDetail/requestHistoricalTasks.hbs
+++ b/SingularityUI/app/templates/requestDetail/requestHistoricalTasks.hbs
@@ -37,7 +37,8 @@
                             </span>
                         </td>
                         <td class="hidden-sm hidden-xs">
-                            {{humanizeText lastTaskState}}
+                            {{log lastTaskState}}
+                            <span class="label label-default">{{humanizeText lastTaskState}}</span>
                         </td>
                         <td class="hidden-sm hidden-xs">
                             {{ taskId.deployId }}

--- a/SingularityUI/app/templates/requestDetail/requestHistoricalTasks.hbs
+++ b/SingularityUI/app/templates/requestDetail/requestHistoricalTasks.hbs
@@ -38,7 +38,7 @@
                         </td>
                         <td class="hidden-sm hidden-xs">
                             {{log lastTaskState}}
-                            <span class="label label-default">{{humanizeText lastTaskState}}</span>
+                            <span class="label label-{{getLabelClass lastTaskState}}">{{humanizeText lastTaskState}}</span>
                         </td>
                         <td class="hidden-sm hidden-xs">
                             {{ taskId.deployId }}


### PR DESCRIPTION
added task state labels as @tpetr suggested
> color-coded badges for task states throughout the singularity UI. Makes it easier to understand what's going on with a quick glance

they are controlled by a switch statement, simpler to read than object literals in this situation IMO since there are many options for 1 color (see http://toddmotto.com/deprecating-the-switch-statement-for-object-literals/)