### PR TITLE
-H needed with sudo for docker versions >=1.7

### DIFF
--- a/SingularityExecutor/src/main/resources/docker.sh.hbs
+++ b/SingularityExecutor/src/main/resources/docker.sh.hbs
@@ -15,7 +15,7 @@ CGROUPS_GUID=${CURRENT_DIR##*runs/}
 CGROUPS_GUID=${CGROUPS_GUID%/*}
 
 function check_contianer_running {
-  status=`sudo -E -u {{{ runContext.user }}} docker inspect -f \{{.State.Running}} $1`
+  status=`sudo -E -H -u {{{ runContext.user }}} docker inspect -f \{{.State.Running}} $1`
   if [ "$status" = "false" ] ; then
     echo "container is no longer running..."
     running=0
@@ -34,11 +34,11 @@ function setup_signals {
 
 function handle_signal {
   echo "Received $2"
-  echo "Stopping via sudo -E -u {{{ runContext.user }}} docker stop -t $STOP_TIME $1"
-  sudo -E -u {{{ runContext.user }}} docker stop -t $STOP_TIME "$1"
-  exit_code=`sudo -E -u {{{ runContext.user }}} docker wait "$cid"`
+  echo "Stopping via sudo -E -H -u {{{ runContext.user }}} docker stop -t $STOP_TIME $1"
+  sudo -E -H -u {{{ runContext.user }}} docker stop -t $STOP_TIME "$1"
+  exit_code=`sudo -E -H -u {{{ runContext.user }}} docker wait "$cid"`
   echo "Attempting to remove container"
-  sudo -E -u {{{ runContext.user }}} docker rm $1
+  sudo -E -H -u {{{ runContext.user }}} docker rm $1
   exit "$exit_code"
 }
 
@@ -116,9 +116,9 @@ sudo chown -R {{{ runContext.user }}} {{{ runContext.taskAppDirectory }}}
 enable_cgroup_hierarchy || true
 
 # Start up the container
-echo "Creating continer with: sudo -E -u {{{ runContext.user }}} docker create $DOCKER_OPTIONS $DOCKER_IMAGE {{{ runContext.cmd }}}"
-cid=`sudo -E -u {{{ runContext.user }}} docker create $DOCKER_OPTIONS $DOCKER_IMAGE {{{runContext.cmd }}}`
-sudo -E -u {{{ runContext.user }}} docker start -a $cid >> {{{ runContext.logFile }}} 2>&1 &
+echo "Creating continer with: sudo -E -H -u {{{ runContext.user }}} docker create $DOCKER_OPTIONS $DOCKER_IMAGE {{{ runContext.cmd }}}"
+cid=`sudo -E -H -u {{{ runContext.user }}} docker create $DOCKER_OPTIONS $DOCKER_IMAGE {{{runContext.cmd }}}`
+sudo -E -H -u {{{ runContext.user }}} docker start -a $cid >> {{{ runContext.logFile }}} 2>&1 &
 running=1
 
 setup_signals "$cid" "handle_signal" SIGINT SIGTERM
@@ -132,5 +132,5 @@ while true; do
   fi
 done
 
-exit_code=`sudo -E -u {{{ runContext.user }}} docker wait "$cid"`
+exit_code=`sudo -E -H -u {{{ runContext.user }}} docker wait "$cid"`
 exit "$exit_code"


### PR DESCRIPTION
For newer docker versions, docker looks for a config file in the `$HOME` directory of the user running docker. When running via sudo, `$HOME` is still /root unless we use the `-H` option, so docker does not have access to the directory and logs a warning. The warnings get pretty verbose so this shuts them up a bit