### PR TITLE
fix NPE in task history persister race condition

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/BlendedHistoryHelper.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/BlendedHistoryHelper.java
@@ -26,7 +26,9 @@ public abstract class BlendedHistoryHelper<T, Q> {
     for (SingularityTaskId taskId : taskIds) {
       List<SingularityTaskHistoryUpdate> historyUpdates = map.get(taskId);
       SingularityTask task = tasks.get(taskId);
-      histories.add(SingularityTaskIdHistory.fromTaskIdAndTaskAndUpdates(taskId, task, historyUpdates));
+      if (task != null) {
+        histories.add(SingularityTaskIdHistory.fromTaskIdAndTaskAndUpdates(taskId, task, historyUpdates));
+      }
     }
 
     Collections.sort(histories);


### PR DESCRIPTION
Fixes NPE that can arise when requesting task history while tasks are being persisted.

/cc @wsorenson 