### PR TITLE
Bounce deny

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -209,7 +209,7 @@ public class RequestResource extends AbstractRequestResource {
     if (placement != SlavePlacement.GREEDY && placement != SlavePlacement.OPTIMISTIC) {
       int currentActiveSlaveCount = slaveManager.getNumObjectsAtState(MachineState.ACTIVE);
       int requiredSlaveCount = requestWithState.getRequest().getInstancesSafe() * 2;
-      checkBadRequest(currentActiveSlaveCount >= requiredSlaveCount, "Not enough slaves to successfully complete a bounce of reqeust %s (minimum required: %s, current: %s)", requestId, requiredSlaveCount, currentActiveSlaveCount);
+      checkBadRequest(currentActiveSlaveCount >= requiredSlaveCount, "Not enough active slaves to successfully complete a bounce of reqeust %s (minimum required: %s, current: %s). Consider deploying or changing the slave placement strategy instead", requestId, requiredSlaveCount, currentActiveSlaveCount);
     }
 
     SingularityCreateResult createResult = requestManager.createCleanupRequest(

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -209,7 +209,7 @@ public class RequestResource extends AbstractRequestResource {
     if (placement != SlavePlacement.GREEDY && placement != SlavePlacement.OPTIMISTIC) {
       int currentActiveSlaveCount = slaveManager.getNumObjectsAtState(MachineState.ACTIVE);
       int requiredSlaveCount = requestWithState.getRequest().getInstancesSafe() * 2;
-      checkBadRequest(currentActiveSlaveCount >= requiredSlaveCount, "Not enough active slaves to successfully complete a bounce of reqeust %s (minimum required: %s, current: %s). Consider deploying or changing the slave placement strategy instead", requestId, requiredSlaveCount, currentActiveSlaveCount);
+      checkBadRequest(currentActiveSlaveCount >= requiredSlaveCount, "Not enough active slaves to successfully complete a bounce of request %s (minimum required: %s, current: %s). Consider deploying or changing the slave placement strategy instead", requestId, requiredSlaveCount, currentActiveSlaveCount);
     }
 
     SingularityCreateResult createResult = requestManager.createCleanupRequest(

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -209,7 +209,7 @@ public class RequestResource extends AbstractRequestResource {
     if (placement != SlavePlacement.GREEDY && placement != SlavePlacement.OPTIMISTIC) {
       int currentActiveSlaveCount = slaveManager.getNumObjectsAtState(MachineState.ACTIVE);
       int requiredSlaveCount = requestWithState.getRequest().getInstancesSafe() * 2;
-      checkBadRequest(currentActiveSlaveCount >= requiredSlaveCount, "Not enough active slaves to successfully complete a bounce of request %s (minimum required: %s, current: %s). Consider deploying or changing the slave placement strategy instead", requestId, requiredSlaveCount, currentActiveSlaveCount);
+      checkBadRequest(currentActiveSlaveCount >= requiredSlaveCount, "Not enough active slaves to successfully complete a bounce of request %s (minimum required: %s, current: %s). Consider deploying or changing the slave placement strategy instead.", requestId, requiredSlaveCount, currentActiveSlaveCount);
     }
 
     SingularityCreateResult createResult = requestManager.createCleanupRequest(


### PR DESCRIPTION
For `OPTIMISTIC` and `GREEDY` it shouldn't matter. But, if placement is `SEPARATE*`, don't allow us to start a bounce we know we can't complete