### PR TITLE
Suppress task messages if a slave is in a decomissioning state

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/smtp/SingularityMailer.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/smtp/SingularityMailer.java
@@ -4,8 +4,10 @@ import io.dropwizard.lifecycle.Managed;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
@@ -24,9 +26,11 @@ import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.hubspot.mesos.JavaUtils;
 import com.hubspot.singularity.ExtendedTaskState;
+import com.hubspot.singularity.MachineState;
 import com.hubspot.singularity.RequestType;
 import com.hubspot.singularity.SingularityMainModule;
 import com.hubspot.singularity.SingularityRequest;
+import com.hubspot.singularity.SingularitySlave;
 import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.SingularityTaskCleanup.TaskCleanupType;
 import com.hubspot.singularity.SingularityTaskHistoryUpdate;
@@ -36,6 +40,7 @@ import com.hubspot.singularity.config.EmailConfigurationEnums.EmailType;
 import com.hubspot.singularity.config.SMTPConfiguration;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.MetadataManager;
+import com.hubspot.singularity.data.SlaveManager;
 import com.hubspot.singularity.data.TaskManager;
 import com.hubspot.singularity.sentry.SingularityExceptionNotifier;
 
@@ -45,6 +50,8 @@ import de.neuland.jade4j.template.JadeTemplate;
 public class SingularityMailer implements Managed {
 
   private static final Logger LOG = LoggerFactory.getLogger(SingularityMailer.class);
+  private static final Set<MachineState> NO_EMAIL_MACHINE_STATES =
+    EnumSet.of(MachineState.STARTING_DECOMMISSION, MachineState.DECOMMISSIONING, MachineState.DECOMMISSIONED);
 
   private final SingularitySmtpSender smtpSender;
   private final SingularityConfiguration configuration;
@@ -53,6 +60,7 @@ public class SingularityMailer implements Managed {
   private final SingularityExceptionNotifier exceptionNotifier;
 
   private final TaskManager taskManager;
+  private final SlaveManager slaveManager;
 
   private final JadeTemplate taskTemplate;
   private final JadeTemplate requestInCooldownTemplate;
@@ -69,6 +77,7 @@ public class SingularityMailer implements Managed {
       SingularitySmtpSender smtpSender,
       SingularityConfiguration configuration,
       TaskManager taskManager,
+      SlaveManager slaveManager,
       MetadataManager metadataManager,
       SingularityExceptionNotifier exceptionNotifier,
       MailTemplateHelpers mailTemplateHelpers,
@@ -81,6 +90,7 @@ public class SingularityMailer implements Managed {
     this.maybeSmtpConfiguration = configuration.getSmtpConfiguration();
     this.configuration = configuration;
     this.taskManager = taskManager;
+    this.slaveManager = slaveManager;
     this.metadataManager = metadataManager;
     this.exceptionNotifier = exceptionNotifier;
     this.adminJoiner = Joiner.on(", ").skipNulls();
@@ -249,6 +259,15 @@ public class SingularityMailer implements Managed {
     if (emailDestination.isEmpty()) {
       LOG.debug("Not configured to send task mail for {}", emailType);
       return;
+    }
+
+    if (task.isPresent()) {
+      final String slaveId = task.get().getMesosTask().getSlaveId().getValue();
+      Optional<SingularitySlave> slave = slaveManager.getObject(slaveId);
+      if (slave.isPresent() && NO_EMAIL_MACHINE_STATES.contains(slave.get().getCurrentState().getState())) {
+        LOG.debug("No task mail for {} because slave is decomissioning: {}", task.get().getTaskId(), slave);
+        return;
+      }
     }
 
     final Map<String, Object> templateProperties = Maps.newHashMap();


### PR DESCRIPTION
There's not much point to notifying end users that a task fails if an admin explicitly asked for it to happen, it just raises false alarm
