### PR TITLE
Improve ExtendedTaskState: verify on startup that every possible TaskState has a mapping

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/ExtendedTaskState.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/ExtendedTaskState.java
@@ -24,6 +24,12 @@ public enum ExtendedTaskState {
         map.put(extendedTaskState.toTaskState().get(), extendedTaskState);
       }
     }
+
+    for (TaskState t : TaskState.values()) {
+      if (map.get(t) == null) {
+        throw new IllegalStateException("No ExtendedTaskState provided for TaskState " + t + ", you probably have incompatible versions of Mesos and Singularity.");
+      }
+    }
   }
 
   private final String displayName;
@@ -58,7 +64,7 @@ public enum ExtendedTaskState {
 
   public static ExtendedTaskState fromTaskState(TaskState taskState) {
     ExtendedTaskState extendedTaskState = map.get(taskState);
-    Preconditions.checkArgument(extendedTaskState != null);
+    Preconditions.checkArgument(extendedTaskState != null, "No ExtendedTaskState for TaskState %s", taskState);
     return extendedTaskState;
   }
 


### PR DESCRIPTION
Improve error message should this somehow fail (right now it is "IllegalArgumentException: null"

Note that this causes tests to fail as we are missing the `TASK_ERROR` state.  I don't know what the proper thing to do is, so I left the test failing, but it needs attention as this causes scheduler aborts if any task enters `TASK_ERROR` state.