### PR TITLE
make sure tasks are in ZK

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/data/CuratorManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/CuratorManager.java
@@ -233,10 +233,10 @@ public abstract class CuratorManager {
     }
   }
 
-  protected <T> Optional<T> getData(String path, Optional<Stat> stat, Transcoder<T> transcoder, Optional<ZkCache<T>> zkCache) {
+  private <T> Optional<T> getData(String path, Optional<Stat> stat, Transcoder<T> transcoder, Optional<ZkCache<T>> zkCache, Optional<Boolean> shouldCheckExists) {
     if (!stat.isPresent() && zkCache.isPresent()) {
       Optional<T> cachedValue = zkCache.get().get(path);
-      if (cachedValue.isPresent()) {
+      if (cachedValue.isPresent() && (!shouldCheckExists.isPresent() || (shouldCheckExists.get().booleanValue() && checkExists(path).isPresent()))) {
         return cachedValue;
       }
     }
@@ -277,15 +277,15 @@ public abstract class CuratorManager {
   }
 
   protected <T> Optional<T> getData(String path, Transcoder<T> transcoder) {
-    return getData(path, Optional.<Stat> absent(), transcoder, Optional.<ZkCache<T>> absent());
+    return getData(path, Optional.<Stat> absent(), transcoder, Optional.<ZkCache<T>> absent(), Optional.<Boolean> absent());
   }
 
-  protected <T> Optional<T> getData(String path, Transcoder<T> transcoder, Optional<ZkCache<T>> zkCache) {
-    return getData(path, Optional.<Stat> absent(), transcoder, zkCache);
+  protected <T> Optional<T> getData(String path, Transcoder<T> transcoder, ZkCache<T> zkCache, boolean shouldCheckExists) {
+    return getData(path, Optional.<Stat> absent(), transcoder, Optional.of(zkCache), Optional.of(shouldCheckExists));
   }
 
   protected Optional<String> getStringData(String path) {
-    return getData(path, StringTranscoder.INSTANCE, Optional.<ZkCache<String>> absent());
+    return getData(path, Optional.<Stat> absent(), StringTranscoder.INSTANCE, Optional.<ZkCache<String>> absent(), Optional.<Boolean> absent());
   }
 
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -429,7 +429,7 @@ public class TaskManager extends CuratorAsyncManager {
   }
 
   public Optional<SingularityTaskHistory> getTaskHistory(SingularityTaskId taskId) {
-    final Optional<SingularityTask> task = getTask(taskId);
+    final Optional<SingularityTask> task = getTaskCheckCache(taskId, true);
 
     if (!task.isPresent()) {
       return Optional.absent();
@@ -471,11 +471,15 @@ public class TaskManager extends CuratorAsyncManager {
     return getData(getPendingPath(pendingTaskId), pendingTaskTranscoder);
   }
 
-  @Timed
-  public Optional<SingularityTask> getTask(SingularityTaskId taskId) {
+  private Optional<SingularityTask> getTaskCheckCache(SingularityTaskId taskId, boolean shouldCheckExists) {
     final String path = getTaskPath(taskId);
 
-    return getData(path, taskTranscoder, Optional.of(taskCache));
+    return getData(path, taskTranscoder, taskCache, shouldCheckExists);
+  }
+
+  @Timed
+  public Optional<SingularityTask> getTask(SingularityTaskId taskId) {
+    return getTaskCheckCache(taskId, false);
   }
 
   public List<SingularityPendingTaskId> getPendingTaskIds() {


### PR DESCRIPTION
when they are used to determine if the rest of the object is. should fix task cache issues.