### PR TITLE
Add blazar configs

### DIFF
--- a/EmbedSingularityExample/.blazar.yaml
+++ b/EmbedSingularityExample/.blazar.yaml
@@ -1,0 +1,2 @@
+env:
+  MAVEN_ARGS: -Dsingularity.jar.name.format=${project.artifactId}

--- a/SingularityExecutor/.blazar.yaml
+++ b/SingularityExecutor/.blazar.yaml
@@ -1,0 +1,2 @@
+env:
+  MAVEN_ARGS: -Dsingularity.jar.name.format=${project.artifactId}

--- a/SingularityExecutorCleanup/.blazar.yaml
+++ b/SingularityExecutorCleanup/.blazar.yaml
@@ -1,0 +1,2 @@
+env:
+  MAVEN_ARGS: -Dsingularity.jar.name.format=${project.artifactId}

--- a/SingularityLogWatcher/.blazar.yaml
+++ b/SingularityLogWatcher/.blazar.yaml
@@ -1,0 +1,2 @@
+env:
+  MAVEN_ARGS: -Dsingularity.jar.name.format=${project.artifactId}

--- a/SingularityOOMKiller/.blazar.yaml
+++ b/SingularityOOMKiller/.blazar.yaml
@@ -1,0 +1,2 @@
+env:
+  MAVEN_ARGS: -Dsingularity.jar.name.format=${project.artifactId}

--- a/SingularityS3Downloader/.blazar.yaml
+++ b/SingularityS3Downloader/.blazar.yaml
@@ -1,0 +1,2 @@
+env:
+  MAVEN_ARGS: -Dsingularity.jar.name.format=${project.artifactId}

--- a/SingularityS3Uploader/.blazar.yaml
+++ b/SingularityS3Uploader/.blazar.yaml
@@ -1,0 +1,2 @@
+env:
+  MAVEN_ARGS: -Dsingularity.jar.name.format=${project.artifactId}

--- a/SingularityService/.blazar.yaml
+++ b/SingularityService/.blazar.yaml
@@ -1,0 +1,2 @@
+env:
+  MAVEN_ARGS: -Dsingularity.jar.name.format=${project.artifactId}


### PR DESCRIPTION
Alternatively, we could change the default in the POM to this format. I don't think that would pose much of a backwards-compatibility issue because people would only pick up the change when they upgrade to Singularity 0.4.6 which will require changing the JAR name either way (since the current format includes the version)

@tpetr 