### PR TITLE
Truncate beginning of S3 log filenames

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/config/UIConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/UIConfiguration.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.Locale;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
 import org.hibernate.validator.constraints.NotEmpty;
@@ -52,14 +53,6 @@ public class UIConfiguration {
   @NotEmpty
   private String finishedTaskLogPath = "stdout";
 
-  public String getRunningTaskLogPath() {
-    return runningTaskLogPath;
-  }
-
-  public String getFinishedTaskLogPath() {
-    return finishedTaskLogPath;
-  }
-
   private boolean hideNewDeployButton = false;
   private boolean hideNewRequestButton = false;
 
@@ -69,6 +62,9 @@ public class UIConfiguration {
    */
   @JsonProperty
   private String rootUrlMode = RootUrlMode.INDEX_CATCHALL.name();
+
+  @NotNull
+  private String taskS3LogOmitPrefix = "";
 
   public boolean isHideNewDeployButton() {
     return hideNewDeployButton;
@@ -136,5 +132,21 @@ public class UIConfiguration {
 
   public void setFinishedTaskLogPath(String finishedTaskLogPath) {
     this.finishedTaskLogPath = finishedTaskLogPath;
+  }
+
+  public String getRunningTaskLogPath() {
+    return runningTaskLogPath;
+  }
+
+  public String getFinishedTaskLogPath() {
+    return finishedTaskLogPath;
+  }
+
+  public String getTaskS3LogOmitPrefix() {
+    return taskS3LogOmitPrefix;
+  }
+
+  public void setTaskS3LogOmitPrefix(String taskS3LogOmitPrefix) {
+    this.taskS3LogOmitPrefix = taskS3LogOmitPrefix;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/views/IndexView.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/views/IndexView.java
@@ -35,6 +35,8 @@ public class IndexView extends View {
 
   private final String commonHostnameSuffixToOmit;
 
+  private final String taskS3LogOmitPrefix;
+
   public IndexView(String singularityUriBase, String appRoot, SingularityConfiguration configuration) {
     super("index.mustache");
 
@@ -68,6 +70,8 @@ public class IndexView extends View {
     this.finishedTaskLogPath = configuration.getUiConfiguration().getFinishedTaskLogPath();
 
     this.commonHostnameSuffixToOmit = configuration.getCommonHostnameSuffixToOmit().or("");
+
+    this.taskS3LogOmitPrefix = configuration.getUiConfiguration().getTaskS3LogOmitPrefix();
   }
 
   public String getAppRoot() {
@@ -140,6 +144,10 @@ public class IndexView extends View {
 
   public String getCommonHostnameSuffixToOmit() {
     return commonHostnameSuffixToOmit;
+  }
+
+  public String getTaskS3LogOmitPrefix() {
+    return taskS3LogOmitPrefix;
   }
 
   @Override

--- a/SingularityUI/app/assets/_index.mustache
+++ b/SingularityUI/app/assets/_index.mustache
@@ -34,6 +34,7 @@
             runningTaskLogPath: "{{{ runningTaskLogPath }}}",
             finishedTaskLogPath: "{{{ finishedTaskLogPath }}}",
             commonHostnameSuffixToOmit: "{{{ commonHostnameSuffixToOmit }}}",
+            taskS3LogOmitPrefix: "{{{ taskS3LogOmitPrefix }}}",
             slaveHttpPort: {{{slaveHttpPort}}},
             {{#slaveHttpsPort}}
             slaveHttpsPort: {{{slaveHttpsPort}}}

--- a/SingularityUI/app/collections/TaskS3Logs.coffee
+++ b/SingularityUI/app/collections/TaskS3Logs.coffee
@@ -3,11 +3,16 @@ S3Log = require '../models/S3Log'
 PaginableCollection = require './PaginableCollection'
 
 class TaskS3Logs extends PaginableCollection
-    
+
     model: S3Log
 
     url: -> "#{ config.apiRoot }/logs/task/#{ @taskId }"
 
     initialize: (models, { @taskId }) =>
+
+    parse: (model) ->
+        for m in model
+            m.taskId = @taskId
+        model
 
 module.exports = TaskS3Logs

--- a/SingularityUI/app/handlebarsHelpers.coffee
+++ b/SingularityUI/app/handlebarsHelpers.coffee
@@ -120,3 +120,6 @@ Handlebars.registerHelper 'getLabelClass', (state) ->
             'danger'
         else
             'default'
+
+Handlebars.registerHelper 'trimS3File', (filename) ->
+    return '...' + filename.substring(filename.indexOf("service.log"));

--- a/SingularityUI/app/handlebarsHelpers.coffee
+++ b/SingularityUI/app/handlebarsHelpers.coffee
@@ -121,5 +121,6 @@ Handlebars.registerHelper 'getLabelClass', (state) ->
         else
             'default'
 
-Handlebars.registerHelper 'trimS3File', (filename) ->
-    return '...' + filename.substring(filename.indexOf("service.log"));
+Handlebars.registerHelper 'trimS3File', (filename, taskId) ->
+    console.log filename
+    return filename.replace(taskId, '...')

--- a/SingularityUI/app/handlebarsHelpers.coffee
+++ b/SingularityUI/app/handlebarsHelpers.coffee
@@ -122,5 +122,4 @@ Handlebars.registerHelper 'getLabelClass', (state) ->
             'default'
 
 Handlebars.registerHelper 'trimS3File', (filename, taskId) ->
-    console.log filename
     return filename.replace(taskId, '...')

--- a/SingularityUI/app/handlebarsHelpers.coffee
+++ b/SingularityUI/app/handlebarsHelpers.coffee
@@ -122,4 +122,9 @@ Handlebars.registerHelper 'getLabelClass', (state) ->
             'default'
 
 Handlebars.registerHelper 'trimS3File', (filename, taskId) ->
-    return filename.replace(taskId, '...')
+    unless config.taskS3LogOmitPrefix
+        return filename
+
+    finalRegex = config.taskS3LogOmitPrefix.replace('%taskId', taskId.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')).replace('%index', '[0-9]+').replace('%s', '[0-9]+')
+
+    return filename.replace(new RegExp(finalRegex), '')

--- a/SingularityUI/app/templates/taskDetail/taskS3Logs.hbs
+++ b/SingularityUI/app/templates/taskDetail/taskS3Logs.hbs
@@ -18,7 +18,7 @@
                         <tr>
                             <td>
                                 <a class="long-link" href="{{ getUrl }}" target="_blank" title="{{ key }}">
-                                    {{ shortKey }}
+                                    {{ trimS3File shortKey }}
                                 </a>
                             </td>
                             <td>

--- a/SingularityUI/app/templates/taskDetail/taskS3Logs.hbs
+++ b/SingularityUI/app/templates/taskDetail/taskS3Logs.hbs
@@ -18,7 +18,7 @@
                         <tr>
                             <td>
                                 <a class="long-link" href="{{ getUrl }}" target="_blank" title="{{ key }}">
-                                    {{ trimS3File shortKey }}
+                                    {{ trimS3File shortKey taskId }}
                                 </a>
                             </td>
                             <td>

--- a/SingularityUI/config.coffee
+++ b/SingularityUI/config.coffee
@@ -53,6 +53,7 @@ exports.config =
             runningTaskLogPath:  process.env.SINGULARITY_RUNNING_TASK_LOG_PATH ? "stdout"
             finishedTaskLogPath: process.env.SINGULARITY_FINISHED_TASK_LOG_PATH ? "stdout"
             commonHostnameSuffixToOmit: process.env.SINGULARITY_COMMON_HOSTNAME_SUFFIX_TO_OMIT ? ""
+            taskS3LogOmitPrefix: process.env.SINGULARITY_TASK_S3_LOG_OMIT_PREFIX ? ''
 
         compiledTemplate = handlebars.compile(indexTemplate)(templateData)
         fs.writeFileSync destination, compiledTemplate


### PR DESCRIPTION
Truncate the beginning of s3 log files to enable reading of useful information.