### PR TITLE
SingularityExecutor in docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,11 @@ RUN apt-get update && \
 ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
 
 COPY SingularityService/target/SingularityService-0.4.2-SNAPSHOT-shaded.jar /etc/singularity/singularity.jar
-COPY docker /etc
+COPY SingularityExecutor/target/SingularityExecutor-0.4.2-SNAPSHOT-shaded.jar /etc/singularity/executor.jar
+
+COPY docker/singularity /etc/singularity
+COPY docker/executor/singularity-executor /usr/local/bin/singularity-executor
+RUN chmod 755 /usr/local/bin/singularity-executor
 
 CMD '/etc/singularity/start.sh'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ master:
     MESOS_WORK_DIR: /var/lib/mesos
 
 slave:
-  image: mesosphere/mesos-slave:0.21.1-1.1.ubuntu1404
+  image: hubspot/singularity
   entrypoint: mesos-slave
   net: host
   environment:

--- a/docker/executor/singularity-executor
+++ b/docker/executor/singularity-executor
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec java -Djava.library.path=/usr/local/lib -jar /etc/singularity/executor.jar


### PR DESCRIPTION
This uses the hubspot/singularity image for the slave as well as the scheduler. By adding the executor jar into the hubspot/singularity image, we can use it for both and have the custom executor available without having to download a separate slave image

/cc @gchomatas 