### PR TITLE
update docker.sh.hbs template

### DIFF
--- a/SingularityExecutor/src/main/resources/docker.sh.hbs
+++ b/SingularityExecutor/src/main/resources/docker.sh.hbs
@@ -56,14 +56,12 @@ function enable_cgroup_hierarchy {
   echo 1 > $CGROUPS_DIR/memory/mesos/$CGROUPS_GUID/memory.use_hierarchy
 }
 
-function join { local IFS="$1"; shift; echo "$*"; }
-
 DOCKER_IMAGE={{{ envContext.dockerInfo.image }}}
 
 # load env vars
 touch docker.env
 {{#each envContext.env}}
-export {{{name}}}={{{bashEscaped value}}}
+{{{name}}}={{{bashEscaped value}}}
 echo "{{{name}}}={{{value}}}" >> docker.env
 {{/each}}
 

--- a/SingularityExecutor/src/main/resources/docker.sh.hbs
+++ b/SingularityExecutor/src/main/resources/docker.sh.hbs
@@ -56,13 +56,15 @@ function enable_cgroup_hierarchy {
   echo 1 > $CGROUPS_DIR/memory/mesos/$CGROUPS_GUID/memory.use_hierarchy
 }
 
+function join { local IFS="$1"; shift; echo "$*"; }
+
 DOCKER_IMAGE={{{ envContext.dockerInfo.image }}}
 
-DOCKER_ENV=()
-
 # load env vars
+touch docker.env
 {{#each envContext.env}}
-DOCKER_ENV+=( -e {{{name}}}={{{bashEscaped value}}} )
+export {{{name}}}={{{bashEscaped value}}}
+echo "{{{name}}}={{{value}}}" >> docker.env
 {{/each}}
 
 # Create log directory for logrotate runs
@@ -75,9 +77,7 @@ fi
 # load artifact's profile.d
 if [[ -d .profile.d ]]; then
   for FILE in $(ls .profile.d/*); do
-    while read -r line; do
-      DOCKER_ENV+=( -e "$line" )
-    done <<< $FILE
+    echo $FILE >> docker.env
   done
 else
   echo "No deploy-specific profile.d"
@@ -91,9 +91,9 @@ DOCKER_PORTS=()
 # set up attached volumes
 DOCKER_VOLUMES=()
 DOCKER_VOLUMES+=( -v "$CURRENT_DIR:/mnt/mesos/sandbox" )
-DOCKER_ENV+=( -e MESOS_SANDBOX=/mnt/mesos/sandbox )
-DOCKER_ENV+=( -e LOG_HOME=/mnt/mesos/sandbox/logs )
-DOCKER_ENV+=( -e MESOS_TASK_ID={{{bashEscaped runContext.taskId}}} )
+echo "MESOS_SANDBOX=/mnt/mesos/sandbox" >> docker.env
+echo "LOG_HOME=/mnt/mesos/sandbox/logs" >> docker.env
+echo "MESOS_TASK_ID={{{bashEscaped runContext.taskId}}}" >> docker.env
 {{#each envContext.containerVolumes}}
 {{#if mode}}raw_mode{{@index}}={{{ mode }}}{{/if}}
 DOCKER_VOLUMES+=( -v "{{{ hostPath }}}:{{{ containerPath }}}{{#if mode}}:${raw_mode{{@index}},,}{{/if}}" )
@@ -109,7 +109,7 @@ DOCKER_NETWORK="--net=host"
 
 DOCKER_WORKDIR="/mnt/mesos/sandbox/{{{ runContext.taskAppDirectory }}}"
 
-DOCKER_OPTIONS="--name=$CONTAINER_NAME --cgroup-parent=mesos/$CGROUPS_GUID -w $DOCKER_WORKDIR $DOCKER_NETWORK ${DOCKER_ENV[@]} ${DOCKER_VOLUMES[@]} ${DOCKER_PORTS[@]}"
+DOCKER_OPTIONS="--name=$CONTAINER_NAME --cgroup-parent=mesos/$CGROUPS_GUID -w $DOCKER_WORKDIR $DOCKER_NETWORK --env-file=docker.env ${DOCKER_VOLUMES[@]} ${DOCKER_PORTS[@]}"
 
 echo "Ensuring {{{ runContext.taskAppDirectory }}} is owned by {{{ runContext.user }}}"
 mkdir -p {{{ runContext.taskAppDirectory }}}

--- a/SingularityExecutor/src/main/resources/docker.sh.hbs
+++ b/SingularityExecutor/src/main/resources/docker.sh.hbs
@@ -58,11 +58,11 @@ function enable_cgroup_hierarchy {
 
 DOCKER_IMAGE={{{ envContext.dockerInfo.image }}}
 
-DOCKER_ENV=""
+DOCKER_ENV=()
 
 # load env vars
 {{#each envContext.env}}
-DOCKER_ENV="$DOCKER_ENV -e {{{name}}}={{{bashEscaped value}}}"
+DOCKER_ENV+=( -e {{{name}}}={{{bashEscaped value}}} )
 {{/each}}
 
 # Create log directory for logrotate runs
@@ -76,7 +76,7 @@ fi
 if [[ -d .profile.d ]]; then
   for FILE in $(ls .profile.d/*); do
     while read -r line; do
-      DOCKER_ENV="$DOCKER_ENV -e $line"
+      DOCKER_ENV+=( -e "$line" )
     done <<< $FILE
   done
 else
@@ -84,17 +84,19 @@ else
 fi
 
 # set up port mappings
-{{#each envContext.dockerInfo.portMappingsList}}DOCKER_PORTS="$DOCKER_PORTS -p {{{ hostPort }}}:{{{ containerPort }}}"
+DOCKER_PORTS=()
+{{#each envContext.dockerInfo.portMappingsList}}DOCKER_PORTS+=( -p {{{ hostPort }}}:{{{ containerPort }}} )
 {{/each}}
 
 # set up attached volumes
-DOCKER_VOLUMES="-v $CURRENT_DIR:/mnt/mesos/sandbox"
-DOCKER_ENV="$DOCKER_ENV -e MESOS_SANDBOX=/mnt/mesos/sandbox"
-DOCKER_ENV="$DOCKER_ENV -e LOG_HOME=/mnt/mesos/sandbox/logs"
-DOCKER_ENV="$DOCKER_ENV -e MESOS_TASK_ID={{{bashEscaped runContext.taskId}}}"
+DOCKER_VOLUMES=()
+DOCKER_VOLUMES+=( -v "$CURRENT_DIR:/mnt/mesos/sandbox" )
+DOCKER_ENV+=( -e MESOS_SANDBOX=/mnt/mesos/sandbox )
+DOCKER_ENV+=( -e LOG_HOME=/mnt/mesos/sandbox/logs )
+DOCKER_ENV+=( -e MESOS_TASK_ID={{{bashEscaped runContext.taskId}}} )
 {{#each envContext.containerVolumes}}
 {{#if mode}}raw_mode{{@index}}={{{ mode }}}{{/if}}
-DOCKER_VOLUMES="$DOCKER_VOLUMES -v {{{ hostPath }}}:{{{ containerPath }}}{{#if mode}}:${raw_mode{{@index}},,}{{/if}}"
+DOCKER_VOLUMES+=( -v "{{{ hostPath }}}:{{{ containerPath }}}{{#if mode}}:${raw_mode{{@index}},,}{{/if}}" )
 {{/each}}
 
 # set up network config
@@ -107,7 +109,7 @@ DOCKER_NETWORK="--net=host"
 
 DOCKER_WORKDIR="/mnt/mesos/sandbox/{{{ runContext.taskAppDirectory }}}"
 
-DOCKER_OPTIONS="--name=$CONTAINER_NAME --cgroup-parent=mesos/$CGROUPS_GUID -w $DOCKER_WORKDIR $DOCKER_NETWORK $DOCKER_ENV $DOCKER_VOLUMES $DOCKER_PORTS"
+DOCKER_OPTIONS="--name=$CONTAINER_NAME --cgroup-parent=mesos/$CGROUPS_GUID -w $DOCKER_WORKDIR $DOCKER_NETWORK ${DOCKER_ENV[@]} ${DOCKER_VOLUMES[@]} ${DOCKER_PORTS[@]}"
 
 echo "Ensuring {{{ runContext.taskAppDirectory }}} is owned by {{{ runContext.user }}}"
 mkdir -p {{{ runContext.taskAppDirectory }}}


### PR DESCRIPTION
with certain variables put in, this template breaks with things like `DOCKER_ENV="$DOCKER_ENV -e JVM_DEFAULT_OPTS="-Xms${JVM_MIN_HEAP:-128m}""`

sets of quotes end up giving us issues. This interprets the variables better