### PR TITLE
Update scope in templates to be compatable with latest handlebars version

### DIFF
--- a/SingularityUI/app/templates/deployDetail/activeTasks.hbs
+++ b/SingularityUI/app/templates/deployDetail/activeTasks.hbs
@@ -53,9 +53,9 @@
                         <td class="hidden-xs">
                             {{timestampFromNow updatedAt}}
                         </td>
-                        {{log ../../config.finishedTaskLogPath}}
+                        {{log ../config.finishedTaskLogPath}}
                         <td class="hidden-xs actions-column">
-                            <a href="{{ appRoot }}/task/{{ taskId.id }}/tail/{{ substituteTaskId ../../config.finishedTaskLogPath taskId.id }}" title="Log">
+                            <a href="{{ appRoot }}/task/{{ taskId.id }}/tail/{{ substituteTaskId ../config.finishedTaskLogPath taskId.id }}" title="Log">
                                 ...
                             </a>
                         </td>

--- a/SingularityUI/app/templates/deployDetail/deployTasks.hbs
+++ b/SingularityUI/app/templates/deployDetail/deployTasks.hbs
@@ -53,9 +53,9 @@
                         <td class="hidden-xs">
                             {{timestampFromNow updatedAt}}
                         </td>
-                        {{log ../../config.finishedTaskLogPath}}
+                        {{log ../config.finishedTaskLogPath}}
                         <td class="hidden-xs actions-column">
-                            <a href="{{ appRoot }}/task/{{ taskId.id }}/tail/{{ substituteTaskId ../../config.finishedTaskLogPath taskId.id }}" title="Log">
+                            <a href="{{ appRoot }}/task/{{ taskId.id }}/tail/{{ substituteTaskId ../config.finishedTaskLogPath taskId.id }}" title="Log">
                                 ...
                             </a>
                         </td>

--- a/SingularityUI/app/templates/requestDetail/requestActiveTasks.hbs
+++ b/SingularityUI/app/templates/requestDetail/requestActiveTasks.hbs
@@ -40,7 +40,7 @@
                         {{timestampFromNow updatedAt}}
                     </td>
                     <td class="hidden-xs actions-column">
-                        <a href="{{ appRoot }}/task/{{ taskId.id }}/tail/{{ substituteTaskId ../../config.runningTaskLogPath taskId.id }}" title="Log">
+                        <a href="{{ appRoot }}/task/{{ taskId.id }}/tail/{{ substituteTaskId ../config.runningTaskLogPath taskId.id }}" title="Log">
                             ...
                         </a>
                     </td>

--- a/SingularityUI/app/templates/requestDetail/requestHistoricalTasks.hbs
+++ b/SingularityUI/app/templates/requestDetail/requestHistoricalTasks.hbs
@@ -55,7 +55,7 @@
                             {{timestampFromNow updatedAt}}
                         </td>
                         <td class="hidden-xs actions-column">
-                            <a href="{{ appRoot }}/task/{{ taskId.id }}/tail/{{ substituteTaskId ../../config.finishedTaskLogPath taskId.id }}" title="Log">
+                            <a href="{{ appRoot }}/task/{{ taskId.id }}/tail/{{ substituteTaskId ../config.finishedTaskLogPath taskId.id }}" title="Log">
                                 ···
                             </a>
                         </td>

--- a/SingularityUI/app/templates/tail.hbs
+++ b/SingularityUI/app/templates/tail.hbs
@@ -32,7 +32,7 @@
                             {{#ifEqual name ../filename}}
                                 <strong>{{ name }}</strong>
                             {{else}}
-                                <a href="{{appRoot}}/task/{{ ../../taskId }}/files/{{ path }}">
+                                <a href="{{appRoot}}/task/{{ ../taskId }}/files/{{ path }}">
                                     {{ name }}
                                 </a>
                             {{/ifEqual}}


### PR DESCRIPTION
Update scope refs in templates to be compatible with handlebars 4.0. 
More info on the change: https://github.com/wycats/handlebars.js/blob/master/release-notes.md#v400---september-1st-2015

The issue likely only surfaced recently due to dependencies being reinstalled for the first time since Sep. 1. handlebars-brunch is very loose with what version of handlebars in pulls in. 2.0< v. <=5.0 (?!?!?)

/cc @tpetr 