### PR TITLE
grab thread count via cgroups

### DIFF
--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorThreadChecker.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorThreadChecker.java
@@ -1,17 +1,22 @@
 package com.hubspot.singularity.executor;
 
-import java.util.List;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.helpers.NOPLogger;
 
+import com.google.common.base.Charsets;
 import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
+import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -20,7 +25,6 @@ import com.hubspot.singularity.executor.SingularityExecutorMonitor.KillState;
 import com.hubspot.singularity.executor.config.SingularityExecutorConfiguration;
 import com.hubspot.singularity.executor.task.SingularityExecutorTaskProcessCallable;
 import com.hubspot.singularity.runner.base.shared.ProcessFailedException;
-import com.hubspot.singularity.runner.base.shared.SimpleProcessManager;
 import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.DockerException;
 
@@ -28,6 +32,8 @@ import com.spotify.docker.client.DockerException;
 public class SingularityExecutorThreadChecker {
 
   private static final Logger LOG = LoggerFactory.getLogger(SingularityExecutorThreadChecker.class);
+
+  private static Pattern CGROUP_CONTAINER_REGEX = Pattern.compile("^\\d:cpu:/(.*)$");
 
   private final SingularityExecutorConfiguration configuration;
   private final ScheduledExecutorService scheduledExecutorService;
@@ -44,6 +50,7 @@ public class SingularityExecutorThreadChecker {
   }
 
   public void start(SingularityExecutorMonitor monitor) {
+
     LOG.info("Starting a thread checker that will run every {}", JavaUtils.durationFromMillis(configuration.getCheckThreadsEveryMillis()));
 
     this.monitor = monitor;
@@ -77,6 +84,7 @@ public class SingularityExecutorThreadChecker {
 
       try {
         usedThreads = getNumUsedThreads(taskProcess);
+        LOG.trace("{} is using {} threads", taskProcess.getTask().getTaskId(), usedThreads);
       } catch (InterruptedException ie) {
         Thread.currentThread().interrupt();
         return;
@@ -101,8 +109,6 @@ public class SingularityExecutorThreadChecker {
   }
 
   private int getNumUsedThreads(SingularityExecutorTaskProcessCallable taskProcess) throws InterruptedException, ProcessFailedException {
-    SimpleProcessManager checkThreadsProcessManager = new SimpleProcessManager(NOPLogger.NOP_LOGGER);
-
     Optional<Integer> dockerPid = Optional.absent();
     if (taskProcess.getTask().getTaskInfo().hasContainer() && taskProcess.getTask().getTaskInfo().getContainer().hasDocker()) {
       try {
@@ -113,16 +119,23 @@ public class SingularityExecutorThreadChecker {
       }
     }
 
-    List<String> cmd = ImmutableList.of("/bin/sh",
-      "-c",
-      String.format("pstree %s -p | wc -l", dockerPid.or(taskProcess.getCurrentPid().get())));
+    try {
+      final Path procCgroupPath = Paths.get(String.format(configuration.getProcCgroupFormat(), dockerPid.or(taskProcess.getCurrentPid().get())));
+      if (Files.exists(procCgroupPath)) {
+        final String cgroupsInfo = new String(Files.readAllBytes(procCgroupPath), Charsets.UTF_8);
+        final Matcher matcher = CGROUP_CONTAINER_REGEX.matcher(cgroupsInfo);
 
-    List<String> output = checkThreadsProcessManager.runCommandWithOutput(cmd);
+        if (!matcher.matches()) {
+          throw new RuntimeException("Unable to parse cgroup container from " + procCgroupPath.toString());
+        }
 
-    if (output.isEmpty()) {
-      throw new ProcessFailedException("Output from ps was empty");
+        return Files.readAllLines(Paths.get(String.format(configuration.getCgroupsMesosCpuTasksFormat(), matcher.group(1))), Charsets.UTF_8).size();
+      } else {
+        throw new RuntimeException(procCgroupPath.toString() + " does not exist");
+      }
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
     }
-    return Integer.parseInt(output.get(0));
   }
 
 }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
@@ -210,6 +210,14 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
   @JsonProperty
   private int dockerStopTimeout = 15;
 
+  @NotEmpty
+  @JsonProperty
+  private String cgroupsMesosCpuTasksFormat = "/cgroup/cpu/%s/tasks";
+
+  @NotEmpty
+  @JsonProperty
+  private String procCgroupFormat = "/proc/%s/cgroup";
+
   public SingularityExecutorConfiguration() {
     super(Optional.of("singularity-executor.log"));
   }
@@ -489,6 +497,22 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
 
   public void setDockerStopTimeout(int dockerStopTimeout) {
     this.dockerStopTimeout = dockerStopTimeout;
+  }
+
+  public String getCgroupsMesosCpuTasksFormat() {
+    return cgroupsMesosCpuTasksFormat;
+  }
+
+  public void setCgroupsMesosCpuTasksFormat(String cgroupsMesosCpuTasksFormat) {
+    this.cgroupsMesosCpuTasksFormat = cgroupsMesosCpuTasksFormat;
+  }
+
+  public String getProcCgroupFormat() {
+    return procCgroupFormat;
+  }
+
+  public void setProcCgroupFormat(String procCgroupFormat) {
+    this.procCgroupFormat = procCgroupFormat;
   }
 
   @Override


### PR DESCRIPTION
Locates the executor's cgroup via `/proc/EXECUTOR_PID/cgroup`, and then calculates the total number of threads in use by all procs inside cgroup via `/cgroup/cpu/CONTAINER/tasks`.