### PR TITLE
Add no-op main class to SingularityServiceIntegrationTests

### DIFF
--- a/SingularityServiceIntegrationTests/src/main/java/com/hubspot/singularity/ServiceIntegrationTests.java
+++ b/SingularityServiceIntegrationTests/src/main/java/com/hubspot/singularity/ServiceIntegrationTests.java
@@ -1,0 +1,9 @@
+package com.hubspot.singularity;
+
+public class ServiceIntegrationTests {
+
+    // No-op main class
+    public static void main(String[] args) {
+
+    }
+}


### PR DESCRIPTION
Sonatype needs a main jar file and associated javadocs for each module when releasing. Adding a no-op main class to solve this.
/cc @tpetr 