### PR TITLE
Don't hide client side paginated tables by default

### DIFF
--- a/SingularityUI/app/styles/table.styl
+++ b/SingularityUI/app/styles/table.styl
@@ -117,6 +117,3 @@ th #schedule
 
 #empty-table
     margin-bottom 20px
-
-.paginated
-    display none


### PR DESCRIPTION
Don't hide client side paginated tables (S3 Logs) by default. This can make the table flash between not paginated and paginated if it is visible when the page refreshes. At least it won't randomly disappear if the pagination fails (for some reason). 

Temporary fix until client side pagination is rewritten.