### PR TITLE
Configuring the Network field should not be predicated on having port mappings configured

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilder.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilder.java
@@ -205,6 +205,10 @@ class SingularityMesosTaskBuilder {
       final DockerInfo.Builder dockerInfoBuilder = DockerInfo.newBuilder();
       dockerInfoBuilder.setImage(dockerInfo.get().getImage());
 
+      if (dockerInfo.get().getNetwork().isPresent()) {
+        dockerInfoBuilder.setNetwork(DockerInfo.Network.valueOf(dockerInfo.get().getNetwork().get().toString()));
+      }
+
       if (ports.isPresent() && !dockerInfo.get().getPortMappings().isEmpty()) {
         for (SingularityDockerPortMapping singularityDockerPortMapping : dockerInfo.get().getPortMappings()) {
           final Optional<DockerInfo.PortMapping> maybePortMapping = buildPortMapping(singularityDockerPortMapping, ports.get());
@@ -212,10 +216,6 @@ class SingularityMesosTaskBuilder {
           if (maybePortMapping.isPresent()) {
             dockerInfoBuilder.addPortMappings(maybePortMapping.get());
           }
-        }
-
-        if (dockerInfo.get().getNetwork().isPresent()) {
-          dockerInfoBuilder.setNetwork(DockerInfo.Network.valueOf(dockerInfo.get().getNetwork().get().toString()));
         }
       }
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilderTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilderTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.mesos.Protos;
@@ -133,10 +134,10 @@ public class SingularityMesosTaskBuilderTest {
                 new SingularityVolume("/container/${TASK_REQUEST_ID}/${TASK_DEPLOY_ID}", Optional.of("/host/${TASK_ID}"), SingularityDockerVolumeMode.RO))),
         Optional.of(new SingularityDockerInfo("docker-image", true, SingularityDockerNetworkType.BRIDGE, Optional.of(Arrays.asList(literalMapping, offerMapping)))));
     final SingularityDeploy deploy = new SingularityDeployBuilder("test", "1")
-    .setContainerInfo(Optional.of(containerInfo))
-    .setCommand(Optional.of("/bin/echo"))
-    .setArguments(Optional.of(Collections.singletonList("wat")))
-    .build();
+      .setContainerInfo(Optional.of(containerInfo))
+      .setCommand(Optional.of("/bin/echo"))
+      .setArguments(Optional.of(Collections.singletonList("wat")))
+      .build();
     final SingularityTaskRequest taskRequest = new SingularityTaskRequest(request, deploy, pendingTask);
     final SingularityTask task = builder.buildTask(offer, Collections.singletonList(portsResource), taskRequest, taskResources, executorResources);
 
@@ -166,6 +167,26 @@ public class SingularityMesosTaskBuilderTest {
     assertEquals("udp", task.getMesosTask().getContainer().getDocker().getPortMappings(1).getProtocol());
 
     assertEquals(Protos.ContainerInfo.DockerInfo.Network.BRIDGE, task.getMesosTask().getContainer().getDocker().getNetwork());
+  }
+
+  @Test
+  public void testDockerMinimalNetworking() {
+    taskResources = new Resources(1, 1, 0);
+
+    final SingularityRequest request = new SingularityRequestBuilder("test", RequestType.WORKER).build();
+    final SingularityContainerInfo containerInfo = new SingularityContainerInfo(
+      SingularityContainerType.DOCKER,
+        Optional.<List<SingularityVolume>>absent(),
+        Optional.of(new SingularityDockerInfo("docker-image", true, SingularityDockerNetworkType.NONE,
+            Optional.<List<SingularityDockerPortMapping>>absent())));
+    final SingularityDeploy deploy = new SingularityDeployBuilder("test", "1")
+      .setContainerInfo(Optional.of(containerInfo))
+      .build();
+    final SingularityTaskRequest taskRequest = new SingularityTaskRequest(request, deploy, pendingTask);
+    final SingularityTask task = builder.buildTask(offer, Collections.<Protos.Resource>emptyList(), taskRequest, taskResources, executorResources);
+
+    assertEquals(Type.DOCKER, task.getMesosTask().getContainer().getType());
+    assertEquals(Protos.ContainerInfo.DockerInfo.Network.NONE, task.getMesosTask().getContainer().getDocker().getNetwork());
   }
 
   private static class CreateFakeId implements Answer<String> {


### PR DESCRIPTION
Imagine a "no network at all" network type, or a worker that does not expose any API but may connect outwardly.