### PR TITLE
close files, less dns hits in logfetch

### DIFF
--- a/scripts/logfetch/callbacks.py
+++ b/scripts/logfetch/callbacks.py
@@ -14,6 +14,7 @@ def generate_callback(request, destination, filename, chunk_size, verbose):
         sys.stderr.write(colored('Downloaded ', 'green') + colored(path, 'white') + '\n')
       else:
         sys.stderr.write(colored('.', 'green'))
+      f.close()
 
   return callback
 

--- a/scripts/logfetch/live_logs.py
+++ b/scripts/logfetch/live_logs.py
@@ -27,9 +27,10 @@ def download_live_logs(args):
         logfile_name = '{0}-{1}'.format(task, log_file)
         if not args.logtype or (args.logtype and logfetch_base.log_matches(log_file, args.logtype.replace('logs/', ''))):
           if should_download(args, logfile_name, task):
+            replaced = logfetch_base.host_to_ip(uri)
             async_requests.append(
-              grequests.AsyncRequest('GET',uri ,
-                callback=generate_callback(uri, args.dest, logfile_name, args.chunk_size, args.verbose),
+              grequests.AsyncRequest('GET',replaced ,
+                callback=generate_callback(replaced, args.dest, logfile_name, args.chunk_size, args.verbose),
                 params={'path' : '{0}/{1}/{2}'.format(metadata['fullPathToRoot'], metadata['currentDirectory'], log_file)},
                 headers=args.headers
               )
@@ -47,9 +48,10 @@ def download_live_logs(args):
         logfile_name = '{0}-{1}'.format(task, log_file)
         if not args.logtype or (args.logtype and logfetch_base.log_matches(log_file, args.logtype.replace('logs/', ''))):
           if should_download(args, logfile_name, task):
+            replaced = logfetch_base.host_to_ip(uri)
             async_requests.append(
-              grequests.AsyncRequest('GET',uri ,
-                callback=generate_callback(uri, args.dest, logfile_name, args.chunk_size, args.verbose),
+              grequests.AsyncRequest('GET',replaced ,
+                callback=generate_callback(replaced, args.dest, logfile_name, args.chunk_size, args.verbose),
                 params={'path' : '{0}/{1}/logs/{2}'.format(metadata['fullPathToRoot'], metadata['currentDirectory'], log_file)},
                 headers=args.headers
               )

--- a/scripts/logfetch/s3_logs.py
+++ b/scripts/logfetch/s3_logs.py
@@ -25,8 +25,9 @@ def download_s3_logs(args):
         if args.verbose:
           sys.stderr.write(colored('Including log {0}'.format(filename), 'blue') + '\n')
         if not already_downloaded(args.dest, filename):
+          url = logfetch_base.host_to_ip(log_file['getUrl'])
           async_requests.append(
-            grequests.AsyncRequest('GET', log_file['getUrl'], callback=generate_callback(log_file['getUrl'], args.dest, filename, args.chunk_size, args.verbose), headers=args.headers)
+            grequests.AsyncRequest('GET', url, callback=generate_callback(url, args.dest, filename, args.chunk_size, args.verbose), headers=args.headers)
           )
         else:
           if args.verbose:

--- a/scripts/logfetch/singularity_request.py
+++ b/scripts/logfetch/singularity_request.py
@@ -9,6 +9,7 @@ def get_json_response(uri, args, params={}):
   if singularity_response.status_code < 199 or singularity_response.status_code > 299:
     sys.stderr.write('{0} params:{1}\n'.format(uri, str(params)))
     sys.stderr.write(colored(ERROR_STATUS_FORMAT.format(singularity_response.status_code), 'red') + '\n')
+    sys.stderr.write(colored('{0}'.format(singularity_response.text), 'red') + '\n')
     return {}
   return singularity_response.json()
 

--- a/scripts/logfetch/tail.py
+++ b/scripts/logfetch/tail.py
@@ -69,11 +69,6 @@ class LogStreamer(threading.Thread):
         sys.stderr.write(colored('Could not tail logs for task {0}, check that the task is still active and that the slave it runs on has not been decommissioned\n'.format(task), 'red'))
         keep_trying = False
 
-  def get_initial_offset(self, uri, path, args):
-    params = {"path" : path}
-
-    return long(requests.get(uri, params=params, headers=args.headers).json()['offset'])
-
   def fetch_new_log_data(self, uri, path, offset, args, task):
     params = {
       "path" : path,


### PR DESCRIPTION
Two fixes that will help us for downloading large numbers of logs with logfetch:
- requests does not cache dns, so we will only resolve each hostname once and save it
- with large numbers of logs to download, we can hit the open files limit (specifically on OSX). Noticed we weren't explicitly closing as we went along with the downloads, so now we are

Also for ease of use:
- better error in logtail when the requested logfile isn't found
- if we can't find the log file, also attempt to return a list of the available files for use in `-l / --logfile` option