### PR TITLE
ON_DEMAND (oneOff) tasks will persist scheduling

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -30,6 +30,7 @@ import com.hubspot.mesos.JavaUtils;
 import com.hubspot.singularity.ExtendedTaskState;
 import com.hubspot.singularity.MachineState;
 import com.hubspot.singularity.RequestState;
+import com.hubspot.singularity.RequestType;
 import com.hubspot.singularity.SingularityCreateResult;
 import com.hubspot.singularity.SingularityDeployMarker;
 import com.hubspot.singularity.SingularityDeployStatistics;
@@ -342,7 +343,9 @@ public class SingularityScheduler {
 
   private int scheduleTasks(SingularitySchedulerStateCache stateCache, SingularityRequest request, RequestState state, SingularityDeployStatistics deployStatistics,
       SingularityPendingRequest pendingRequest, List<SingularityTaskId> matchingTaskIds) {
-    deleteScheduledTasks(stateCache.getScheduledTasks(), pendingRequest);
+    if (request.getRequestType() != RequestType.ON_DEMAND) {
+      deleteScheduledTasks(stateCache.getScheduledTasks(), pendingRequest);
+    }
 
     final int numMissingInstances = getNumMissingInstances(matchingTaskIds, request, pendingRequest);
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -1204,6 +1204,38 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
   }
 
   @Test
+  public void testOnDemandTasksPersist() {
+    SingularityRequestBuilder bldr = new SingularityRequestBuilder(requestId, RequestType.ON_DEMAND);
+    requestResource.submit(bldr.build(), Optional.<String> absent());
+    deploy("d2");
+    deployChecker.checkDeploys();
+
+    requestResource.scheduleImmediately(requestId, user, Collections.<String> emptyList());
+
+    resourceOffers();
+
+    requestResource.scheduleImmediately(requestId, user, Collections.<String> emptyList());
+
+    resourceOffers();
+
+    Assert.assertEquals(2, taskManager.getActiveTaskIds().size());
+
+    requestResource.scheduleImmediately(requestId, user, Collections.<String> emptyList());
+
+    scheduler.drainPendingQueue(stateCacheProvider.get());
+
+    requestResource.scheduleImmediately(requestId, user, Collections.<String> emptyList());
+
+    scheduler.drainPendingQueue(stateCacheProvider.get());
+
+    Assert.assertEquals(2, taskManager.getPendingTaskIds().size());
+
+    resourceOffers();
+
+    Assert.assertEquals(4, taskManager.getActiveTaskIds().size());
+  }
+
+  @Test
   public void testEmptyDecommissioning() {
     sms.resourceOffers(driver, Arrays.asList(createOffer(1, 129, "slave1", "host1", Optional.of("rack1"))));
 
@@ -1255,6 +1287,8 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
 
     for (SingularityKilledTaskIdRecord taskId : taskManager.getKilledTaskIdRecords()) {
       Assert.assertTrue(taskId.getTaskId().getInstanceNo() > 2);
+
+      scheduler.drainPendingQueue(stateCacheProvider.get());
     }
 
   }


### PR DESCRIPTION
- This changes pre-existing behavior that cleared pending tasks when a
new schedule request is issued.

Given the nature of ON_DEMAND tasks, this is probably the user expected
behavior