### PR TITLE
Simpler way to fetch tasks by deploy id

### DIFF
--- a/SingularityService/singularity_test.sql
+++ b/SingularityService/singularity_test.sql
@@ -20,6 +20,7 @@ CREATE TABLE deployHistory (
 
 CREATE TABLE taskHistory (
   taskId VARCHAR(200) PRIMARY KEY,
+  deployId VARCHAR(100) NULL,
   requestId VARCHAR(100) NOT NULL,
   updatedAt TIMESTAMP NOT NULL DEFAULT '1971-01-01 00:00:01',
   lastTaskStatus VARCHAR(25) NULL,

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -402,7 +402,7 @@ public class TaskManager extends CuratorAsyncManager {
   }
 
   public List<SingularityTaskId> getTaskIdsForDeploy(String requestId, final String deployId, TaskFilter taskFilter) {
-    List<SingularityTaskId> requestTaskIds =  getTaskIdsForRequest(requestId, taskFilter);
+    List<SingularityTaskId> requestTaskIds = getTaskIdsForRequest(requestId, taskFilter);
     final Iterable<SingularityTaskId> deployTaskIds = Iterables.filter(requestTaskIds, new Predicate<SingularityTaskId>() {
       @Override
       public boolean apply(SingularityTaskId input) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -7,6 +7,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.transaction.CuratorTransactionFinal;
 import org.apache.curator.utils.ZKPaths;
@@ -397,6 +399,25 @@ public class TaskManager extends CuratorAsyncManager {
     Iterables.removeAll(requestTaskIds, activeTaskIds);
 
     return requestTaskIds;
+  }
+
+  public List<SingularityTaskId> getTaskIdsForDeploy(String requestId, final String deployId, TaskFilter taskFilter) {
+    List<SingularityTaskId> requestTaskIds =  getTaskIdsForRequest(requestId, taskFilter);
+    final Iterable<SingularityTaskId> deployTaskIds = Iterables.filter(requestTaskIds, new Predicate<SingularityTaskId>() {
+      @Override
+      public boolean apply(SingularityTaskId input) {
+        return input.getDeployId().equals(deployId);
+      }
+    });
+    return ImmutableList.copyOf(deployTaskIds);
+  }
+
+  public List<SingularityTaskId> getActiveTaskIdsForDeploy(String requestId, final String deployId) {
+    return getTaskIdsForDeploy(requestId, deployId, TaskFilter.ACTIVE);
+  }
+
+  public List<SingularityTaskId> getInactiveTaskIdsForDeploy(String requestId, final String deployId) {
+    return getTaskIdsForDeploy(requestId, deployId, TaskFilter.INACTIVE);
   }
 
   public Optional<SingularityTaskHistory> getTaskHistory(SingularityTaskId taskId) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/BlendedHistoryHelper.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/BlendedHistoryHelper.java
@@ -1,13 +1,37 @@
 package com.hubspot.singularity.data.history;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import com.google.common.collect.Lists;
+import com.hubspot.singularity.SingularityTask;
+import com.hubspot.singularity.SingularityTaskHistoryUpdate;
+import com.hubspot.singularity.SingularityTaskId;
+import com.hubspot.singularity.SingularityTaskIdHistory;
+import com.hubspot.singularity.data.TaskManager;
 
 public abstract class BlendedHistoryHelper<T, Q> {
 
   protected abstract List<T> getFromZk(Q id);
   protected abstract List<T> getFromHistory(Q id, int historyStart, int numFromHistory);
+
+  public List<SingularityTaskIdHistory> getTaskHistoriesFor(TaskManager taskManager, Collection<SingularityTaskId> taskIds) {
+    Map<SingularityTaskId, SingularityTask> tasks = taskManager.getTasks(taskIds);
+    Map<SingularityTaskId, List<SingularityTaskHistoryUpdate>> map = taskManager.getTaskHistoryUpdates(taskIds);
+
+    List<SingularityTaskIdHistory> histories = Lists.newArrayListWithCapacity(taskIds.size());
+
+    for (SingularityTaskId taskId : taskIds) {
+      List<SingularityTaskHistoryUpdate> historyUpdates = map.get(taskId);
+      SingularityTask task = tasks.get(taskId);
+      histories.add(SingularityTaskIdHistory.fromTaskIdAndTaskAndUpdates(taskId, task, historyUpdates));
+    }
+
+    Collections.sort(histories);
+    return histories;
+  }
 
   public List<T> getBlendedHistory(Q id, Integer limitStart, Integer limitCount) {
     final List<T> fromZk = getFromZk(id);

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/DeployTaskHistoryHelper.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/DeployTaskHistoryHelper.java
@@ -1,22 +1,12 @@
 package com.hubspot.singularity.data.history;
 
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.hubspot.singularity.SingularityDeployKey;
-import com.hubspot.singularity.SingularityTask;
-import com.hubspot.singularity.SingularityTaskHistoryUpdate;
 import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.SingularityTaskIdHistory;
-import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.TaskManager;
 
 @Singleton
@@ -24,89 +14,21 @@ public class DeployTaskHistoryHelper extends BlendedHistoryHelper<SingularityTas
 
   private final TaskManager taskManager;
   private final HistoryManager historyManager;
-  private final SingularityConfiguration singularityConfiguration;
 
   @Inject
-  public DeployTaskHistoryHelper(TaskManager taskManager, HistoryManager historyManager, SingularityConfiguration singularityConfiguration) {
+  public DeployTaskHistoryHelper(TaskManager taskManager, HistoryManager historyManager) {
     this.taskManager = taskManager;
     this.historyManager = historyManager;
-    this.singularityConfiguration = singularityConfiguration;
-  }
-
-  public List<SingularityTaskIdHistory> getHistoriesFor(Collection<SingularityTaskId> taskIds) {
-    Map<SingularityTaskId, SingularityTask> tasks = taskManager.getTasks(taskIds);
-    Map<SingularityTaskId, List<SingularityTaskHistoryUpdate>> map = taskManager.getTaskHistoryUpdates(taskIds);
-
-    List<SingularityTaskIdHistory> histories = Lists.newArrayListWithCapacity(taskIds.size());
-
-    for (SingularityTaskId taskId : taskIds) {
-      List<SingularityTaskHistoryUpdate> historyUpdates = map.get(taskId);
-      SingularityTask task = tasks.get(taskId);
-
-      histories.add(SingularityTaskIdHistory.fromTaskIdAndTaskAndUpdates(taskId, task, historyUpdates));
-    }
-
-    Collections.sort(histories);
-
-    return histories;
   }
 
   @Override
   protected List<SingularityTaskIdHistory> getFromZk(final SingularityDeployKey deployKey) {
-    List<SingularityTaskId> requestTaskIds = taskManager.getTaskIdsForRequest(deployKey.getRequestId());
-
-    final Iterable<SingularityTaskId> deployTaskIds = Iterables.filter(requestTaskIds, new Predicate<SingularityTaskId>() {
-      @Override
-      public boolean apply(SingularityTaskId input) {
-        return input.getDeployId().equals(deployKey.getDeployId());
-      }
-    });
-
-    return getHistoriesFor(ImmutableList.copyOf(deployTaskIds));
+    List<SingularityTaskId> deployTaskIds = taskManager.getInactiveTaskIdsForDeploy(deployKey.getRequestId(), deployKey.getDeployId());
+    return getTaskHistoriesFor(taskManager, deployTaskIds);
   }
 
   @Override
   protected List<SingularityTaskIdHistory> getFromHistory(final SingularityDeployKey deployKey, int historyStart, int numFromHistory) {
-    List<SingularityTaskIdHistory> requestHistories = historyManager.getTaskHistoryForRequest(deployKey.getRequestId(), historyStart, numFromHistory);
-
-    final Iterable<SingularityTaskIdHistory> deployHistories = Iterables.filter(requestHistories, new Predicate<SingularityTaskIdHistory>() {
-      @Override
-      public boolean apply(SingularityTaskIdHistory input) {
-        return input.getTaskId().getDeployId().equals(deployKey.getDeployId());
-      }
-    });
-
-    return ImmutableList.copyOf(deployHistories);
+    return historyManager.getTaskHistoryForDeploy(deployKey.getDeployId(), historyStart, numFromHistory);
   }
-
-  public List<SingularityTaskIdHistory> getActiveDeployTasks(SingularityDeployKey key) {
-    List<SingularityTaskIdHistory> histories = this.getFromZk(key);
-
-    final Iterable<SingularityTaskIdHistory> activeHistories = Iterables.filter(histories, new Predicate<SingularityTaskIdHistory>() {
-      @Override
-      public boolean apply(SingularityTaskIdHistory input) {
-        return !input.getLastTaskState().get().isDone();
-      }
-    });
-
-    return ImmutableList.copyOf(activeHistories);
-  }
-
-  public List<SingularityTaskIdHistory> getInactiveDeployTasks(SingularityDeployKey key, Integer limitCount, Integer limitStart) {
-    // We don't know our limits yet before filtering task state
-    Integer limit = (int) (singularityConfiguration.getHistoryPurgingConfiguration().getDeleteTaskHistoryAfterTasksPerRequest().or(10000) * 1.2);
-    List<SingularityTaskIdHistory> histories = this.getBlendedHistory(key, 0, limit);
-
-    final Iterable<SingularityTaskIdHistory> inactiveHistories = Iterables.filter(histories, new Predicate<SingularityTaskIdHistory>() {
-      @Override
-      public boolean apply(SingularityTaskIdHistory input) {
-        return input.getLastTaskState().get().isDone();
-      }
-    });
-
-    ImmutableList result = ImmutableList.copyOf(inactiveHistories);
-
-    return result.subList(limitStart, Math.min(result.size(), limitStart + limitCount));
-  }
-
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/DeployTaskHistoryHelper.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/DeployTaskHistoryHelper.java
@@ -29,6 +29,6 @@ public class DeployTaskHistoryHelper extends BlendedHistoryHelper<SingularityTas
 
   @Override
   protected List<SingularityTaskIdHistory> getFromHistory(final SingularityDeployKey deployKey, int historyStart, int numFromHistory) {
-    return historyManager.getTaskHistoryForDeploy(deployKey.getDeployId(), historyStart, numFromHistory);
+    return historyManager.getTaskHistoryForDeploy(deployKey.getRequestId(), deployKey.getDeployId(), historyStart, numFromHistory);
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/HistoryJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/HistoryJDBI.java
@@ -23,8 +23,8 @@ public interface HistoryJDBI {
   @SqlUpdate("INSERT INTO deployHistory (requestId, deployId, createdAt, user, deployStateAt, deployState, bytes) VALUES (:requestId, :deployId, :createdAt, :user, :deployStateAt, :deployState, :bytes)")
   void insertDeployHistory(@Bind("requestId") String requestId, @Bind("deployId") String deployId, @Bind("createdAt") Date createdAt, @Bind("user") String user, @Bind("deployStateAt") Date deployStateAt, @Bind("deployState") String deployState, @Bind("bytes") byte[] bytes);
 
-  @SqlUpdate("INSERT INTO taskHistory (requestId, taskId, bytes, updatedAt, lastTaskStatus, runId) VALUES (:requestId, :taskId, :bytes, :updatedAt, :lastTaskStatus, :runId)")
-  void insertTaskHistory(@Bind("requestId") String requestId, @Bind("taskId") String taskId, @Bind("bytes") byte[] bytes, @Bind("updatedAt") Date updatedAt, @Bind("lastTaskStatus") String lastTaskStatus, @Bind("runId") String runId);
+  @SqlUpdate("INSERT INTO taskHistory (requestId, taskId, bytes, updatedAt, lastTaskStatus, runId, deployId) VALUES (:requestId, :taskId, :bytes, :updatedAt, :lastTaskStatus, :runId, :deployId)")
+  void insertTaskHistory(@Bind("requestId") String requestId, @Bind("taskId") String taskId, @Bind("bytes") byte[] bytes, @Bind("updatedAt") Date updatedAt, @Bind("lastTaskStatus") String lastTaskStatus, @Bind("runId") String runId, @Bind("deployId") String deployId);
 
   @SqlQuery("SELECT bytes FROM taskHistory WHERE taskId = :taskId")
   byte[] getTaskHistoryForTask(@Bind("taskId") String taskId);
@@ -37,6 +37,9 @@ public interface HistoryJDBI {
 
   @SqlQuery("SELECT taskId, requestId, updatedAt, lastTaskStatus, runId FROM taskHistory WHERE requestId = :requestId ORDER BY updatedAt DESC LIMIT :limitStart, :limitCount")
   List<SingularityTaskIdHistory> getTaskHistoryForRequest(@Bind("requestId") String requestId, @Bind("limitStart") Integer limitStart, @Bind("limitCount") Integer limitCount);
+
+  @SqlQuery("SELECT taskId, requestId, updatedAt, lastTaskStatus, runId FROM taskHistory WHERE deployId = :deployId ORDER BY updatedAt DESC LIMIT :limitStart, :limitCount")
+  List<SingularityTaskIdHistory> getTaskHistoryForDeploy(@Bind("deployId") String deployId, @Bind("limitStart") Integer limitStart, @Bind("limitCount") Integer limitCount);
 
   @SqlQuery("SELECT request, createdAt, requestState, user FROM requestHistory WHERE requestId = :requestId ORDER BY createdAt <orderDirection> LIMIT :limitStart, :limitCount")
   List<SingularityRequestHistory> getRequestHistory(@Bind("requestId") String requestId, @Define("orderDirection") String orderDirection, @Bind("limitStart") Integer limitStart, @Bind("limitCount") Integer limitCount);

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/HistoryJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/HistoryJDBI.java
@@ -38,8 +38,8 @@ public interface HistoryJDBI {
   @SqlQuery("SELECT taskId, requestId, updatedAt, lastTaskStatus, runId FROM taskHistory WHERE requestId = :requestId ORDER BY updatedAt DESC LIMIT :limitStart, :limitCount")
   List<SingularityTaskIdHistory> getTaskHistoryForRequest(@Bind("requestId") String requestId, @Bind("limitStart") Integer limitStart, @Bind("limitCount") Integer limitCount);
 
-  @SqlQuery("SELECT taskId, requestId, updatedAt, lastTaskStatus, runId FROM taskHistory WHERE deployId = :deployId ORDER BY updatedAt DESC LIMIT :limitStart, :limitCount")
-  List<SingularityTaskIdHistory> getTaskHistoryForDeploy(@Bind("deployId") String deployId, @Bind("limitStart") Integer limitStart, @Bind("limitCount") Integer limitCount);
+  @SqlQuery("SELECT taskId, requestId, updatedAt, lastTaskStatus, runId FROM taskHistory WHERE requestId = :requestId AND deployId = :deployId ORDER BY updatedAt DESC LIMIT :limitStart, :limitCount")
+  List<SingularityTaskIdHistory> getTaskHistoryForDeploy(@Bind("requestId") String requestId, @Bind("deployId") String deployId, @Bind("limitStart") Integer limitStart, @Bind("limitCount") Integer limitCount);
 
   @SqlQuery("SELECT request, createdAt, requestState, user FROM requestHistory WHERE requestId = :requestId ORDER BY createdAt <orderDirection> LIMIT :limitStart, :limitCount")
   List<SingularityRequestHistory> getRequestHistory(@Bind("requestId") String requestId, @Define("orderDirection") String orderDirection, @Bind("limitStart") Integer limitStart, @Bind("limitCount") Integer limitCount);

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/HistoryManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/HistoryManager.java
@@ -28,7 +28,7 @@ public interface HistoryManager {
 
   List<SingularityTaskIdHistory> getTaskHistoryForRequest(String requestId, Integer limitStart, Integer limitCount);
 
-  List<SingularityTaskIdHistory> getTaskHistoryForDeploy(String deployId, Integer limitStart, Integer limitCount);
+  List<SingularityTaskIdHistory> getTaskHistoryForDeploy(String requestId, String deployId, Integer limitStart, Integer limitCount);
 
   Optional<SingularityTaskHistory> getTaskHistory(String taskId);
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/HistoryManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/HistoryManager.java
@@ -28,6 +28,8 @@ public interface HistoryManager {
 
   List<SingularityTaskIdHistory> getTaskHistoryForRequest(String requestId, Integer limitStart, Integer limitCount);
 
+  List<SingularityTaskIdHistory> getTaskHistoryForDeploy(String deployId, Integer limitStart, Integer limitCount);
+
   Optional<SingularityTaskHistory> getTaskHistory(String taskId);
 
   List<SingularityRequestHistory> getRequestHistory(String requestId, Optional<OrderDirection> orderDirection, Integer limitStart, Integer limitCount);

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/JDBIHistoryManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/JDBIHistoryManager.java
@@ -41,6 +41,11 @@ public class JDBIHistoryManager implements HistoryManager {
   }
 
   @Override
+  public List<SingularityTaskIdHistory> getTaskHistoryForDeploy(String deployId, Integer limitStart, Integer limitCount) {
+    return history.getTaskHistoryForDeploy(deployId, limitStart, limitCount);
+  }
+
+  @Override
   public void saveRequestHistoryUpdate(SingularityRequestHistory requestHistory) {
     history.insertRequestHistory(requestHistory.getRequest().getId(), singularityRequestTranscoder.toBytes(requestHistory.getRequest()), new Date(requestHistory.getCreatedAt()),
         requestHistory.getEventType().name(), requestHistory.getUser().orNull());
@@ -101,7 +106,7 @@ public class JDBIHistoryManager implements HistoryManager {
     }
 
     history.insertTaskHistory(taskIdHistory.getTaskId().getRequestId(), taskIdHistory.getTaskId().getId(), taskHistoryTranscoder.toBytes(taskHistory), new Date(taskIdHistory.getUpdatedAt()),
-        lastTaskStatus, taskHistory.getTask().getTaskRequest().getPendingTask().getRunId().orNull());
+        lastTaskStatus, taskHistory.getTask().getTaskRequest().getPendingTask().getRunId().orNull(), taskIdHistory.getTaskId().getDeployId());
   }
 
   @Override

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/JDBIHistoryManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/JDBIHistoryManager.java
@@ -41,8 +41,8 @@ public class JDBIHistoryManager implements HistoryManager {
   }
 
   @Override
-  public List<SingularityTaskIdHistory> getTaskHistoryForDeploy(String deployId, Integer limitStart, Integer limitCount) {
-    return history.getTaskHistoryForDeploy(deployId, limitStart, limitCount);
+  public List<SingularityTaskIdHistory> getTaskHistoryForDeploy(String requestId, String deployId, Integer limitStart, Integer limitCount) {
+    return history.getTaskHistoryForDeploy(requestId, deployId, limitStart, limitCount);
   }
 
   @Override

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/NoopHistoryManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/NoopHistoryManager.java
@@ -50,6 +50,11 @@ public class NoopHistoryManager implements HistoryManager {
   }
 
   @Override
+  public List<SingularityTaskIdHistory> getTaskHistoryForDeploy(String deployId, Integer limitStart, Integer limitCount) {
+    return Collections.emptyList();
+  }
+
+  @Override
   public Optional<SingularityTaskHistory> getTaskHistory(String taskId) {
     return Optional.absent();
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/NoopHistoryManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/NoopHistoryManager.java
@@ -50,7 +50,7 @@ public class NoopHistoryManager implements HistoryManager {
   }
 
   @Override
-  public List<SingularityTaskIdHistory> getTaskHistoryForDeploy(String deployId, Integer limitStart, Integer limitCount) {
+  public List<SingularityTaskIdHistory> getTaskHistoryForDeploy(String requestId, String deployId, Integer limitStart, Integer limitCount) {
     return Collections.emptyList();
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/TaskHistoryHelper.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/TaskHistoryHelper.java
@@ -1,16 +1,11 @@
 package com.hubspot.singularity.data.history;
 
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import com.google.common.base.Optional;
-import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.SingularityTaskHistory;
-import com.hubspot.singularity.SingularityTaskHistoryUpdate;
 import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.SingularityTaskIdHistory;
 import com.hubspot.singularity.data.TaskManager;
@@ -27,29 +22,11 @@ public class TaskHistoryHelper extends BlendedHistoryHelper<SingularityTaskIdHis
     this.historyManager = historyManager;
   }
 
-  public List<SingularityTaskIdHistory> getHistoriesFor(Collection<SingularityTaskId> taskIds) {
-    Map<SingularityTaskId, SingularityTask> tasks = taskManager.getTasks(taskIds);
-    Map<SingularityTaskId, List<SingularityTaskHistoryUpdate>> history = taskManager.getTaskHistoryUpdates(taskIds);
-
-    List<SingularityTaskIdHistory> histories = Lists.newArrayListWithCapacity(taskIds.size());
-
-    for (SingularityTaskId taskId : taskIds) {
-      List<SingularityTaskHistoryUpdate> historyUpdates = history.get(taskId);
-      SingularityTask task = tasks.get(taskId);
-
-      histories.add(SingularityTaskIdHistory.fromTaskIdAndTaskAndUpdates(taskId, task, historyUpdates));
-    }
-
-    Collections.sort(histories);
-
-    return histories;
-  }
-
   @Override
   protected List<SingularityTaskIdHistory> getFromZk(String requestId) {
     final List<SingularityTaskId> inactiveTasksInZk = taskManager.getInactiveTaskIdsForRequest(requestId);
 
-    return getHistoriesFor(inactiveTasksInZk);
+    return getTaskHistoriesFor(taskManager, inactiveTasksInZk);
   }
 
   @Override

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/HistoryResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/HistoryResource.java
@@ -98,7 +98,7 @@ public class HistoryResource extends AbstractHistoryResource {
     authorizationHelper.checkForAuthorizationByRequestId(requestId, user);
     List<SingularityTaskId> activeTaskIds = taskManager.getActiveTaskIdsForRequest(requestId);
 
-    return taskHistoryHelper.getHistoriesFor(activeTaskIds);
+    return taskHistoryHelper.getTaskHistoriesFor(taskManager, activeTaskIds);
   }
 
   @GET
@@ -115,9 +115,9 @@ public class HistoryResource extends AbstractHistoryResource {
   public List<SingularityTaskIdHistory> getActiveDeployTasks(
       @ApiParam("Request ID for deploy") @PathParam("requestId") String requestId,
       @ApiParam("Deploy ID") @PathParam("deployId") String deployId) {
-    SingularityDeployKey key = new SingularityDeployKey(requestId, deployId);
-
-    return deployTaskHistoryHelper.getActiveDeployTasks(key);
+    authorizationHelper.checkForAuthorizationByRequestId(requestId, user);
+    List<SingularityTaskId> activeTaskIds = taskManager.getActiveTaskIdsForDeploy(requestId, deployId);
+    return taskHistoryHelper.getTaskHistoriesFor(taskManager, activeTaskIds);
   }
 
   @GET
@@ -131,9 +131,9 @@ public class HistoryResource extends AbstractHistoryResource {
     final Integer limitCount = getLimitCount(count);
     final Integer limitStart = getLimitStart(limitCount, page);
 
+    authorizationHelper.checkForAuthorizationByRequestId(requestId, user);
     SingularityDeployKey key = new SingularityDeployKey(requestId, deployId);
-
-    return deployTaskHistoryHelper.getInactiveDeployTasks(key, limitCount, limitStart);
+    return deployTaskHistoryHelper.getBlendedHistory(key, limitCount, limitStart);
   }
 
   @GET

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/HistoryResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/HistoryResource.java
@@ -133,7 +133,7 @@ public class HistoryResource extends AbstractHistoryResource {
 
     authorizationHelper.checkForAuthorizationByRequestId(requestId, user);
     SingularityDeployKey key = new SingularityDeployKey(requestId, deployId);
-    return deployTaskHistoryHelper.getBlendedHistory(key, limitCount, limitStart);
+    return deployTaskHistoryHelper.getBlendedHistory(key, limitStart, limitCount);
   }
 
   @GET

--- a/mysql/migrations.sql
+++ b/mysql/migrations.sql
@@ -77,5 +77,7 @@ ALTER TABLE `taskHistory` MODIFY `bytes` MEDIUMBLOB NOT NULL;
 ALTER TABLE `taskHistory` ADD COLUMN runId VARCHAR(100) NULL;
 
 --changeset ssalinas:7 dbms:mysql
-ALTER TABLE `taskHistory` ADD COLUMN deployId VARCHAR(100) NULL;
+ALTER TABLE `taskHistory`
+  ADD COLUMN deployId VARCHAR(100) NULL,
+  ADD KEY `deployId` (`deployId`, `requestId`, `updatedAt`);
 UPDATE `taskHistory` SET `deployId` = SUBSTRING_INDEX(SUBSTRING_INDEX(`taskId`, '-', -5), '-', 1) WHERE `deployId` IS NULL;

--- a/mysql/migrations.sql
+++ b/mysql/migrations.sql
@@ -78,4 +78,4 @@ ALTER TABLE `taskHistory` ADD COLUMN runId VARCHAR(100) NULL;
 
 --changeset ssalinas:7 dbms:mysql
 ALTER TABLE `taskHistory` ADD COLUMN deployId VARCHAR(100) NULL;
-UPDATE `taskHistory` SET `deployId`` = SUBSTRING_INDEX(SUBSTRING_INDEX(`taskId``, '-', -5), '-', 1) WHERE `deployId`` IS NULL;
+UPDATE `taskHistory` SET `deployId` = SUBSTRING_INDEX(SUBSTRING_INDEX(`taskId`, '-', -5), '-', 1) WHERE `deployId` IS NULL;

--- a/mysql/migrations.sql
+++ b/mysql/migrations.sql
@@ -75,3 +75,7 @@ ALTER TABLE `taskHistory` MODIFY `bytes` MEDIUMBLOB NOT NULL;
 
 --changeset wsorenson:6 dbms:mysql
 ALTER TABLE `taskHistory` ADD COLUMN runId VARCHAR(100) NULL;
+
+--changeset ssalinas:7 dbms:mysql
+ALTER TABLE `taskHistory` ADD COLUMN deployId VARCHAR(100) NULL;
+UPDATE `taskHistory` SET `deployId`` = SUBSTRING_INDEX(SUBSTRING_INDEX(`taskId``, '-', -5), '-', 1) WHERE `deployId`` IS NULL;


### PR DESCRIPTION
@wsorenson addresses the comments from #629 
/cc @tpetr 

Also, would welcome any suggestions on the query to populate deployId. The requestId can also have dashes, so I'm currently substring-ing twice to get the depolyId as the first element, then trim off the rest