### PR TITLE
compose updates for new release

### DIFF
--- a/compose-dev.yml
+++ b/compose-dev.yml
@@ -17,7 +17,7 @@ master:
     MESOS_WORK_DIR: /var/lib/mesos
 
 slave:
-  image: hubspot/singularityexecutorslave:0.4.3
+  image: hubspot/singularityexecutorslave:0.4.4-SNAPSHOT
   command: mesos-slave
   net: host
   environment:
@@ -30,7 +30,7 @@ slave:
     - /sys:/sys
 
 scheduler:
-  image: hubspot/singularityservice:0.4.3
+  image: hubspot/singularityservice:0.4.4-SNAPSHOT
   net: host
   environment:
     - DOCKER_HOST

--- a/dev
+++ b/dev
@@ -3,12 +3,12 @@
 DOCKER_IP=`echo "$DOCKER_HOST" | awk -F/ '{print $3}' | awk -F: '{print $1}'`
 
 function pull {
-  docker-compose pull
+  docker-compose -f compose-dev.yml pull
 }
 
 function remove {
   echo "Removing old containers"
-  docker-compose rm
+  docker-compose -f compose-dev.yml rm
 }
 
 function build {
@@ -18,7 +18,7 @@ function build {
 
 function stop {
   echo "Stopping old containers with docker-compose $1"
-  docker-compose $1
+  docker-compose -f compose-dev.yml $1
   if [ "$1" == "kill" ]; then
     echo "Yep... Good and dead..."
   fi
@@ -27,15 +27,16 @@ function stop {
 function start {
   if [ "$1" == "attach" ]; then
     echo "Starting and attaching to docker-compose up"
-    docker-compose up
+    docker-compose -f compose-dev.yml up
   else
     echo "Starting via docker-compose up"
-    docker-compose up &> /dev/null &
+    docker-compose -f compose-dev.yml up &> /dev/null &
   fi
 }
 
 function help {
   echo "usage:
+    pull    -> grab needed images for docker hub
     start   -> start mesos clsuter in background
     attach  -> start mesos cluster and watch output in console
     restart -> stop all containers and restart in background


### PR DESCRIPTION
Adds a second development version of the docker-compose file, pointing to snapshot versions. The original docker-compose.yml will be pinned to the release version so that those trying out Singularity will always be trying a stable version

The `dev` helper script will always point to the development file (providing a nice shortcut so you don't need to have to type `-f compose-dev.yml` every time.