### PR TITLE
allow JAR name format to be overridden

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,8 @@
   </developers>
 
   <properties>
+    <singularity.jar.name.format>${project.artifactId}-${project.version}</singularity.jar.name.format>
+
     <!-- build the docs for releases -->
     <basepom.release.profiles>oss-release,build-swagger-documentation</basepom.release.profiles>
 
@@ -276,6 +278,22 @@
               <version>${project.version}</version>
             </dependency>
           </dependencies>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <configuration>
+            <createDependencyReducedPom>true</createDependencyReducedPom>
+            <finalName>${singularity.jar.name.format}</finalName>
+          </configuration>
+          <executions>
+            <execution>
+              <phase>package</phase>
+              <goals>
+                <goal>shade</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
         <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -286,14 +286,6 @@
             <createDependencyReducedPom>true</createDependencyReducedPom>
             <finalName>${singularity.jar.name.format}</finalName>
           </configuration>
-          <executions>
-            <execution>
-              <phase>package</phase>
-              <goals>
-                <goal>shade</goal>
-              </goals>
-            </execution>
-          </executions>
         </plugin>
         <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
         <plugin>


### PR DESCRIPTION
For example, set `-Dsingularity.jar.name.format=\${project.artifactId}` as a maven arg to generate JARs without the version in the filename.

/cc @ssalinas @jhaber 