### PR TITLE
Docker shell commands

### DIFF
--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorMesosFrameworkMessageHandler.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorMesosFrameworkMessageHandler.java
@@ -17,6 +17,7 @@ import com.hubspot.singularity.executor.shells.SingularityExecutorShellCommandRu
 import com.hubspot.singularity.executor.shells.SingularityExecutorShellCommandUpdater;
 import com.hubspot.singularity.executor.task.SingularityExecutorTask;
 import com.hubspot.singularity.executor.task.SingularityExecutorTaskProcessCallable;
+import com.spotify.docker.client.DockerClient;
 
 public class SingularityExecutorMesosFrameworkMessageHandler {
 

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
@@ -247,6 +247,9 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
   @JsonProperty
   private String shellCommandUserPlaceholder = "{USER}";
 
+  @JsonProperty
+  private String shellCommandPidFile = ".shell_command_pid";
+
   public SingularityExecutorConfiguration() {
     super(Optional.of("singularity-executor.log"));
   }
@@ -607,6 +610,14 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
     this.shellCommandOutFile = shellCommandOutFile;
   }
 
+  public String getShellCommandPidFile() {
+    return shellCommandPidFile;
+  }
+
+  public void setShellCommandPidFile(String shellCommandPidFile) {
+    this.shellCommandPidFile = shellCommandPidFile;
+  }
+
   @Override
   public String toString() {
     return "SingularityExecutorConfiguration[" +
@@ -654,6 +665,7 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
             ", shellCommandOutFile='" + shellCommandOutFile + '\'' +
             ", shellCommandPidPlaceholder='" + shellCommandPidPlaceholder + '\'' +
             ", shellCommandUserPlaceholder='" + shellCommandUserPlaceholder + '\'' +
+            ", shellCommandPidFile='" + shellCommandPidFile + '\'' +
             ']';
   }
 

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/shells/SingularityExecutorShellCommandDescriptor.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/shells/SingularityExecutorShellCommandDescriptor.java
@@ -5,8 +5,10 @@ import java.util.List;
 
 import javax.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SingularityExecutorShellCommandDescriptor {
 
   @JsonProperty
@@ -21,6 +23,10 @@ public class SingularityExecutorShellCommandDescriptor {
   @JsonProperty
   @NotNull
   private List<SingularityExecutorShellCommandOptionDescriptor> options = Collections.emptyList();
+
+  @JsonProperty
+  @NotNull
+  private boolean switchUser = true;
 
   public List<SingularityExecutorShellCommandOptionDescriptor> getOptions() {
     return options;
@@ -46,4 +52,11 @@ public class SingularityExecutorShellCommandDescriptor {
     return command;
   }
 
+  public boolean isSwitchUser() {
+    return switchUser;
+  }
+
+  public void setSwitchUser(boolean switchUser) {
+    this.switchUser = switchUser;
+  }
 }


### PR DESCRIPTION
@tpetr make shell commands work in docker:
- There are often multiple processes in docker, read the pid we want to operate on from a file if it exists (i.e. so we can write the pid of a java process under a wrapper/supervisor to the file, and operate on the correct pid)
- if not otherwise specified, pid in the docker container will be 1
- add a `switchUser` configuration to the descriptor. Most times we will want the command to run as the same user as the task, so defaults to true. When true we will prepend the user switch already set in our config
- If the task is docker, the executor will insert a `docker exec (container id)` after the user switch (if in use). So now the only part of the command you specify in the config is the command itself, the executor takes care of the context