### PR TITLE
Previous name field for LB

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeploy.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeploy.java
@@ -56,6 +56,7 @@ public class SingularityDeploy {
   private final Optional<String> serviceBasePath;
   private final Optional<List<String>> loadBalancerGroups;
   private final Optional<Map<String, Object>> loadBalancerOptions;
+  private final Optional<String> previousName;
 
   public static SingularityDeployBuilder newBuilder(String requestId, String id) {
     return new SingularityDeployBuilder(requestId, id);
@@ -90,7 +91,8 @@ public class SingularityDeploy {
       @JsonProperty("considerHealthyAfterRunningForSeconds") Optional<Long> considerHealthyAfterRunningForSeconds,
       @JsonProperty("loadBalancerOptions") Optional<Map<String, Object>> loadBalancerOptions,
       @JsonProperty("skipHealthchecksOnDeploy") Optional<Boolean> skipHealthchecksOnDeploy,
-      @JsonProperty("healthCheckProtocol") Optional<HealthcheckProtocol> healthcheckProtocol) {
+      @JsonProperty("healthCheckProtocol") Optional<HealthcheckProtocol> healthcheckProtocol,
+      @JsonProperty("previousName") Optional<String> previousName) {
     this.requestId = requestId;
 
     this.command = command;
@@ -129,6 +131,7 @@ public class SingularityDeploy {
     this.serviceBasePath = serviceBasePath;
     this.loadBalancerGroups = loadBalancerGroups;
     this.loadBalancerOptions = loadBalancerOptions;
+    this.previousName = previousName;
   }
 
   public SingularityDeployBuilder toBuilder() {
@@ -155,6 +158,7 @@ public class SingularityDeploy {
     .setServiceBasePath(serviceBasePath)
     .setLoadBalancerGroups(copyOfList(loadBalancerGroups))
     .setLoadBalancerOptions(copyOfMap(loadBalancerOptions))
+    .setPreviousName(previousName)
 
     .setMetadata(copyOfMap(metadata))
     .setVersion(version)
@@ -292,6 +296,11 @@ public class SingularityDeploy {
     return loadBalancerOptions;
   }
 
+  @ApiModelProperty(required=false, value="Name of a service to replace in the load balancer")
+  public Optional<String> getPreviousName() {
+    return previousName;
+  }
+
   @ApiModelProperty(required=false, value="Allows skipping of health checks when deploying.")
   public Optional<Boolean> getSkipHealthchecksOnDeploy() {
     return skipHealthchecksOnDeploy;
@@ -339,6 +348,7 @@ public class SingularityDeploy {
       ", serviceBasePath=" + serviceBasePath +
       ", loadBalancerGroups=" + loadBalancerGroups +
       ", loadBalancerOptions=" + loadBalancerOptions +
+      ", previousName=" + previousName +
       '}';
   }
 

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeployBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeployBuilder.java
@@ -50,6 +50,7 @@ public class SingularityDeployBuilder {
   private Optional<String> serviceBasePath;
   private Optional<List<String>> loadBalancerGroups;
   private Optional<Map<String, Object>> loadBalancerOptions;
+  private Optional<String> previousName;
 
   public SingularityDeployBuilder(String requestId, String id) {
     this.requestId = requestId;
@@ -81,12 +82,13 @@ public class SingularityDeployBuilder {
     this.serviceBasePath = Optional.absent();
     this.loadBalancerGroups = Optional.absent();
     this.loadBalancerOptions = Optional.absent();
+    this.previousName = Optional.absent();
   }
 
   public SingularityDeploy build() {
     return new SingularityDeploy(requestId, id, command, arguments, containerInfo, customExecutorCmd, customExecutorId, customExecutorSource, customExecutorResources, customExecutorUser, resources, env,
         uris, metadata, executorData, version, timestamp, deployHealthTimeoutSeconds, healthcheckUri, healthcheckIntervalSeconds, healthcheckTimeoutSeconds, healthcheckMaxRetries,
-        healthcheckMaxTotalTimeoutSeconds, serviceBasePath, loadBalancerGroups, considerHealthyAfterRunningForSeconds, loadBalancerOptions, skipHealthchecksOnDeploy, healthcheckProtocol);
+        healthcheckMaxTotalTimeoutSeconds, serviceBasePath, loadBalancerGroups, considerHealthyAfterRunningForSeconds, loadBalancerOptions, skipHealthchecksOnDeploy, healthcheckProtocol, previousName);
   }
 
   public String getRequestId() {
@@ -345,6 +347,15 @@ public class SingularityDeployBuilder {
     return this;
   }
 
+  public Optional<String> getPreviousName() {
+    return previousName;
+  }
+
+  public SingularityDeployBuilder setPreviousName(Optional<String> previousName) {
+    this.previousName = previousName;
+    return this;
+  }
+
   @Override
   public String toString() {
     return "SingularityDeployBuilder{" +
@@ -377,6 +388,7 @@ public class SingularityDeployBuilder {
       ", serviceBasePath=" + serviceBasePath +
       ", loadBalancerGroups=" + loadBalancerGroups +
       ", loadBalancerOptions=" + loadBalancerOptions +
+      ", previousName=" + previousName +
       '}';
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/hooks/LoadBalancerClientImpl.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/hooks/LoadBalancerClientImpl.java
@@ -21,6 +21,7 @@ import com.hubspot.baragon.models.BaragonRequest;
 import com.hubspot.baragon.models.BaragonRequestState;
 import com.hubspot.baragon.models.BaragonResponse;
 import com.hubspot.baragon.models.BaragonService;
+import com.hubspot.baragon.models.RequestAction;
 import com.hubspot.baragon.models.UpstreamInfo;
 import com.hubspot.mesos.JavaUtils;
 import com.hubspot.singularity.LoadBalancerRequestType.LoadBalancerRequestId;
@@ -154,7 +155,7 @@ public class LoadBalancerClientImpl implements LoadBalancerClient {
     final List<UpstreamInfo> addUpstreams = tasksToUpstreams(add, loadBalancerRequestId.toString());
     final List<UpstreamInfo> removeUpstreams = tasksToUpstreams(remove, loadBalancerRequestId.toString());
 
-    final BaragonRequest loadBalancerRequest = new BaragonRequest(loadBalancerRequestId.toString(), lbService, addUpstreams, removeUpstreams);
+    final BaragonRequest loadBalancerRequest = new BaragonRequest(loadBalancerRequestId.toString(), lbService, addUpstreams, removeUpstreams, Collections.<UpstreamInfo>emptyList(), deploy.getPreviousName(), Optional.of(RequestAction.UPDATE));
 
     try {
       LOG.trace("Deploy {} is preparing to send {}", deploy.getId(), loadBalancerRequest);


### PR DESCRIPTION
wire up a `previousName` field that will go to Baragon's `replaceServiceId`. This means that we can have once service replace another in the load balancer with no downtime. Before we would need to stop one, delete it from Baragon, then deploy the new one. Now it's all one step