### PR TITLE
reserved slaves and task placement by slave attributes

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
@@ -90,6 +90,7 @@ public class SingularityRequest {
     .setRackAffinity(copyOfList(rackAffinity))
     .setWaitAtLeastMillisAfterTaskFinishesForReschedule(waitAtLeastMillisAfterTaskFinishesForReschedule)
     .setSlavePlacement(slavePlacement)
+    .setRequiredSlaveAttributes(requiredSlaveAttributes)
     .setScheduledExpectedRuntimeMillis(scheduledExpectedRuntimeMillis)
     .setGroup(group);
   }
@@ -153,6 +154,10 @@ public class SingularityRequest {
 
   public Optional<Long> getScheduledExpectedRuntimeMillis() {
     return scheduledExpectedRuntimeMillis;
+  }
+
+  public Optional<Map<String, String>> getRequiredSlaveAttributes() {
+    return requiredSlaveAttributes;
   }
 
   @JsonIgnore
@@ -221,10 +226,6 @@ public class SingularityRequest {
 
   public Optional<String> getGroup() {
     return group;
-  }
-
-  public Optional<Map<String, String>> getRequiredSlaveAttributes() {
-    return requiredSlaveAttributes;
   }
 
   @Override

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
@@ -3,6 +3,7 @@ package com.hubspot.singularity;
 import static com.hubspot.singularity.JsonHelpers.copyOfList;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -36,6 +37,7 @@ public class SingularityRequest {
   private final Optional<Boolean> rackSensitive;
   private final Optional<List<String>> rackAffinity;
   private final Optional<SlavePlacement> slavePlacement;
+  private final Optional<Map<String, String>> requiredSlaveAttributes;
 
   private final Optional<Boolean> loadBalanced;
 
@@ -47,7 +49,7 @@ public class SingularityRequest {
       @JsonProperty("rackSensitive") Optional<Boolean> rackSensitive, @JsonProperty("loadBalanced") Optional<Boolean> loadBalanced,
       @JsonProperty("killOldNonLongRunningTasksAfterMillis") Optional<Long> killOldNonLongRunningTasksAfterMillis, @JsonProperty("scheduleType") Optional<ScheduleType> scheduleType,
       @JsonProperty("quartzSchedule") Optional<String> quartzSchedule, @JsonProperty("rackAffinity") Optional<List<String>> rackAffinity,
-      @JsonProperty("slavePlacement") Optional<SlavePlacement> slavePlacement, @JsonProperty("scheduledExpectedRuntimeMillis") Optional<Long> scheduledExpectedRuntimeMillis,
+      @JsonProperty("slavePlacement") Optional<SlavePlacement> slavePlacement, @JsonProperty("requiredSlaveAttrbiutes") Optional<Map<String, String>> requiredSlaveAttributes, @JsonProperty("scheduledExpectedRuntimeMillis") Optional<Long> scheduledExpectedRuntimeMillis,
       @JsonProperty("waitAtLeastMillisAfterTaskFinishesForReschedule") Optional<Long> waitAtLeastMillisAfterTaskFinishesForReschedule, @JsonProperty("group") Optional<String> group) {
     this.id = id;
     this.owners = owners;
@@ -62,6 +64,7 @@ public class SingularityRequest {
     this.quartzSchedule = quartzSchedule;
     this.rackAffinity = rackAffinity;
     this.slavePlacement = slavePlacement;
+    this.requiredSlaveAttributes = requiredSlaveAttributes;
     this.scheduledExpectedRuntimeMillis = scheduledExpectedRuntimeMillis;
     this.waitAtLeastMillisAfterTaskFinishesForReschedule = waitAtLeastMillisAfterTaskFinishesForReschedule;
     this.group = group;
@@ -220,6 +223,10 @@ public class SingularityRequest {
     return group;
   }
 
+  public Optional<Map<String, String>> getRequiredSlaveAttributes() {
+    return requiredSlaveAttributes;
+  }
+
   @Override
   public String toString() {
     return "SingularityRequest[" +
@@ -238,6 +245,7 @@ public class SingularityRequest {
             ", rackSensitive=" + rackSensitive +
             ", rackAffinity=" + rackAffinity +
             ", slavePlacement=" + slavePlacement +
+            ", requiredSlaveAttrbiutes=" + requiredSlaveAttributes +
             ", loadBalanced=" + loadBalanced +
             ", group=" + group +
             ']';
@@ -266,12 +274,13 @@ public class SingularityRequest {
             Objects.equals(rackSensitive, request.rackSensitive) &&
             Objects.equals(rackAffinity, request.rackAffinity) &&
             Objects.equals(slavePlacement, request.slavePlacement) &&
+            Objects.equals(requiredSlaveAttributes, request.requiredSlaveAttributes) &&
             Objects.equals(loadBalanced, request.loadBalanced) &&
             Objects.equals(group, request.group);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, requestType, owners, numRetriesOnFailure, schedule, quartzSchedule, scheduleType, killOldNonLongRunningTasksAfterMillis, scheduledExpectedRuntimeMillis, waitAtLeastMillisAfterTaskFinishesForReschedule, instances, rackSensitive, rackAffinity, slavePlacement, loadBalanced, group);
+    return Objects.hash(id, requestType, owners, numRetriesOnFailure, schedule, quartzSchedule, scheduleType, killOldNonLongRunningTasksAfterMillis, scheduledExpectedRuntimeMillis, waitAtLeastMillisAfterTaskFinishesForReschedule, instances, rackSensitive, rackAffinity, slavePlacement, requiredSlaveAttributes, loadBalanced, group);
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
@@ -49,7 +49,7 @@ public class SingularityRequest {
       @JsonProperty("rackSensitive") Optional<Boolean> rackSensitive, @JsonProperty("loadBalanced") Optional<Boolean> loadBalanced,
       @JsonProperty("killOldNonLongRunningTasksAfterMillis") Optional<Long> killOldNonLongRunningTasksAfterMillis, @JsonProperty("scheduleType") Optional<ScheduleType> scheduleType,
       @JsonProperty("quartzSchedule") Optional<String> quartzSchedule, @JsonProperty("rackAffinity") Optional<List<String>> rackAffinity,
-      @JsonProperty("slavePlacement") Optional<SlavePlacement> slavePlacement, @JsonProperty("requiredSlaveAttrbiutes") Optional<Map<String, String>> requiredSlaveAttributes, @JsonProperty("scheduledExpectedRuntimeMillis") Optional<Long> scheduledExpectedRuntimeMillis,
+      @JsonProperty("slavePlacement") Optional<SlavePlacement> slavePlacement, @JsonProperty("requiredSlaveAttributes") Optional<Map<String, String>> requiredSlaveAttributes, @JsonProperty("scheduledExpectedRuntimeMillis") Optional<Long> scheduledExpectedRuntimeMillis,
       @JsonProperty("waitAtLeastMillisAfterTaskFinishesForReschedule") Optional<Long> waitAtLeastMillisAfterTaskFinishesForReschedule, @JsonProperty("group") Optional<String> group) {
     this.id = id;
     this.owners = owners;
@@ -245,7 +245,7 @@ public class SingularityRequest {
             ", rackSensitive=" + rackSensitive +
             ", rackAffinity=" + rackAffinity +
             ", slavePlacement=" + slavePlacement +
-            ", requiredSlaveAttrbiutes=" + requiredSlaveAttributes +
+            ", requiredSlaveAttributes=" + requiredSlaveAttributes +
             ", loadBalanced=" + loadBalanced +
             ", group=" + group +
             ']';

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestBuilder.java
@@ -209,6 +209,11 @@ public class SingularityRequestBuilder {
     return this;
   }
 
+  public SingularityRequestBuilder setRequiredSlaveAttributes(Optional<Map<String, String>> requiredSlaveAttributes) {
+    this.requiredSlaveAttributes = requiredSlaveAttributes;
+    return this;
+  }
+
   @Override
   public String toString() {
     return "SingularityRequestBuilder [id=" + id + ", requestType=" + requestType + ", owners=" + owners + ", numRetriesOnFailure=" + numRetriesOnFailure + ", schedule=" + schedule

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestBuilder.java
@@ -1,6 +1,7 @@
 package com.hubspot.singularity;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import com.google.common.base.Optional;
@@ -31,6 +32,7 @@ public class SingularityRequestBuilder {
   private Optional<Boolean> rackSensitive;
   private Optional<List<String>> rackAffinity;
   private Optional<SlavePlacement> slavePlacement;
+  private Optional<Map<String, String>> requiredSlaveAttributes;
 
   private Optional<Boolean> loadBalanced;
 
@@ -50,6 +52,7 @@ public class SingularityRequestBuilder {
     this.quartzSchedule = Optional.absent();
     this.rackAffinity = Optional.absent();
     this.slavePlacement = Optional.absent();
+    this.requiredSlaveAttributes = Optional.absent();
     this.scheduledExpectedRuntimeMillis = Optional.absent();
     this.daemon = Optional.absent();
     this.waitAtLeastMillisAfterTaskFinishesForReschedule = Optional.absent();
@@ -58,7 +61,7 @@ public class SingularityRequestBuilder {
 
   public SingularityRequest build() {
     return new SingularityRequest(id, requestType, owners, numRetriesOnFailure, schedule, daemon, instances, rackSensitive, loadBalanced, killOldNonLongRunningTasksAfterMillis, scheduleType, quartzSchedule,
-        rackAffinity, slavePlacement, scheduledExpectedRuntimeMillis, waitAtLeastMillisAfterTaskFinishesForReschedule, group);
+        rackAffinity, slavePlacement, requiredSlaveAttributes, scheduledExpectedRuntimeMillis, waitAtLeastMillisAfterTaskFinishesForReschedule, group);
   }
 
   public Optional<Boolean> getLoadBalanced() {
@@ -211,7 +214,7 @@ public class SingularityRequestBuilder {
     return "SingularityRequestBuilder [id=" + id + ", requestType=" + requestType + ", owners=" + owners + ", numRetriesOnFailure=" + numRetriesOnFailure + ", schedule=" + schedule
         + ", quartzSchedule=" + quartzSchedule + ", scheduleType=" + scheduleType + ", killOldNonLongRunningTasksAfterMillis=" + killOldNonLongRunningTasksAfterMillis
         + ", scheduledExpectedRuntimeMillis=" + scheduledExpectedRuntimeMillis + ", waitAtLeastMillisAfterTaskFinishesForReschedule=" + waitAtLeastMillisAfterTaskFinishesForReschedule + ", daemon="
-        + daemon + ", instances=" + instances + ", rackSensitive=" + rackSensitive + ", rackAffinity=" + rackAffinity + ", slavePlacement=" + slavePlacement + ", loadBalanced=" + loadBalanced + ", group=" + group + "]";
+        + daemon + ", instances=" + instances + ", rackSensitive=" + rackSensitive + ", rackAffinity=" + rackAffinity + ", slavePlacement=" + slavePlacement + ", requiredSlaveAttrbiutes=" + requiredSlaveAttributes + ", loadBalanced=" + loadBalanced + ", group=" + group + "]";
   }
 
   @Override
@@ -237,6 +240,7 @@ public class SingularityRequestBuilder {
             Objects.equals(rackSensitive, that.rackSensitive) &&
             Objects.equals(rackAffinity, that.rackAffinity) &&
             Objects.equals(slavePlacement, that.slavePlacement) &&
+            Objects.equals(requiredSlaveAttributes, that.requiredSlaveAttributes) &&
             Objects.equals(loadBalanced, that.loadBalanced) &&
             Objects.equals(group, that.group);
   }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularitySlave.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularitySlave.java
@@ -1,5 +1,7 @@
 package com.hubspot.singularity;
 
+import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -11,25 +13,28 @@ public class SingularitySlave extends SingularityMachineAbstraction<SingularityS
 
   private final String host;
   private final String rackId;
+  private final Map<String, String> attributes;
 
-  public SingularitySlave(String slaveId, String host, String rackId) {
+  public SingularitySlave(String slaveId, String host, String rackId, Map<String, String> attributes) {
     super(slaveId);
 
     this.host = host;
     this.rackId = rackId;
+    this.attributes = attributes;
   }
 
   @JsonCreator
   public SingularitySlave(@JsonProperty("slaveId") String slaveId, @JsonProperty("firstSeenAt") long firstSeenAt, @JsonProperty("currentState") SingularityMachineStateHistoryUpdate currentState,
-      @JsonProperty("host") String host, @JsonProperty("rackId") String rackId) {
+      @JsonProperty("host") String host, @JsonProperty("rackId") String rackId, @JsonProperty("attributes") Map<String, String> attributes) {
     super(slaveId, firstSeenAt, currentState);
     this.host = host;
     this.rackId = rackId;
+    this.attributes = attributes;
   }
 
   @Override
   public SingularitySlave changeState(SingularityMachineStateHistoryUpdate newState) {
-    return new SingularitySlave(getId(), getFirstSeenAt(), newState, host, rackId);
+    return new SingularitySlave(getId(), getFirstSeenAt(), newState, host, rackId, attributes);
   }
 
   @ApiModelProperty("Slave hostname")
@@ -52,6 +57,10 @@ public class SingularitySlave extends SingularityMachineAbstraction<SingularityS
   @ApiModelProperty("Slave rack ID")
   public String getRackId() {
     return rackId;
+  }
+
+  public Map<String, String> getAttributes() {
+    return attributes;
   }
 
   @Override

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -1,5 +1,6 @@
 package com.hubspot.singularity.config;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -185,6 +186,9 @@ public class SingularityConfiguration extends Configuration {
   @JsonProperty("auth")
   @NotNull
   private AuthConfiguration authConfiguration = new AuthConfiguration();
+
+  @NotNull
+  private Map<String, String> reserveSlavesWithAttributes = Collections.emptyMap();
 
   public long getAskDriverToKillTasksAgainAfterMillis() {
     return askDriverToKillTasksAgainAfterMillis;
@@ -754,4 +758,11 @@ public class SingularityConfiguration extends Configuration {
     this.historyPurgingConfiguration = historyPurgingConfiguration;
   }
 
+  public Map<String, String> getReserveSlavesWithAttributes() {
+    return reserveSlavesWithAttributes;
+  }
+
+  public void setReserveSlavesWithAttrbiutes(Map<String, String> reserveSlavesWithAttributes) {
+    this.reserveSlavesWithAttributes = reserveSlavesWithAttributes;
+  }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackHelper.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackHelper.java
@@ -1,5 +1,6 @@
 package com.hubspot.singularity.mesos;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.inject.Singleton;
@@ -65,6 +66,50 @@ public class SingularitySlaveAndRackHelper {
 
   public String getRackIdOrDefault(Offer offer) {
     return getRackId(offer).or(defaultRackId);
+  }
+
+  public Map<String, String> getTextAttributes(Map<String, String> attributes) {
+    Map<String, String> textAttributes = new HashMap<>(attributes);
+    if (textAttributes.containsKey(rackIdAttributeKey)) {
+      textAttributes.remove(rackIdAttributeKey);
+    }
+    return textAttributes;
+  }
+
+  public Map<String, String> getTextAttributes(Offer offer) {
+    Map<String, String> textAttributes = new HashMap<>();
+    for (Attribute attribute : offer.getAttributesList()) {
+      if (!attribute.getName().equals(rackIdAttributeKey)) {
+        if (attribute.hasText()) {
+          textAttributes.put(attribute.getName(), attribute.getText().getValue());
+        } else if (attribute.hasScalar()) {
+          textAttributes.put(attribute.getName(), Double.toString(attribute.getScalar().getValue()));
+        } else if (attribute.hasRanges()) {
+          textAttributes.put(attribute.getName(), attribute.getRanges().getRangeList().toString());
+        }
+      }
+    }
+    return textAttributes;
+  }
+
+  public Map<String, String> reservedSlaveAttributes(Offer offer) {
+    Map<String, String> reservedAttributes = new HashMap<>();
+    Map<String, String> offerTextAttributes = getTextAttributes(offer);
+    for (Map.Entry<String, String> entry : configuration.getReserveSlavesWithAttributes().entrySet()) {
+      if (offerTextAttributes.containsKey(entry.getKey()) && offerTextAttributes.get(entry.getKey()).equals(entry.getValue())) {
+        reservedAttributes.put(entry.getKey(), entry.getValue());
+      }
+    }
+    return reservedAttributes;
+  }
+
+  public boolean hasRequiredAttributes(Map<String, String> attributes, Map<String, String> requiredAttributes) {
+    for (Map.Entry<String, String> entry : requiredAttributes.entrySet()) {
+      if (!(attributes.containsKey(entry.getKey()) && attributes.get(entry.getKey()).equals(entry.getValue()))) {
+        return false;
+      }
+    }
+    return true;
   }
 
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
@@ -103,23 +103,23 @@ class SingularitySlaveAndRackManager {
       }
     }
 
-    final SlavePlacement slavePlacement = taskRequest.getRequest().getSlavePlacement().or(configuration.getDefaultSlavePlacement());
-
-    if (!taskRequest.getRequest().isRackSensitive() && slavePlacement == SlavePlacement.GREEDY) {
-      return SlaveMatchState.NOT_RACK_OR_SLAVE_PARTICULAR;
-    }
-
     Map<String, String> reservedSlaveAttributes = slaveAndRackHelper.reservedSlaveAttributes(offer);
     if (!reservedSlaveAttributes.isEmpty()) {
       if (!taskRequest.getRequest().getRequiredSlaveAttributes().isPresent() ||
         !slaveAndRackHelper.hasRequiredAttributes(taskRequest.getRequest().getRequiredSlaveAttributes().get(), reservedSlaveAttributes)) {
-          return SlaveMatchState.SLAVE_ATTRIBUTES_DO_NOT_MATCH;
+        return SlaveMatchState.SLAVE_ATTRIBUTES_DO_NOT_MATCH;
       }
     }
 
     if (taskRequest.getRequest().getRequiredSlaveAttributes().isPresent()
       && !slaveAndRackHelper.hasRequiredAttributes(slaveAndRackHelper.getTextAttributes(offer), taskRequest.getRequest().getRequiredSlaveAttributes().get())) {
       return SlaveMatchState.SLAVE_ATTRIBUTES_DO_NOT_MATCH;
+    }
+
+    final SlavePlacement slavePlacement = taskRequest.getRequest().getSlavePlacement().or(configuration.getDefaultSlavePlacement());
+
+    if (!taskRequest.getRequest().isRackSensitive() && slavePlacement == SlavePlacement.GREEDY) {
+      return SlaveMatchState.NOT_RACK_OR_SLAVE_PARTICULAR;
     }
 
     final int numDesiredInstances = taskRequest.getRequest().getInstancesSafe();

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SlaveTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SlaveTest.java
@@ -1,7 +1,10 @@
 package com.hubspot.singularity.scheduler;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 
+import com.google.common.collect.ImmutableMap;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -32,8 +35,8 @@ public class SlaveTest extends SingularityCuratorTestBase {
 
   @Test
   public void testDeadSlavesArePurged() {
-    SingularitySlave liveSlave = new SingularitySlave("1", "h1", "r1");
-    SingularitySlave deadSlave = new SingularitySlave("2", "h1", "r1");
+    SingularitySlave liveSlave = new SingularitySlave("1", "h1", "r1", ImmutableMap.of("uniqueAttribute", "1"));
+    SingularitySlave deadSlave = new SingularitySlave("2", "h1", "r1", ImmutableMap.of("uniqueAttribute", "2"));
 
     final long now = System.currentTimeMillis();
 

--- a/compose-dev.yml
+++ b/compose-dev.yml
@@ -25,6 +25,7 @@ slave:
     MESOS_HOSTNAME: localhost
     MESOS_IP: 127.0.0.1
     MESOS_CONTAINERIZERS: docker,mesos
+    MESOS_ATTRIBUTES: "example:value;myNumber:1"
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock
     - /sys:/sys


### PR DESCRIPTION
Two features added:

1. If a request specifies `requiredSlaveAttributes` only accept an offer from a slave with those attributes
2. Ability to specify `reserveSlavesWithAttrbiutes` in config, this will mean that no tasks will be placed on a slave unless the tasks `requiredSlaveAttributes` match all of the attributes for that slave that are also in `reserveSlavesWithAttrbiutes`

@tpetr 