### PR TITLE
thread checker, case where docker container has already stopped

### DIFF
--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorThreadChecker.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorThreadChecker.java
@@ -115,7 +115,7 @@ public class SingularityExecutorThreadChecker {
         String containerName = String.format("%s%s", configuration.getDockerPrefix(), taskProcess.getTask().getTaskId());
         int possiblePid = dockerClient.inspectContainer(containerName).state().pid();
         if (possiblePid == 0) {
-          LOG.warn(String.format("Container %s has pid 0. Running: (%s). Will not try to get threads", containerName, dockerClient.inspectContainer(containerName).state().running()));
+          LOG.warn(String.format("Container %s has pid %s (running: %s). Defaulting to 0 threads running.", containerName, possiblePid, dockerClient.inspectContainer(containerName).state().running()));
           return 0;
         } else {
           dockerPid = Optional.of(possiblePid);

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorThreadChecker.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorThreadChecker.java
@@ -114,8 +114,8 @@ public class SingularityExecutorThreadChecker {
       try {
         String containerName = String.format("%s%s", configuration.getDockerPrefix(), taskProcess.getTask().getTaskId());
         int possiblePid = dockerClient.inspectContainer(containerName).state().pid();
-        if (possiblePid == 0 && !dockerClient.inspectContainer(containerName).state().running()) {
-          LOG.warn(String.format("Container %s is no longer running, will not try to get used threads", containerName));
+        if (possiblePid == 0) {
+          LOG.warn(String.format("Container %s has pid 0. Running: (%s). Will not try to get threads", containerName, dockerClient.inspectContainer(containerName).state().running()));
           return 0;
         } else {
           dockerPid = Optional.of(possiblePid);

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
       <dependency>
         <groupId>com.spotify</groupId>
         <artifactId>docker-client</artifactId>
-        <version>2.7.20</version>
+        <version>3.1.5</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>


### PR DESCRIPTION
@tpetr found our docker threads issue. In the case where we inspect the container, but it has already stopped, the pid returns as 0. This is due to the docker daemon's response to inspect, not the client's processing. The wrapper checks every few seconds for the container to be running, so a badly timed thread check will throw up the error we saw with /proc/0/cgroup

So, I've added a check that if the pid is 0, we check that it is running. If it isn't running, we return 0. No need for throwing sentry errors when we are about to shut down anyways and nothing is really wrong

