### PR TITLE
Don't enable task/request table search until collection loads (and then focus the field)

### DIFF
--- a/SingularityUI/app/templates/requestsTable/requestsBase.hbs
+++ b/SingularityUI/app/templates/requestsTable/requestsBase.hbs
@@ -32,7 +32,7 @@
 
 <div class="row">
     <div class="col-md-12">
-        <input type="search" class="big-search-box" placeholder="Filter requests" value="{{ searchFilter }}" required />
+        <input disabled type="search" class="big-search-box" placeholder="Loading requests..." value="{{ searchFilter }}" required />
     </div>
 
     <div class="col-md-12">

--- a/SingularityUI/app/templates/tasksTable/tasksBase.hbs
+++ b/SingularityUI/app/templates/tasksTable/tasksBase.hbs
@@ -22,7 +22,7 @@
 
 <div class="row">
     <div class="col-md-12">
-        <input type="search" class="big-search-box" placeholder="Filter tasks" value="{{ searchFilter }}" required>
+        <input disabled type="search" class="big-search-box" placeholder="Loading tasks..." value="{{ searchFilter }}" required>
     </div>
 </div>
 

--- a/SingularityUI/app/views/requests.coffee
+++ b/SingularityUI/app/views/requests.coffee
@@ -114,21 +114,7 @@ class RequestsView extends View
 
         @currentRequests = requests
 
-    preventSearchOverwrite: ->
-        # If you've got a lot of requests like we do at HubSpot, the collection
-        # behind this view will take a while to download & parse. If you type stuff
-        # in the search field before this happens, it'll all be wiped.
-        $searchBox = @$ 'input[type="search"]'
-        searchVal = $searchBox.val()
-
-        @searchFilter = searchVal if not @searchFilter
-
-        if $searchBox.is ':focus'
-            @focusSearchAfterRender = true
-
     render: =>
-        @preventSearchOverwrite()
-
         # Renders the base template
         # The table contents are rendered bit by bit as the user scrolls down.
         context =
@@ -148,12 +134,10 @@ class RequestsView extends View
             partials.partials.requestsFilter = @templateFilter
 
         @$el.html @templateBase context, partials
+        @afterRender()
 
-        if @focusSearchAfterRender
-            $searchBox = @$ 'input[type="search"]'
-            $searchBox.focus()
-            $searchBox[0].setSelectionRange @searchFilter.length, @searchFilter.length
-            @focusSearchAfterRender = false
+    afterRender: =>
+        super
 
         @renderTable()
         @$('.actions-column a[title]').tooltip()
@@ -172,14 +156,13 @@ class RequestsView extends View
             hide: (e) ->
                 @hidePopover(e)
 
-        super.afterRender()
-
     # Prepares the staged rendering and triggers the first one
     renderTable: =>
         return if not @$('table').length
 
         @$('table').show()
         @$('.empty-table-message').remove()
+        @$('input[type="search"]').removeAttr('disabled').attr('placeholder','Filter requests').focus()
 
         $(window).scrollTop 0
         @filterCollection()

--- a/SingularityUI/app/views/tasks.coffee
+++ b/SingularityUI/app/views/tasks.coffee
@@ -72,20 +72,7 @@ class TasksView extends View
 
         @currentTasks = tasks
 
-    preventSearchOverwrite: ->
-        # If you've got a lot of tasks like we do at HubSpot, the collection
-        # behind this view will take a while to download & parse. If you type stuff
-        # in the search field before this happens, it'll all be wiped.
-        $searchBox = @$ 'input[type="search"]'
-        searchVal = $searchBox.val()
-
-        @searchFilter = searchVal if not @searchFilter
-
-        if $searchBox.is ':focus'
-            @focusSearchAfterRender = true
-
     render: =>
-        @preventSearchOverwrite()
         # Renders the base template
         # The table contents are rendered bit by bit as the user scrolls down.
         context =
@@ -100,12 +87,6 @@ class TasksView extends View
 
         @$el.html @templateBase context, partials
 
-        if @focusSearchAfterRender
-            $searchBox = @$ 'input[type="search"]'
-            $searchBox.focus()
-            $searchBox[0].setSelectionRange @searchFilter.length, @searchFilter.length
-            @focusSearchAfterRender = false
-
         @renderTable()
 
         super.afterRender()
@@ -116,6 +97,7 @@ class TasksView extends View
 
         @$('table').show()
         @$('.empty-table-message').remove()
+        @$('input[type="search"]').removeAttr('disabled').attr('placeholder','Filter tasks').focus()
 
         $(window).scrollTop 0
         @filterCollection()


### PR DESCRIPTION
The purpose of this PR is simply to focus the input field, but it made it easier to do this after refactoring the code a bit - removing the `preventSearchOverwrite` method, and just disabling the input field until the table loads, so no need to prevent anything.

@tpetr 