### PR TITLE
add shutdown hook to singularity executor

### DIFF
--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorMonitor.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorMonitor.java
@@ -7,9 +7,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+import com.google.inject.name.Named;
+import com.hubspot.singularity.executor.config.SingularityExecutorModule;
 import org.apache.mesos.ExecutorDriver;
 import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.TaskState;
@@ -25,6 +28,7 @@ import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import com.hubspot.mesos.JavaUtils;
 import com.hubspot.singularity.executor.config.SingularityExecutorConfiguration;
 import com.hubspot.singularity.executor.config.SingularityExecutorLogging;
@@ -32,6 +36,7 @@ import com.hubspot.singularity.executor.task.SingularityExecutorTask;
 import com.hubspot.singularity.executor.task.SingularityExecutorTaskProcessCallable;
 import com.hubspot.singularity.executor.utils.ExecutorUtils;
 
+@Singleton
 public class SingularityExecutorMonitor {
 
   private static final Logger LOG = LoggerFactory.getLogger(SingularityExecutorMonitor.class);
@@ -41,6 +46,8 @@ public class SingularityExecutorMonitor {
   private final ScheduledExecutorService exitChecker;
 
   private final Lock exitLock;
+  private final AtomicBoolean alreadyShutDown;
+  private final CountDownLatch latch;
 
   @SuppressWarnings("rawtypes")
   private volatile Optional<Future> exitCheckerFuture;
@@ -57,7 +64,7 @@ public class SingularityExecutorMonitor {
   private final Map<String, SingularityExecutorTaskProcessCallable> processRunningTasks;
 
   @Inject
-  public SingularityExecutorMonitor(SingularityExecutorLogging logging, ExecutorUtils executorUtils, SingularityExecutorProcessKiller processKiller, SingularityExecutorThreadChecker threadChecker, SingularityExecutorConfiguration configuration) {
+  public SingularityExecutorMonitor(@Named(SingularityExecutorModule.ALREADY_SHUT_DOWN) AtomicBoolean alreadyShutDown, SingularityExecutorLogging logging, ExecutorUtils executorUtils, SingularityExecutorProcessKiller processKiller, SingularityExecutorThreadChecker threadChecker, SingularityExecutorConfiguration configuration) {
     this.logging = logging;
     this.configuration = configuration;
     this.executorUtils = executorUtils;
@@ -75,6 +82,8 @@ public class SingularityExecutorMonitor {
 
     this.runState = RunState.RUNNING;
     this.exitLock = new ReentrantLock();
+    this.alreadyShutDown = alreadyShutDown;
+    this.latch = new CountDownLatch(4);
 
     this.exitCheckerFuture = Optional.of(startExitChecker(Optional.<ExecutorDriver> absent()));
   }
@@ -88,6 +97,11 @@ public class SingularityExecutorMonitor {
   }
 
   public void shutdown(Optional<ExecutorDriver> driver) {
+    if (!alreadyShutDown.compareAndSet(false, true)) {
+      LOG.info("Already ran shut down process");
+      return;
+    }
+
     LOG.info("Shutdown requested with driver {}", driver);
 
     threadChecker.getExecutorService().shutdown();
@@ -97,15 +111,15 @@ public class SingularityExecutorMonitor {
     runningProcessPool.shutdown();
 
     for (SingularityExecutorTask task : tasks.values()) {
-      task.getLog().info("Executor shutting down - requested task kill with state: {}", requestKill(task.getTaskId()));
+      if (!task.wasKilled()) {
+        task.getLog().info("Executor shutting down - requested task kill with state: {}", requestKill(task.getTaskId()));
+      }
     }
 
     processKiller.getExecutorService().shutdown();
 
     exitChecker.shutdown();
-
-    CountDownLatch latch = new CountDownLatch(4);
-
+    
     JavaUtils.awaitTerminationWithLatch(latch, "threadChecker", threadChecker.getExecutorService(), configuration.getShutdownTimeoutWaitMillis());
     JavaUtils.awaitTerminationWithLatch(latch, "processBuilder", processBuilderPool, configuration.getShutdownTimeoutWaitMillis());
     JavaUtils.awaitTerminationWithLatch(latch, "runningProcess", runningProcessPool, configuration.getShutdownTimeoutWaitMillis());

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorMonitor.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorMonitor.java
@@ -119,7 +119,7 @@ public class SingularityExecutorMonitor {
     processKiller.getExecutorService().shutdown();
 
     exitChecker.shutdown();
-    
+
     JavaUtils.awaitTerminationWithLatch(latch, "threadChecker", threadChecker.getExecutorService(), configuration.getShutdownTimeoutWaitMillis());
     JavaUtils.awaitTerminationWithLatch(latch, "processBuilder", processBuilderPool, configuration.getShutdownTimeoutWaitMillis());
     JavaUtils.awaitTerminationWithLatch(latch, "runningProcess", runningProcessPool, configuration.getShutdownTimeoutWaitMillis());

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorRunner.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorRunner.java
@@ -1,11 +1,13 @@
 package com.hubspot.singularity.executor;
 
+import org.apache.mesos.ExecutorDriver;
 import org.apache.mesos.MesosExecutorDriver;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.base.Optional;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
@@ -42,17 +44,29 @@ public class SingularityExecutorRunner {
 
   private final String name;
   private final SingularityExecutor singularityExecutor;
+  private final SingularityExecutorMonitor monitor;
 
   @Inject
-  public SingularityExecutorRunner(@Named(SingularityRunnerBaseModule.PROCESS_NAME) String name, SingularityExecutor singularityExecutor) {
+  public SingularityExecutorRunner(@Named(SingularityRunnerBaseModule.PROCESS_NAME) String name, SingularityExecutor singularityExecutor, SingularityExecutorMonitor monitor) {
     this.name = name;
     this.singularityExecutor = singularityExecutor;
+    this.monitor = monitor;
   }
 
   public Protos.Status run() {
     LOG.info("{} starting MesosExecutorDriver...", name);
 
     final MesosExecutorDriver driver = new MesosExecutorDriver(singularityExecutor);
+
+    Runtime.getRuntime().addShutdownHook(new Thread("SingularityExecutorRunnerGracefulShutdown") {
+
+      @Override
+      public void run() {
+        LOG.info("Executor is shutting down...");
+        monitor.shutdown(Optional.of((ExecutorDriver) driver));
+      }
+
+    });
 
     return driver.run();
   }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorModule.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorModule.java
@@ -1,6 +1,7 @@
 package com.hubspot.singularity.executor.config;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Template;
@@ -21,6 +22,7 @@ public class SingularityExecutorModule extends AbstractModule {
   public static final String LOGROTATE_TEMPLATE = "logrotate.conf";
   public static final String DOCKER_TEMPLATE = "docker.sh";
   public static final String LOCAL_DOWNLOAD_HTTP_CLIENT = "SingularityExecutorModule.local.download.http.client";
+  public static final String ALREADY_SHUT_DOWN = "already.shut.down";
 
   @Override
   protected void configure() {
@@ -80,5 +82,12 @@ public class SingularityExecutorModule extends AbstractModule {
   @Singleton
   public DockerClient providesDockerClient() {
     return new DefaultDockerClient("unix:///var/run/docker.sock");
+  }
+
+  @Provides
+  @Singleton
+  @Named(ALREADY_SHUT_DOWN)
+  public AtomicBoolean providesAlreadyShutDown() {
+    return new AtomicBoolean(false);
   }
 }


### PR DESCRIPTION
right now SingularityExecutor isn't gracefully shutting down when it receives a signal. Adding a shutdown hook to trigger the same shutdown process (`monitor.shutdown()`) as would happen when mesos tells it to shut down