### PR TITLE
when bouncing a request, record BOUNCED history event

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestHistory.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestHistory.java
@@ -15,7 +15,7 @@ public class SingularityRequestHistory implements Comparable<SingularityRequestH
   private final SingularityRequest request;
 
   public enum RequestHistoryType {
-    CREATED, UPDATED, DELETED, PAUSED, UNPAUSED, ENTERED_COOLDOWN, EXITED_COOLDOWN, FINISHED, DEPLOYED_TO_UNPAUSE;
+    CREATED, UPDATED, DELETED, PAUSED, UNPAUSED, ENTERED_COOLDOWN, EXITED_COOLDOWN, FINISHED, DEPLOYED_TO_UNPAUSE, BOUNCED;
   }
 
   @JsonCreator

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
@@ -185,6 +185,10 @@ public class RequestManager extends CuratorAsyncManager {
     return activate(request, RequestHistoryType.EXITED_COOLDOWN, timestamp, user);
   }
 
+  public SingularityCreateResult bounce(SingularityRequest request, long timestamp, Optional<String> user) {
+    return activate(request, RequestHistoryType.BOUNCED, timestamp, user);
+  }
+
   public SingularityCreateResult deployToUnpause(SingularityRequest request, long timestamp, Optional<String> user) {
     return save(request, RequestState.DEPLOYING_TO_UNPAUSE, RequestHistoryType.DEPLOYED_TO_UNPAUSE, timestamp, user);
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -198,6 +198,8 @@ public class RequestResource extends AbstractRequestResource {
 
     checkConflict(createResult != SingularityCreateResult.EXISTED, "%s is already bouncing", requestId);
 
+    requestManager.bounce(requestWithState.getRequest(), System.currentTimeMillis(), queryUser);
+
     return fillEntireRequest(requestWithState);
   }
 


### PR DESCRIPTION
No easy way to tell in the UI that a request was bounced otherwise.

/cc @ssalinas @wsorenson 