### PR TITLE
Eagerly reject a few fields that may not be null

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityContainerInfo.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityContainerInfo.java
@@ -7,6 +7,7 @@ import org.apache.mesos.Protos.ContainerInfo.Type;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
 
 public class SingularityContainerInfo {
   private final SingularityContainerType type;
@@ -18,6 +19,8 @@ public class SingularityContainerInfo {
       @JsonProperty("type") SingularityContainerType type,
       @JsonProperty("volumes") Optional<List<SingularityVolume>> volumes,
       @JsonProperty("docker") Optional<SingularityDockerInfo> docker) {
+    Preconditions.checkArgument(type != null, "SingularityContainerInfo.type may not be null");
+
     this.type = type;
     this.volumes = volumes;
     this.docker = docker;

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityDockerInfo.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityDockerInfo.java
@@ -8,6 +8,7 @@ import org.apache.mesos.Protos;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
 
 public class SingularityDockerInfo {
   private final String image;
@@ -20,6 +21,8 @@ public class SingularityDockerInfo {
                                @JsonProperty("privileged") boolean privileged,
                                @JsonProperty("network") SingularityDockerNetworkType network,
                                @JsonProperty("portMappings") Optional<List<SingularityDockerPortMapping>> portMappings) {
+    Preconditions.checkArgument(image != null, "SingularityDockerInfo.image may not be null");
+
     this.image = image;
     this.privileged = privileged;
     this.network = Optional.fromNullable(network);

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityVolume.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityVolume.java
@@ -5,6 +5,7 @@ import org.apache.mesos.Protos;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
 
 public class SingularityVolume {
   private final String containerPath;
@@ -16,6 +17,8 @@ public class SingularityVolume {
       @JsonProperty("containerPath") String containerPath,
       @JsonProperty("hostPath") Optional<String> hostPath,
       @JsonProperty("mode") SingularityDockerVolumeMode mode) {
+    Preconditions.checkArgument(containerPath != null, "SingularityVolume.containerPath may not be null");
+
     this.containerPath = containerPath;
     this.hostPath = hostPath;
     this.mode = Optional.fromNullable(mode);


### PR DESCRIPTION
If they are stored into ZooKeeper with these fields nulled,
you can get stuck in a restart loop.  So just bail before they
are ever accepted.