### PR TITLE
more reliable lb delete during request cleanup

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestLbCleanup.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestLbCleanup.java
@@ -1,0 +1,80 @@
+package com.hubspot.singularity;
+
+import java.util.List;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Optional;
+
+@JsonIgnoreProperties (ignoreUnknown = true)
+public class SingularityRequestLbCleanup {
+  private String requestId;
+  private Set<String> loadBalancerGroups;
+  private String serviceBasePath;
+  private List<String> activeTaskIds;
+  private Optional<SingularityLoadBalancerUpdate> loadBalancerUpdate;
+
+  public SingularityRequestLbCleanup(@JsonProperty("requestId") String requestId,
+                                     @JsonProperty("loadBalancerGroups") Set<String> loadBalancerGroups,
+                                     @JsonProperty("serviceBasePath") String serviceBasePath,
+                                     @JsonProperty("activeTaskIds") List<String> activeTaskIds,
+                                     @JsonProperty("loadBalancerUpdate") Optional<SingularityLoadBalancerUpdate> loadBalancerUpdate) {
+    this.requestId = requestId;
+    this.loadBalancerGroups = loadBalancerGroups;
+    this.serviceBasePath = serviceBasePath;
+    this.activeTaskIds = activeTaskIds;
+    this.loadBalancerUpdate = loadBalancerUpdate;
+  }
+
+  public String getRequestId() {
+    return requestId;
+  }
+
+  public void setRequestId(String requestId) {
+    this.requestId = requestId;
+  }
+
+  public Set<String> getLoadBalancerGroups() {
+    return loadBalancerGroups;
+  }
+
+  public void setLoadBalancerGroups(Set<String> loadBalancerGroups) {
+    this.loadBalancerGroups = loadBalancerGroups;
+  }
+
+  public String getServiceBasePath() {
+    return serviceBasePath;
+  }
+
+  public void setServiceBasePath(String serviceBasePath) {
+    this.serviceBasePath = serviceBasePath;
+  }
+
+  public List<String> getActiveTaskIds() {
+    return activeTaskIds;
+  }
+
+  public void setActiveTaskIds(List<String> activeTaskIds) {
+    this.activeTaskIds = activeTaskIds;
+  }
+
+  public Optional<SingularityLoadBalancerUpdate> getLoadBalancerUpdate() {
+    return loadBalancerUpdate;
+  }
+
+  public void setLoadBalancerUpdate(Optional<SingularityLoadBalancerUpdate> loadBalancerUpdate) {
+    this.loadBalancerUpdate = loadBalancerUpdate;
+  }
+
+  @Override
+  public String toString() {
+    return "SingularityRequestLbCleanup{" +
+        "requestId='" + requestId + '\'' +
+        ", loadBalancerGroups=" + loadBalancerGroups +
+        ", serviceBasePath='" + serviceBasePath + '\'' +
+        ", activeTaskIds=" + activeTaskIds +
+        ", loadBalancerUpdate=" + loadBalancerUpdate +
+        '}';
+  }
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -117,7 +117,7 @@ public class SingularityConfiguration extends Configuration {
 
   private String loadBalancerUri;
 
-  private boolean deletePausedRequestsFromLoadBalancer = true;
+  private boolean deleteRemovedRequestsFromLoadBalancer = false;
 
   private int logFetchMaxThreads = 15;
 
@@ -828,11 +828,11 @@ public class SingularityConfiguration extends Configuration {
     this.graphiteConfiguration = graphiteConfiguration;
   }
 
-  public boolean isDeletePausedRequestsFromLoadBalancer() {
-    return deletePausedRequestsFromLoadBalancer;
+  public boolean isDeleteRemovedRequestsFromLoadBalancer() {
+    return deleteRemovedRequestsFromLoadBalancer;
   }
 
-  public void setDeletePausedRequestsFromLoadBalancer(boolean deletePausedRequestsFromLoadBalancer) {
-    this.deletePausedRequestsFromLoadBalancer = deletePausedRequestsFromLoadBalancer;
+  public void setDeleteRemovedRequestsFromLoadBalancer(boolean deleteRemovedRequestsFromLoadBalancer) {
+    this.deleteRemovedRequestsFromLoadBalancer = deleteRemovedRequestsFromLoadBalancer;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
@@ -27,6 +27,7 @@ import com.hubspot.singularity.SingularityRequestCleanup;
 import com.hubspot.singularity.SingularityRequestCleanup.RequestCleanupType;
 import com.hubspot.singularity.SingularityRequestHistory;
 import com.hubspot.singularity.SingularityRequestHistory.RequestHistoryType;
+import com.hubspot.singularity.SingularityRequestLbCleanup;
 import com.hubspot.singularity.SingularityRequestWithState;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.transcoders.Transcoder;
@@ -41,7 +42,7 @@ public class RequestManager extends CuratorAsyncManager {
   private final Transcoder<SingularityPendingRequest> pendingRequestTranscoder;
   private final Transcoder<SingularityRequestCleanup> requestCleanupTranscoder;
   private final Transcoder<SingularityRequestHistory> requestHistoryTranscoder;
-  private final Transcoder<SingularityLoadBalancerUpdate> loadBalancerUpdateTranscoder;
+  private final Transcoder<SingularityRequestLbCleanup> requestLbCleanupTranscoder;
 
   private final SingularityEventListener singularityEventListener;
 
@@ -55,7 +56,7 @@ public class RequestManager extends CuratorAsyncManager {
 
   @Inject
   public RequestManager(CuratorFramework curator, SingularityConfiguration configuration, MetricRegistry metricRegistry, SingularityEventListener singularityEventListener,
-      Transcoder<SingularityRequestCleanup> requestCleanupTranscoder, Transcoder<SingularityRequestWithState> requestTranscoder, Transcoder<SingularityLoadBalancerUpdate> loadBalancerUpdateTranscoder,
+      Transcoder<SingularityRequestCleanup> requestCleanupTranscoder, Transcoder<SingularityRequestWithState> requestTranscoder, Transcoder<SingularityRequestLbCleanup> requestLbCleanupTranscoder,
       Transcoder<SingularityPendingRequest> pendingRequestTranscoder, Transcoder<SingularityRequestHistory> requestHistoryTranscoder) {
     super(curator, configuration, metricRegistry);
     this.requestTranscoder = requestTranscoder;
@@ -63,7 +64,7 @@ public class RequestManager extends CuratorAsyncManager {
     this.pendingRequestTranscoder = pendingRequestTranscoder;
     this.requestHistoryTranscoder = requestHistoryTranscoder;
     this.singularityEventListener = singularityEventListener;
-    this.loadBalancerUpdateTranscoder = loadBalancerUpdateTranscoder;
+    this.requestLbCleanupTranscoder = requestLbCleanupTranscoder;
   }
 
   private String getRequestPath(String requestId) {
@@ -278,6 +279,14 @@ public class RequestManager extends CuratorAsyncManager {
     delete(getRequestPath(request.getId()));
   }
 
+  public List<SingularityRequestLbCleanup> getLbCleanupRequests() {
+    return getAsyncChildren(LB_CLEANUP_PATH_ROOT, requestLbCleanupTranscoder);
+  }
+
+  public Optional<SingularityRequestLbCleanup> getLbCleanupRequest(String requestId) {
+    return getData(getLBCleanupPath(requestId), requestLbCleanupTranscoder);
+  }
+
   public List<String> getLBCleanupRequestIds() {
     return getChildren(LB_CLEANUP_PATH_ROOT);
   }
@@ -286,19 +295,11 @@ public class RequestManager extends CuratorAsyncManager {
     return ZKPaths.makePath(LB_CLEANUP_PATH_ROOT, requestId);
   }
 
-  public SingularityCreateResult createLBCleanupRequest(String requestId) {
-    return create(getLBCleanupPath(requestId));
+  public void saveLBCleanupRequest(SingularityRequestLbCleanup cleanup) {
+    save(getLBCleanupPath(cleanup.getRequestId()), cleanup, requestLbCleanupTranscoder);
   }
 
   public SingularityDeleteResult deleteLBCleanupRequest(String requestId) {
     return delete(getLBCleanupPath(requestId));
-  }
-
-  public Optional<SingularityLoadBalancerUpdate> getLoadBalancerState(String requestId) {
-    return getData(getLBCleanupPath(requestId), loadBalancerUpdateTranscoder);
-  }
-
-  public void saveLoadBalancerState(String requestId, SingularityLoadBalancerUpdate lbUpdate) {
-    save(getLBCleanupPath(requestId), lbUpdate, loadBalancerUpdateTranscoder);
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/transcoders/SingularityTranscoderModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/transcoders/SingularityTranscoderModule.java
@@ -24,6 +24,7 @@ import com.hubspot.singularity.SingularityRequest;
 import com.hubspot.singularity.SingularityRequestCleanup;
 import com.hubspot.singularity.SingularityRequestDeployState;
 import com.hubspot.singularity.SingularityRequestHistory;
+import com.hubspot.singularity.SingularityRequestLbCleanup;
 import com.hubspot.singularity.SingularityRequestWithState;
 import com.hubspot.singularity.SingularitySlave;
 import com.hubspot.singularity.SingularityState;
@@ -56,6 +57,7 @@ public class SingularityTranscoderModule implements Module {
     bindTranscoder(binder).asJson(SingularityRack.class);
     bindTranscoder(binder).asJson(SingularityRequest.class);
     bindTranscoder(binder).asJson(SingularityRequestCleanup.class);
+    bindTranscoder(binder).asJson(SingularityRequestLbCleanup.class);
     bindTranscoder(binder).asJson(SingularityRequestDeployState.class);
     bindTranscoder(binder).asJson(SingularityRequestWithState.class);
     bindTranscoder(binder).asJson(SingularitySlave.class);

--- a/SingularityService/src/main/java/com/hubspot/singularity/hooks/LoadBalancerClient.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/hooks/LoadBalancerClient.java
@@ -1,6 +1,7 @@
 package com.hubspot.singularity.hooks;
 
 import java.util.List;
+import java.util.Set;
 
 import com.hubspot.singularity.LoadBalancerRequestType.LoadBalancerRequestId;
 import com.hubspot.singularity.SingularityDeploy;
@@ -16,5 +17,5 @@ public interface LoadBalancerClient {
 
   SingularityLoadBalancerUpdate cancel(LoadBalancerRequestId loadBalancerRequestId);
 
-  SingularityLoadBalancerUpdate delete(LoadBalancerRequestId loadBalancerRequestId, SingularityRequest request, SingularityDeploy deploy);
+  SingularityLoadBalancerUpdate delete(LoadBalancerRequestId loadBalancerRequestId, String requestId, Set<String> loadBalancerGroups, String serviceBasePath);
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/hooks/LoadBalancerClientImpl.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/hooks/LoadBalancerClientImpl.java
@@ -211,11 +211,8 @@ public class LoadBalancerClientImpl implements LoadBalancerClient {
   }
 
   @Override
-  public SingularityLoadBalancerUpdate delete(LoadBalancerRequestId loadBalancerRequestId, SingularityRequest request, SingularityDeploy deploy) {
-    final List<String> serviceOwners = request.getOwners().or(Collections.<String> emptyList());
-    final Set<String> loadBalancerGroups = deploy.getLoadBalancerGroups().or(Collections.<String> emptySet());
-    final BaragonService lbService = new BaragonService(request.getId(), serviceOwners, deploy.getServiceBasePath().get(), loadBalancerGroups, deploy.getLoadBalancerOptions().orNull());
-
+  public SingularityLoadBalancerUpdate delete(LoadBalancerRequestId loadBalancerRequestId, String requestId, Set<String> loadBalancerGroups, String serviceBasePath) {
+    final BaragonService lbService = new BaragonService(requestId, Collections.<String> emptyList(), serviceBasePath, loadBalancerGroups, Collections.<String, Object>emptyMap());
     final BaragonRequest loadBalancerRequest = new BaragonRequest(loadBalancerRequestId.toString(), lbService, Collections.<UpstreamInfo>emptyList(), Collections.<UpstreamInfo>emptyList(), Collections.<UpstreamInfo>emptyList(), Optional.<String>absent(), Optional.of(RequestAction.DELETE));
 
     return sendBaragonRequest(loadBalancerRequestId, loadBalancerRequest, LoadBalancerMethod.DELETE);

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
@@ -204,17 +204,6 @@ public class SingularityCleaner {
               LOG.debug("Waiting on {} (it will expire after {}), because {} is {}", requestCleanup, JavaUtils.durationFromMillis(getObsoleteExpirationTime()), requestCleanup.getRequestId(), requestWithState.get().getState());
               continue;
             }
-          } else {
-            if (requestWithState.isPresent()) {
-              if (requestWithState.get().getRequest().isLoadBalanced() && configuration.isDeletePausedRequestsFromLoadBalancer()) {
-                createLbCleanupRequest(requestId, matchingActiveTaskIds);
-              }
-            } else {
-              Optional<SingularityRequestHistory> maybeHistory = requestHistoryHelper.getLastHistory(requestId);
-              if (maybeHistory.isPresent() && maybeHistory.get().getRequest().isLoadBalanced() && configuration.isDeletePausedRequestsFromLoadBalancer()) {
-                createLbCleanupRequest(requestId, matchingActiveTaskIds);
-              }
-            }
           }
           break;
         case DELETING:
@@ -222,12 +211,12 @@ public class SingularityCleaner {
             killActiveTasks = false;
             killScheduledTasks = false;
             LOG.info("Ignoring {}, because {} still existed", requestCleanup, requestCleanup.getRequestId());
-            if (requestWithState.get().getRequest().isLoadBalanced() && configuration.isDeletePausedRequestsFromLoadBalancer()) {
+            if (requestWithState.get().getRequest().isLoadBalanced() && configuration.isDeleteRemovedRequestsFromLoadBalancer()) {
               createLbCleanupRequest(requestId, matchingActiveTaskIds);
             }
           } else {
             Optional<SingularityRequestHistory> maybeHistory = requestHistoryHelper.getLastHistory(requestId);
-            if (maybeHistory.isPresent() && maybeHistory.get().getRequest().isLoadBalanced() && configuration.isDeletePausedRequestsFromLoadBalancer()) {
+            if (maybeHistory.isPresent() && maybeHistory.get().getRequest().isLoadBalanced() && configuration.isDeleteRemovedRequestsFromLoadBalancer()) {
               createLbCleanupRequest(requestId, matchingActiveTaskIds);
             }
             cleanupDeployState(requestCleanup);

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
@@ -1,5 +1,6 @@
 package com.hubspot.singularity.scheduler;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -30,6 +31,8 @@ import com.hubspot.singularity.SingularityPendingTask;
 import com.hubspot.singularity.SingularityRequest;
 import com.hubspot.singularity.SingularityRequestCleanup;
 import com.hubspot.singularity.SingularityRequestDeployState;
+import com.hubspot.singularity.SingularityRequestHistory;
+import com.hubspot.singularity.SingularityRequestLbCleanup;
 import com.hubspot.singularity.SingularityRequestWithState;
 import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.SingularityTaskCleanup;
@@ -39,6 +42,7 @@ import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.DeployManager;
 import com.hubspot.singularity.data.RequestManager;
 import com.hubspot.singularity.data.TaskManager;
+import com.hubspot.singularity.data.history.RequestHistoryHelper;
 import com.hubspot.singularity.hooks.LoadBalancerClient;
 import com.hubspot.singularity.scheduler.SingularityDeployHealthHelper.DeployHealth;
 import com.hubspot.singularity.sentry.SingularityExceptionNotifier;
@@ -55,13 +59,15 @@ public class SingularityCleaner {
   private final SingularityDeployHealthHelper deployHealthHelper;
   private final LoadBalancerClient lbClient;
   private final SingularityExceptionNotifier exceptionNotifier;
+  private final RequestHistoryHelper requestHistoryHelper;
 
   private final SingularityConfiguration configuration;
   private final long killNonLongRunningTasksInCleanupAfterMillis;
 
   @Inject
   public SingularityCleaner(TaskManager taskManager, SingularityDeployHealthHelper deployHealthHelper, DeployManager deployManager, RequestManager requestManager,
-      SingularityDriverManager driverManager, SingularityConfiguration configuration, LoadBalancerClient lbClient, SingularityExceptionNotifier exceptionNotifier) {
+      SingularityDriverManager driverManager, SingularityConfiguration configuration, LoadBalancerClient lbClient, SingularityExceptionNotifier exceptionNotifier,
+      RequestHistoryHelper requestHistoryHelper) {
     this.taskManager = taskManager;
     this.lbClient = lbClient;
     this.deployHealthHelper = deployHealthHelper;
@@ -69,6 +75,7 @@ public class SingularityCleaner {
     this.requestManager = requestManager;
     this.driverManager = driverManager;
     this.exceptionNotifier = exceptionNotifier;
+    this.requestHistoryHelper = requestHistoryHelper;
 
     this.configuration = configuration;
 
@@ -183,7 +190,8 @@ public class SingularityCleaner {
 
       boolean killActiveTasks = requestCleanup.getKillTasks().or(configuration.isDefaultValueForKillTasksOfPausedRequests());
       boolean killScheduledTasks = true;
-      boolean deleteFromLoadBalancer = false;
+
+      final Iterable<SingularityTaskId> matchingActiveTaskIds = Iterables.filter(activeTaskIds, SingularityTaskId.matchingRequest(requestId));
 
       switch (requestCleanup.getCleanupType()) {
         case PAUSING:
@@ -197,8 +205,15 @@ public class SingularityCleaner {
               continue;
             }
           } else {
-            if (requestWithState.isPresent() && requestWithState.get().getRequest().isLoadBalanced()) {
-              deleteFromLoadBalancer = true;
+            if (requestWithState.isPresent()) {
+              if (requestWithState.get().getRequest().isLoadBalanced() && configuration.isDeletePausedRequestsFromLoadBalancer()) {
+                createLbCleanupRequest(requestId, matchingActiveTaskIds);
+              }
+            } else {
+              Optional<SingularityRequestHistory> maybeHistory = requestHistoryHelper.getLastHistory(requestId);
+              if (maybeHistory.isPresent() && maybeHistory.get().getRequest().isLoadBalanced() && configuration.isDeletePausedRequestsFromLoadBalancer()) {
+                createLbCleanupRequest(requestId, matchingActiveTaskIds);
+              }
             }
           }
           break;
@@ -207,7 +222,14 @@ public class SingularityCleaner {
             killActiveTasks = false;
             killScheduledTasks = false;
             LOG.info("Ignoring {}, because {} still existed", requestCleanup, requestCleanup.getRequestId());
+            if (requestWithState.get().getRequest().isLoadBalanced() && configuration.isDeletePausedRequestsFromLoadBalancer()) {
+              createLbCleanupRequest(requestId, matchingActiveTaskIds);
+            }
           } else {
+            Optional<SingularityRequestHistory> maybeHistory = requestHistoryHelper.getLastHistory(requestId);
+            if (maybeHistory.isPresent() && maybeHistory.get().getRequest().isLoadBalanced() && configuration.isDeletePausedRequestsFromLoadBalancer()) {
+              createLbCleanupRequest(requestId, matchingActiveTaskIds);
+            }
             cleanupDeployState(requestCleanup);
           }
           break;
@@ -221,7 +243,7 @@ public class SingularityCleaner {
       }
 
       if (killActiveTasks) {
-        for (SingularityTaskId matchingTaskId : Iterables.filter(activeTaskIds, SingularityTaskId.matchingRequest(requestId))) {
+        for (SingularityTaskId matchingTaskId : matchingActiveTaskIds) {
           LOG.debug("Killing task {} due to {}", matchingTaskId, requestCleanup);
           driverManager.killAndRecord(matchingTaskId, requestCleanup.getCleanupType());
           numTasksKilled++;
@@ -238,14 +260,27 @@ public class SingularityCleaner {
         }
       }
 
-      if (deleteFromLoadBalancer && configuration.isDeletePausedRequestsFromLoadBalancer()) {
-        requestManager.createLBCleanupRequest(requestId);
-      }
-
       requestManager.deleteCleanRequest(requestId, requestCleanup.getCleanupType());
     }
 
     LOG.info("Killed {} tasks (removed {} scheduled) in {}", numTasksKilled, numScheduledTasksRemoved, JavaUtils.duration(start));
+  }
+
+  private void createLbCleanupRequest(String requestId, Iterable<SingularityTaskId> matchingActiveTaskIds) {
+    Optional<String> maybeCurrentDeployId = deployManager.getInUseDeployId(requestId);
+    Optional<SingularityDeploy> maybeDeploy = Optional.absent();
+    if (maybeCurrentDeployId.isPresent()) {
+      maybeDeploy = deployManager.getDeploy(requestId, maybeCurrentDeployId.get());
+      if (maybeDeploy.isPresent()) {
+        List<String> taskIds = new ArrayList<>();
+        for (SingularityTaskId taskId : matchingActiveTaskIds) {
+          taskIds.add(taskId.getId());
+        }
+        requestManager.saveLBCleanupRequest(new SingularityRequestLbCleanup(requestId, maybeDeploy.get().getLoadBalancerGroups().get(), maybeDeploy.get().getServiceBasePath().get(), taskIds, Optional.<SingularityLoadBalancerUpdate>absent()));
+        return;
+      }
+    }
+    exceptionNotifier.notify("Insufficient data to create LB request cleanup", ImmutableMap.of("requestId", requestId, "deployId", maybeCurrentDeployId.toString(), "deploy", maybeDeploy.toString()));
   }
 
   private void bounce(SingularityRequestCleanup requestCleanup, final List<SingularityTaskId> activeTaskIds) {
@@ -273,8 +308,9 @@ public class SingularityCleaner {
   public void drainCleanupQueue() {
     drainRequestCleanupQueue();
     drainTaskCleanupQueue();
-    drainLBTaskCleanupQueue();
-    drainLBRequestCleanupQueue();
+    final List<SingularityTaskId> lbCleanupTasks = taskManager.getLBCleanupTasks();
+    drainLBTaskCleanupQueue(lbCleanupTasks);
+    drainLBRequestCleanupQueue(lbCleanupTasks);
     checkKilledTaskIdRecords();
   }
 
@@ -503,10 +539,8 @@ public class SingularityCleaner {
     return CheckLBState.WAITING;
   }
 
-  private void drainLBTaskCleanupQueue() {
+  private void drainLBTaskCleanupQueue(List<SingularityTaskId> lbCleanupTasks) {
     final long start = System.currentTimeMillis();
-
-    final List<SingularityTaskId> lbCleanupTasks = taskManager.getLBCleanupTasks();
 
     if (lbCleanupTasks.isEmpty()) {
       LOG.trace("LB task cleanup queue is empty");
@@ -544,10 +578,10 @@ public class SingularityCleaner {
     LOG.info("LB cleaned {} tasks ({} left, {} obsolete) in {}", cleanedTasks, lbCleanupTasks.size() - (ignoredTasks + cleanedTasks), ignoredTasks, JavaUtils.duration(start));
   }
 
-  private void drainLBRequestCleanupQueue() {
+  private void drainLBRequestCleanupQueue(List<SingularityTaskId> lbCleanupTasks) {
     final long start = System.currentTimeMillis();
 
-    final List<String> lbCleanupRequests = requestManager.getLBCleanupRequestIds();
+    final List<SingularityRequestLbCleanup> lbCleanupRequests = requestManager.getLbCleanupRequests();
 
     if (lbCleanupRequests.isEmpty()) {
       LOG.trace("LB request cleanup queue is empty");
@@ -559,12 +593,12 @@ public class SingularityCleaner {
     int cleanedRequests = 0;
     int ignoredRequests = 0;
 
-    for (String requestId : lbCleanupRequests) {
+    for (SingularityRequestLbCleanup cleanup : lbCleanupRequests) {
       final long checkStart = System.currentTimeMillis();
 
-      final CheckLBState checkLbState = checkRequestLbState(requestId);
+      final CheckLBState checkLbState = checkRequestLbState(cleanup, lbCleanupTasks);
 
-      LOG.debug("LB cleanup for request {} had state {} after {}", requestId, checkLbState, JavaUtils.duration(checkStart));
+      LOG.debug("LB cleanup for request {} had state {} after {}", cleanup.getRequestId(), checkLbState, JavaUtils.duration(checkStart));
 
       switch (checkLbState) {
         case WAITING:
@@ -579,42 +613,49 @@ public class SingularityCleaner {
           ignoredRequests++;
       }
 
-      requestManager.deleteLBCleanupRequest(requestId);
+      requestManager.deleteLBCleanupRequest(cleanup.getRequestId());
     }
     LOG.info("LB cleaned {} requests ({} left, {} obsolete) in {}", cleanedRequests, lbCleanupRequests.size() - (ignoredRequests + cleanedRequests), ignoredRequests, JavaUtils.duration(start));
 
   }
 
-  private CheckLBState checkRequestLbState(String requestId) {
-    Optional<SingularityLoadBalancerUpdate> maybeDeleteUpdate = requestManager.getLoadBalancerState(requestId);
+  private boolean  canRunRequestLbCleanup(SingularityRequestLbCleanup cleanup, List<SingularityTaskId> lbCleanupTasks) {
+    Optional<SingularityRequestWithState> maybeRequestWithState = requestManager.getRequest(cleanup.getRequestId());
+    if (maybeRequestWithState.isPresent() && SingularityRequestWithState.isActive(maybeRequestWithState)) {
+      LOG.trace("Request is still active, will wait for request lb cleanup");
+      return false;
+    }
+    for (String taskId : cleanup.getActiveTaskIds()) {
+      if (taskManager.isActiveTask(taskId)) {
+        LOG.trace("Request still has active tasks, will wait for lb request cleanup");
+        return false;
+      }
+    }
+    for (SingularityTaskId taskId : lbCleanupTasks) {
+      if (taskId.getRequestId().equals(cleanup.getRequestId())) {
+        LOG.trace("Waiting for task lb cleanup to finish before trying request lb cleanup for request {}", cleanup.getRequestId());
+        return false;
+      }
+    }
+    return true;
+  }
 
-    Optional<SingularityRequestWithState> maybeRequestWithState = requestManager.getRequest(requestId);
-
-    if (!maybeRequestWithState.isPresent()) {
-      exceptionNotifier.notify(String.format("LB delete failed for paused request %s, request data not found", requestId), ImmutableMap.of("requestId", requestId));
+  private CheckLBState checkRequestLbState(SingularityRequestLbCleanup cleanup, List<SingularityTaskId> lbCleanupTasks) {
+    if (!canRunRequestLbCleanup(cleanup , lbCleanupTasks)) {
       return CheckLBState.RETRY;
     }
 
-    final LoadBalancerRequestId loadBalancerRequestId = getLoadBalancerRequestId(requestId, maybeDeleteUpdate);
+    Optional<SingularityLoadBalancerUpdate> maybeDeleteUpdate = cleanup.getLoadBalancerUpdate();
+    final LoadBalancerRequestId loadBalancerRequestId = getLoadBalancerRequestId(cleanup.getRequestId(), maybeDeleteUpdate);
     SingularityLoadBalancerUpdate lbDeleteUpdate;
-
     if (shouldEnqueueLbRequest(maybeDeleteUpdate)) {
-      Optional<String> maybeCurrentDeployId = deployManager.getInUseDeployId(requestId);
-      Optional<SingularityDeploy> maybeDeploy = Optional.absent();
-      if (maybeCurrentDeployId.isPresent()) {
-        maybeDeploy = deployManager.getDeploy(requestId, maybeCurrentDeployId.get());
-      }
-      if (maybeDeploy.isPresent()) {
-        lbDeleteUpdate = lbClient.delete(loadBalancerRequestId, maybeRequestWithState.get().getRequest(), maybeDeploy.get());
-        requestManager.saveLoadBalancerState(requestId, lbDeleteUpdate);
-      } else {
-        exceptionNotifier.notify(String.format("LB delete failed for paused request %s, current deploy not found", requestId),
-          ImmutableMap.of("requestId", requestId, "currentDeployId", maybeCurrentDeployId.toString(), "currentDeploy", maybeDeploy.toString()));
-        return CheckLBState.RETRY;
-      }
+      lbDeleteUpdate = lbClient.delete(loadBalancerRequestId, cleanup.getRequestId(), cleanup.getLoadBalancerGroups(), cleanup.getServiceBasePath());
+      cleanup.setLoadBalancerUpdate(Optional.of(lbDeleteUpdate));
+      requestManager.saveLBCleanupRequest(cleanup);
     } else if (maybeDeleteUpdate.get().getLoadBalancerState() == BaragonRequestState.WAITING || maybeDeleteUpdate.get().getLoadBalancerState() == BaragonRequestState.CANCELING) {
       lbDeleteUpdate = lbClient.getState(loadBalancerRequestId);
-      requestManager.saveLoadBalancerState(requestId, lbDeleteUpdate);
+      cleanup.setLoadBalancerUpdate(Optional.of(lbDeleteUpdate));
+      requestManager.saveLBCleanupRequest(cleanup);
     } else {
       lbDeleteUpdate = maybeDeleteUpdate.get();
     }
@@ -644,13 +685,13 @@ public class SingularityCleaner {
 
   private LoadBalancerRequestId getLoadBalancerRequestId(String requestId, Optional<SingularityLoadBalancerUpdate> lbDeleteUpdate) {
     if (!lbDeleteUpdate.isPresent()) {
-      return new LoadBalancerRequestId(requestId, LoadBalancerRequestType.DELETE, Optional.<Integer> absent());
+      return new LoadBalancerRequestId(String.format("%s-%s", requestId, System.currentTimeMillis()), LoadBalancerRequestType.DELETE, Optional.<Integer>absent());
     }
 
     switch (lbDeleteUpdate.get().getLoadBalancerState()) {
       case FAILED:
       case CANCELED:
-        return new LoadBalancerRequestId(requestId, LoadBalancerRequestType.DELETE, Optional.of(lbDeleteUpdate.get().getLoadBalancerRequestId().getAttemptNumber() + 1));
+        return new LoadBalancerRequestId(String.format("%s-%s", requestId, System.currentTimeMillis()), LoadBalancerRequestType.DELETE, Optional.of(lbDeleteUpdate.get().getLoadBalancerRequestId().getAttemptNumber() + 1));
       default:
         return lbDeleteUpdate.get().getLoadBalancerRequestId();
     }

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/TestingLoadBalancerClient.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/TestingLoadBalancerClient.java
@@ -1,6 +1,7 @@
 package com.hubspot.singularity.scheduler;
 
 import java.util.List;
+import java.util.Set;
 
 import com.google.common.base.Optional;
 import com.hubspot.baragon.models.BaragonRequestState;
@@ -44,7 +45,7 @@ public class TestingLoadBalancerClient implements LoadBalancerClient {
   }
 
   @Override
-  public SingularityLoadBalancerUpdate delete(LoadBalancerRequestId loadBalancerRequestId, SingularityRequest request, SingularityDeploy deploy) {
+  public SingularityLoadBalancerUpdate delete(LoadBalancerRequestId loadBalancerRequestId, String requestId, Set<String> loadBalancerGroups, String serviceBasePath) {
     return getReturnValue(loadBalancerRequestId, LoadBalancerMethod.DELETE);
   }
 


### PR DESCRIPTION
After running the lb delete for requests awhile, noticed there were some edge cases and race conditions to take care of. This does the following:
- The request might have been removed and not paused -> removed, check the request history if we don't find the request at first
- We only need minimal information for an LB delete, save that when we create the cleanup request so we aren't fetching deploys/requests that have possibly been deleted
- If the task cleanup comes after the delete, it will recreate the lb service, make sure all tasks are killed and cleanup up before running lb request deletes