### PR TITLE
downgrade jackson-datatype-protobuf back to 0.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
       <dependency>
         <groupId>com.hubspot.jackson</groupId>
         <artifactId>jackson-datatype-protobuf</artifactId>
-        <version>0.8.0</version>
+        <version>0.4.0</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
`jackson-datatype-protobuf` was upgraded from 0.4.0 to 0.8.0 in #611, which caused Singularity to have perf issues (hitting `zkAsyncTimeout` in TaskManager.getActiveTasks()). We believe the slowdown is from this commit: https://github.com/HubSpot/jackson-datatype-protobuf/commit/daab7a5e1e44dce6e16d6e14f239fd664d53c9da

Since we haven't hit any issues that the protobuf updates have addressed, it's probably fine to keep it on the old version for now.

FYI @stevenschlansker in case you pulled this stuff into your custom build

/cc @jhaber 