### PR TITLE
clear scheduled tasks list on fetch

### DIFF
--- a/SingularityUI/app/controllers/RequestDetail.coffee
+++ b/SingularityUI/app/controllers/RequestDetail.coffee
@@ -123,6 +123,7 @@ class RequestDetailController extends Controller
 
         @collections.activeTasks.fetch().error    @ignore404
         @collections.scheduledTasks.fetch().error @ignore404
+        @collections.scheduledTasks.fetch({reset: true}).error @ignore404
         
         if @collections.requestHistory.currentPage is 1
             requestHistoryFetch = @collections.requestHistory.fetch()


### PR DESCRIPTION
on the request page scheduled tasks (table) will pile up when they've actually become active, this clears it on subsequent fetches.