### PR TITLE
Add request and task links to breadcrumbs on tail view

### DIFF
--- a/SingularityUI/app/styles/tailer.styl
+++ b/SingularityUI/app/styles/tailer.styl
@@ -42,7 +42,7 @@
 .tail-contents
     overflow scroll
     position absolute
-    top 130px
+    top 178px
     left 0
     bottom 0
     right 0

--- a/SingularityUI/app/templates/tail.hbs
+++ b/SingularityUI/app/templates/tail.hbs
@@ -3,6 +3,16 @@
         <div class="row">
             <div class="col-md-9">
                 <ul class="breadcrumb">
+                    <li>
+                      <a href="{{appRoot}}/request/{{ taskHistory.task.taskId.requestId }}">
+                          Request
+                      </a>
+                    </li>
+                    <li>
+                      <a href="{{appRoot}}/task/{{ taskId }}">
+                          Task
+                      </a>
+                    </li>
                     {{#each breadcrumbs}}
                         <li>
                             {{#ifEqual name ../filename}}

--- a/SingularityUI/app/templates/tail.hbs
+++ b/SingularityUI/app/templates/tail.hbs
@@ -1,18 +1,32 @@
 <div class="tail-header">
     <div class="container">
+      <div class="row">
+          <div class="col-md-12">
+                <ul class="breadcrumb">
+                    <li>
+                        Request
+                        <a href="{{appRoot}}/request/{{ taskHistory.task.taskId.requestId }}">
+                            {{ taskHistory.task.taskId.requestId }}
+                        </a>
+                    </li>
+                    <li>
+                        Deploy
+                        <a href="{{appRoot}}/request/{{ taskHistory.task.taskId.requestId }}/deploy/{{ taskHistory.task.taskId.deployId }}">
+                            {{ taskHistory.task.taskId.deployId }}
+                        </a>
+                    </li>
+                    <li>
+                      Task
+                      <a href="{{appRoot}}/task/{{ taskId }}">
+                          {{ taskId }}
+                      </a>
+                    </li>
+                </ul>
+          </div>
+      </div>
         <div class="row">
             <div class="col-md-9">
                 <ul class="breadcrumb">
-                    <li>
-                      <a href="{{appRoot}}/request/{{ taskHistory.task.taskId.requestId }}">
-                          Request
-                      </a>
-                    </li>
-                    <li>
-                      <a href="{{appRoot}}/task/{{ taskId }}">
-                          Task
-                      </a>
-                    </li>
                     {{#each breadcrumbs}}
                         <li>
                             {{#ifEqual name ../filename}}

--- a/SingularityUI/app/views/tail.coffee
+++ b/SingularityUI/app/views/tail.coffee
@@ -24,6 +24,8 @@ class TailView extends View
         @listenTo @collection.state, 'change:moreToFetch', @showOrHideMoreToFetchSpinners
         @listenTo @collection.state, 'change:moreToFetchAtBeginning', @showOrHideMoreToFetchSpinners
 
+        @listenTo @model, 'sync', @render
+
         # For the visual loading indicator thing
         @listenTo @collection, 'request', =>
             @$el.addClass 'fetching-data'
@@ -46,7 +48,7 @@ class TailView extends View
 
     render: =>
         breadcrumbs = utils.pathToBreadcrumbs @path
-        @$el.html @template {@taskId, @filename, breadcrumbs, ajaxError: @ajaxError.toJSON()}
+        @$el.html @template {@taskId, @filename, breadcrumbs, ajaxError: @ajaxError.toJSON(), taskHistory: @model.toJSON()}
 
         @$contents = @$ '.tail-contents'
         @$linesWrapper = @$contents.children('.lines-wrapper')


### PR DESCRIPTION
![screen shot 2015-10-23 at 11 47 33 am](https://cloud.githubusercontent.com/assets/3221272/10697842/ebde3934-797b-11e5-8072-24d72d657c14.png)

I'm open to discussion on where to place these links. Putting them on their own row above the breadcrumbs took up too much precious vertical space, and making the links their full names instead of Request and Task would end up pushing out any longer file names.