### PR TITLE
Error handling

### DIFF
--- a/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/config/MissingConfigException.java
+++ b/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/config/MissingConfigException.java
@@ -1,7 +1,7 @@
 package com.hubspot.singularity.runner.base.config;
 
 public class MissingConfigException extends IllegalStateException {
-  public MissingConfigException(Exception e) {
-    super(e);
+  public MissingConfigException(String message) {
+    super(message);
   }
 }

--- a/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/config/MissingConfigException.java
+++ b/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/config/MissingConfigException.java
@@ -1,0 +1,7 @@
+package com.hubspot.singularity.runner.base.config;
+
+public class MissingConfigException extends IllegalStateException {
+  public MissingConfigException(Exception e) {
+    super(e);
+  }
+}

--- a/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/config/MissingConfigException.java
+++ b/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/config/MissingConfigException.java
@@ -1,6 +1,6 @@
 package com.hubspot.singularity.runner.base.config;
 
-public class MissingConfigException extends IllegalStateException {
+public class MissingConfigException extends RuntimeException {
   public MissingConfigException(String message) {
     super(message);
   }

--- a/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/shared/JsonObjectFileHelper.java
+++ b/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/shared/JsonObjectFileHelper.java
@@ -28,15 +28,17 @@ public class JsonObjectFileHelper {
 
     log.info("Reading {}", file);
 
-    byte[] bytes = Files.readAllBytes(file);
-
-    log.trace("Read {} bytes from {} in {}", bytes.length, file, JavaUtils.duration(start));
-
-    if (bytes.length == 0) {
-      return Optional.absent();
-    }
+    byte[] bytes = new byte[0];
 
     try {
+      bytes = Files.readAllBytes(file);
+
+      log.trace("Read {} bytes from {} in {}", bytes.length, file, JavaUtils.duration(start));
+
+      if (bytes.length == 0) {
+       return Optional.absent();
+      }
+
       T object = objectMapper.readValue(bytes, clazz);
       return Optional.of(object);
     } catch (IOException e) {

--- a/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/shared/JsonObjectFileHelper.java
+++ b/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/shared/JsonObjectFileHelper.java
@@ -4,6 +4,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 
@@ -36,11 +37,13 @@ public class JsonObjectFileHelper {
       log.trace("Read {} bytes from {} in {}", bytes.length, file, JavaUtils.duration(start));
 
       if (bytes.length == 0) {
-       return Optional.absent();
+        return Optional.absent();
       }
 
       T object = objectMapper.readValue(bytes, clazz);
       return Optional.of(object);
+    } catch (NoSuchFileException nsfe) {
+      log.warn("File {} does not exist", file);
     } catch (IOException e) {
       log.warn("File {} is not a valid {} ({})", file, clazz.getSimpleName(), new String(bytes, UTF_8), e);
     }

--- a/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/shared/SingularityRunner.java
+++ b/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/shared/SingularityRunner.java
@@ -9,6 +9,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.Stage;
+import com.hubspot.singularity.runner.base.config.MissingConfigException;
 import com.hubspot.singularity.runner.base.sentry.SingularityRunnerExceptionNotifier;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -40,6 +41,9 @@ public class SingularityRunner {
       LOG.info("Exiting normally");
 
       System.exit(0);
+    } catch (MissingConfigException mce) {
+      LOG.error("Missing required configuration, exiting", mce);
+      System.exit(1);
     } catch (Throwable t) {
       LOG.error("Caught unexpected exception, exiting", t);
       exceptionNotifier.notify(t, Collections.<String, String>emptyMap());

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3Uploader.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3Uploader.java
@@ -235,7 +235,6 @@ public class SingularityS3Uploader implements Closeable {
         }
       } catch (Exception e) {
         LOG.warn("Exception uploading {}", file, e);
-        exceptionNotifier.notify(e, ImmutableMap.of("file", file.toString()));
         throw e;
       }
 

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3Uploader.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3Uploader.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.Timer.Context;
+import com.github.rholder.retry.RetryException;
 import com.github.rholder.retry.Retryer;
 import com.github.rholder.retry.RetryerBuilder;
 import com.github.rholder.retry.StopStrategies;
@@ -179,6 +180,10 @@ public class SingularityS3Uploader implements Closeable {
           metrics.error();
           LOG.warn("{} Couldn't upload {} due to {} ({}) - {}", logIdentifier, file, se.getErrorCode(), se.getResponseCode(), se.getErrorMessage(), se);
           exceptionNotifier.notify(se, ImmutableMap.of("logIdentifier", logIdentifier, "file", file.toString(), "errorCode", se.getErrorCode(), "responseCode", Integer.toString(se.getResponseCode()), "errorMessage", se.getErrorMessage()));
+        } catch (RetryException re) {
+          metrics.error();
+          LOG.warn("{} Couldn't upload or delete {}", logIdentifier, file, re);
+          exceptionNotifier.notify(re.getCause(), ImmutableMap.of("logIdentifier", logIdentifier, "file", file.toString(), "failedAttempts", Integer.toString(re.getNumberOfFailedAttempts())));
         } catch (Exception e) {
           metrics.error();
           LOG.warn("{} Couldn't upload or delete {}", logIdentifier, file, e);

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3UploaderDriver.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3UploaderDriver.java
@@ -127,11 +127,11 @@ public class SingularityS3UploaderDriver extends WatchServiceHelper implements S
 
   @Override
   public void startAndWait() {
-    try {
-      Preconditions.checkState(configuration.getS3AccessKey().or(s3Configuration.getS3AccessKey()).isPresent(), "s3AccessKey not set in any s3 configs!");
-      Preconditions.checkState(configuration.getS3SecretKey().or(s3Configuration.getS3SecretKey()).isPresent(), "s3SecretKey not set in any s3 configs!");
-    } catch (IllegalStateException ise) {
-      throw new MissingConfigException(ise);
+    if (!configuration.getS3AccessKey().or(s3Configuration.getS3AccessKey()).isPresent()) {
+      throw new MissingConfigException("s3AccessKey not set in any s3 configs!");
+    }
+    if (!configuration.getS3SecretKey().or(s3Configuration.getS3SecretKey()).isPresent()) {
+      throw new MissingConfigException("s3SecretKey not set in any s3 configs!");
     }
 
     try {

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3UploaderDriver.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3UploaderDriver.java
@@ -42,6 +42,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.hubspot.mesos.JavaUtils;
+import com.hubspot.singularity.runner.base.config.MissingConfigException;
 import com.hubspot.singularity.runner.base.config.SingularityRunnerBaseModule;
 import com.hubspot.singularity.runner.base.configuration.SingularityRunnerBaseConfiguration;
 import com.hubspot.singularity.runner.base.sentry.SingularityRunnerExceptionNotifier;
@@ -126,8 +127,13 @@ public class SingularityS3UploaderDriver extends WatchServiceHelper implements S
 
   @Override
   public void startAndWait() {
-    Preconditions.checkState(configuration.getS3AccessKey().or(s3Configuration.getS3AccessKey()).isPresent(), "s3AccessKey not set in any s3 configs!");
-    Preconditions.checkState(configuration.getS3SecretKey().or(s3Configuration.getS3SecretKey()).isPresent(), "s3SecretKey not set in any s3 configs!");
+    try {
+      Preconditions.checkState(configuration.getS3AccessKey().or(s3Configuration.getS3AccessKey()).isPresent(), "s3AccessKey not set in any s3 configs!");
+      Preconditions.checkState(configuration.getS3SecretKey().or(s3Configuration.getS3SecretKey()).isPresent(), "s3SecretKey not set in any s3 configs!");
+    } catch (IllegalStateException ise) {
+      throw new MissingConfigException(ise);
+    }
+
     try {
       readInitialFiles();
     } catch (Throwable t) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SandboxManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SandboxManager.java
@@ -3,6 +3,7 @@ package com.hubspot.singularity.data;
 import java.net.ConnectException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.concurrent.ExecutionException;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -55,7 +56,7 @@ public class SandboxManager {
       }
 
       return objectMapper.readValue(response.getResponseBodyAsStream(), MESOS_FILE_OBJECTS);
-    } catch (ConnectException ce) {
+    } catch (ExecutionException | ConnectException ce) {
       throw new SlaveNotFoundException(ce);
     } catch (Exception e) {
       throw Throwables.propagate(e);
@@ -91,7 +92,7 @@ public class SandboxManager {
       }
 
       return Optional.of(objectMapper.readValue(response.getResponseBodyAsStream(), MesosFileChunkObject.class));
-    } catch (ConnectException ce) {
+    } catch (ExecutionException | ConnectException ce) {
       throw new SlaveNotFoundException(ce);
     } catch (Exception e) {
       throw Throwables.propagate(e);

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SandboxManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SandboxManager.java
@@ -56,10 +56,14 @@ public class SandboxManager {
       }
 
       return objectMapper.readValue(response.getResponseBodyAsStream(), MESOS_FILE_OBJECTS);
-    } catch (ExecutionException | ConnectException ce) {
+    } catch (ConnectException ce) {
       throw new SlaveNotFoundException(ce);
     } catch (Exception e) {
-      throw Throwables.propagate(e);
+      if (e.getCause().getClass() == ConnectException.class) {
+        throw new SlaveNotFoundException(e);
+      } else {
+        throw Throwables.propagate(e);
+      }
     }
   }
 
@@ -92,10 +96,14 @@ public class SandboxManager {
       }
 
       return Optional.of(objectMapper.readValue(response.getResponseBodyAsStream(), MesosFileChunkObject.class));
-    } catch (ExecutionException | ConnectException ce) {
+    } catch (ConnectException ce) {
       throw new SlaveNotFoundException(ce);
     } catch (Exception e) {
-      throw Throwables.propagate(e);
+      if (e.getCause().getClass() == ConnectException.class) {
+        throw new SlaveNotFoundException(e);
+      } else {
+        throw Throwables.propagate(e);
+      }
     }
   }
 }


### PR DESCRIPTION
- Don't throw s3 uploader err to sentry unless all retries fail
- Catch NoSuchFileException in ExecutorCleanup
- Properly catch ExecutionException so we throw back SlaveNotFoundException when a slave is no longer running

@tpetr 