### PR TITLE
When submitting a task, handle empty args gracefully

### DIFF
--- a/SingularityUI/app/models/Request.coffee
+++ b/SingularityUI/app/models/Request.coffee
@@ -66,8 +66,11 @@ class Request extends Model
             contentType: 'application/json'
 
         if typeof confirmedOrPromptData is 'string'
+          if confirmedOrPromptData != ''
             options.data = JSON.stringify([confirmedOrPromptData])
-            options.processData = false
+          else
+            options.data = '[]'
+          options.processData = false
 
         $.ajax options
         


### PR DESCRIPTION
if the arguments box is empty ('') send [] rather than [''] as arguments

ping @wsorenson @tpetr would be lovely if this makes 0.4.3