### PR TITLE
Support nested groups + auth cache in ZK

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityAuthState.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityAuthState.java
@@ -1,0 +1,25 @@
+package com.hubspot.singularity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Optional;
+
+public class SingularityAuthState {
+  private final Optional<Long> lastUpdatedAt;
+
+  @JsonCreator
+  public SingularityAuthState(@JsonProperty("lastUpdatedAt") Optional<Long> lastUpdatedAt) {
+    this.lastUpdatedAt = lastUpdatedAt;
+  }
+
+  public Optional<Long> getLastUpdatedAt() {
+    return lastUpdatedAt;
+  }
+
+  @Override
+  public String toString() {
+    return "SingularityAuthState[" +
+            "lastUpdatedAt=" + lastUpdatedAt +
+            ']';
+  }
+}

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityState.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityState.java
@@ -48,6 +48,7 @@ public class SingularityState {
   private final int underProvisionedRequests;
 
   private final Optional<Boolean> authDatastoreHealthy;
+  private final Optional<Long> authLastUpdatedAt;
 
   @JsonCreator
   public SingularityState(@JsonProperty("activeTasks") int activeTasks, @JsonProperty("activeRequests") int activeRequests, @JsonProperty("cooldownRequests") int cooldownRequests,
@@ -58,7 +59,7 @@ public class SingularityState {
       @JsonProperty("lateTasks") int lateTasks, @JsonProperty("futureTasks") int futureTasks, @JsonProperty("maxTaskLag") long maxTaskLag, @JsonProperty("generatedAt") long generatedAt,
       @JsonProperty("overProvisionedRequestIds") List<String> overProvisionedRequestIds, @JsonProperty("underProvisionedRequestIds") List<String> underProvisionedRequestIds,
       @JsonProperty("overProvisionedRequests") int overProvisionedRequests, @JsonProperty("underProvisionedRequests") int underProvisionedRequests, @JsonProperty("finishedRequests") int finishedRequests,
-      @JsonProperty("unknownRacks") int unknownRacks, @JsonProperty("unknownSlaves") int unknownSlaves, @JsonProperty("authDatastoreHealthy") Optional<Boolean> authDatastoreHealthy) {
+      @JsonProperty("unknownRacks") int unknownRacks, @JsonProperty("unknownSlaves") int unknownSlaves, @JsonProperty("authDatastoreHealthy") Optional<Boolean> authDatastoreHealthy, @JsonProperty("authLastUpdatedAt") Optional<Long> authLastUpdatedAt) {
     this.activeTasks = activeTasks;
     this.activeRequests = activeRequests;
     this.pausedRequests = pausedRequests;
@@ -89,6 +90,7 @@ public class SingularityState {
     this.overProvisionedRequestIds = overProvisionedRequestIds;
     this.underProvisionedRequestIds = underProvisionedRequestIds;
     this.authDatastoreHealthy = authDatastoreHealthy;
+    this.authLastUpdatedAt = authLastUpdatedAt;
   }
 
   public int getFinishedRequests() {
@@ -225,15 +227,44 @@ public class SingularityState {
     return authDatastoreHealthy;
   }
 
-  @Override
-  public String toString() {
-    return "SingularityState [activeTasks=" + activeTasks + ", pausedRequests=" + pausedRequests + ", activeRequests=" + activeRequests + ", cooldownRequests=" + cooldownRequests
-        + ", scheduledTasks=" + scheduledTasks + ", lateTasks=" + lateTasks + ", futureTasks=" + futureTasks + ", cleaningTasks=" + cleaningTasks + ", lbCleanupTasks=" + lbCleanupTasks
-        + ", maxTaskLag=" + maxTaskLag + ", pendingRequests=" + pendingRequests + ", cleaningRequests=" + cleaningRequests + ", finishedRequests=" + finishedRequests + ", activeSlaves="
-        + activeSlaves + ", deadSlaves=" + deadSlaves + ", decommissioningSlaves=" + decommissioningSlaves + ", unknownSlaves=" + unknownSlaves + ", activeRacks=" + activeRacks + ", deadRacks="
-        + deadRacks + ", decommissioningRacks=" + decommissioningRacks + ", unknownRacks=" + unknownRacks + ", oldestDeploy=" + oldestDeploy + ", numDeploys=" + numDeploys + ", generatedAt="
-        + generatedAt + ", hostStates=" + hostStates + ", overProvisionedRequestIds=" + overProvisionedRequestIds + ", underProvisionedRequestIds=" + underProvisionedRequestIds
-        + ", overProvisionedRequests=" + overProvisionedRequests + ", underProvisionedRequests=" + underProvisionedRequests + ", authDatastoreHealthy=" + authDatastoreHealthy + "]";
+  public Optional<Long> getAuthLastUpdatedAt() {
+    return authLastUpdatedAt;
   }
 
+  @Override
+  public String toString() {
+    return "SingularityState[" +
+            "activeTasks=" + activeTasks +
+            ", pausedRequests=" + pausedRequests +
+            ", activeRequests=" + activeRequests +
+            ", cooldownRequests=" + cooldownRequests +
+            ", scheduledTasks=" + scheduledTasks +
+            ", lateTasks=" + lateTasks +
+            ", futureTasks=" + futureTasks +
+            ", cleaningTasks=" + cleaningTasks +
+            ", lbCleanupTasks=" + lbCleanupTasks +
+            ", maxTaskLag=" + maxTaskLag +
+            ", pendingRequests=" + pendingRequests +
+            ", cleaningRequests=" + cleaningRequests +
+            ", finishedRequests=" + finishedRequests +
+            ", activeSlaves=" + activeSlaves +
+            ", deadSlaves=" + deadSlaves +
+            ", decommissioningSlaves=" + decommissioningSlaves +
+            ", unknownSlaves=" + unknownSlaves +
+            ", activeRacks=" + activeRacks +
+            ", deadRacks=" + deadRacks +
+            ", decommissioningRacks=" + decommissioningRacks +
+            ", unknownRacks=" + unknownRacks +
+            ", oldestDeploy=" + oldestDeploy +
+            ", numDeploys=" + numDeploys +
+            ", generatedAt=" + generatedAt +
+            ", hostStates=" + hostStates +
+            ", overProvisionedRequestIds=" + overProvisionedRequestIds +
+            ", underProvisionedRequestIds=" + underProvisionedRequestIds +
+            ", overProvisionedRequests=" + overProvisionedRequests +
+            ", underProvisionedRequests=" + underProvisionedRequests +
+            ", authDatastoreHealthy=" + authDatastoreHealthy +
+            ", authLastUpdatedAt=" + authLastUpdatedAt +
+            ']';
+  }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityUser.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityUser.java
@@ -14,13 +14,15 @@ public class SingularityUser {
   private final Optional<String> name;
   private final Optional<String> email;
   private final Set<String> groups;
+  private final Optional<Long> lastUpdatedAt;
 
   @JsonCreator
-  public SingularityUser(@JsonProperty("id") String id, @JsonProperty("name") Optional<String> name, @JsonProperty("email") Optional<String> email, @JsonProperty("groups") Set<String> groups) {
+  public SingularityUser(@JsonProperty("id") String id, @JsonProperty("name") Optional<String> name, @JsonProperty("email") Optional<String> email, @JsonProperty("groups") Set<String> groups, @JsonProperty("lastUpdated") Optional<Long> lastUpdatedAt) {
     this.id = id;
     this.name = name;
     this.email = email;
     this.groups = copyOf(groups);
+    this.lastUpdatedAt = lastUpdatedAt;
   }
 
   public String getId() {
@@ -39,6 +41,10 @@ public class SingularityUser {
     return groups;
   }
 
+  public Optional<Long> getLastUpdatedAt() {
+    return lastUpdatedAt;
+  }
+
   @Override
   public String toString() {
     return "SingularityUser[" +
@@ -46,6 +52,7 @@ public class SingularityUser {
             ", name=" + name +
             ", email=" + email +
             ", groups=" + groups +
+            ", lastUpdatedAt=" + lastUpdatedAt +
             ']';
   }
 
@@ -61,11 +68,12 @@ public class SingularityUser {
     return Objects.equals(id, that.id) &&
             Objects.equals(name, that.name) &&
             Objects.equals(email, that.email) &&
-            Objects.equals(groups, that.groups);
+            Objects.equals(groups, that.groups) &&
+            Objects.equals(lastUpdatedAt, that.lastUpdatedAt);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, name, email, groups);
+    return Objects.hash(id, name, email, groups, lastUpdatedAt);
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityUserBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityUserBuilder.java
@@ -1,28 +1,24 @@
 package com.hubspot.singularity;
 
-import static com.google.common.collect.ImmutableSet.copyOf;
-
+import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
 
-public class SingularityUser {
+public class SingularityUserBuilder {
   private final String id;
-  private final Optional<String> name;
-  private final Optional<String> email;
-  private final Set<String> groups;
-  private final Optional<Long> lastUpdatedAt;
+  private Optional<String> name;
+  private Optional<String> email;
+  private Set<String> groups;
+  private Optional<Long> lastUpdatedAt;
 
-  @JsonCreator
-  public SingularityUser(@JsonProperty("id") String id, @JsonProperty("name") Optional<String> name, @JsonProperty("email") Optional<String> email, @JsonProperty("groups") Set<String> groups, @JsonProperty("lastUpdated") Optional<Long> lastUpdatedAt) {
+  public SingularityUserBuilder(String id) {
     this.id = id;
-    this.name = name;
-    this.email = email;
-    this.groups = copyOf(groups);
-    this.lastUpdatedAt = lastUpdatedAt;
+    this.name = Optional.absent();
+    this.email = Optional.absent();
+    this.groups = Collections.emptySet();
+    this.lastUpdatedAt = Optional.absent();
   }
 
   public String getId() {
@@ -33,21 +29,45 @@ public class SingularityUser {
     return name;
   }
 
+  public SingularityUserBuilder setName(Optional<String> name) {
+    this.name = name;
+    return this;
+  }
+
   public Optional<String> getEmail() {
     return email;
+  }
+
+  public SingularityUserBuilder setEmail(Optional<String> email) {
+    this.email = email;
+    return this;
   }
 
   public Set<String> getGroups() {
     return groups;
   }
 
+  public SingularityUserBuilder setGroups(Set<String> groups) {
+    this.groups = groups;
+    return this;
+  }
+
   public Optional<Long> getLastUpdatedAt() {
     return lastUpdatedAt;
   }
 
+  public SingularityUserBuilder setLastUpdatedAt(Optional<Long> lastUpdatedAt) {
+    this.lastUpdatedAt = lastUpdatedAt;
+    return this;
+  }
+
+  public SingularityUser build() {
+    return new SingularityUser(id, name, email, groups, lastUpdatedAt);
+  }
+
   @Override
   public String toString() {
-    return "SingularityUser[" +
+    return "SingularityUserBuilder[" +
             "id='" + id + '\'' +
             ", name=" + name +
             ", email=" + email +
@@ -64,7 +84,7 @@ public class SingularityUser {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    SingularityUser that = (SingularityUser) o;
+    SingularityUserBuilder that = (SingularityUserBuilder) o;
     return Objects.equals(id, that.id) &&
             Objects.equals(name, that.name) &&
             Objects.equals(email, that.email) &&
@@ -75,13 +95,5 @@ public class SingularityUser {
   @Override
   public int hashCode() {
     return Objects.hash(id, name, email, groups, lastUpdatedAt);
-  }
-
-  public SingularityUserBuilder toBuilder() {
-    return new SingularityUserBuilder(id)
-            .setName(name)
-            .setEmail(email)
-            .setGroups(groups)
-            .setLastUpdatedAt(lastUpdatedAt);
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityAuthModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityAuthModule.java
@@ -5,6 +5,7 @@ import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.TypeLiteral;
 import com.hubspot.singularity.auth.SingularityAuthorizationHelper;
+import com.hubspot.singularity.auth.SingularityAuthorizationUpdater;
 import com.hubspot.singularity.auth.authenticator.SingularityAuthenticator;
 import com.hubspot.singularity.auth.datastore.SingularityAuthDatastore;
 import com.hubspot.singularity.config.SingularityConfiguration;
@@ -22,5 +23,6 @@ public class SingularityAuthModule implements Module {
     binder.bind(SingularityAuthDatastore.class).to(configuration.getAuthConfiguration().getDatastore().getAuthDatastoreClass());
     binder.bind(new TypeLiteral<Optional<SingularityUser>>() {}).toProvider(SingularityAuthenticator.class);
     binder.bind(SingularityAuthorizationHelper.class);
+    binder.bind(SingularityAuthorizationUpdater.class);
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityAuthModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityAuthModule.java
@@ -5,7 +5,7 @@ import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.TypeLiteral;
 import com.hubspot.singularity.auth.SingularityAuthorizationHelper;
-import com.hubspot.singularity.auth.SingularityAuthorizationUpdater;
+import com.hubspot.singularity.auth.SingularityAuthUpdater;
 import com.hubspot.singularity.auth.authenticator.SingularityAuthenticator;
 import com.hubspot.singularity.auth.datastore.SingularityAuthDatastore;
 import com.hubspot.singularity.config.SingularityConfiguration;
@@ -23,6 +23,6 @@ public class SingularityAuthModule implements Module {
     binder.bind(SingularityAuthDatastore.class).to(configuration.getAuthConfiguration().getDatastore().getAuthDatastoreClass());
     binder.bind(new TypeLiteral<Optional<SingularityUser>>() {}).toProvider(SingularityAuthenticator.class);
     binder.bind(SingularityAuthorizationHelper.class);
-    binder.bind(SingularityAuthorizationUpdater.class);
+    binder.bind(SingularityAuthUpdater.class);
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityMainModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityMainModule.java
@@ -37,6 +37,7 @@ import com.google.inject.name.Named;
 import com.google.inject.name.Names;
 import com.hubspot.mesos.JavaUtils;
 import com.hubspot.mesos.client.MesosClient;
+import com.hubspot.singularity.config.AuthConfiguration;
 import com.hubspot.singularity.config.CustomExecutorConfiguration;
 import com.hubspot.singularity.config.HistoryPurgingConfiguration;
 import com.hubspot.singularity.config.MesosConfiguration;
@@ -256,6 +257,12 @@ public class SingularityMainModule implements Module {
   @Singleton
   public HistoryPurgingConfiguration historyPurgingConfiguration(final SingularityConfiguration config) {
     return config.getHistoryPurgingConfiguration();
+  }
+
+  @Provides
+  @Singleton
+  public AuthConfiguration authConfiguration(final SingularityConfiguration config) {
+    return config.getAuthConfiguration();
   }
 
   private JadeTemplate getJadeTemplate(String name) throws IOException {

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAuthorizationUpdater.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAuthorizationUpdater.java
@@ -1,0 +1,88 @@
+package com.hubspot.singularity.auth;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Optional;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.hubspot.singularity.SingularityAuthState;
+import com.hubspot.singularity.SingularityUser;
+import com.hubspot.singularity.auth.datastore.SingularityAuthDatastore;
+import com.hubspot.singularity.config.AuthConfiguration;
+import com.hubspot.singularity.data.AuthManager;
+import com.hubspot.singularity.scheduler.SingularityLeaderOnlyPoller;
+
+@Singleton
+public class SingularityAuthorizationUpdater extends SingularityLeaderOnlyPoller {
+  private static final Logger LOG = LoggerFactory.getLogger(SingularityAuthorizationUpdater.class);
+
+  private final AuthManager authManager;
+  private final AuthConfiguration authConfiguration;
+  private final SingularityAuthDatastore datastore;
+
+  @Inject
+  public SingularityAuthorizationUpdater(AuthConfiguration authConfiguration, AuthManager authManager, SingularityAuthDatastore datastore) {
+    super(authConfiguration.getUpdateUsersEveryMinutes(), TimeUnit.MINUTES);
+    this.authManager = authManager;
+    this.datastore = datastore;
+    this.authConfiguration = authConfiguration;
+  }
+
+  @Override
+  protected boolean isEnabled() {
+    return authConfiguration.isEnabled();
+  }
+
+  @Override
+  protected boolean abortsOnError() {
+    return false;
+  }
+
+  @Override
+  public void runActionOnPoll() {
+    final long getUsersStart = System.currentTimeMillis();
+    final List<SingularityUser> users = datastore.getUsers();
+
+    LOG.info("Loaded {} users from {} in {}ms", users.size(), datastore.getClass().getSimpleName(), System.currentTimeMillis() - getUsersStart);
+
+    final Set<String> existingUserIds = new HashSet<>(authManager.getUserIds());
+
+    final long updateUserStart = System.currentTimeMillis();
+    int newUsers = 0;
+    for (SingularityUser user : users) {
+      authManager.updateUser(user);
+
+      if (!existingUserIds.contains(user.getId())) {
+        newUsers++;
+      } else {
+        existingUserIds.remove(user.getId());
+      }
+    }
+
+    int purgedUsers = 0;
+    for (String userId : existingUserIds) {
+      final Optional<SingularityUser> maybeUser = authManager.getUser(userId);
+
+      if (!maybeUser.isPresent()) {
+        LOG.warn("Failed to load data for stale user: {}", userId);
+        continue;
+      }
+
+      if (maybeUser.get().getLastUpdatedAt().isPresent() && ((System.currentTimeMillis() - maybeUser.get().getLastUpdatedAt().get()) > TimeUnit.DAYS.toMillis(authConfiguration.getPurgeOldUsersAfterDays()))) {
+        LOG.info("Purging user {}", userId);
+        authManager.deleteUser(userId);
+        purgedUsers++;
+      }
+    }
+
+    LOG.info("Updated {} users in {}ms: {} users added, {} stale users, {} users purged", users.size(), System.currentTimeMillis() - updateUserStart, newUsers, existingUserIds.size(), purgedUsers);
+
+    authManager.setAuthState(new SingularityAuthState(Optional.of(System.currentTimeMillis())));
+  }
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/authenticator/SingularityHeaderPassthroughAuthenticator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/authenticator/SingularityHeaderPassthroughAuthenticator.java
@@ -7,18 +7,18 @@ import com.google.common.base.Strings;
 import com.google.inject.Inject;
 import com.google.inject.servlet.RequestScoped;
 import com.hubspot.singularity.SingularityUser;
-import com.hubspot.singularity.auth.datastore.SingularityAuthDatastore;
 import com.hubspot.singularity.config.SingularityConfiguration;
+import com.hubspot.singularity.data.AuthManager;
 
 @RequestScoped
 public class SingularityHeaderPassthroughAuthenticator implements SingularityAuthenticator {
-  private final SingularityAuthDatastore datastore;
+  private final AuthManager authManager;
   private final String requestUserHeaderName;
   private final HttpServletRequest request;
 
   @Inject
-  public SingularityHeaderPassthroughAuthenticator(SingularityAuthDatastore datastore, SingularityConfiguration configuration, HttpServletRequest request) {
-    this.datastore = datastore;
+  public SingularityHeaderPassthroughAuthenticator(AuthManager authManager, SingularityConfiguration configuration, HttpServletRequest request) {
+    this.authManager = authManager;
     this.requestUserHeaderName = configuration.getAuthConfiguration().getRequestUserHeaderName();
     this.request = request;
   }
@@ -31,6 +31,6 @@ public class SingularityHeaderPassthroughAuthenticator implements SingularityAut
       return Optional.absent();
     }
 
-    return datastore.getUser(maybeUsername.get());
+    return authManager.getUser(maybeUsername.get());
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/datastore/SingularityAuthDatastore.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/datastore/SingularityAuthDatastore.java
@@ -1,10 +1,12 @@
 package com.hubspot.singularity.auth.datastore;
 
+import java.util.List;
+
 import com.google.common.base.Optional;
 import com.hubspot.singularity.SingularityUser;
 
 public interface SingularityAuthDatastore {
   Optional<SingularityUser> getUser(String username);
-  void bustCache();
   Optional<Boolean> isHealthy();
+  List<SingularityUser> getUsers();
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/datastore/SingularityDisabledAuthDatastore.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/datastore/SingularityDisabledAuthDatastore.java
@@ -1,5 +1,8 @@
 package com.hubspot.singularity.auth.datastore;
 
+import java.util.Collections;
+import java.util.List;
+
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -16,12 +19,12 @@ public class SingularityDisabledAuthDatastore implements SingularityAuthDatastor
   }
 
   @Override
-  public void bustCache() {
-    // no-op
+  public Optional<Boolean> isHealthy() {
+    return Optional.absent();
   }
 
   @Override
-  public Optional<Boolean> isHealthy() {
-    return Optional.absent();
+  public List<SingularityUser> getUsers() {
+    return Collections.emptyList();
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/datastore/SingularityLDAPDatastore.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/datastore/SingularityLDAPDatastore.java
@@ -4,14 +4,14 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.directory.api.ldap.model.cursor.EntryCursor;
+import org.apache.directory.api.ldap.model.entry.Attribute;
 import org.apache.directory.api.ldap.model.entry.Entry;
 import org.apache.directory.api.ldap.model.exception.LdapException;
 import org.apache.directory.api.ldap.model.message.SearchScope;
@@ -25,15 +25,10 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.ListenableFutureTask;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import com.google.inject.name.Named;
-import com.hubspot.singularity.SingularityMainModule;
 import com.hubspot.singularity.SingularityUser;
 import com.hubspot.singularity.config.LDAPConfiguration;
 import com.hubspot.singularity.config.SingularityConfiguration;
@@ -44,8 +39,6 @@ public class SingularityLDAPDatastore implements SingularityAuthDatastore {
 
   private final LdapConnectionPool connectionPool;
   private final LDAPConfiguration configuration;
-  private final LoadingCache<String, Optional<SingularityUser>> userCache;
-  private final ExecutorService executorService;
 
   private static LdapConnectionPool createConnectionPool(LDAPConfiguration configuration) throws IOException {
     final LdapConnectionConfig config = new LdapConnectionConfig();
@@ -84,26 +77,11 @@ public class SingularityLDAPDatastore implements SingularityAuthDatastore {
   }
 
   @Inject
-  public SingularityLDAPDatastore(@Named(SingularityMainModule.LDAP_REFRESH_THREADPOOL_NAME) ScheduledExecutorService executorService,
-                                  SingularityConfiguration configuration) throws IOException {
+  public SingularityLDAPDatastore(SingularityConfiguration configuration) throws IOException {
     checkArgument(configuration.getLdapConfiguration().isPresent(), "LDAP configuration not present");
 
     this.connectionPool = createConnectionPool(configuration.getLdapConfiguration().get());
     this.configuration = configuration.getLdapConfiguration().get();
-    this.executorService = executorService;
-
-    this.userCache = CacheBuilder.newBuilder()
-            .recordStats()
-            .refreshAfterWrite(configuration.getLdapConfiguration().get().getCacheExpirationMs(), TimeUnit.MILLISECONDS)
-            .initialCapacity(configuration.getLdapConfiguration().get().getCacheInitialCapacity())
-            .concurrencyLevel(configuration.getLdapConfiguration().get().getCacheConcurrencyLevel())
-            .maximumSize(configuration.getLdapConfiguration().get().getCacheMaximumSize())
-            .build(new LDAPCacheLoader());
-  }
-
-  @Override
-  public void bustCache() {
-    userCache.invalidateAll();
   }
 
   @Override
@@ -130,14 +108,63 @@ public class SingularityLDAPDatastore implements SingularityAuthDatastore {
   }
 
   @Override
+  public List<SingularityUser> getUsers() {
+    final Multimap<String, String> userToGroup = ArrayListMultimap.create();
+    final List<SingularityUser> users = new ArrayList<>();
+
+    try {
+      final LdapConnection connection = connectionPool.getConnection();
+
+      try {
+        checkState(connection.isConnected(), "not connected");
+        checkState(connection.isAuthenticated(), "not authenticated");
+        connection.bind();
+
+        try {
+          final EntryCursor groupCursor = connection.search(configuration.getGroupBaseDN(), configuration.getValidGroupFilter(), SearchScope.SUBTREE, configuration.getGroupNameAttribute(), "memberUid");
+
+          while (groupCursor.next()) {
+            final Entry groupEntry = groupCursor.get();
+
+            final String groupName = groupEntry.get(configuration.getGroupNameAttribute()).getString();
+
+            for (Attribute attribute : groupEntry.getAttributes()) {
+              if (attribute.getId().equals(configuration.getGroupMemberAttribute())) {
+                userToGroup.put(attribute.getString(), groupName);
+              }
+            }
+          }
+
+          final EntryCursor userCursor = connection.search(configuration.getUserBaseDN(), configuration.getValidUserFilter(), SearchScope.ONELEVEL, configuration.getUserNameAttribute(), configuration.getUserEmailAttribute());
+
+          while (userCursor.next()) {
+            final Entry userEntry = userCursor.get();
+
+            final String userId = userEntry.get(configuration.getUserIdAttribute()).getString();
+
+            final Set<String> groups = userToGroup.containsKey(userId) ? new HashSet<>(userToGroup.get(userId)) : Collections.<String>emptySet();
+
+            users.add(new SingularityUser(userId, Optional.fromNullable(Strings.emptyToNull(userEntry.get(configuration.getUserNameAttribute()).getString())), Optional.fromNullable(Strings.emptyToNull(userEntry.get(configuration.getUserEmailAttribute()).getString())), groups, Optional.of(System.currentTimeMillis())));
+          }
+        } finally {
+          connection.unBind();
+        }
+      } finally {
+        connectionPool.releaseConnection(connection);
+      }
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+
+    return users;
+  }
+
+  @Override
   public Optional<SingularityUser> getUser(String user) {
     if (configuration.isStripUserEmailDomain()) {
       user = user.split("@")[0];
     }
-    return userCache.getUnchecked(user);
-  }
 
-  private Optional<SingularityUser> getUserInfoFromLDAP(String user) {
     final Set<String> groups = new HashSet<>();
 
     try {
@@ -162,13 +189,13 @@ public class SingularityLDAPDatastore implements SingularityAuthDatastore {
           // get group info
           final EntryCursor cursor = connection.search(configuration.getGroupBaseDN(),
                   String.format(configuration.getGroupFilter(), user),
-                  SearchScope.ONELEVEL, configuration.getGroupNameAttribute());
+                  SearchScope.SUBTREE, configuration.getGroupNameAttribute());
 
           while (cursor.next()) {
             groups.add(cursor.get().get(configuration.getGroupNameAttribute()).getString());
           }
 
-          return Optional.of(new SingularityUser(user, Optional.fromNullable(Strings.emptyToNull(userEntry.get(configuration.getUserNameAttribute()).getString())), Optional.fromNullable(Strings.emptyToNull(userEntry.get(configuration.getUserEmailAttribute()).getString())), groups));
+          return Optional.of(new SingularityUser(user,Optional.fromNullable(Strings.emptyToNull(userEntry.get(configuration.getUserNameAttribute()).getString())), Optional.fromNullable(Strings.emptyToNull(userEntry.get(configuration.getUserEmailAttribute()).getString())), groups, Optional.of(System.currentTimeMillis())));
         } finally {
           connection.unBind();
         }
@@ -177,31 +204,6 @@ public class SingularityLDAPDatastore implements SingularityAuthDatastore {
       }
     } catch (Exception e) {
       throw Throwables.propagate(e);
-    }
-  }
-
-  private class LDAPCacheLoader extends CacheLoader<String, Optional<SingularityUser>> {
-    @Override
-    public Optional<SingularityUser> load(String key) throws Exception {
-      LOG.trace("Hitting LDAP for {}'s info", key);
-      return getUserInfoFromLDAP(key);
-    }
-
-    @Override
-    public ListenableFuture<Optional<SingularityUser>> reload(final String key, Optional<SingularityUser> oldValue) throws Exception {
-      LOG.trace("Reloading data for {}", key);
-
-      final long reloadStartTime = System.currentTimeMillis();
-      final ListenableFutureTask<Optional<SingularityUser>> task = ListenableFutureTask.create(new Callable<Optional<SingularityUser>>() {
-        @Override
-        public Optional<SingularityUser> call() throws Exception {
-          final Optional<SingularityUser> user = getUserInfoFromLDAP(key);
-          LOG.trace("Reloaded {} user info in {} ms", key, System.currentTimeMillis() - reloadStartTime);
-          return user;
-        }
-      });
-      executorService.submit(task);
-      return task;
     }
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/datastore/SingularityLDAPDatastore.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/datastore/SingularityLDAPDatastore.java
@@ -10,6 +10,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.directory.api.ldap.model.cursor.CursorException;
 import org.apache.directory.api.ldap.model.cursor.EntryCursor;
 import org.apache.directory.api.ldap.model.entry.Attribute;
 import org.apache.directory.api.ldap.model.entry.Entry;
@@ -152,7 +153,7 @@ public class SingularityLDAPDatastore implements SingularityAuthDatastore {
       } finally {
         connectionPool.releaseConnection(connection);
       }
-    } catch (Exception e) {
+    } catch (LdapException | CursorException e) {
       throw Throwables.propagate(e);
     }
 
@@ -202,7 +203,7 @@ public class SingularityLDAPDatastore implements SingularityAuthDatastore {
       } finally {
         connectionPool.releaseConnection(connection);
       }
-    } catch (Exception e) {
+    } catch (LdapException | CursorException e) {
       throw Throwables.propagate(e);
     }
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/AuthConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/AuthConfiguration.java
@@ -37,6 +37,12 @@ public class AuthConfiguration {
   @NotNull
   private String requestUserHeaderName = "X-Username";  // used by SingularityHeaderPassthroughAuthenticator
 
+  @JsonProperty
+  private long purgeOldUsersAfterDays = 2;
+
+  @JsonProperty
+  private long updateUsersEveryMinutes = 10;
+
   public boolean isEnabled() {
     return enabled;
   }
@@ -91,5 +97,21 @@ public class AuthConfiguration {
 
   public void setRequestUserHeaderName(String requestUserHeaderName) {
     this.requestUserHeaderName = requestUserHeaderName;
+  }
+
+  public long getPurgeOldUsersAfterDays() {
+    return purgeOldUsersAfterDays;
+  }
+
+  public void setPurgeOldUsersAfterDays(long purgeOldUsersAfterDays) {
+    this.purgeOldUsersAfterDays = purgeOldUsersAfterDays;
+  }
+
+  public long getUpdateUsersEveryMinutes() {
+    return updateUsersEveryMinutes;
+  }
+
+  public void setUpdateUsersEveryMinutes(long updateUsersEveryMinutes) {
+    this.updateUsersEveryMinutes = updateUsersEveryMinutes;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/LDAPConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/LDAPConfiguration.java
@@ -1,7 +1,5 @@
 package com.hubspot.singularity.config;
 
-import java.util.concurrent.TimeUnit;
-
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
@@ -51,6 +49,14 @@ public class LDAPConfiguration {
   @NotEmpty
   private String userEmailAttribute = "mail";
 
+  @JsonProperty
+  @NotEmpty
+  private String userIdAttribute = "uid";
+
+  @JsonProperty
+  @NotEmpty
+  private String validUserFilter = "(objectClass=posixUser)";
+
   //
   // LDAP GROUP LOOKUP
   //
@@ -66,24 +72,13 @@ public class LDAPConfiguration {
   @NotEmpty
   private String groupNameAttribute = "cn";
 
-  //
-  // CACHING CONFIGURATION
-  //
   @JsonProperty
-  @Min(1)
-  private int cacheInitialCapacity = 40;
+  @NotEmpty
+  private String validGroupFilter = "(objectClass=posixGroup)";
 
   @JsonProperty
-  @Min(1)
-  private int cacheConcurrencyLevel = 4;
-
-  @JsonProperty
-  @Min(0)
-  private long cacheMaximumSize = 200;  // 0 == no caching
-
-  @JsonProperty
-  @Min(1)
-  private long cacheExpirationMs = TimeUnit.MINUTES.toMillis(5);
+  @NotEmpty
+  private String groupMemberAttribute = "memberUid";
 
   //
   // LDAP CONNECTION POOL
@@ -210,38 +205,6 @@ public class LDAPConfiguration {
     this.groupNameAttribute = groupNameAttribute;
   }
 
-  public int getCacheInitialCapacity() {
-    return cacheInitialCapacity;
-  }
-
-  public void setCacheInitialCapacity(int cacheInitialCapacity) {
-    this.cacheInitialCapacity = cacheInitialCapacity;
-  }
-
-  public int getCacheConcurrencyLevel() {
-    return cacheConcurrencyLevel;
-  }
-
-  public void setCacheConcurrencyLevel(int cacheConcurrencyLevel) {
-    this.cacheConcurrencyLevel = cacheConcurrencyLevel;
-  }
-
-  public long getCacheMaximumSize() {
-    return cacheMaximumSize;
-  }
-
-  public void setCacheMaximumSize(long cacheMaximumSize) {
-    this.cacheMaximumSize = cacheMaximumSize;
-  }
-
-  public long getCacheExpirationMs() {
-    return cacheExpirationMs;
-  }
-
-  public void setCacheExpirationMs(long cacheExpirationMs) {
-    this.cacheExpirationMs = cacheExpirationMs;
-  }
-
   public boolean isPoolTestOnBorrow() {
     return poolTestOnBorrow;
   }
@@ -320,6 +283,38 @@ public class LDAPConfiguration {
 
   public void setStripUserEmailDomain(boolean stripUserEmailDomain) {
     this.stripUserEmailDomain = stripUserEmailDomain;
+  }
+
+  public String getValidGroupFilter() {
+    return validGroupFilter;
+  }
+
+  public void setValidGroupFilter(String validGroupFilter) {
+    this.validGroupFilter = validGroupFilter;
+  }
+
+  public String getGroupMemberAttribute() {
+    return groupMemberAttribute;
+  }
+
+  public void setGroupMemberAttribute(String groupMemberAttribute) {
+    this.groupMemberAttribute = groupMemberAttribute;
+  }
+
+  public String getValidUserFilter() {
+    return validUserFilter;
+  }
+
+  public void setValidUserFilter(String validUserFilter) {
+    this.validUserFilter = validUserFilter;
+  }
+
+  public String getUserIdAttribute() {
+    return userIdAttribute;
+  }
+
+  public void setUserIdAttribute(String userIdAttribute) {
+    this.userIdAttribute = userIdAttribute;
   }
 
   public enum LdapPoolWhenExhaustedAction {

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/LDAPConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/LDAPConfiguration.java
@@ -55,7 +55,7 @@ public class LDAPConfiguration {
 
   @JsonProperty
   @NotEmpty
-  private String validUserFilter = "(objectClass=posixUser)";
+  private String validUserFilter = "(objectClass=posixAccount)";
 
   //
   // LDAP GROUP LOOKUP

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/AuthManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/AuthManager.java
@@ -1,0 +1,56 @@
+package com.hubspot.singularity.data;
+
+import java.util.List;
+
+import org.apache.curator.framework.CuratorFramework;
+
+import com.google.common.base.Optional;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.hubspot.singularity.SingularityAuthState;
+import com.hubspot.singularity.SingularityCreateResult;
+import com.hubspot.singularity.SingularityDeleteResult;
+import com.hubspot.singularity.SingularityUser;
+import com.hubspot.singularity.config.SingularityConfiguration;
+import com.hubspot.singularity.data.transcoders.Transcoder;
+
+@Singleton
+public class AuthManager extends CuratorAsyncManager {
+  private static final String ROOT_PATH = "/auth";
+  private static final String USERS_PATH = ROOT_PATH + "/users";
+  private static final String USER_PATH = USERS_PATH + "/";
+
+  private final Transcoder<SingularityUser> singularityUserTranscoder;
+  private final Transcoder<SingularityAuthState> singularityAuthStateTranscoder;
+
+  @Inject
+  public AuthManager(CuratorFramework curator, SingularityConfiguration configuration, Transcoder<SingularityUser> singularityUserTranscoder, Transcoder<SingularityAuthState> singularityAuthStateTranscoder) {
+    super(curator, configuration.getZookeeperAsyncTimeout());
+    this.singularityUserTranscoder = singularityUserTranscoder;
+    this.singularityAuthStateTranscoder = singularityAuthStateTranscoder;
+  }
+
+  public List<String> getUserIds() {
+    return getChildren(USERS_PATH);
+  }
+
+  public Optional<SingularityUser> getUser(String userId) {
+    return getData(USER_PATH + userId, singularityUserTranscoder);
+  }
+
+  public SingularityCreateResult updateUser(SingularityUser user) {
+    return save(USER_PATH + user.getId(), user, singularityUserTranscoder);
+  }
+
+  public SingularityDeleteResult deleteUser(String userId) {
+    return delete(USER_PATH + userId);
+  }
+
+  public Optional<SingularityAuthState> getAuthState() {
+    return getData(USERS_PATH, singularityAuthStateTranscoder);
+  }
+
+  public SingularityCreateResult setAuthState(SingularityAuthState authState) {
+    return save(USERS_PATH, authState, singularityAuthStateTranscoder);
+  }
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityDataModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityDataModule.java
@@ -20,5 +20,6 @@ public class SingularityDataModule extends AbstractModule {
 
     bind(ExecutorIdGenerator.class).in(Scopes.SINGLETON);
     bind(WebhookManager.class).in(Scopes.SINGLETON);
+    bind(AuthManager.class).in(Scopes.SINGLETON);
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
@@ -323,4 +323,8 @@ public class SingularityValidator {
       return false;
     }
   }
+
+  public boolean isUserValid(SingularityUser user) {
+    return !user.getId().contains("/");
+  }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/transcoders/SingularityTranscoderModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/transcoders/SingularityTranscoderModule.java
@@ -4,6 +4,7 @@ import static com.hubspot.singularity.data.transcoders.SingularityJsonTranscoder
 
 import com.google.inject.Binder;
 import com.google.inject.Module;
+import com.hubspot.singularity.SingularityAuthState;
 import com.hubspot.singularity.SingularityDeploy;
 import com.hubspot.singularity.SingularityDeployHistory;
 import com.hubspot.singularity.SingularityDeployKey;
@@ -34,6 +35,7 @@ import com.hubspot.singularity.SingularityTaskHistory;
 import com.hubspot.singularity.SingularityTaskHistoryUpdate;
 import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.SingularityTaskStatusHolder;
+import com.hubspot.singularity.SingularityUser;
 import com.hubspot.singularity.SingularityWebhook;
 
 public class SingularityTranscoderModule implements Module {
@@ -63,6 +65,8 @@ public class SingularityTranscoderModule implements Module {
     bindTranscoder(binder).asJson(SingularityTaskHistoryUpdate.class);
     bindTranscoder(binder).asJson(SingularityWebhook.class);
     bindTranscoder(binder).asJson(SingularityMachineStateHistoryUpdate.class);
+    bindTranscoder(binder).asJson(SingularityUser.class);
+    bindTranscoder(binder).asJson(SingularityAuthState.class);
 
     bindTranscoder(binder).asCompressedJson(SingularityDeployHistory.class);
     bindTranscoder(binder).asCompressedJson(SingularityDeploy.class);

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/AuthResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/AuthResource.java
@@ -1,7 +1,6 @@
 package com.hubspot.singularity.resources;
 
 import javax.ws.rs.GET;
-import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
@@ -11,8 +10,6 @@ import com.google.inject.Inject;
 import com.hubspot.singularity.SingularityService;
 import com.hubspot.singularity.SingularityUser;
 import com.hubspot.singularity.SingularityUserHolder;
-import com.hubspot.singularity.auth.SingularityAuthorizationHelper;
-import com.hubspot.singularity.auth.datastore.SingularityAuthDatastore;
 import com.hubspot.singularity.config.SingularityConfiguration;
 
 @Path(AuthResource.PATH)
@@ -20,18 +17,12 @@ import com.hubspot.singularity.config.SingularityConfiguration;
 public class AuthResource {
   public static final String PATH = SingularityService.API_BASE_PATH + "/auth";
 
-  private final SingularityAuthorizationHelper authorizationHelper;
-  private final SingularityAuthDatastore authDatastore;
   private final Optional<SingularityUser> user;
   private final SingularityConfiguration configuration;
 
   @Inject
-  public AuthResource(SingularityAuthorizationHelper authorizationHelper,
-                      SingularityAuthDatastore authDatastore,
-                      Optional<SingularityUser> user,
+  public AuthResource(Optional<SingularityUser> user,
                       SingularityConfiguration configuration) {
-    this.authorizationHelper = authorizationHelper;
-    this.authDatastore = authDatastore;
     this.user = user;
     this.configuration = configuration;
   }
@@ -40,12 +31,5 @@ public class AuthResource {
   @Path("/user")
   public SingularityUserHolder getUser() {
     return new SingularityUserHolder(user, user.isPresent(), configuration.getAuthConfiguration().isEnabled());
-  }
-
-  @POST
-  @Path("/cache/clear")
-  public void clearAuthCache() {
-    authorizationHelper.checkAdminAuthorization(user);
-    authDatastore.bustCache();
   }
 }

--- a/SingularityService/src/test/java/com/hubspot/singularity/SingularityAuthorizationHelperTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/SingularityAuthorizationHelperTest.java
@@ -57,10 +57,10 @@ public class SingularityAuthorizationHelperTest {
   public static final SingularityRequest REQUEST_WITH_GROUP_B = new SingularityRequestBuilder("test_b", RequestType.SERVICE).setGroup(Optional.of("b")).build();
 
   public static final Optional<SingularityUser> NOT_LOGGED_IN = Optional.absent();
-  public static final Optional<SingularityUser> USER_GROUP_A = Optional.of(new SingularityUser("test1", Optional.of("test user1"), Optional.of("test1@test.com"), ImmutableSet.of("a")));
-  public static final Optional<SingularityUser> USER_GROUP_AB = Optional.of(new SingularityUser("test2", Optional.of("test user2"), Optional.of("test2@test.com"), ImmutableSet.of("a", "b")));
-  public static final Optional<SingularityUser> USER_GROUP_B = Optional.of(new SingularityUser("test3", Optional.of("test user3"), Optional.of("test3@test.com"), ImmutableSet.of("b")));
-  public static final Optional<SingularityUser> USER_GROUP_ADMIN = Optional.of(new SingularityUser("admin", Optional.of("admin user"), Optional.of("admin@test.com"), ImmutableSet.of("admin")));
+  public static final Optional<SingularityUser> USER_GROUP_A = Optional.of(new SingularityUser("test1", Optional.of("test user1"), Optional.of("test1@test.com"), ImmutableSet.of("a"), Optional.<Long>absent()));
+  public static final Optional<SingularityUser> USER_GROUP_AB = Optional.of(new SingularityUser("test2", Optional.of("test user2"), Optional.of("test2@test.com"), ImmutableSet.of("a", "b"), Optional.<Long>absent()));
+  public static final Optional<SingularityUser> USER_GROUP_B = Optional.of(new SingularityUser("test3", Optional.of("test user3"), Optional.of("test3@test.com"), ImmutableSet.of("b"), Optional.<Long>absent()));
+  public static final Optional<SingularityUser> USER_GROUP_ADMIN = Optional.of(new SingularityUser("admin", Optional.of("admin user"), Optional.of("admin@test.com"), ImmutableSet.of("admin"), Optional.<Long>absent()));
 
   private SingularityAuthorizationHelper buildAuthorizationHelper(SingularityConfiguration configuration) {
     return new SingularityAuthorizationHelper(requestManager, configuration);

--- a/SingularityService/src/test/java/com/hubspot/singularity/TestingAuthDatastore.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/TestingAuthDatastore.java
@@ -1,0 +1,44 @@
+package com.hubspot.singularity;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.base.Optional;
+import com.hubspot.singularity.auth.datastore.SingularityAuthDatastore;
+
+public class TestingAuthDatastore implements SingularityAuthDatastore {
+  private final Map<String, SingularityUser> users;
+
+  public TestingAuthDatastore() {
+    this.users = new HashMap<>();
+  }
+
+  public void addUser(SingularityUser user) {
+    users.put(user.getId(), user);
+  }
+
+  public void removeUser(String userId) {
+    users.remove(userId);
+  }
+
+  public void clearUsers() {
+    users.clear();
+  }
+
+  @Override
+  public Optional<SingularityUser> getUser(String username) {
+    return Optional.fromNullable(users.get(username));
+  }
+
+  @Override
+  public Optional<Boolean> isHealthy() {
+    return Optional.absent();
+  }
+
+  @Override
+  public List<SingularityUser> getUsers() {
+    return new ArrayList<>(users.values());
+  }
+}

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/AuthUpdaterTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/AuthUpdaterTest.java
@@ -1,0 +1,97 @@
+package com.hubspot.singularity.scheduler;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Inject;
+import com.hubspot.singularity.SingularitySchedulerTestBase;
+import com.hubspot.singularity.SingularityUser;
+import com.hubspot.singularity.SingularityUserBuilder;
+import com.hubspot.singularity.TestingAuthDatastore;
+import com.hubspot.singularity.auth.SingularityAuthUpdater;
+import com.hubspot.singularity.config.AuthConfiguration;
+import com.hubspot.singularity.data.AuthManager;
+
+public class AuthUpdaterTest extends SingularitySchedulerTestBase {
+  private static final String TEST_USER_ID1 = "test1";
+  private static final String TEST_USER_ID2 = "test2";
+  private static final String TEST_USER_GROUP = "testgroup";
+
+  @Inject
+  private AuthManager authManager;
+
+  private final TestingAuthDatastore authDatastore;
+
+  public AuthUpdaterTest() {
+    super(false);
+
+    authDatastore = new TestingAuthDatastore();
+  }
+
+  @Test
+  public void testUserUpdate() {
+    authDatastore.clearUsers();
+
+    final SingularityAuthUpdater authUpdater = new SingularityAuthUpdater(new AuthConfiguration(), authManager, authDatastore);
+
+    final long now = System.currentTimeMillis();
+
+    final SingularityUser testUser = new SingularityUserBuilder(TEST_USER_ID1)
+            .setLastUpdatedAt(Optional.of(now))
+            .build();
+    final SingularityUser testUserWithGroup = new SingularityUserBuilder(TEST_USER_ID1)
+            .setGroups(ImmutableSet.of(TEST_USER_GROUP))
+            .setLastUpdatedAt(Optional.of(now))
+            .build();
+
+    authDatastore.addUser(testUser);
+
+    // user in datastore but not ZK
+    assertEquals(Optional.of(testUser), authDatastore.getUser(TEST_USER_ID1));
+    assertEquals(Optional.absent(), authManager.getUser(TEST_USER_ID1));
+
+    authUpdater.runActionOnPoll();
+
+    // user in ZK
+    assertEquals(Optional.of(testUser), authManager.getUser(TEST_USER_ID1));
+
+    // user updates
+    authDatastore.addUser(testUserWithGroup);
+
+    authUpdater.runActionOnPoll();
+
+    // updated user in ZK
+    assertEquals(Optional.of(testUserWithGroup), authManager.getUser(TEST_USER_ID1));
+  }
+
+  @Test
+  public void testUserPurge() {
+    authDatastore.clearUsers();
+
+    final SingularityAuthUpdater authUpdater = new SingularityAuthUpdater(new AuthConfiguration(), authManager, authDatastore);
+
+    final SingularityUser userYesterday = new SingularityUserBuilder(TEST_USER_ID1)
+            .setLastUpdatedAt(Optional.of(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1)))
+            .build();
+    final SingularityUser userFiveDaysAgo = new SingularityUserBuilder(TEST_USER_ID2)
+            .setLastUpdatedAt(Optional.of(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(5)))
+            .build();
+
+    authManager.updateUser(userYesterday);
+    authManager.updateUser(userFiveDaysAgo);
+
+    assertEquals(Optional.of(userYesterday), authManager.getUser(userYesterday.getId()));
+    assertEquals(Optional.of(userFiveDaysAgo), authManager.getUser(userFiveDaysAgo.getId()));
+
+    authUpdater.runActionOnPoll();  // purge userFiveDaysAgo, but not userYesterday
+
+    assertEquals(Optional.of(userYesterday), authManager.getUser(userYesterday.getId()));
+    assertEquals(Optional.absent(), authManager.getUser(userFiveDaysAgo.getId()));
+  }
+
+}

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/AuthUpdaterTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/AuthUpdaterTest.java
@@ -16,6 +16,7 @@ import com.hubspot.singularity.TestingAuthDatastore;
 import com.hubspot.singularity.auth.SingularityAuthUpdater;
 import com.hubspot.singularity.config.AuthConfiguration;
 import com.hubspot.singularity.data.AuthManager;
+import com.hubspot.singularity.data.SingularityValidator;
 
 public class AuthUpdaterTest extends SingularitySchedulerTestBase {
   private static final String TEST_USER_ID1 = "test1";
@@ -24,6 +25,9 @@ public class AuthUpdaterTest extends SingularitySchedulerTestBase {
 
   @Inject
   private AuthManager authManager;
+
+  @Inject
+  private SingularityValidator validator;
 
   private final TestingAuthDatastore authDatastore;
 
@@ -37,7 +41,7 @@ public class AuthUpdaterTest extends SingularitySchedulerTestBase {
   public void testUserUpdate() {
     authDatastore.clearUsers();
 
-    final SingularityAuthUpdater authUpdater = new SingularityAuthUpdater(new AuthConfiguration(), authManager, authDatastore);
+    final SingularityAuthUpdater authUpdater = new SingularityAuthUpdater(new AuthConfiguration(), authManager, authDatastore, validator);
 
     final long now = System.currentTimeMillis();
 
@@ -73,7 +77,7 @@ public class AuthUpdaterTest extends SingularitySchedulerTestBase {
   public void testUserPurge() {
     authDatastore.clearUsers();
 
-    final SingularityAuthUpdater authUpdater = new SingularityAuthUpdater(new AuthConfiguration(), authManager, authDatastore);
+    final SingularityAuthUpdater authUpdater = new SingularityAuthUpdater(new AuthConfiguration(), authManager, authDatastore, validator);
 
     final SingularityUser userYesterday = new SingularityUserBuilder(TEST_USER_ID1)
             .setLastUpdatedAt(Optional.of(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1)))


### PR DESCRIPTION
- update LDAP queries to support hierarchical groups 
- removes CacheLoader usage in favor of storing in ZK
- surface `authLastUpdatedAt` (when was the auth store last successfully updated) in SingularityState
- add `lastUpdatedAt` field to SingularityUser
- add SingularityAuthUpdater, a leader-only poller for updating the auth cache.
- tests

still TODO:
- safe way to trigger ad-hoc auth cache updates.