### PR TITLE
add correct path to static assets

### DIFF
--- a/SingularityUI/app/assets/_index.mustache
+++ b/SingularityUI/app/assets/_index.mustache
@@ -19,6 +19,7 @@
     {{/navColor}}
     <script>
         window.config = {
+            staticRoot: "{{{staticRoot}}}",
             appRoot: "{{{appRoot}}}",
             apiDocs: "{{{apiDocs}}}",
             apiRoot: localStorage.getItem("apiRootOverride") || "{{{apiRoot}}}",

--- a/SingularityUI/app/thirdPartyConfigurations.coffee
+++ b/SingularityUI/app/thirdPartyConfigurations.coffee
@@ -36,7 +36,7 @@ Messenger.options =
 # ZeroClipboard options
 ZeroClipboard.config
     debug: false
-    swfPath: "#{ config.appRoot }/static/swf/ZeroClipboard.swf"
+    swfPath: "#{ config.staticRoot }/swf/ZeroClipboard.swf"
 
 # Overwrite Handlebars logging
 Handlebars.logger.log = (stuff...) =>


### PR DESCRIPTION
the zeroclipboard path has been referencing the `config.appRoot` which changed a while back, with the inclusion of `/ui`. Consequently the path to the movie file was incorrect, breaking the copy text feature. this fixes the isssue, using the `staticRoot` instead.

