### PR TITLE
Prevent 'remove' from being double bound

### DIFF
--- a/SingularityUI/app/handlebarsHelpers.coffee
+++ b/SingularityUI/app/handlebarsHelpers.coffee
@@ -152,7 +152,7 @@ Handlebars.registerHelper 'isRunningState', (list, options) ->
             options.inverse(@)
 
 Handlebars.registerHelper 'isSingularityExecutor', (value, options) ->
-    if value.indexOf 'singularity-executor' != -1
+    if value and value.indexOf 'singularity-executor' != -1
         options.fn(@)
     else
         options.inverse(@)

--- a/SingularityUI/app/views/task.coffee
+++ b/SingularityUI/app/views/task.coffee
@@ -15,7 +15,6 @@ class TaskView extends View
         _.extend super,
             'click [data-action="viewObjectJSON"]': 'viewJson'
             'click [data-action="viewJsonProperty"]': 'viewJsonProperty'
-            'click [data-action="remove"]': 'killTask'
             'submit [data-action="runShell"]': 'executeCommand'
             'change [data-action="cmd"]': 'cmdSelected'
 
@@ -67,12 +66,6 @@ class TaskView extends View
                 modelClone.attributes[key].splice 0, modelClone.attributes[key].length, value[index]
 
         utils.viewJSON modelClone
-
-    killTask: (event) ->
-        taskModel = new Task id: @taskId
-        taskModel.promptKill =>
-            setTimeout (=> @trigger 'refreshrequest'), 1000
-
 
     executeCommand: (event) ->
         event.preventDefault()


### PR DESCRIPTION
The Kill Task button is already being bound to the action in the overview subview. Remove the redundant event in the parent view.
@tpetr 