### PR TITLE
make error message better

### DIFF
--- a/SingularityUI/app/application.coffee
+++ b/SingularityUI/app/application.coffee
@@ -105,15 +105,12 @@ class Application
             if jqxhr.status is 502
                 Messenger().info
                     message:   "Singularity is deploying, your requests cannot be handled. Things should resolve in a few seconds so just hang tight!"
-                    hideAfter: 10
             else if jqxhr.statusText is 'timeout'
                 Messenger().error
                     message:   "<p>A <code>#{ jqxhr.statusText }</code> error occurred while accessing:</p><pre>#{ url }</pre>"
-                    hideAFter: 20
             else if jqxhr.status is 0
                 Messenger().error
                     message:   "<p>Could not reach the Singularity API. Please make sure SingularityUI is properly set up.</p><p>If running through Brunch, this might be your browser blocking cross-domain requests.</p>"
-                    hideAfter: 20
             else
                 console.log jqxhr.responseText
 
@@ -123,12 +120,22 @@ class Application
                   serverMessage = jqxhr.responseText
 
                 serverMessage = _.escape serverMessage
+                id = "message_" + Date.now()
+                selector = "##{id}"
 
                 Messenger().error
-                    message:   "<p>An uncaught error occurred with your request. The server said:</p><pre>#{ serverMessage }</pre><p>The error has been saved to your JS console.</p>"
-                    hideAfter: 20
-
+                    message:   """<div id="#{id}">
+                                    <p>An uncaught error occurred with your request. The server said:</p>
+                                    <pre class="copy-text">#{ serverMessage }</pre>
+                                    <p>The error has been saved to your JS console. <span class='copy-link'>Copy error message</span>.</p>
+                                </div>"""
                 console.error jqxhr
+                options = 
+                    selector: selector
+                    linkText: 'Copy error message'
+                    copyLink: '.copy-link'
+
+                utils.makeMeCopy(options)
                 throw new Error "AJAX Error"
 
     # Usually called by Controllers when they're initialized. Loader is overwritten by views

--- a/SingularityUI/app/controllers/TasksTable.coffee
+++ b/SingularityUI/app/controllers/TasksTable.coffee
@@ -42,7 +42,6 @@ class TasksTableController extends Controller
                 if resp.error
                     Messenger().error
                         message:   "<p>This task is no longer pending.</p>"
-                        hideAFter: 20
                     @refresh()
             app.hideFixedPageLoader()
 

--- a/SingularityUI/app/styles/vendorOverrides.styl
+++ b/SingularityUI/app/styles/vendorOverrides.styl
@@ -1,0 +1,6 @@
+ul
+  &.messenger-theme-air
+    -moz-user-select: all
+    -webkit-user-select: all
+    -o-user-select: all
+    user-select: all

--- a/SingularityUI/app/thirdPartyConfigurations.coffee
+++ b/SingularityUI/app/thirdPartyConfigurations.coffee
@@ -30,7 +30,7 @@ Messenger.options =
     maxMessages: 1
     messageDefaults:
         type: 'error'
-        hideAfter: 5
+        hideAfter: false
         showCloseButton: true
 
 # ZeroClipboard options

--- a/SingularityUI/app/utils.coffee
+++ b/SingularityUI/app/utils.coffee
@@ -80,6 +80,17 @@ class Utils
                 $item.find("h4").append $copyLink
                 new ZeroClipboard $copyLink[0]
 
+    # Copy anything
+    @makeMeCopy: (options) =>
+        $element = $(options.selector)
+        linkText = options.linkText || 'Copy'
+        textSelector = options.textSelector || '.copy-text'
+        
+        text = $element.find(textSelector).html()
+        $copyLink = $ "<a data-clipboard-text='#{ _.escape text }'>#{linkText}</a>"
+        $(options.copyLink).html($copyLink)
+        new ZeroClipboard $copyLink[0]
+
     @fixTableColumns: ($table) =>
         $headings = $table.find "th"
         if $headings.length and $table.css('table-layout') isnt 'fixed'


### PR DESCRIPTION
messages no longer disappear, serverMessage text is selectable, and a copy link for the serverMessage is included

<img width="816" alt="screenshot 2015-09-15 18 53 08" src="https://cloud.githubusercontent.com/assets/3275453/9892489/521fc936-5bdd-11e5-87d3-01553ffe3e92.png">
