### PR TITLE
Show extra cmd line arguments and allow rerunning of tasks

### DIFF
--- a/SingularityUI/app/collections/RequestHistoricalTasks.coffee
+++ b/SingularityUI/app/collections/RequestHistoricalTasks.coffee
@@ -4,7 +4,7 @@ PaginableCollection = require './PaginableCollection'
 class HistoricalTasks extends PaginableCollection
 
     model: class TaskHistoryItem extends Backbone.Model
-        ignoreAttributes: ['id']
+        ignoreAttributes: ['id', 'canBeRunNow']
 
     url: -> "#{ config.apiRoot }/history/request/#{ @requestId }/tasks"
 

--- a/SingularityUI/app/controllers/RequestDetail.coffee
+++ b/SingularityUI/app/controllers/RequestDetail.coffee
@@ -137,10 +137,11 @@ class RequestDetailController extends Controller
                     if @collections.requestHistory.length is 0
                         app.router.notFound()
 
-        if @collections.taskHistory.currentPage is 1
-            @collections.taskHistory.fetch
-                error:    @ignore404
-                success:  @addRequestInfo
+        requestFetch.done =>
+            if @collections.taskHistory.currentPage is 1
+                @collections.taskHistory.fetch
+                    error:    @ignore404
+                    success:  @addRequestInfo
         if @collections.deployHistory.currentPage is 1
             @collections.deployHistory.fetch().error  @ignore404
 

--- a/SingularityUI/app/controllers/RequestDetail.coffee
+++ b/SingularityUI/app/controllers/RequestDetail.coffee
@@ -140,9 +140,7 @@ class RequestDetailController extends Controller
         if @collections.taskHistory.currentPage is 1
             @collections.taskHistory.fetch
                 error:    @ignore404
-                success: () =>
-                    @addRequestInfo()
-                    console.log @collections.taskHistory
+                success:  @addRequestInfo
         if @collections.deployHistory.currentPage is 1
             @collections.deployHistory.fetch().error  @ignore404
 

--- a/SingularityUI/app/controllers/RequestDetail.coffee
+++ b/SingularityUI/app/controllers/RequestDetail.coffee
@@ -56,7 +56,7 @@ class RequestDetailController extends Controller
         @subviews.header = new SimpleSubview
             model:      @models.request
             template:   @templates.header
-        
+
         # would have used header subview for this info,
         # but header expects a request model that
         # no longer exists if a request is deleted
@@ -109,6 +109,10 @@ class RequestDetailController extends Controller
 
         app.showView @view
 
+    addRequestInfo: =>
+        for t in @collections.taskHistory.models
+            t.attributes.canBeRunNow = @models.request.attributes.canBeRunNow
+
     refresh: ->
         requestFetch = @models.request.fetch()
 
@@ -124,7 +128,7 @@ class RequestDetailController extends Controller
         @collections.activeTasks.fetch().error    @ignore404
         @collections.scheduledTasks.fetch().error @ignore404
         @collections.scheduledTasks.fetch({reset: true}).error @ignore404
-        
+
         if @collections.requestHistory.currentPage is 1
             requestHistoryFetch = @collections.requestHistory.fetch()
             requestHistoryFetch.error => @ignore404
@@ -134,7 +138,11 @@ class RequestDetailController extends Controller
                         app.router.notFound()
 
         if @collections.taskHistory.currentPage is 1
-            @collections.taskHistory.fetch().error    @ignore404
+            @collections.taskHistory.fetch
+                error:    @ignore404
+                success: () =>
+                    @addRequestInfo()
+                    console.log @collections.taskHistory
         if @collections.deployHistory.currentPage is 1
             @collections.deployHistory.fetch().error  @ignore404
 

--- a/SingularityUI/app/models/Request.coffee
+++ b/SingularityUI/app/models/Request.coffee
@@ -183,25 +183,25 @@ class Request extends Model
                 localStorage.setItem(@localStorageCommandLineInputKeyPrefix + "historyIndex", 0);
                 localStorage.setItem(@localStorageCommandLineInputKeyPrefix + "historyLength", commands.length);
 
-                $('#commandLineInput').keydown (e) =>
-                    inc = 0
-                    switch e.which
-                      when 38
-                          inc = 1 # up
-                      when 40
-                          inc = -1 # down
-                      else
-                          return
-                    index = parseInt(localStorage.getItem(@localStorageCommandLineInputKeyPrefix + 'historyIndex'))
-                    length = parseInt(localStorage.getItem(@localStorageCommandLineInputKeyPrefix + 'historyLength'))
-                    index += inc
-                    if index < 0
-                        index = 0
-                    else if index > length - 1
-                        index = length - 1
-                    localStorage.setItem @localStorageCommandLineInputKeyPrefix + 'historyIndex', index
-                    $('#commandLineInput').val commands[index]
-                    e.preventDefault()
+                # $('#commandLineInput').keydown (e) =>
+                #     inc = 0
+                #     switch e.which
+                #       when 38
+                #           inc = 1 # up
+                #       when 40
+                #           inc = -1 # down
+                #       else
+                #           return
+                #     index = parseInt(localStorage.getItem(@localStorageCommandLineInputKeyPrefix + 'historyIndex'))
+                #     length = parseInt(localStorage.getItem(@localStorageCommandLineInputKeyPrefix + 'historyLength'))
+                #     index += inc
+                #     if index < 0
+                #         index = 0
+                #     else if index > length - 1
+                #         index = length - 1
+                #     localStorage.setItem @localStorageCommandLineInputKeyPrefix + 'historyIndex', index
+                #     $('#commandLineInput').val commands[index]
+                #     e.preventDefault()
 
             callback: (data) =>
                 @data = data

--- a/SingularityUI/app/models/Request.coffee
+++ b/SingularityUI/app/models/Request.coffee
@@ -183,26 +183,6 @@ class Request extends Model
                 localStorage.setItem(@localStorageCommandLineInputKeyPrefix + "historyIndex", 0);
                 localStorage.setItem(@localStorageCommandLineInputKeyPrefix + "historyLength", commands.length);
 
-                # $('#commandLineInput').keydown (e) =>
-                #     inc = 0
-                #     switch e.which
-                #       when 38
-                #           inc = 1 # up
-                #       when 40
-                #           inc = -1 # down
-                #       else
-                #           return
-                #     index = parseInt(localStorage.getItem(@localStorageCommandLineInputKeyPrefix + 'historyIndex'))
-                #     length = parseInt(localStorage.getItem(@localStorageCommandLineInputKeyPrefix + 'historyLength'))
-                #     index += inc
-                #     if index < 0
-                #         index = 0
-                #     else if index > length - 1
-                #         index = length - 1
-                #     localStorage.setItem @localStorageCommandLineInputKeyPrefix + 'historyIndex', index
-                #     $('#commandLineInput').val commands[index]
-                #     e.preventDefault()
-
             callback: (data) =>
                 @data = data
 

--- a/SingularityUI/app/models/Request.coffee
+++ b/SingularityUI/app/models/Request.coffee
@@ -74,7 +74,7 @@ class Request extends Model
           options.processData = false
 
         $.ajax options
-        
+
     scale: (confirmedOrPromptData) =>
         $.ajax
           url: "#{ @url() }/instances?user=#{ app.getUsername() }"
@@ -83,7 +83,7 @@ class Request extends Model
           data:         JSON.stringify
               id:      @get "id"
               instances: confirmedOrPromptData
-          
+
     bounce: =>
         $.ajax
             url:  "#{ @url() }/bounce?user=#{ app.getUsername() }"
@@ -114,7 +114,7 @@ class Request extends Model
 
     promptScale: (callback) =>
         vex.dialog.prompt
-            message: scaleTemplate 
+            message: scaleTemplate
                 id: @get "id"
             buttons: [
                 $.extend _.clone(vex.dialog.buttons.YES), text: 'Scale'
@@ -143,7 +143,7 @@ class Request extends Model
 
             beforeClose: =>
                 return if @data is false
-                
+
                 fileName = @data.filename.trim()
                 commandLineInput = @data.commandLineInput.trim()
 
@@ -160,7 +160,7 @@ class Request extends Model
                     @run( @data.commandLineInput ).done callback( @data )
                     return true
 
-            afterOpen: => 
+            afterOpen: =>
                 $('#filename').val localStorage.getItem('taskRunRedirectFilename')
                 $('#commandLineInput').val localStorage.getItem(@localStorageCommandLineInputKeyPrefix + @id)
                 $('#autoTail').prop 'checked', (localStorage.getItem('taskRunAutoTail') is 'on')

--- a/SingularityUI/app/models/Request.coffee
+++ b/SingularityUI/app/models/Request.coffee
@@ -136,7 +136,8 @@ class Request extends Model
     promptRun: (callback) =>
         vex.dialog.prompt
             message: "<h3>Run Task</h3>"
-            input: runTemplate id: @get "id"
+            input: runTemplate
+                id: @get "id"
             buttons: [
                 $.extend _.clone(vex.dialog.buttons.YES), text: 'Run now'
                 vex.dialog.buttons.NO
@@ -154,11 +155,15 @@ class Request extends Model
 
                 else
                     history = localStorage.getItem(@localStorageCommandLineInputKeyPrefix + @id)
-                    if !!history
+
+                    if history?
+                        last = history.split(",")[history.split(",").length - 1]
                         history += ","
                     else
                         history = ""
-                    localStorage.setItem(@localStorageCommandLineInputKeyPrefix + @id, history + commandLineInput) if commandLineInput?
+
+                    if commandLineInput != last
+                        localStorage.setItem(@localStorageCommandLineInputKeyPrefix + @id, history + commandLineInput) if commandLineInput?
                     localStorage.setItem('taskRunRedirectFilename', fileName) if filename?
                     localStorage.setItem('taskRunAutoTail', @data.autoTail)
                     @data.id = @get 'id'

--- a/SingularityUI/app/models/Request.coffee
+++ b/SingularityUI/app/models/Request.coffee
@@ -133,7 +133,6 @@ class Request extends Model
                 @unpause().done callback
 
     promptRun: (command = "", callback) =>
-        console.log command
         vex.dialog.prompt
             message: ""
             input: runTemplate
@@ -156,7 +155,12 @@ class Request extends Model
 
                 else
                     if command is ""
-                        localStorage.setItem(@localStorageCommandLineInputKeyPrefix + @id, commandLineInput) if commandLineInput?
+                        history = localStorage.getItem(@localStorageCommandLineInputKeyPrefix + @id)
+                        if !!history
+                            history += ","
+                        else
+                            history = ""
+                        localStorage.setItem(@localStorageCommandLineInputKeyPrefix + @id, history + commandLineInput) if commandLineInput?
                     localStorage.setItem('taskRunRedirectFilename', fileName) if filename?
                     localStorage.setItem('taskRunAutoTail', @data.autoTail)
                     @data.id = @get 'id'
@@ -167,7 +171,10 @@ class Request extends Model
             afterOpen: =>
                 $('#filename').val localStorage.getItem('taskRunRedirectFilename')
                 if command is ""
-                    $('#commandLineInput').val localStorage.getItem(@localStorageCommandLineInputKeyPrefix + @id)
+                    history = localStorage.getItem(@localStorageCommandLineInputKeyPrefix + @id)
+                    if !!history
+                        history = history.split(",")
+                        $('#commandLineInput').val history[history.length - 1]
                 $('#autoTail').prop 'checked', (localStorage.getItem('taskRunAutoTail') is 'on')
 
             callback: (data) =>

--- a/SingularityUI/app/models/Request.coffee
+++ b/SingularityUI/app/models/Request.coffee
@@ -132,10 +132,13 @@ class Request extends Model
                 return unless confirmed
                 @unpause().done callback
 
-    promptRun: (callback) =>
+    promptRun: (command = "", callback) =>
+        console.log command
         vex.dialog.prompt
             message: ""
-            input: runTemplate id: @get "id"
+            input: runTemplate
+                id: @get "id"
+                command: command
             buttons: [
                 $.extend _.clone(vex.dialog.buttons.YES), text: 'Run now'
                 vex.dialog.buttons.NO
@@ -143,7 +146,7 @@ class Request extends Model
 
             beforeClose: =>
                 return if @data is false
-
+                console.log @data
                 fileName = @data.filename.trim()
                 commandLineInput = @data.commandLineInput.trim()
 
@@ -152,7 +155,8 @@ class Request extends Model
                     return false
 
                 else
-                    localStorage.setItem(@localStorageCommandLineInputKeyPrefix + @id, commandLineInput) if commandLineInput?
+                    if command is ""
+                        localStorage.setItem(@localStorageCommandLineInputKeyPrefix + @id, commandLineInput) if commandLineInput?
                     localStorage.setItem('taskRunRedirectFilename', fileName) if filename?
                     localStorage.setItem('taskRunAutoTail', @data.autoTail)
                     @data.id = @get 'id'
@@ -162,7 +166,8 @@ class Request extends Model
 
             afterOpen: =>
                 $('#filename').val localStorage.getItem('taskRunRedirectFilename')
-                $('#commandLineInput').val localStorage.getItem(@localStorageCommandLineInputKeyPrefix + @id)
+                if command is ""
+                    $('#commandLineInput').val localStorage.getItem(@localStorageCommandLineInputKeyPrefix + @id)
                 $('#autoTail').prop 'checked', (localStorage.getItem('taskRunAutoTail') is 'on')
 
             callback: (data) =>

--- a/SingularityUI/app/models/Request.coffee
+++ b/SingularityUI/app/models/Request.coffee
@@ -138,6 +138,9 @@ class Request extends Model
             message: "<h3>Run Task</h3>"
             input: runTemplate
                 id: @get "id"
+                prefix: @localStorageCommandLineInputKeyPrefix
+                commands: localStorage.getItem(@localStorageCommandLineInputKeyPrefix + @id)
+
             buttons: [
                 $.extend _.clone(vex.dialog.buttons.YES), text: 'Run now'
                 vex.dialog.buttons.NO
@@ -174,10 +177,11 @@ class Request extends Model
             afterOpen: =>
                 $('#filename').val localStorage.getItem('taskRunRedirectFilename')
                 $('#autoTail').prop 'checked', (localStorage.getItem('taskRunAutoTail') is 'on')
-                history = localStorage.getItem(@localStorageCommandLineInputKeyPrefix + @id)
-                if !!history
-                    history = history.split(",")
-                    $('#commandLineInput').val history[history.length - 1]
+                cmdString = localStorage.getItem(@localStorageCommandLineInputKeyPrefix + @id)
+                commands = if cmdString then cmdString.split(",").reverse() else []
+                $('#commandLineInput').val commands[0]
+                localStorage.setItem(@localStorageCommandLineInputKeyPrefix + "historyIndex", 0);
+                localStorage.setItem(@localStorageCommandLineInputKeyPrefix + "historyLength", commands.length);
 
             callback: (data) =>
                 @data = data

--- a/SingularityUI/app/models/Request.coffee
+++ b/SingularityUI/app/models/Request.coffee
@@ -183,6 +183,30 @@ class Request extends Model
                 localStorage.setItem(@localStorageCommandLineInputKeyPrefix + "historyIndex", 0);
                 localStorage.setItem(@localStorageCommandLineInputKeyPrefix + "historyLength", commands.length);
 
+                $("#commandLineInput").keydown(function(e) {
+              		var inc = 0;
+              		switch(e.which) {
+                    case 38: // up
+              				inc = 1;
+              	      break;
+                    case 40: // down
+              				inc = -1;
+              	      break;
+                    default: return;
+                  }
+            			var index = parseInt(localStorage.getItem(@localStorageCommandLineInputKeyPrefix + "historyIndex"));
+            			var length = parseInt(localStorage.getItem(@localStorageCommandLineInputKeyPrefix + "historyLength"));
+            			index += inc;
+            			if (index < 0) {
+            				index = 0
+            			} else if (index > length - 1) {
+            				index = length - 1;
+            			}
+            			localStorage.setItem(@localStorageCommandLineInputKeyPrefix + "historyIndex", index);
+            			$("#commandLineInput").val(commands[index]);
+                  e.preventDefault();
+              	});
+
             callback: (data) =>
                 @data = data
 

--- a/SingularityUI/app/models/Request.coffee
+++ b/SingularityUI/app/models/Request.coffee
@@ -135,7 +135,7 @@ class Request extends Model
 
     promptRun: (callback) =>
         vex.dialog.prompt
-            message: ""
+            message: "<h3>Run Task</h3>"
             input: runTemplate id: @get "id"
             buttons: [
                 $.extend _.clone(vex.dialog.buttons.YES), text: 'Run now'
@@ -184,7 +184,7 @@ class Request extends Model
             .done =>
                 command = task.attributes.task.taskRequest.pendingTask.cmdLineArgsList
                 vex.dialog.prompt
-                    message: ""
+                    message: "<h3>Rerun Task</h3>"
                     input: runTemplate
                         id: @get "id"
                         command: command

--- a/SingularityUI/app/models/Request.coffee
+++ b/SingularityUI/app/models/Request.coffee
@@ -183,29 +183,25 @@ class Request extends Model
                 localStorage.setItem(@localStorageCommandLineInputKeyPrefix + "historyIndex", 0);
                 localStorage.setItem(@localStorageCommandLineInputKeyPrefix + "historyLength", commands.length);
 
-                $("#commandLineInput").keydown(function(e) {
-              		var inc = 0;
-              		switch(e.which) {
-                    case 38: // up
-              				inc = 1;
-              	      break;
-                    case 40: // down
-              				inc = -1;
-              	      break;
-                    default: return;
-                  }
-            			var index = parseInt(localStorage.getItem(@localStorageCommandLineInputKeyPrefix + "historyIndex"));
-            			var length = parseInt(localStorage.getItem(@localStorageCommandLineInputKeyPrefix + "historyLength"));
-            			index += inc;
-            			if (index < 0) {
-            				index = 0
-            			} else if (index > length - 1) {
-            				index = length - 1;
-            			}
-            			localStorage.setItem(@localStorageCommandLineInputKeyPrefix + "historyIndex", index);
-            			$("#commandLineInput").val(commands[index]);
-                  e.preventDefault();
-              	});
+                $('#commandLineInput').keydown (e) =>
+                    inc = 0
+                    switch e.which
+                      when 38
+                          inc = 1 # up
+                      when 40
+                          inc = -1 # down
+                      else
+                          return
+                    index = parseInt(localStorage.getItem(@localStorageCommandLineInputKeyPrefix + 'historyIndex'))
+                    length = parseInt(localStorage.getItem(@localStorageCommandLineInputKeyPrefix + 'historyLength'))
+                    index += inc
+                    if index < 0
+                        index = 0
+                    else if index > length - 1
+                        index = length - 1
+                    localStorage.setItem @localStorageCommandLineInputKeyPrefix + 'historyIndex', index
+                    $('#commandLineInput').val commands[index]
+                    e.preventDefault()
 
             callback: (data) =>
                 @data = data

--- a/SingularityUI/app/models/Task.coffee
+++ b/SingularityUI/app/models/Task.coffee
@@ -48,7 +48,7 @@ class Task extends Model
     promptRun: (callback) =>
         # We tell the Request to run
         requestModel = new Request id: @get('request').id
-        requestModel.promptRun => callback()
+        requestModel.promptRun "", => callback()
 
 
 

--- a/SingularityUI/app/models/Task.coffee
+++ b/SingularityUI/app/models/Task.coffee
@@ -48,7 +48,7 @@ class Task extends Model
     promptRun: (callback) =>
         # We tell the Request to run
         requestModel = new Request id: @get('request').id
-        requestModel.promptRun "", => callback()
+        requestModel.promptRun => callback()
 
 
 

--- a/SingularityUI/app/templates/deployDetail/deployInfo.hbs
+++ b/SingularityUI/app/templates/deployDetail/deployInfo.hbs
@@ -4,57 +4,81 @@
 
 <div class="row">
     <ul class="list-unstyled horizontal-description-list">
-        <li class="col-md-4">
-            <div>
-                <h4>Initiated<a data-clipboard-text="{{ timestampFromNow data.deployMarker.timestamp }}">Copy</a></h4>
-                <p>{{ timestampFromNow data.deployMarker.timestamp }}</p>
-            </div>
-        </li>
-        <li class="col-md-4">
-            <div>
-                <h4>Completed<a data-clipboard-text="{{ timestampFromNow data.deployResult.timestamp }}">Copy</a></h4>
-                <p>{{ timestampFromNow data.deployResult.timestamp }}</p>
-            </div>
-        </li>
-        <li class="col-md-4">
-            <div>
-                <h4>Command<a data-clipboard-text="{{ data.deploy.executorData.cmd }}">Copy</a></h4>
-                <p>{{ data.deploy.executorData.cmd }}</p>
-            </div>
-        </li>
-        <li class="col-md-4">
-            <div>
-                <h4>Resources<a data-clipboard-text="CPUs: {{ data.deploy.resources.cpus }} |
-                Memory (Mb): {{ data.deploy.resources.memoryMb }} |
-                Ports: {{ data.deploy.resources.numPorts }}">Copy</a></h4>
-                <p>CPUs: {{ data.deploy.resources.cpus }} | Memory (MB): {{ data.deploy.resources.memoryMb }} | Ports: {{ data.deploy.resources.numPorts }}
-                </p>
-            </div>
-        </li>
-        <li class="col-md-4">
-            <div>
-                <h4>Number of Tasks<a data-clipboard-text="{{ data.deployStatistics.numTasks }}">Copy</a></h4>
-                <p>{{ data.deployStatistics.numTasks }}</p>
-            </div>
-        </li>
-        <li class="col-md-4">
-            <div>
-                <h4>Last Task State<a data-clipboard-text="{{ humanizeText data.deployStatistics.lastTaskState }}">Copy</a></h4>
-                <p>{{ humanizeText data.deployStatistics.lastTaskState }}</p>
-            </div>
-        </li>
-        <li class="col-md-4">
-            <div>
-                <h4>Sequential Retries<a data-clipboard-text="{{ data.deployStatistics.numSequentialRetries }}">Copy</a></h4>
-                <p>{{ data.deployStatistics.numSequentialRetries }}</p>
-            </div>
-        </li>
-        <li class="col-md-4">
-            <div>
-                <h4>Average Runtime Milliseconds<a data-clipboard-text="{{ data.deployStatistics.averageRuntimeMillis }}">Copy</a></h4>
-                <p>{{ data.deployStatistics.averageRuntimeMillis }}</p>
-            </div>
-        </li>
+        {{#if data.deployMarker.timestamp }}
+          <li class="col-md-4">
+              <div>
+                  <h4>Initiated<a data-clipboard-text="{{ timestampFromNow data.deployMarker.timestamp }}">Copy</a></h4>
+                  <p>{{ timestampFromNow data.deployMarker.timestamp }}</p>
+              </div>
+          </li>
+        {{/if}}
+        {{#if data.deployResult.timestamp}}
+          <li class="col-md-4">
+              <div>
+                  <h4>Completed<a data-clipboard-text="{{ timestampFromNow data.deployResult.timestamp }}">Copy</a></h4>
+                  <p>{{ timestampFromNow data.deployResult.timestamp }}</p>
+              </div>
+          </li>
+        {{/if}}
+        {{#if data.deploy.executorData.cmd}}
+          <li class="col-md-4">
+              <div>
+                  <h4>Command<a data-clipboard-text="{{ data.deploy.executorData.cmd }}">Copy</a></h4>
+                  <p>{{ data.deploy.executorData.cmd }}</p>
+              </div>
+          </li>
+        {{/if}}
+        {{#if data.deploy.resources.cpus}}
+          <li class="col-md-4">
+              <div>
+                  <h4>Resources<a data-clipboard-text="CPUs: {{ data.deploy.resources.cpus }} |
+                  Memory (Mb): {{ data.deploy.resources.memoryMb }} |
+                  Ports: {{ data.deploy.resources.numPorts }}">Copy</a></h4>
+                  <p>CPUs: {{ data.deploy.resources.cpus }} | Memory (MB): {{ data.deploy.resources.memoryMb }} | Ports: {{ data.deploy.resources.numPorts }}
+                  </p>
+              </div>
+          </li>
+        {{/if}}
+        {{#if data.deployStatistics.numTasks}}
+          <li class="col-md-4">
+              <div>
+                  <h4>Number of Tasks<a data-clipboard-text="{{ data.deployStatistics.numTasks }}">Copy</a></h4>
+                  <p>{{ data.deployStatistics.numTasks }}</p>
+              </div>
+          </li>
+        {{/if}}
+        {{#if data.deployStatistics.lastTaskState}}
+          <li class="col-md-4">
+              <div>
+                  <h4>Last Task State<a data-clipboard-text="{{ humanizeText data.deployStatistics.lastTaskState }}">Copy</a></h4>
+                  <p>{{ humanizeText data.deployStatistics.lastTaskState }}</p>
+              </div>
+          </li>
+        {{/if}}
+        {{#if data.deployStatistics.numSequentialRetries}}
+          <li class="col-md-4">
+              <div>
+                  <h4>Sequential Retries<a data-clipboard-text="{{ data.deployStatistics.numSequentialRetries }}">Copy</a></h4>
+                  <p>{{ data.deployStatistics.numSequentialRetries }}</p>
+              </div>
+          </li>
+        {{/if}}
+        {{#if data.deployStatistics.averageRuntimeMillis}}
+          <li class="col-md-4">
+              <div>
+                  <h4>Average Runtime Milliseconds<a data-clipboard-text="{{ data.deployStatistics.averageRuntimeMillis }}">Copy</a></h4>
+                  <p>{{ data.deployStatistics.averageRuntimeMillis }}</p>
+              </div>
+          </li>
+        {{/if}}
+        {{#if data.deploy.executorData.extraCmdLineArgs}}
+          <li class="col-md-4">
+              <div>
+                  <h4>Extra Command Line Arguments<a data-clipboard-text="{{ data.deploy.executorData.extraCmdLineArgs }}">Copy</a></h4>
+                  <p>{{ data.deploy.executorData.extraCmdLineArgs }}</p>
+              </div>
+          </li>
+        {{/if}}
     </ul>
 </div>
 </div>

--- a/SingularityUI/app/templates/requestDetail/requestHistoricalTasks.hbs
+++ b/SingularityUI/app/templates/requestDetail/requestHistoricalTasks.hbs
@@ -61,7 +61,7 @@
                         </td>
                         {{#if canBeRunNow}}
                             <td class="hidden-xs actions-column">
-                                <a data-action="rerun-task" data-command="some command" title="Rerun">
+                                <a data-action="rerun-task" data-taskId="{{ id }}" title="Rerun">
                                     ↺
                                 </a>
                             </td>

--- a/SingularityUI/app/templates/requestDetail/requestHistoricalTasks.hbs
+++ b/SingularityUI/app/templates/requestDetail/requestHistoricalTasks.hbs
@@ -61,7 +61,7 @@
                         </td>
                         {{#if canBeRunNow}}
                             <td class="hidden-xs actions-column">
-                                <a data-action="run-request-now" data-command="some command" title="Rerun">
+                                <a data-action="rerun-task" data-command="some command" title="Rerun">
                                     ↺
                                 </a>
                             </td>

--- a/SingularityUI/app/templates/requestDetail/requestHistoricalTasks.hbs
+++ b/SingularityUI/app/templates/requestDetail/requestHistoricalTasks.hbs
@@ -27,6 +27,9 @@
                     <th class="hidden-xs">
                         {{! Actions }}
                     </th>
+                    <th class="hidden-xs">
+                        {{! Actions }}
+                    </th>
                 </tr>
             </thead>
             <tbody>
@@ -56,6 +59,15 @@
                                 ...
                             </a>
                         </td>
+                        {{#if canBeRunNow}}
+                            <td class="hidden-xs actions-column">
+                                <a data-action="run-request-now" title="Rerun">
+                                    ↺
+                                </a>
+                            </td>
+                        {{else}}
+                            <td class="hidden-xs actions-column"></td>
+                        {{/if}}
                         <td class="hidden-xs actions-column">
                             <a data-action="viewJSON" title="JSON">
                                 { }

--- a/SingularityUI/app/templates/requestDetail/requestHistoricalTasks.hbs
+++ b/SingularityUI/app/templates/requestDetail/requestHistoricalTasks.hbs
@@ -56,12 +56,12 @@
                         </td>
                         <td class="hidden-xs actions-column">
                             <a href="{{ appRoot }}/task/{{ taskId.id }}/tail/{{ substituteTaskId ../../config.finishedTaskLogPath taskId.id }}" title="Log">
-                                ...
+                                ···
                             </a>
                         </td>
                         {{#if canBeRunNow}}
                             <td class="hidden-xs actions-column">
-                                <a data-action="run-request-now" title="Rerun">
+                                <a data-action="run-request-now" data-command="some command" title="Rerun">
                                     ↺
                                 </a>
                             </td>

--- a/SingularityUI/app/templates/taskDetail/taskInfo.hbs
+++ b/SingularityUI/app/templates/taskDetail/taskInfo.hbs
@@ -44,11 +44,19 @@
                 </div>
             </li>
         {{/if}}
-        {{#if data.task.deploy.executorData.extraCmdLineArgs }}
+        {{#if data.task.taskRequest.deploy.executorData.extraCmdLineArgs}}
             <li class="col-md-4">
                 <div>
-                    <h4>Extra Command Line Arguments</h4>
-                    <p>{{ data.task.deploy.executorData.extraCmdLineArgs }}</p>
+                    <h4>Extra Cmd Line Arguments (from Deploy)</h4>
+                    <p>{{ data.task.taskRequest.deploy.executorData.extraCmdLineArgs }}</p>
+                </div>
+            </li>
+        {{/if}}
+        {{#if data.task.taskRequest.pendingTask.cmdLineArgsList }}
+            <li class="col-md-4">
+                <div>
+                    <h4>Extra Cmd Line Arguments (from Task)</h4>
+                    <p>{{ data.task.taskRequest.pendingTask.cmdLineArgsList }}</p>
                 </div>
             </li>
         {{/if}}

--- a/SingularityUI/app/templates/taskDetail/taskInfo.hbs
+++ b/SingularityUI/app/templates/taskDetail/taskInfo.hbs
@@ -44,5 +44,13 @@
                 </div>
             </li>
         {{/if}}
+        {{#if data.task.deploy.executorData.extraCmdLineArgs }}
+            <li class="col-md-4">
+                <div>
+                    <h4>Extra Command Line Arguments</h4>
+                    <p>{{ data.task.deploy.executorData.extraCmdLineArgs }}</p>
+                </div>
+            </li>
+        {{/if}}
     </ul>
 </div>

--- a/SingularityUI/app/templates/taskDetail/taskInfo.hbs
+++ b/SingularityUI/app/templates/taskDetail/taskInfo.hbs
@@ -47,7 +47,7 @@
         {{#if data.task.taskRequest.deploy.executorData.extraCmdLineArgs}}
             <li class="col-md-4">
                 <div>
-                    <h4>Extra Cmd Line Arguments (from Deploy)</h4>
+                    <h4>Extra Cmd Line Arguments (for Deploy)</h4>
                     <p>{{ data.task.taskRequest.deploy.executorData.extraCmdLineArgs }}</p>
                 </div>
             </li>
@@ -55,7 +55,7 @@
         {{#if data.task.taskRequest.pendingTask.cmdLineArgsList }}
             <li class="col-md-4">
                 <div>
-                    <h4>Extra Cmd Line Arguments (from Task)</h4>
+                    <h4>Extra Cmd Line Arguments (for Task)</h4>
                     <p>{{ data.task.taskRequest.pendingTask.cmdLineArgsList }}</p>
                 </div>
             </li>

--- a/SingularityUI/app/templates/vex/requestRun.hbs
+++ b/SingularityUI/app/templates/vex/requestRun.hbs
@@ -8,7 +8,34 @@
 <hr class='border-color-light-gray'>
 
 <script>
-		
+	// Need to handle this event here since it's inside vex...
+	$("#commandLineInput").keydown(function(e) {
+		var inc = 0;
+		switch(e.which) {
+      case 38: // up
+				inc = 1;
+	      break;
+      case 40: // down
+				inc = -1;
+	      break;
+      default: return;
+    }
+		if ("{{ prefix }}" !== "") {
+			var index = parseInt(localStorage.getItem("{{ prefix }}" + "historyIndex"));
+			var length = parseInt(localStorage.getItem("{{ prefix }}" + "historyLength"));
+			index += inc;
+			if (index < 0) {
+				index = 0
+			} else if (index > length - 1) {
+				index = length - 1;
+			}
+			localStorage.setItem("{{ prefix }}" + "historyIndex", index);
+			cmdString = "{{ commands }}";
+			commands = cmdString ? cmdString.split(",").reverse() : []
+			$("#commandLineInput").val(commands[index]);
+		}
+    e.preventDefault();
+	});
 </script>
 
 <p><label class='label-light'><input id="autoTail" name="autoTail" type="checkbox"> Wait for task to start, then start tailing:</label></p>

--- a/SingularityUI/app/templates/vex/requestRun.hbs
+++ b/SingularityUI/app/templates/vex/requestRun.hbs
@@ -8,7 +8,7 @@
 <hr class='border-color-light-gray'>
 
 <script>
-
+		
 </script>
 
 <p><label class='label-light'><input id="autoTail" name="autoTail" type="checkbox"> Wait for task to start, then start tailing:</label></p>

--- a/SingularityUI/app/templates/vex/requestRun.hbs
+++ b/SingularityUI/app/templates/vex/requestRun.hbs
@@ -7,6 +7,10 @@
 </div>
 <hr class='border-color-light-gray'>
 
+<script>
+
+</script>
+
 <p><label class='label-light'><input id="autoTail" name="autoTail" type="checkbox"> Wait for task to start, then start tailing:</label></p>
 <div id="noFilenameError" class="alert alert-warning hide" role="alert">Please enter a filename or uncheck the box</div>
 <div class="vex-dialog-input">

--- a/SingularityUI/app/templates/vex/requestRun.hbs
+++ b/SingularityUI/app/templates/vex/requestRun.hbs
@@ -7,6 +7,12 @@
 </div>
 <hr class='border-color-light-gray'>
 
+<p><label class='label-light'><input id="autoTail" name="autoTail" type="checkbox"> Wait for task to start, then start tailing:</label></p>
+<div id="noFilenameError" class="alert alert-warning hide" role="alert">Please enter a filename or uncheck the box</div>
+<div class="vex-dialog-input">
+	<input id='filename' name="filename" type="text" class="vex-dialog-prompt-input" placeholder="e.g. service.log" value="">
+</div>
+
 <script>
 	// Need to handle this event here since it's inside vex...
 	$("#commandLineInput").keydown(function(e) {
@@ -37,9 +43,3 @@
     e.preventDefault();
 	});
 </script>
-
-<p><label class='label-light'><input id="autoTail" name="autoTail" type="checkbox"> Wait for task to start, then start tailing:</label></p>
-<div id="noFilenameError" class="alert alert-warning hide" role="alert">Please enter a filename or uncheck the box</div>
-<div class="vex-dialog-input">
-	<input id='filename' name="filename" type="text" class="vex-dialog-prompt-input" placeholder="e.g. service.log" value="">
-</div>

--- a/SingularityUI/app/templates/vex/requestRun.hbs
+++ b/SingularityUI/app/templates/vex/requestRun.hbs
@@ -3,7 +3,7 @@
 
 <p>Additional command line input: <small>(optional)</small></p>
 <div class="vex-dialog-input">
-	<input id='commandLineInput' name="commandLineInput" type="text" class="vex-dialog-prompt-input" placeholder="" value="">
+	<input id='commandLineInput' name="commandLineInput" type="text" class="vex-dialog-prompt-input" placeholder="" value="{{ command }}">
 </div>
 <hr class='border-color-light-gray'>
 

--- a/SingularityUI/app/templates/vex/requestRun.hbs
+++ b/SingularityUI/app/templates/vex/requestRun.hbs
@@ -12,34 +12,3 @@
 <div class="vex-dialog-input">
 	<input id='filename' name="filename" type="text" class="vex-dialog-prompt-input" placeholder="e.g. service.log" value="">
 </div>
-
-<script>
-	// Need to handle this event here since it's inside vex...
-	$("#commandLineInput").keydown(function(e) {
-		var inc = 0;
-		switch(e.which) {
-      case 38: // up
-				inc = 1;
-	      break;
-      case 40: // down
-				inc = -1;
-	      break;
-      default: return;
-    }
-		if ("{{ prefix }}" !== "") {
-			var index = parseInt(localStorage.getItem("{{ prefix }}" + "historyIndex"));
-			var length = parseInt(localStorage.getItem("{{ prefix }}" + "historyLength"));
-			index += inc;
-			if (index < 0) {
-				index = 0
-			} else if (index > length - 1) {
-				index = length - 1;
-			}
-			localStorage.setItem("{{ prefix }}" + "historyIndex", index);
-			cmdString = "{{ commands }}";
-			commands = cmdString ? cmdString.split(",").reverse() : []
-			$("#commandLineInput").val(commands[index]);
-		}
-    e.preventDefault();
-	});
-</script>

--- a/SingularityUI/app/views/request.coffee
+++ b/SingularityUI/app/views/request.coffee
@@ -78,8 +78,8 @@ class RequestView extends View
                 setTimeout ( => @trigger 'refreshrequest'), 2500
 
     rerunTask: (e) =>
-        command = e.target.getAttribute 'data-command'
-        @model.promptRerun command, (data) =>
+        taskId = e.target.getAttribute 'data-taskId'
+        @model.promptRerun taskId, (data) =>
             # If user wants to redirect to a file after the task starts
             if data.autoTail is 'on'
                 autoTailer = new AutoTailer({

--- a/SingularityUI/app/views/request.coffee
+++ b/SingularityUI/app/views/request.coffee
@@ -16,6 +16,7 @@ class RequestView extends View
 
             'click [data-action="remove"]': 'removeRequest'
             'click [data-action="run-request-now"]': 'runRequest'
+            'click [data-action="rerun-task"]': 'rerunTask'
             'click [data-action="pause"]': 'pauseRequest'
             'click [data-action="scale"]': 'scaleRequest'
             'click [data-action="unpause"]': 'unpauseRequest'
@@ -61,8 +62,24 @@ class RequestView extends View
             app.router.navigate 'requests', trigger: true
 
     runRequest: (e) =>
+        @model.promptRun (data) =>
+            # If user wants to redirect to a file after the task starts
+            if data.autoTail is 'on'
+                autoTailer = new AutoTailer({
+                    requestId: @requestId
+                    autoTailFilename: data.filename
+                    autoTailTimestamp: +new Date()
+                })
+
+                autoTailer.startAutoTailPolling()
+
+            else
+                @trigger 'refreshrequest'
+                setTimeout ( => @trigger 'refreshrequest'), 2500
+
+    rerunTask: (e) =>
         command = e.target.getAttribute 'data-command'
-        @model.promptRun command, (data) =>
+        @model.promptRerun command, (data) =>
             # If user wants to redirect to a file after the task starts
             if data.autoTail is 'on'
                 autoTailer = new AutoTailer({

--- a/SingularityUI/app/views/request.coffee
+++ b/SingularityUI/app/views/request.coffee
@@ -61,7 +61,8 @@ class RequestView extends View
             app.router.navigate 'requests', trigger: true
 
     runRequest: (e) =>
-        @model.promptRun (data) =>
+        command = e.target.getAttribute 'data-command'
+        @model.promptRun command, (data) =>
             # If user wants to redirect to a file after the task starts
             if data.autoTail is 'on'
                 autoTailer = new AutoTailer({


### PR DESCRIPTION
New UI features:
- Show the command line arguments that were run on the task and deploy detail pages, under "Info" section.
- Add a Rerun button (↺) in the task history table for on-demand tasks that will open the run now dialog with the cmd line arguments box prepopulated with what that task originally ran with.
- In the dialog shown after clicking "Run Now" you can now use the up and down arrow keys to scroll though argument history for that request.