### PR TITLE
remove old property-style runnable config code

### DIFF
--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
@@ -5,7 +5,6 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import javax.validation.constraints.Min;
@@ -16,7 +15,6 @@ import org.hibernate.validator.constraints.NotEmpty;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
-import com.google.common.base.Splitter;
 import com.hubspot.mesos.MesosUtils;
 import com.hubspot.singularity.runner.base.configuration.BaseRunnerConfiguration;
 import com.hubspot.singularity.runner.base.configuration.Configuration;
@@ -24,57 +22,6 @@ import com.hubspot.singularity.runner.base.constraints.DirectoryExists;
 
 @Configuration(filename = "/etc/singularity.executor.yaml", consolidatedField = "executor")
 public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
-  public static final String SHUTDOWN_TIMEOUT_MILLIS = "executor.shutdown.timeout.millis";
-
-  public static final String HARD_KILL_AFTER_MILLIS = "executor.hard.kill.after.millis";
-  public static final String NUM_CORE_KILL_THREADS = "executor.num.core.kill.threads";
-
-  public static final String NUM_CORE_THREAD_CHECK_THREADS = "executor.num.core.thread.check.threads";
-  public static final String CHECK_THREADS_EVERY_MILLIS = "executor.check.threads.every.millis";
-
-  public static final String MAX_TASK_MESSAGE_LENGTH = "executor.status.update.max.task.message.length";
-
-  public static final String IDLE_EXECUTOR_SHUTDOWN_AFTER_MILLIS = "executor.idle.shutdown.after.millis";
-  public static final String SHUTDOWN_STOP_DRIVER_AFTER_MILLIS = "executor.shutdown.stop.driver.after.millis";
-
-  public static final String TASK_APP_DIRECTORY = "executor.task.app.directory";
-
-  public static final String TASK_EXECUTOR_JAVA_LOG_PATH = "executor.task.java.log.path";
-  public static final String TASK_EXECUTOR_BASH_LOG_PATH = "executor.task.bash.log.path";
-  public static final String TASK_SERVICE_LOG_PATH = "executor.task.service.log.path";
-
-  public static final String DEFAULT_USER = "executor.default.user";
-
-  public static final String GLOBAL_TASK_DEFINITION_DIRECTORY = "executor.global.task.definition.directory";
-  public static final String GLOBAL_TASK_DEFINITION_SUFFIX = "executor.global.task.definition.suffix";
-
-  public static final String LOGROTATE_COMMAND = "executor.logrotate.command";
-  public static final String LOGROTATE_CONFIG_DIRECTORY = "executor.logrotate.config.folder";
-  public static final String LOGROTATE_STATE_FILE = "executor.logrotate.state.file";
-  public static final String LOGROTATE_DIRECTORY = "executor.logrotate.to.directory";
-  public static final String LOGROTATE_MAXAGE_DAYS = "executor.logrotate.maxage.days";
-  public static final String LOGROTATE_COUNT = "executor.logrotate.count";
-  public static final String LOGROTATE_DATEFORMAT = "executor.logrotate.dateformat";
-
-  public static final String LOGROTATE_EXTRAS_DATEFORMAT = "executor.logrotate.extras.dateformat";
-  public static final String LOGROTATE_EXTRAS_FILES = "executor.logrotate.extras.files";
-
-  public static final String TAIL_LOG_LINES_TO_SAVE = "executor.service.log.tail.lines.to.save";
-  public static final String TAIL_LOG_FILENAME = "executor.service.log.tail.file.name";
-
-  public static final String S3_FILES_TO_BACKUP = "executor.s3.uploader.extras.files";
-  public static final String S3_UPLOADER_PATTERN = "executor.s3.uploader.pattern";
-  public static final String S3_UPLOADER_BUCKET = "executor.s3.uploader.bucket";
-
-  public static final String USE_LOCAL_DOWNLOAD_SERVICE = "executor.use.local.download.service";
-
-  public static final String LOCAL_DOWNLOAD_SERVICE_TIMEOUT_MILLIS = "executor.local.download.service.timeout.millis";
-
-  public static final String MAX_TASK_THREADS = "executor.max.task.threads";
-
-  public static final String DOCKER_PREFIX = "executor.docker.prefix";
-  public static final String DOCKER_STOP_TIMEOUT = "executor.docker.stop.timeout";
-
   @NotEmpty
   @JsonProperty
   private String executorJavaLog = "executor.java.log";
@@ -608,146 +555,5 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
             ", failTaskOnInvalidArtifactSignature=" + failTaskOnInvalidArtifactSignature +
             ", signatureVerifyOut='" + signatureVerifyOut + '\'' +
             ']';
-  }
-
-  @Override
-  public void updateFromProperties(Properties properties) {
-    final Splitter commaSplitter = Splitter.on(',').omitEmptyStrings().trimResults();
-
-    if (properties.containsKey(SHUTDOWN_TIMEOUT_MILLIS)) {
-      setShutdownTimeoutWaitMillis(Long.parseLong(properties.getProperty(SHUTDOWN_TIMEOUT_MILLIS)));
-    }
-
-    if (properties.containsKey(HARD_KILL_AFTER_MILLIS)) {
-      setHardKillAfterMillis(Long.parseLong(properties.getProperty(HARD_KILL_AFTER_MILLIS)));
-    }
-
-    if (properties.containsKey(NUM_CORE_KILL_THREADS)) {
-      setKillThreads(Integer.parseInt(properties.getProperty(NUM_CORE_KILL_THREADS)));
-    }
-
-    if (properties.containsKey(NUM_CORE_THREAD_CHECK_THREADS)) {
-      setThreadCheckThreads(Integer.parseInt(properties.getProperty(NUM_CORE_THREAD_CHECK_THREADS)));
-    }
-
-    if (properties.containsKey(CHECK_THREADS_EVERY_MILLIS)) {
-      setCheckThreadsEveryMillis(Long.parseLong(properties.getProperty(CHECK_THREADS_EVERY_MILLIS)));
-    }
-
-    if (properties.containsKey(MAX_TASK_MESSAGE_LENGTH)) {
-      setMaxTaskMessageLength(Integer.parseInt(properties.getProperty(MAX_TASK_MESSAGE_LENGTH)));
-    }
-
-    if (properties.containsKey(IDLE_EXECUTOR_SHUTDOWN_AFTER_MILLIS)) {
-      setIdleExecutorShutdownWaitMillis(Long.parseLong(properties.getProperty(IDLE_EXECUTOR_SHUTDOWN_AFTER_MILLIS)));
-    }
-
-    if (properties.containsKey(SHUTDOWN_STOP_DRIVER_AFTER_MILLIS)) {
-      setShutdownTimeoutWaitMillis(Long.parseLong(properties.getProperty(SHUTDOWN_STOP_DRIVER_AFTER_MILLIS)));
-    }
-
-    if (properties.containsKey(TASK_APP_DIRECTORY)) {
-      setTaskAppDirectory(properties.getProperty(TASK_APP_DIRECTORY));
-    }
-
-    if (properties.containsKey(TASK_EXECUTOR_JAVA_LOG_PATH)) {
-      setExecutorJavaLog(properties.getProperty(TASK_EXECUTOR_JAVA_LOG_PATH));
-    }
-
-    if (properties.containsKey(TASK_EXECUTOR_BASH_LOG_PATH)) {
-      setExecutorBashLog(properties.getProperty(TASK_EXECUTOR_BASH_LOG_PATH));
-    }
-
-    if (properties.containsKey(TASK_SERVICE_LOG_PATH)) {
-      setServiceLog(properties.getProperty(TASK_SERVICE_LOG_PATH));
-    }
-
-    if (properties.containsKey(DEFAULT_USER)) {
-      setDefaultRunAsUser(properties.getProperty(DEFAULT_USER));
-    }
-
-    if (properties.containsKey(GLOBAL_TASK_DEFINITION_DIRECTORY)) {
-      setGlobalTaskDefinitionDirectory(properties.getProperty(GLOBAL_TASK_DEFINITION_DIRECTORY));
-    }
-
-    if (properties.containsKey(GLOBAL_TASK_DEFINITION_SUFFIX)) {
-      setGlobalTaskDefinitionSuffix(properties.getProperty(GLOBAL_TASK_DEFINITION_SUFFIX));
-    }
-
-    if (properties.containsKey(LOGROTATE_COMMAND)) {
-      setLogrotateCommand(properties.getProperty(LOGROTATE_COMMAND));
-    }
-
-    if (properties.containsKey(LOGROTATE_CONFIG_DIRECTORY)) {
-      setLogrotateConfDirectory(properties.getProperty(LOGROTATE_CONFIG_DIRECTORY));
-    }
-
-    if (properties.containsKey(LOGROTATE_STATE_FILE)) {
-      setLogrotateStateFile(properties.getProperty(LOGROTATE_STATE_FILE));
-    }
-
-    if (properties.containsKey(LOGROTATE_DIRECTORY)) {
-      setLogrotateToDirectory(properties.getProperty(LOGROTATE_DIRECTORY));
-    }
-
-    if (properties.containsKey(LOGROTATE_MAXAGE_DAYS)) {
-      setLogrotateMaxageDays(Integer.parseInt(properties.getProperty(LOGROTATE_MAXAGE_DAYS)));
-    }
-
-    if (properties.containsKey(LOGROTATE_COUNT)) {
-      setLogrotateCount(Integer.parseInt(properties.getProperty(LOGROTATE_COUNT)));
-    }
-
-    if (properties.containsKey(LOGROTATE_DATEFORMAT)) {
-      setLogrotateDateformat(properties.getProperty(LOGROTATE_DATEFORMAT));
-    }
-
-    if (properties.containsKey(LOGROTATE_EXTRAS_DATEFORMAT)) {
-      setLogrotateExtrasDateformat(properties.getProperty(LOGROTATE_EXTRAS_DATEFORMAT));
-    }
-
-    if (properties.containsKey(LOGROTATE_EXTRAS_FILES)) {
-      setLogrotateAdditionalFiles(commaSplitter.splitToList(properties.getProperty(LOGROTATE_EXTRAS_FILES)));
-    }
-
-    if (properties.containsKey(TAIL_LOG_LINES_TO_SAVE)) {
-      setTailLogLinesToSave(Integer.parseInt(properties.getProperty(TAIL_LOG_LINES_TO_SAVE)));
-    }
-
-    if (properties.containsKey(TAIL_LOG_FILENAME)) {
-      setServiceFinishedTailLog(properties.getProperty(TAIL_LOG_FILENAME));
-    }
-
-    if (properties.containsKey(S3_FILES_TO_BACKUP)) {
-      setS3UploaderAdditionalFiles(commaSplitter.splitToList(properties.getProperty(S3_FILES_TO_BACKUP)));
-    }
-
-    if (properties.containsKey(S3_UPLOADER_PATTERN)) {
-      setS3UploaderKeyPattern(properties.getProperty(S3_UPLOADER_PATTERN));
-    }
-
-    if (properties.containsKey(S3_UPLOADER_BUCKET)) {
-      setS3UploaderBucket(properties.getProperty(S3_UPLOADER_BUCKET));
-    }
-
-    if (properties.containsKey(USE_LOCAL_DOWNLOAD_SERVICE)) {
-      setUseLocalDownloadService(Boolean.parseBoolean(properties.getProperty(USE_LOCAL_DOWNLOAD_SERVICE)));
-    }
-
-    if (properties.containsKey(LOCAL_DOWNLOAD_SERVICE_TIMEOUT_MILLIS)) {
-      setLocalDownloadServiceTimeoutMillis(Long.parseLong(properties.getProperty(LOCAL_DOWNLOAD_SERVICE_TIMEOUT_MILLIS)));
-    }
-
-    if (properties.containsKey(MAX_TASK_THREADS)) {
-      setMaxTaskThreads(Optional.of(Integer.parseInt(properties.getProperty(MAX_TASK_THREADS))));
-    }
-
-    if (properties.containsKey(DOCKER_PREFIX)) {
-      setDockerPrefix(properties.getProperty(DOCKER_PREFIX));
-    }
-
-    if (properties.containsKey(DOCKER_STOP_TIMEOUT)) {
-      setDockerStopTimeout(Integer.parseInt(properties.getProperty(DOCKER_STOP_TIMEOUT)));
-    }
   }
 }

--- a/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/config/SingularityExecutorCleanupConfiguration.java
+++ b/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/config/SingularityExecutorCleanupConfiguration.java
@@ -2,7 +2,6 @@ package com.hubspot.singularity.executor.cleanup.config;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import javax.validation.constraints.Min;
@@ -12,21 +11,13 @@ import org.hibernate.validator.constraints.NotEmpty;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
-import com.hubspot.mesos.JavaUtils;
 import com.hubspot.singularity.SingularityClientCredentials;
-import com.hubspot.singularity.client.SingularityClientModule;
 import com.hubspot.singularity.runner.base.configuration.BaseRunnerConfiguration;
 import com.hubspot.singularity.runner.base.configuration.Configuration;
 import com.hubspot.singularity.runner.base.constraints.DirectoryExists;
 
 @Configuration(filename = "/etc/singularity.executor.cleanup.yaml", consolidatedField = "executorCleanup")
 public class SingularityExecutorCleanupConfiguration extends BaseRunnerConfiguration {
-  public static final String SAFE_MODE_WONT_RUN_WITH_NO_TASKS = "executor.cleanup.safe.mode.wont.run.with.no.tasks";
-  public static final String EXECUTOR_CLEANUP_CLEANUP_APP_DIRECTORY_OF_FAILED_TASKS_AFTER_MILLIS = "executor.cleanup.cleanup.app.directory.of.failed.tasks.after.millis";
-  public static final String EXECUTOR_CLEANUP_RESULTS_DIRECTORY = "executor.cleanup.results.directory";
-  public static final String EXECUTOR_CLEANUP_RESULTS_SUFFIX = "executor.cleanup.results.suffix";
-  public static final String EXECUTOR_CLEANUP_RUN_DOCKER = "executor.cleanup.docker";
-
   @JsonProperty
   private boolean safeModeWontRunWithNoTasks = true;
 
@@ -137,36 +128,5 @@ public class SingularityExecutorCleanupConfiguration extends BaseRunnerConfigura
             ", runDockerCleanup=" + runDockerCleanup +
             ", singularityClientCredentials=" + singularityClientCredentials +
             ']';
-  }
-
-  @Override
-  public void updateFromProperties(Properties properties) {
-    if (properties.containsKey(SAFE_MODE_WONT_RUN_WITH_NO_TASKS)) {
-      setSafeModeWontRunWithNoTasks(Boolean.parseBoolean(properties.getProperty(SAFE_MODE_WONT_RUN_WITH_NO_TASKS)));
-    }
-
-    if (properties.containsKey(EXECUTOR_CLEANUP_CLEANUP_APP_DIRECTORY_OF_FAILED_TASKS_AFTER_MILLIS)) {
-      setCleanupAppDirectoryOfFailedTasksAfterMillis(Long.parseLong(properties.getProperty(EXECUTOR_CLEANUP_CLEANUP_APP_DIRECTORY_OF_FAILED_TASKS_AFTER_MILLIS)));
-    }
-
-    if (properties.containsKey(EXECUTOR_CLEANUP_RESULTS_DIRECTORY)) {
-      setExecutorCleanupResultsDirectory(properties.getProperty(EXECUTOR_CLEANUP_RESULTS_DIRECTORY));
-    }
-
-    if (properties.containsKey(EXECUTOR_CLEANUP_RESULTS_SUFFIX)) {
-      setExecutorCleanupResultsSuffix(properties.getProperty(EXECUTOR_CLEANUP_RESULTS_SUFFIX));
-    }
-
-    if (properties.containsKey(SingularityClientModule.HOSTS_PROPERTY_NAME)) {
-      setSingularityHosts(JavaUtils.COMMA_SPLITTER.splitToList(properties.getProperty(SingularityClientModule.HOSTS_PROPERTY_NAME)));
-    }
-
-    if (properties.containsKey(SingularityClientModule.CONTEXT_PATH)) {
-      setSingularityContextPath(properties.getProperty(SingularityClientModule.CONTEXT_PATH));
-    }
-
-    if (properties.containsKey(EXECUTOR_CLEANUP_RUN_DOCKER)) {
-      setRunDockerCleanup(Boolean.parseBoolean(properties.getProperty(EXECUTOR_CLEANUP_RUN_DOCKER)));
-    }
   }
 }

--- a/SingularityLogWatcher/src/main/java/com/hubspot/singularity/logwatcher/config/SingularityLogWatcherConfiguration.java
+++ b/SingularityLogWatcher/src/main/java/com/hubspot/singularity/logwatcher/config/SingularityLogWatcherConfiguration.java
@@ -3,7 +3,6 @@ package com.hubspot.singularity.logwatcher.config;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.Properties;
 
 import javax.validation.constraints.Min;
 
@@ -18,17 +17,6 @@ import com.hubspot.singularity.runner.base.constraints.DirectoryExists;
 
 @Configuration(filename = "/etc/singularity.logwatcher.yaml", consolidatedField = "logwatcher")
 public class SingularityLogWatcherConfiguration extends BaseRunnerConfiguration {
-  public static final String BYTE_BUFFER_CAPACITY = "logwatcher.bytebuffer.capacity";
-  public static final String POLL_MILLIS = "logwatcher.poll.millis";
-  public static final String FLUENTD_HOSTS = "logwatcher.fluentd.comma.separated.hosts.and.ports";
-
-  public static final String STORE_DIRECTORY = "logwatcher.store.directory";
-  public static final String STORE_SUFFIX = "logwatcher.store.suffix";
-
-  public static final String RETRY_DELAY_SECONDS = "logwatcher.retry.delay.seconds";
-
-  public static final String FLUENTD_TAG_PREFIX = "logwatcher.fluentd.tag.prefix";
-
   @Min(1)
   @JsonProperty
   private int byteBufferCapacity = 8192;
@@ -163,36 +151,5 @@ public class SingularityLogWatcherConfiguration extends BaseRunnerConfiguration 
             ", fluentdTagPrefix='" + fluentdTagPrefix + '\'' +
             ", retryDelaySeconds=" + retryDelaySeconds +
             ']';
-  }
-
-  @Override
-  public void updateFromProperties(Properties properties) {
-    if (properties.containsKey(BYTE_BUFFER_CAPACITY)) {
-      setByteBufferCapacity(Integer.parseInt(properties.getProperty(BYTE_BUFFER_CAPACITY)));
-    }
-
-    if (properties.containsKey(POLL_MILLIS)) {
-      setPollMillis(Long.parseLong(properties.getProperty(POLL_MILLIS)));
-    }
-
-    if (properties.containsKey(FLUENTD_HOSTS)) {
-      setFluentdHosts(properties.getProperty(FLUENTD_HOSTS));
-    }
-
-    if (properties.containsKey(STORE_DIRECTORY)) {
-      setStoreDirectory(properties.getProperty(STORE_DIRECTORY));
-    }
-
-    if (properties.containsKey(STORE_SUFFIX)) {
-      setStoreSuffix(properties.getProperty(STORE_SUFFIX));
-    }
-
-    if (properties.containsKey(RETRY_DELAY_SECONDS)) {
-      setRetryDelaySeconds(Long.parseLong(properties.getProperty(RETRY_DELAY_SECONDS)));
-    }
-
-    if (properties.containsKey(FLUENTD_TAG_PREFIX)) {
-      setFluentdTagPrefix(properties.getProperty(FLUENTD_TAG_PREFIX));
-    }
   }
 }

--- a/SingularityOOMKiller/src/main/java/com/hubspot/singularity/oomkiller/config/SingularityOOMKillerConfiguration.java
+++ b/SingularityOOMKiller/src/main/java/com/hubspot/singularity/oomkiller/config/SingularityOOMKillerConfiguration.java
@@ -1,7 +1,5 @@
 package com.hubspot.singularity.oomkiller.config;
 
-import java.util.Properties;
-
 import javax.validation.constraints.Min;
 
 import org.hibernate.validator.constraints.NotEmpty;
@@ -13,12 +11,6 @@ import com.hubspot.singularity.runner.base.configuration.Configuration;
 
 @Configuration(filename = "/etc/singularity.oomkiller.yaml", consolidatedField = "oomkiller")
 public class SingularityOOMKillerConfiguration extends BaseRunnerConfiguration {
-  public static final String REQUEST_KILL_THRESHOLD_RATIO = "oomkiller.request.kill.threshold.ratio";
-  public static final String KILL_PROCESS_DIRECTLY_THRESHOLD_RATIO = "oomkiller.kill.process.directly.threshold.ratio";
-  public static final String CHECK_FOR_OOM_EVERY_MILLIS = "oomkiller.check.for.oom.every.millis";
-  public static final String SLAVE_HOSTNAME = "oomkiller.slave.hostname";
-  public static final String CGROUP_PROCS_PATH_FORMAT = "oomkiller.cgroups.procs.path.format";
-
   @JsonProperty
   private double requestKillThresholdRatio = 1.0;
 
@@ -90,28 +82,5 @@ public class SingularityOOMKillerConfiguration extends BaseRunnerConfiguration {
             ", slaveHostname='" + slaveHostname + '\'' +
             ", cgroupProcsPathFormat='" + cgroupProcsPathFormat + '\'' +
             ']';
-  }
-
-  @Override
-  public void updateFromProperties(Properties properties) {
-    if (properties.containsKey(REQUEST_KILL_THRESHOLD_RATIO)) {
-      setRequestKillThresholdRatio(Double.parseDouble(properties.getProperty(REQUEST_KILL_THRESHOLD_RATIO)));
-    }
-
-    if (properties.containsKey(KILL_PROCESS_DIRECTLY_THRESHOLD_RATIO)) {
-      setKillProcessDirectlyThresholdRatio(Double.parseDouble(properties.getProperty(KILL_PROCESS_DIRECTLY_THRESHOLD_RATIO)));
-    }
-
-    if (properties.containsKey(CHECK_FOR_OOM_EVERY_MILLIS)) {
-      setCheckForOOMEveryMillis(Long.parseLong(properties.getProperty(CHECK_FOR_OOM_EVERY_MILLIS)));
-    }
-
-    if (properties.containsKey(SLAVE_HOSTNAME)) {
-      setSlaveHostname(properties.getProperty(SLAVE_HOSTNAME));
-    }
-
-    if (properties.containsKey(CGROUP_PROCS_PATH_FORMAT)) {
-      setCgroupProcsPathFormat(properties.getProperty(CGROUP_PROCS_PATH_FORMAT));
-    }
   }
 }

--- a/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/config/SingularityRunnerBaseModule.java
+++ b/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/config/SingularityRunnerBaseModule.java
@@ -37,7 +37,6 @@ public class SingularityRunnerBaseModule extends AbstractModule {
   public static final String YAML = "yaml";
   public static final String OBFUSCATED_YAML = "obfuscated.yaml";
   public static final String HOST_NAME_PROPERTY = "singularity.host.name";
-  public static final String HOST_ADDRESS_PROPERTY = "singularity.host.address";
   public static final String CONSOLIDATED_CONFIG_FILENAME = "consolidated.config.filename";
 
   public static final String CONFIG_PROPERTY = "singularityConfigFilename";

--- a/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/configuration/BaseRunnerConfiguration.java
+++ b/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/configuration/BaseRunnerConfiguration.java
@@ -2,24 +2,16 @@ package com.hubspot.singularity.runner.base.configuration;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 
 import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
-import com.google.common.base.Strings;
 
-public abstract class BaseRunnerConfiguration implements OverridableByProperty {
+public abstract class BaseRunnerConfiguration {
   public static final String DEFAULT_ROOT_LOG_LEVEL = "INFO";
   public static final String DEFAULT_HUBSPOT_LOG_LEVEL = "INFO";
   public static final String DEFAULT_DIRECTORY = "/var/log/singularity/";
-
-  public static final String LOGGING_PATTERN = "logging.pattern";
-  public static final String ROOT_LOG_NAME = "root.log.name";
-
-  public static final String ROOT_LOG_LEVEL = "root.log.level";
-  public static final String HUBSPOT_LOG_LEVEL = "hubspot.log.level";
 
   @NotNull
   @JsonProperty
@@ -83,26 +75,5 @@ public abstract class BaseRunnerConfiguration implements OverridableByProperty {
 
   public void setLoggingPattern(Optional<String> loggingPattern) {
     this.loggingPattern = loggingPattern;
-  }
-
-  public void updateLoggingFromProperties(Properties properties) {
-    if (properties.containsKey(SingularityRunnerBaseConfiguration.ROOT_LOG_DIRECTORY) && !Strings.isNullOrEmpty(properties.getProperty(SingularityRunnerBaseConfiguration.ROOT_LOG_DIRECTORY))) {
-      setLoggingDirectory(Optional.of(properties.getProperty(SingularityRunnerBaseConfiguration.ROOT_LOG_DIRECTORY)));
-    }
-    if (properties.containsKey(LOGGING_PATTERN) && !Strings.isNullOrEmpty(properties.getProperty(LOGGING_PATTERN))) {
-      setLoggingPattern(Optional.of(properties.getProperty(LOGGING_PATTERN)));
-    }
-
-    if (properties.containsKey(ROOT_LOG_NAME) && !Strings.isNullOrEmpty(properties.getProperty(ROOT_LOG_NAME))) {
-      setLoggingFilename(Optional.of(properties.getProperty(ROOT_LOG_NAME)));
-    }
-
-    if (properties.containsKey(ROOT_LOG_LEVEL) && !Strings.isNullOrEmpty(properties.getProperty(ROOT_LOG_LEVEL))) {
-      getLoggingLevel().put("ROOT", properties.getProperty(ROOT_LOG_LEVEL));
-    }
-
-    if (properties.containsKey(HUBSPOT_LOG_LEVEL) && !Strings.isNullOrEmpty(properties.getProperty(HUBSPOT_LOG_LEVEL))) {
-      getLoggingLevel().put("com.hubspot", properties.getProperty(HUBSPOT_LOG_LEVEL));
-    }
   }
 }

--- a/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/configuration/OverridableByProperty.java
+++ b/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/configuration/OverridableByProperty.java
@@ -1,7 +1,0 @@
-package com.hubspot.singularity.runner.base.configuration;
-
-import java.util.Properties;
-
-public interface OverridableByProperty {
-  void updateFromProperties(Properties properties);
-}

--- a/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/configuration/SingularityRunnerBaseConfiguration.java
+++ b/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/configuration/SingularityRunnerBaseConfiguration.java
@@ -1,7 +1,5 @@
 package com.hubspot.singularity.runner.base.configuration;
 
-import java.util.Properties;
-
 import javax.validation.constraints.NotNull;
 
 import org.hibernate.validator.constraints.NotEmpty;
@@ -12,14 +10,6 @@ import com.hubspot.singularity.runner.base.constraints.DirectoryExists;
 
 @Configuration(filename = "/etc/singularity.base.yaml", consolidatedField = "base")
 public class SingularityRunnerBaseConfiguration extends BaseRunnerConfiguration {
-  public static final String ROOT_LOG_DIRECTORY = "root.log.directory";
-
-  public static final String LOG_METADATA_DIRECTORY = "logwatcher.metadata.directory";
-  public static final String LOG_METADATA_SUFFIX = "logwatcher.metadata.suffix";
-
-  public static final String S3_METADATA_SUFFIX = "s3uploader.metadata.suffix";
-  public static final String S3_METADATA_DIRECTORY = "s3uploader.metadata.directory";
-
   @DirectoryExists
   @JsonProperty
   private String s3UploaderMetadataDirectory;
@@ -106,24 +96,4 @@ public class SingularityRunnerBaseConfiguration extends BaseRunnerConfiguration 
             ", logWatcherMetadataSuffix='" + logWatcherMetadataSuffix + '\'' +
             ']';
   }
-
-  @Override
-  public void updateFromProperties(Properties properties) {
-    if (properties.containsKey(LOG_METADATA_DIRECTORY)) {
-      setLogWatcherMetadataDirectory(properties.getProperty(LOG_METADATA_DIRECTORY));
-    }
-
-    if (properties.containsKey(LOG_METADATA_SUFFIX)) {
-      setLogWatcherMetadataSuffix(properties.getProperty(LOG_METADATA_SUFFIX));
-    }
-
-    if (properties.containsKey(S3_METADATA_DIRECTORY)) {
-      setS3UploaderMetadataDirectory(properties.getProperty(S3_METADATA_DIRECTORY));
-    }
-
-    if (properties.containsKey(S3_METADATA_SUFFIX)) {
-      setS3UploaderMetadataSuffix(properties.getProperty(S3_METADATA_SUFFIX));
-    }
-  }
-
 }

--- a/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/configuration/SingularityRunnerBaseLoggingConfiguration.java
+++ b/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/configuration/SingularityRunnerBaseLoggingConfiguration.java
@@ -1,23 +1,14 @@
 package com.hubspot.singularity.runner.base.configuration;
 
-import java.util.Properties;
-
 import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
-import com.google.common.base.Strings;
 import com.hubspot.mesos.JavaUtils;
 
-public class SingularityRunnerBaseLoggingConfiguration implements OverridableByProperty {
-  public static final String DEFAULT_ROOT_LOG_LEVEL = "INFO";
-  public static final String DEFAULT_HUBSPOT_LOG_LEVEL = "INFO";
+public class SingularityRunnerBaseLoggingConfiguration {
   public static final String DEFAULT_DIRECTORY = "/var/log/singularity/";
 
-  public static final String LOGGING_PATTERN = "logging.pattern";
-  public static final String ROOT_LOG_NAME = "root.log.name";
-
-  public static final String ROOT_LOG_LEVEL = "root.log.level";
   public static final String HUBSPOT_LOG_LEVEL = "hubspot.log.level";
 
   public static SingularityRunnerBaseLoggingConfiguration defaultBaseConfig() {
@@ -90,28 +81,4 @@ public class SingularityRunnerBaseLoggingConfiguration implements OverridableByP
   public void setLoggingPattern(Optional<String> loggingPattern) {
     this.loggingPattern = loggingPattern;
   }
-
-  @Override
-  public void updateFromProperties(Properties properties) {
-    if (properties.containsKey(SingularityRunnerBaseConfiguration.ROOT_LOG_DIRECTORY) && !Strings.isNullOrEmpty(properties.getProperty(SingularityRunnerBaseConfiguration.ROOT_LOG_DIRECTORY))) {
-      setDirectory(Optional.of(properties.getProperty(SingularityRunnerBaseConfiguration.ROOT_LOG_DIRECTORY)));
-    }
-    if (properties.containsKey(LOGGING_PATTERN) && !Strings.isNullOrEmpty(properties.getProperty(LOGGING_PATTERN))) {
-      setLoggingPattern(Optional.of(properties.getProperty(LOGGING_PATTERN)));
-    }
-
-    if (properties.containsKey(ROOT_LOG_NAME) && !Strings.isNullOrEmpty(properties.getProperty(ROOT_LOG_NAME))) {
-      setFilename(Optional.of(properties.getProperty(ROOT_LOG_NAME)));
-    }
-
-    if (properties.containsKey(ROOT_LOG_LEVEL) && !Strings.isNullOrEmpty(properties.getProperty(ROOT_LOG_LEVEL))) {
-      setRootLogLevel(Optional.of(properties.getProperty(ROOT_LOG_LEVEL)));
-    }
-
-    if (properties.containsKey(HUBSPOT_LOG_LEVEL) && !Strings.isNullOrEmpty(properties.getProperty(HUBSPOT_LOG_LEVEL))) {
-      setHubSpotLogLevel(Optional.of(properties.getProperty(HUBSPOT_LOG_LEVEL)));
-    }
-  }
-
-
 }

--- a/SingularityS3Base/src/main/java/com/hubspot/singularity/s3/base/config/SingularityS3Configuration.java
+++ b/SingularityS3Base/src/main/java/com/hubspot/singularity/s3/base/config/SingularityS3Configuration.java
@@ -2,7 +2,6 @@ package com.hubspot.singularity.s3.base.config;
 
 import static com.hubspot.mesos.JavaUtils.obfuscateValue;
 
-import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import javax.validation.constraints.Min;
@@ -19,17 +18,6 @@ import com.hubspot.singularity.runner.base.jackson.Obfuscate;
 
 @Configuration(filename = "/etc/singularity.s3base.yaml", consolidatedField = "s3")
 public class SingularityS3Configuration extends BaseRunnerConfiguration {
-  public static final String ARTIFACT_CACHE_DIRECTORY = "artifact.cache.directory";
-
-  public static final String S3_ACCESS_KEY = "s3.access.key";
-  public static final String S3_SECRET_KEY = "s3.secret.key";
-
-  public static final String S3_CHUNK_SIZE = "s3.downloader.chunk.size";
-  public static final String S3_DOWNLOAD_TIMEOUT_MILLIS = "s3.downloader.timeout.millis";
-
-  public static final String LOCAL_DOWNLOAD_HTTP_PORT = "s3.downloader.http.port";
-  public static final String LOCAL_DOWNLOAD_HTTP_DOWNLOAD_PATH = "s3.downloader.http.download.path";
-
   @NotEmpty
   @DirectoryExists
   @JsonProperty
@@ -158,36 +146,5 @@ public class SingularityS3Configuration extends BaseRunnerConfiguration {
             ", localDownloadHttpPort=" + localDownloadHttpPort +
             ", localDownloadPath='" + localDownloadPath + '\'' +
             ']';
-  }
-
-  @Override
-  public void updateFromProperties(Properties properties) {
-    if (properties.containsKey(ARTIFACT_CACHE_DIRECTORY)) {
-      setArtifactCacheDirectory(properties.getProperty(ARTIFACT_CACHE_DIRECTORY));
-    }
-
-    if (properties.containsKey(S3_ACCESS_KEY)) {
-      setS3AccessKey(properties.getProperty(S3_ACCESS_KEY));
-    }
-
-    if (properties.containsKey(S3_SECRET_KEY)) {
-      setS3SecretKey(properties.getProperty(S3_SECRET_KEY));
-    }
-
-    if (properties.containsKey(S3_CHUNK_SIZE)) {
-      setS3ChunkSize(Long.parseLong(properties.getProperty(S3_CHUNK_SIZE)));
-    }
-
-    if (properties.containsKey(S3_DOWNLOAD_TIMEOUT_MILLIS)) {
-      setS3DownloadTimeoutMillis(Long.parseLong(properties.getProperty(S3_DOWNLOAD_TIMEOUT_MILLIS)));
-    }
-
-    if (properties.containsKey(LOCAL_DOWNLOAD_HTTP_DOWNLOAD_PATH)) {
-      setLocalDownloadPath(properties.getProperty(LOCAL_DOWNLOAD_HTTP_DOWNLOAD_PATH));
-    }
-
-    if (properties.containsKey(LOCAL_DOWNLOAD_HTTP_PORT)) {
-      setLocalDownloadHttpPort(Integer.parseInt(properties.getProperty(LOCAL_DOWNLOAD_HTTP_PORT)));
-    }
   }
 }

--- a/SingularityS3Downloader/src/main/java/com/hubspot/singularity/s3downloader/config/SingularityS3DownloaderConfiguration.java
+++ b/SingularityS3Downloader/src/main/java/com/hubspot/singularity/s3downloader/config/SingularityS3DownloaderConfiguration.java
@@ -1,6 +1,5 @@
 package com.hubspot.singularity.s3downloader.config;
 
-import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import javax.validation.constraints.Min;
@@ -12,11 +11,6 @@ import com.hubspot.singularity.runner.base.configuration.Configuration;
 
 @Configuration(filename = "/etc/singularity.s3downloader.yaml", consolidatedField = "s3downloader")
 public class SingularityS3DownloaderConfiguration extends BaseRunnerConfiguration {
-
-  public static final String NUM_DOWNLOADER_THREADS = "s3downloader.downloader.threads";
-
-  public static final String HTTP_SERVER_TIMEOUT = "s3downloader.http.timeout";
-
   @Min(1)
   @JsonProperty
   private long httpServerTimeout = TimeUnit.MINUTES.toMillis(30);
@@ -73,16 +67,5 @@ public class SingularityS3DownloaderConfiguration extends BaseRunnerConfiguratio
   public String toString() {
     return "SingularityS3DownloaderConfiguration [httpServerTimeout=" + httpServerTimeout + ", numEnqueueThreads=" + numEnqueueThreads + ", millisToWaitForReEnqueue=" + millisToWaitForReEnqueue
         + ", numDownloaderThreads=" + numDownloaderThreads + "]";
-  }
-
-  @Override
-  public void updateFromProperties(Properties properties) {
-    if (properties.containsKey(NUM_DOWNLOADER_THREADS)) {
-      setNumDownloaderThreads(Integer.parseInt(properties.getProperty(NUM_DOWNLOADER_THREADS)));
-    }
-
-    if (properties.containsKey(HTTP_SERVER_TIMEOUT)) {
-      setHttpServerTimeout(Long.parseLong(properties.getProperty(HTTP_SERVER_TIMEOUT)));
-    }
   }
 }

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/config/SingularityS3UploaderConfiguration.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/config/SingularityS3UploaderConfiguration.java
@@ -2,7 +2,6 @@ package com.hubspot.singularity.s3uploader.config;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import javax.validation.constraints.Min;
@@ -13,25 +12,10 @@ import com.google.common.base.Optional;
 import com.hubspot.singularity.runner.base.configuration.BaseRunnerConfiguration;
 import com.hubspot.singularity.runner.base.configuration.Configuration;
 import com.hubspot.singularity.runner.base.jackson.Obfuscate;
-import com.hubspot.singularity.s3.base.config.SingularityS3Configuration;
 import com.hubspot.singularity.s3.base.config.SingularityS3Credentials;
 
 @Configuration(filename = "/etc/singularity.s3uploader.yaml", consolidatedField = "s3uploader")
 public class SingularityS3UploaderConfiguration extends BaseRunnerConfiguration {
-  public static final String POLL_MILLIS = "s3uploader.poll.for.shutdown.millis";
-
-  public static final String CHECK_FOR_UPLOADS_EVERY_SECONDS = "s3uploader.check.uploads.every.seconds";
-  public static final String STOP_CHECKING_AFTER_HOURS_WITHOUT_NEW_FILE = "s3uploader.stop.checking.after.hours.without.new.file";
-
-  public static final String EXECUTOR_MAX_UPLOAD_THREADS = "s3uploader.max.upload.threads";
-
-  public static final String MAX_SINGLE_UPLOAD_BYTES = "s3uploader.max.single.upload.size";
-  public static final String UPLOAD_PART_SIZE = "s3uploader.upload.part.size";
-  public static final String RETRY_WAIT_MS = "s3uploader.retry.wait.ms";
-  public static final String RETRY_COUNT = "s3uploader.retry.count";
-
-  public static final String CHECK_FOR_OPEN_FILES = "s3uploader.check.for.open.files";
-
   @Min(0)
   @JsonProperty
   private long pollForShutDownMillis = 1000;
@@ -193,47 +177,5 @@ public class SingularityS3UploaderConfiguration extends BaseRunnerConfiguration 
             ", checkForOpenFiles=" + checkForOpenFiles +
             ", s3BucketCredentials=" + s3BucketCredentials +
             ']';
-  }
-
-  @Override
-  public void updateFromProperties(Properties properties) {
-    if (properties.containsKey(POLL_MILLIS)) {
-      setPollForShutDownMillis(Long.parseLong(properties.getProperty(POLL_MILLIS)));
-    }
-
-    if (properties.containsKey(CHECK_FOR_UPLOADS_EVERY_SECONDS)) {
-      setCheckUploadsEverySeconds(Long.parseLong(properties.getProperty(CHECK_FOR_UPLOADS_EVERY_SECONDS)));
-    }
-
-    if (properties.containsKey(STOP_CHECKING_AFTER_HOURS_WITHOUT_NEW_FILE)) {
-      setStopCheckingAfterMillisWithoutNewFile(Long.parseLong(properties.getProperty(STOP_CHECKING_AFTER_HOURS_WITHOUT_NEW_FILE)));
-    }
-
-    if (properties.containsKey(EXECUTOR_MAX_UPLOAD_THREADS)) {
-      setExecutorMaxUploadThreads(Integer.parseInt(properties.getProperty(EXECUTOR_MAX_UPLOAD_THREADS)));
-    }
-
-    if (properties.containsKey(SingularityS3Configuration.S3_ACCESS_KEY)) {
-      setS3AccessKey(Optional.of(properties.getProperty(SingularityS3Configuration.S3_ACCESS_KEY)));
-    }
-
-    if (properties.containsKey(SingularityS3Configuration.S3_SECRET_KEY)) {
-      setS3SecretKey(Optional.of(properties.getProperty(SingularityS3Configuration.S3_SECRET_KEY)));
-    }
-    if (properties.containsKey(MAX_SINGLE_UPLOAD_BYTES)) {
-      setMaxSingleUploadSizeBytes(Long.parseLong(properties.getProperty(MAX_SINGLE_UPLOAD_BYTES)));
-    }
-    if (properties.containsKey(UPLOAD_PART_SIZE)) {
-      setUploadPartSize(Long.parseLong(properties.getProperty(UPLOAD_PART_SIZE)));
-    }
-    if (properties.containsKey(RETRY_COUNT)) {
-      setRetryCount(Integer.parseInt(properties.getProperty(RETRY_COUNT)));
-    }
-    if (properties.containsKey(RETRY_WAIT_MS)) {
-      setRetryWaitMs(Integer.parseInt(RETRY_WAIT_MS));
-    }
-    if (properties.containsKey(CHECK_FOR_OPEN_FILES)) {
-      setCheckForOpenFiles(Boolean.parseBoolean(properties.getProperty(CHECK_FOR_OPEN_FILES)));
-    }
   }
 }


### PR DESCRIPTION
It looks like the wiring to load the `.properties` files was removed in #680, but this removes extra code related to it.