### PR TITLE
allow runnable configs to be consolidated into one file

### DIFF
--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
@@ -21,7 +21,7 @@ import com.hubspot.singularity.runner.base.configuration.BaseRunnerConfiguration
 import com.hubspot.singularity.runner.base.configuration.Configuration;
 import com.hubspot.singularity.runner.base.constraints.DirectoryExists;
 
-@Configuration("/etc/singularity.executor.yaml")
+@Configuration(filename = "/etc/singularity.executor.yaml", consolidatedField = "executor")
 public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
   public static final String SHUTDOWN_TIMEOUT_MILLIS = "executor.shutdown.timeout.millis";
 

--- a/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/config/SingularityExecutorCleanupConfiguration.java
+++ b/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/config/SingularityExecutorCleanupConfiguration.java
@@ -19,7 +19,7 @@ import com.hubspot.singularity.runner.base.configuration.BaseRunnerConfiguration
 import com.hubspot.singularity.runner.base.configuration.Configuration;
 import com.hubspot.singularity.runner.base.constraints.DirectoryExists;
 
-@Configuration("/etc/singularity.executor.cleanup.yaml")
+@Configuration(filename = "/etc/singularity.executor.cleanup.yaml", consolidatedField = "executorCleanup")
 public class SingularityExecutorCleanupConfiguration extends BaseRunnerConfiguration {
   public static final String SAFE_MODE_WONT_RUN_WITH_NO_TASKS = "executor.cleanup.safe.mode.wont.run.with.no.tasks";
   public static final String EXECUTOR_CLEANUP_CLEANUP_APP_DIRECTORY_OF_FAILED_TASKS_AFTER_MILLIS = "executor.cleanup.cleanup.app.directory.of.failed.tasks.after.millis";

--- a/SingularityLogWatcher/src/main/java/com/hubspot/singularity/logwatcher/config/SingularityLogWatcherConfiguration.java
+++ b/SingularityLogWatcher/src/main/java/com/hubspot/singularity/logwatcher/config/SingularityLogWatcherConfiguration.java
@@ -16,7 +16,7 @@ import com.hubspot.singularity.runner.base.configuration.BaseRunnerConfiguration
 import com.hubspot.singularity.runner.base.configuration.Configuration;
 import com.hubspot.singularity.runner.base.constraints.DirectoryExists;
 
-@Configuration("/etc/singularity.logwatcher.yaml")
+@Configuration(filename = "/etc/singularity.logwatcher.yaml", consolidatedField = "logwatcher")
 public class SingularityLogWatcherConfiguration extends BaseRunnerConfiguration {
   public static final String BYTE_BUFFER_CAPACITY = "logwatcher.bytebuffer.capacity";
   public static final String POLL_MILLIS = "logwatcher.poll.millis";

--- a/SingularityOOMKiller/src/main/java/com/hubspot/singularity/oomkiller/config/SingularityOOMKillerConfiguration.java
+++ b/SingularityOOMKiller/src/main/java/com/hubspot/singularity/oomkiller/config/SingularityOOMKillerConfiguration.java
@@ -11,7 +11,7 @@ import com.google.common.base.Optional;
 import com.hubspot.singularity.runner.base.configuration.BaseRunnerConfiguration;
 import com.hubspot.singularity.runner.base.configuration.Configuration;
 
-@Configuration("/etc/singularity.oomkiller.yaml")
+@Configuration(filename = "/etc/singularity.oomkiller.yaml", consolidatedField = "oomkiller")
 public class SingularityOOMKillerConfiguration extends BaseRunnerConfiguration {
   public static final String REQUEST_KILL_THRESHOLD_RATIO = "oomkiller.request.kill.threshold.ratio";
   public static final String KILL_PROCESS_DIRECTLY_THRESHOLD_RATIO = "oomkiller.kill.process.directly.threshold.ratio";

--- a/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/config/ConfigurationBinder.java
+++ b/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/config/ConfigurationBinder.java
@@ -3,6 +3,7 @@ package com.hubspot.singularity.runner.base.config;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
+import com.google.common.base.Optional;
 import com.google.inject.Binder;
 import com.google.inject.Scopes;
 import com.google.inject.multibindings.Multibinder;
@@ -22,17 +23,17 @@ public class ConfigurationBinder {
     this.multibinder = Multibinder.newSetBinder(binder, BaseRunnerConfiguration.class);
   }
 
-  public <T extends BaseRunnerConfiguration> ConfigurationBinder bindPrimaryConfiguration(Class<T> configurationClass) {
-    bindConfiguration(configurationClass);
+  public <T extends BaseRunnerConfiguration> ConfigurationBinder bindPrimaryConfiguration(Class<T> configurationClass, Optional<String> filename) {
+    bindConfiguration(configurationClass, filename);
     binder.bind(BaseRunnerConfiguration.class).to(configurationClass);
     return this;
   }
 
-  public <T extends BaseRunnerConfiguration> ConfigurationBinder bindConfiguration(Class<T> configurationClass) {
+  public <T extends BaseRunnerConfiguration> ConfigurationBinder bindConfiguration(Class<T> configurationClass, Optional<String> filename) {
     checkNotNull(configurationClass, "configurationClass");
     checkState(configurationClass.getAnnotation(Configuration.class) != null, "%s must be annotated with @Configuration", configurationClass.getSimpleName());
 
-    binder.bind(configurationClass).toProvider(new SingularityRunnerConfigurationProvider<T>(configurationClass)).in(Scopes.SINGLETON);
+    binder.bind(configurationClass).toProvider(new SingularityRunnerConfigurationProvider<T>(configurationClass, filename)).in(Scopes.SINGLETON);
     multibinder.addBinding().to(configurationClass);
     return this;
   }

--- a/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/config/SingularityRunnerBaseLogging.java
+++ b/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/config/SingularityRunnerBaseLogging.java
@@ -57,7 +57,7 @@ public class SingularityRunnerBaseLogging {
     for (BaseRunnerConfiguration configuration : configurations) {
       try {
         final Configuration annotation = configuration.getClass().getAnnotation(Configuration.class);
-        final String filename = consolidatedConfigFilename.or(annotation == null ? "(unknown)" : annotation.value());
+        final String filename = consolidatedConfigFilename.or(annotation == null ? "(unknown)" : annotation.filename());
         LOG.info(String.format("Loaded %s from %s:%n%s", configuration.getClass().getSimpleName(), filename, yamlMapper.writeValueAsString(configuration)));
       } catch (Exception e) {
         LOG.warn(String.format("Exception while attempting to print %s!", configuration.getClass().getName()), e);

--- a/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/config/SingularityRunnerBaseLogging.java
+++ b/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/config/SingularityRunnerBaseLogging.java
@@ -31,13 +31,15 @@ public class SingularityRunnerBaseLogging {
   private final SingularityRunnerBaseConfiguration baseConfiguration;
   private final BaseRunnerConfiguration primaryConfiguration;
   private final Set<BaseRunnerConfiguration> configurations;
+  private final Optional<String> consolidatedConfigFilename;
 
   @Inject
-  public SingularityRunnerBaseLogging(@Named(SingularityRunnerBaseModule.OBFUSCATED_YAML) ObjectMapper yamlMapper, SingularityRunnerBaseConfiguration baseConfiguration, BaseRunnerConfiguration primaryConfiguration, Set<BaseRunnerConfiguration> configurations) {
+  public SingularityRunnerBaseLogging(@Named(SingularityRunnerBaseModule.OBFUSCATED_YAML) ObjectMapper yamlMapper, SingularityRunnerBaseConfiguration baseConfiguration, BaseRunnerConfiguration primaryConfiguration, Set<BaseRunnerConfiguration> configurations, @Named(SingularityRunnerBaseModule.CONSOLIDATED_CONFIG_FILENAME) Optional<String> consolidatedConfigFilename) {
     this.yamlMapper = yamlMapper;
     this.primaryConfiguration = primaryConfiguration;
     this.configurations = configurations;
     this.baseConfiguration = baseConfiguration;
+    this.consolidatedConfigFilename = consolidatedConfigFilename;
 
     configureRootLogger();
     printProperties();
@@ -55,7 +57,7 @@ public class SingularityRunnerBaseLogging {
     for (BaseRunnerConfiguration configuration : configurations) {
       try {
         final Configuration annotation = configuration.getClass().getAnnotation(Configuration.class);
-        final String filename = annotation == null ? "(unknown)" : annotation.value();
+        final String filename = consolidatedConfigFilename.or(annotation == null ? "(unknown)" : annotation.value());
         LOG.info(String.format("Loaded %s from %s:%n%s", configuration.getClass().getSimpleName(), filename, yamlMapper.writeValueAsString(configuration)));
       } catch (Exception e) {
         LOG.warn(String.format("Exception while attempting to print %s!", configuration.getClass().getName()), e);

--- a/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/config/SingularityRunnerBaseModule.java
+++ b/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/config/SingularityRunnerBaseModule.java
@@ -19,7 +19,9 @@ import com.google.common.base.Strings;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
+import com.google.inject.TypeLiteral;
 import com.google.inject.name.Named;
+import com.google.inject.name.Names;
 import com.hubspot.jackson.datatype.protobuf.ProtobufModule;
 import com.hubspot.mesos.JavaUtils;
 import com.hubspot.singularity.runner.base.configuration.BaseRunnerConfiguration;
@@ -30,6 +32,7 @@ public class SingularityRunnerBaseModule extends AbstractModule {
   public static final String PROCESS_NAME = "process.name";
   public static final String YAML = "yaml";
   public static final String OBFUSCATED_YAML = "obfuscated.yaml";
+  public static final String CONSOLIDATED_CONFIG_FILENAME = "consolidated.config.filename";
 
   public static final String CONFIG_PROPERTY = "singularityConfigFilename";
 
@@ -64,6 +67,8 @@ public class SingularityRunnerBaseModule extends AbstractModule {
     }
 
     bind(SingularityRunnerBaseLogging.class).asEagerSingleton();
+
+    bind(new TypeLiteral<Optional<String>>(){}).annotatedWith(Names.named(CONSOLIDATED_CONFIG_FILENAME)).toInstance(consolidatedConfigFilename);
   }
 
   @Provides

--- a/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/config/SingularityRunnerConfigurationProvider.java
+++ b/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/config/SingularityRunnerConfigurationProvider.java
@@ -12,6 +12,7 @@ import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
@@ -23,6 +24,7 @@ import io.dropwizard.configuration.ConfigurationValidationException;
 
 public class SingularityRunnerConfigurationProvider<T extends BaseRunnerConfiguration> implements Provider<T> {
   private final Class<T> clazz;
+  private final Optional<String> filename;
 
   @Inject
   @Named(SingularityRunnerBaseModule.YAML)
@@ -31,15 +33,16 @@ public class SingularityRunnerConfigurationProvider<T extends BaseRunnerConfigur
   @Inject
   private Validator validator;
 
-  public SingularityRunnerConfigurationProvider(Class<T> clazz) {
+  public SingularityRunnerConfigurationProvider(Class<T> clazz, Optional<String> filename) {
     this.clazz = clazz;
+    this.filename = filename;
   }
 
   @Override
   public T get() {
     final Configuration configuration = clazz.getAnnotation(Configuration.class);
 
-    final String yamlPath = configuration.value();
+    final String yamlPath = filename.or(configuration.value());
     final String propsPath = yamlPath.replace(".yaml", ".properties");
 
     final File yamlFile = new File(yamlPath);

--- a/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/configuration/Configuration.java
+++ b/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/configuration/Configuration.java
@@ -9,5 +9,6 @@ import java.lang.annotation.Target;
 @Target({ TYPE })
 @Retention(RUNTIME)
 public @interface Configuration {
-  String value();
+  String filename();
+  String consolidatedField();
 }

--- a/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/configuration/SingularityRunnerBaseConfiguration.java
+++ b/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/configuration/SingularityRunnerBaseConfiguration.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
 import com.hubspot.singularity.runner.base.constraints.DirectoryExists;
 
-@Configuration("/etc/singularity.base.yaml")
+@Configuration(filename = "/etc/singularity.base.yaml", consolidatedField = "base")
 public class SingularityRunnerBaseConfiguration extends BaseRunnerConfiguration {
   public static final String ROOT_LOG_DIRECTORY = "root.log.directory";
 

--- a/SingularityS3Base/src/main/java/com/hubspot/singularity/s3/base/config/SingularityS3Configuration.java
+++ b/SingularityS3Base/src/main/java/com/hubspot/singularity/s3/base/config/SingularityS3Configuration.java
@@ -15,7 +15,7 @@ import com.hubspot.singularity.runner.base.configuration.Configuration;
 import com.hubspot.singularity.runner.base.constraints.DirectoryExists;
 import com.hubspot.singularity.runner.base.jackson.Obfuscate;
 
-@Configuration("/etc/singularity.s3base.yaml")
+@Configuration(filename = "/etc/singularity.s3base.yaml", consolidatedField = "s3")
 public class SingularityS3Configuration extends BaseRunnerConfiguration {
   public static final String ARTIFACT_CACHE_DIRECTORY = "artifact.cache.directory";
 

--- a/SingularityS3Downloader/src/main/java/com/hubspot/singularity/s3downloader/config/SingularityS3DownloaderConfiguration.java
+++ b/SingularityS3Downloader/src/main/java/com/hubspot/singularity/s3downloader/config/SingularityS3DownloaderConfiguration.java
@@ -10,7 +10,7 @@ import com.google.common.base.Optional;
 import com.hubspot.singularity.runner.base.configuration.BaseRunnerConfiguration;
 import com.hubspot.singularity.runner.base.configuration.Configuration;
 
-@Configuration("/etc/singularity.s3downloader.yaml")
+@Configuration(filename = "/etc/singularity.s3downloader.yaml", consolidatedField = "s3downloader")
 public class SingularityS3DownloaderConfiguration extends BaseRunnerConfiguration {
 
   public static final String NUM_DOWNLOADER_THREADS = "s3downloader.downloader.threads";

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/config/SingularityS3UploaderConfiguration.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/config/SingularityS3UploaderConfiguration.java
@@ -16,7 +16,7 @@ import com.hubspot.singularity.runner.base.jackson.Obfuscate;
 import com.hubspot.singularity.s3.base.config.SingularityS3Configuration;
 import com.hubspot.singularity.s3.base.config.SingularityS3Credentials;
 
-@Configuration("/etc/singularity.s3uploader.yaml")
+@Configuration(filename = "/etc/singularity.s3uploader.yaml", consolidatedField = "s3uploader")
 public class SingularityS3UploaderConfiguration extends BaseRunnerConfiguration {
   public static final String POLL_MILLIS = "s3uploader.poll.for.shutdown.millis";
 


### PR DESCRIPTION
Simplifies deployment of Singularity runnables -- still testing. Set `-DsingularityConfigFilename` to use a consolidated config file.

/cc @wsorenson @ssalinas 