### PR TITLE
remove fuzzy matching in requests and tasks pages

### DIFF
--- a/SingularityUI/app/views/requests.coffee
+++ b/SingularityUI/app/views/requests.coffee
@@ -59,12 +59,18 @@ class RequestsView extends View
 
         # Only show requests that match the search query
         if @searchFilter
-            searchFilter = @searchFilter.toLowerCase().split("@")[0]
-            fuse = new Fuse(
-                requests
-                keys: ["request.id", "requestDeployState.activeDeploy.user", "request.owners"]
-                threshold: 0.4)
-            requests = fuse.search(searchFilter).reverse()
+            requests = _.filter requests, (request) =>
+                searchFilter = @searchFilter.toLowerCase().split("@")[0]
+                valuesToSearch = []
+
+                for user in request.request.owners ? []
+                  valuesToSearch.push(user.split("@")[0])
+
+                valuesToSearch.push(request.request.id)
+                valuesToSearch.push(request.requestDeployState?.activeDeploy?.user)
+
+                searchTarget = valuesToSearch.join("")
+                searchTarget.toLowerCase().indexOf(searchFilter) isnt -1
 
         # Only show requests that match the clicky filters
         if @state in @haveSubfilter and @subFilter isnt 'all'

--- a/SingularityUI/app/views/tasks.coffee
+++ b/SingularityUI/app/views/tasks.coffee
@@ -50,12 +50,9 @@ class TasksView extends View
 
         # Only show tasks that match the search query
         if @searchFilter
-            searchFilter = @searchFilter.toLowerCase()
-            fuse = new Fuse(
-                tasks
-                keys: ["id", "host"]
-                threshold: 0.4)
-            tasks = fuse.search(searchFilter).reverse()
+            tasks = _.filter tasks, (task) =>
+                searchField = "#{ task.id }#{ task.host }".toLowerCase().replace(/-/g, '_')
+                searchField.toLowerCase().indexOf(@searchFilter.toLowerCase().replace(/-/g, '_')) isnt -1
         # Sort the table if the user clicked on the table heading things
         if @sortAttribute?
             tasks = _.sortBy tasks, (task) =>


### PR DESCRIPTION
the Fuse library can't handle long search queries (ex. searching for tasks on specific slaves) -- removing from the requests and tasks pages for now

@kwm4385 