### PR TITLE
Validate and add TASK_ERROR support

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/ExtendedTaskState.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/ExtendedTaskState.java
@@ -14,7 +14,7 @@ public enum ExtendedTaskState {
   TASK_STARTING("starting", false, Optional.of(TaskState.TASK_STARTING)), TASK_RUNNING("running", false, Optional.of(TaskState.TASK_RUNNING)),
   TASK_CLEANING("cleaning", false, Optional.<TaskState> absent()), TASK_FINISHED("finished", true, Optional.of(TaskState.TASK_FINISHED)),
   TASK_FAILED("failed", true, Optional.of(TaskState.TASK_FAILED)), TASK_KILLED("killed", true, Optional.of(TaskState.TASK_KILLED)),
-  TASK_LOST("lost", true, Optional.of(TaskState.TASK_LOST)), TASK_LOST_WHILE_DOWN("lost", true, Optional.<TaskState> absent());
+  TASK_LOST("lost", true, Optional.of(TaskState.TASK_LOST)), TASK_LOST_WHILE_DOWN("lost", true, Optional.<TaskState> absent()), TASK_ERROR("error", true, Optional.of(TaskState.TASK_ERROR));
 
   private static final Map<TaskState, ExtendedTaskState> map;
   static {
@@ -36,7 +36,7 @@ public enum ExtendedTaskState {
   private final boolean isDone;
   private final Optional<TaskState> taskState;
 
-  private ExtendedTaskState(String displayName, boolean isDone, Optional<TaskState> taskState) {
+  ExtendedTaskState(String displayName, boolean isDone, Optional<TaskState> taskState) {
     this.displayName = displayName;
     this.isDone = isDone;
     this.taskState = taskState;

--- a/SingularityBase/src/main/java/com/hubspot/singularity/ExtendedTaskState.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/ExtendedTaskState.java
@@ -24,6 +24,12 @@ public enum ExtendedTaskState {
         map.put(extendedTaskState.toTaskState().get(), extendedTaskState);
       }
     }
+
+    for (TaskState t : TaskState.values()) {
+      if (map.get(t) == null) {
+        throw new IllegalStateException("No ExtendedTaskState provided for TaskState " + t);
+      }
+    }
   }
 
   private final String displayName;
@@ -58,7 +64,7 @@ public enum ExtendedTaskState {
 
   public static ExtendedTaskState fromTaskState(TaskState taskState) {
     ExtendedTaskState extendedTaskState = map.get(taskState);
-    Preconditions.checkArgument(extendedTaskState != null);
+    Preconditions.checkArgument(extendedTaskState != null, "No ExtendedTaskState for TaskState %s", taskState);
     return extendedTaskState;
   }
 


### PR DESCRIPTION
https://github.com/HubSpot/Singularity/pull/598 + `TASK_ERROR` support

From http://mesos.apache.org/blog/mesos-0-21-0-released/:

> We have also introduced the notion of a TASK_ERROR state, distinct from TASK_LOST. The semantic difference is that tasks that are updated as lost can be rescheduled and should succeed, while tasks with status error will continue to fail if they are rescheduled. In Mesos 0.21.0 we do not send TASK_ERROR but it has been defined so frameworks can prepare to receive it. We will start sending it in Mesos 0.22.0.
