### PR TITLE
Introduce an incremental bounce

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeployKey.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeployKey.java
@@ -26,6 +26,10 @@ public class SingularityDeployKey extends SingularityId {
     return new SingularityDeployKey(deployMarker.getRequestId(), deployMarker.getDeployId());
   }
 
+  public static SingularityDeployKey fromTaskId(SingularityTaskId taskId) {
+    return new SingularityDeployKey(taskId.getRequestId(), taskId.getDeployId());
+  }
+
   public static Map<SingularityDeployKey, SingularityDeploy> fromDeploys(Collection<SingularityDeploy> deploys) {
     return Maps.uniqueIndex(deploys, new Function<SingularityDeploy, SingularityDeployKey>() {
       @Override

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestCleanup.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestCleanup.java
@@ -7,7 +7,7 @@ import com.google.common.base.Optional;
 public class SingularityRequestCleanup {
 
   public enum RequestCleanupType {
-    DELETING, PAUSING, BOUNCE;
+    DELETING, PAUSING, BOUNCE, INCREMENTAL_BOUNCE;
   }
 
   private final Optional<String> user;

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskCleanup.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskCleanup.java
@@ -7,7 +7,7 @@ import com.google.common.base.Optional;
 public class SingularityTaskCleanup {
 
   public enum TaskCleanupType {
-    USER_REQUESTED(true, true), DECOMISSIONING(false, false), SCALING_DOWN(true, false), BOUNCING(false, false), DEPLOY_FAILED(true, true), NEW_DEPLOY_SUCCEEDED(true, false), DEPLOY_CANCELED(true, true), UNHEALTHY_NEW_TASK(true, true), OVERDUE_NEW_TASK(true, true);
+    USER_REQUESTED(true, true), DECOMISSIONING(false, false), SCALING_DOWN(true, false), BOUNCING(false, false), INCREMENTAL_BOUNCE(false, false), DEPLOY_FAILED(true, true), NEW_DEPLOY_SUCCEEDED(true, false), DEPLOY_CANCELED(true, true), UNHEALTHY_NEW_TASK(true, true), OVERDUE_NEW_TASK(true, true);
 
     private final boolean killLongRunningTaskInstantly;
     private final boolean killNonLongRunningTaskInstantly;

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -206,10 +206,10 @@ public class RequestResource extends AbstractRequestResource {
     checkConflict(requestWithState.getState() != RequestState.PAUSED, "Request %s is paused. Unable to bounce (it must be manually unpaused first)", requestWithState.getRequest().getId());
 
     SlavePlacement placement = requestWithState.getRequest().getSlavePlacement().or(configuration.getDefaultSlavePlacement());
-    if (!incremental && (placement != SlavePlacement.GREEDY && placement != SlavePlacement.OPTIMISTIC)) {
+    if (placement != SlavePlacement.GREEDY && placement != SlavePlacement.OPTIMISTIC) {
       int currentActiveSlaveCount = slaveManager.getNumObjectsAtState(MachineState.ACTIVE);
-      int requiredSlaveCount = requestWithState.getRequest().getInstancesSafe() * 2;
-      checkBadRequest(currentActiveSlaveCount >= requiredSlaveCount, "Not enough active slaves to successfully complete a bounce of request %s (minimum required: %s, current: %s). Consider deploying, doing an incremental bounce, or changing the slave placement strategy instead.", requestId, requiredSlaveCount, currentActiveSlaveCount);
+      int requiredSlaveCount = incremental ? requestWithState.getRequest().getInstancesSafe() + 1 : requestWithState.getRequest().getInstancesSafe() * 2;
+      checkBadRequest(currentActiveSlaveCount >= requiredSlaveCount, "Not enough active slaves to successfully complete a bounce of request %s (minimum required: %s, current: %s). Consider deploying, or changing the slave placement strategy instead.", requestId, requiredSlaveCount, currentActiveSlaveCount);
     }
 
     SingularityCreateResult createResult = requestManager.createCleanupRequest(

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -196,7 +196,7 @@ public class RequestResource extends AbstractRequestResource {
   @ApiOperation(value="Bounce a specific Singularity request. A bounce launches replacement task(s), and then kills the original task(s) if the replacement(s) are healthy.",
   response=SingularityRequestParent.class)
   public SingularityRequestParent bounce(@ApiParam("The request ID to bounce") @PathParam("requestId") String requestId,
-      @ApiParam("Incrementally bounce, shutting down old tasks as new ones are started successfully") @QueryParam("incremental") Optional<Boolean> incremental) {
+      @ApiParam("Incrementally bounce, shutting down old tasks as new ones are started successfully") @QueryParam("incremental") boolean incremental) {
     SingularityRequestWithState requestWithState = fetchRequestWithState(requestId);
 
     authorizationHelper.checkForAuthorization(requestWithState.getRequest(), user, SingularityAuthorizationScope.WRITE);
@@ -205,17 +205,15 @@ public class RequestResource extends AbstractRequestResource {
 
     checkConflict(requestWithState.getState() != RequestState.PAUSED, "Request %s is paused. Unable to bounce (it must be manually unpaused first)", requestWithState.getRequest().getId());
 
-    boolean isIncremental = incremental.or(false);
-
     SlavePlacement placement = requestWithState.getRequest().getSlavePlacement().or(configuration.getDefaultSlavePlacement());
-    if (!isIncremental && (placement != SlavePlacement.GREEDY && placement != SlavePlacement.OPTIMISTIC)) {
+    if (!incremental && (placement != SlavePlacement.GREEDY && placement != SlavePlacement.OPTIMISTIC)) {
       int currentActiveSlaveCount = slaveManager.getNumObjectsAtState(MachineState.ACTIVE);
       int requiredSlaveCount = requestWithState.getRequest().getInstancesSafe() * 2;
-      checkBadRequest(currentActiveSlaveCount >= requiredSlaveCount, "Not enough active slaves to successfully complete a bounce of request %s (minimum required: %s, current: %s). Consider deploying or changing the slave placement strategy instead.", requestId, requiredSlaveCount, currentActiveSlaveCount);
+      checkBadRequest(currentActiveSlaveCount >= requiredSlaveCount, "Not enough active slaves to successfully complete a bounce of request %s (minimum required: %s, current: %s). Consider deploying, doing an incremental bounce, or changing the slave placement strategy instead.", requestId, requiredSlaveCount, currentActiveSlaveCount);
     }
 
     SingularityCreateResult createResult = requestManager.createCleanupRequest(
-            new SingularityRequestCleanup(JavaUtils.getUserEmail(user), isIncremental ? RequestCleanupType.INCREMENTAL_BOUNCE : RequestCleanupType.BOUNCE, System.currentTimeMillis(), Optional.<Boolean>absent(), requestId, Optional.of(getAndCheckDeployId(requestId))));
+            new SingularityRequestCleanup(JavaUtils.getUserEmail(user), incremental ? RequestCleanupType.INCREMENTAL_BOUNCE : RequestCleanupType.BOUNCE, System.currentTimeMillis(), Optional.<Boolean>absent(), requestId, Optional.of(getAndCheckDeployId(requestId))));
 
     checkConflict(createResult != SingularityCreateResult.EXISTED, "%s is already bouncing", requestId);
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
@@ -133,7 +133,7 @@ public class SingularityCleaner {
     // For an incremental bounce, shut down old tasks as new ones are started
     if (taskCleanup.getCleanupType() == TaskCleanupType.INCREMENTAL_BOUNCE) {
       String key = String.format("%s-%s", taskCleanup.getTaskId().getRequestId(), taskCleanup.getTaskId().getDeployId());
-      int runningCleaningTasks = incrementalBounceRemainingInstanceMap.getOrDefault(key, 0);
+      int runningCleaningTasks = incrementalBounceRemainingInstanceMap.get(key) != null ? incrementalBounceRemainingInstanceMap.get(key) : 0;
       if (matchingTasks.size() + runningCleaningTasks > request.getInstancesSafe()) {
         if (runningCleaningTasks > 0) {
           int count = incrementalBounceRemainingInstanceMap.get(key);

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
@@ -392,7 +392,7 @@ public class SingularityCleaner {
       cleaningTasks.add(cleanupTask.getTaskId());
       if (cleanupTask.getCleanupType() == TaskCleanupType.INCREMENTAL_BOUNCE) {
         String key = String.format("%s-%s", cleanupTask.getTaskId().getRequestId(), cleanupTask.getTaskId().getDeployId());
-        if (incrementalBounceRemainingInstanceMap.containsKey(key)) {
+        if (!incrementalBounceRemainingInstanceMap.containsKey(key)) {
           incrementalBounceRemainingInstanceMap.put(key, 1);
         } else {
           int count = incrementalBounceRemainingInstanceMap.get(key);

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -1,6 +1,7 @@
 package com.hubspot.singularity.scheduler;
 
 import java.text.ParseException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -339,7 +340,8 @@ public class SingularityScheduler {
 
   private List<SingularityTaskId> getMatchingTaskIds(SingularitySchedulerStateCache stateCache, SingularityRequest request, SingularityPendingRequest pendingRequest) {
     if (request.isLongRunning()) {
-      Collection<SingularityTaskId> exclude = stateCache.getCleaningTasks();
+      Collection<SingularityTaskId> exclude = Sets.newHashSet();
+      exclude.addAll(stateCache.getCleaningTasks());
       exclude.addAll(stateCache.getKilledTasks());
       return SingularityTaskId.matchingAndNotIn(stateCache.getActiveTaskIds(), request.getId(), pendingRequest.getDeployId(), exclude);
     } else {

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -339,7 +339,9 @@ public class SingularityScheduler {
 
   private List<SingularityTaskId> getMatchingTaskIds(SingularitySchedulerStateCache stateCache, SingularityRequest request, SingularityPendingRequest pendingRequest) {
     if (request.isLongRunning()) {
-      return SingularityTaskId.matchingAndNotIn(stateCache.getActiveTaskIds(), request.getId(), pendingRequest.getDeployId(), stateCache.getCleaningTasks());
+      Collection<SingularityTaskId> exclude = stateCache.getCleaningTasks();
+      exclude.addAll(stateCache.getKilledTasks());
+      return SingularityTaskId.matchingAndNotIn(stateCache.getActiveTaskIds(), request.getId(), pendingRequest.getDeployId(), exclude);
     } else {
       return Lists.newArrayList(Iterables.filter(stateCache.getActiveTaskIds(), SingularityTaskId.matchingRequest(request.getId())));
     }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularitySchedulerStateCache.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularitySchedulerStateCache.java
@@ -86,7 +86,7 @@ public class SingularitySchedulerStateCache {
   public Collection<SingularityTaskId> getKilledTasks() {
     if (!killedTasks.isPresent()) {
       List<SingularityKilledTaskIdRecord> killedTaskRecords = taskManager.getKilledTaskIdRecords();
-      Collection<SingularityTaskId> taskIds = new ArrayList<>();
+      Collection<SingularityTaskId> taskIds = Sets.newHashSet();
       for (SingularityKilledTaskIdRecord record : killedTaskRecords) {
         taskIds.add(record.getTaskId());
       }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularitySchedulerStateCache.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularitySchedulerStateCache.java
@@ -1,5 +1,6 @@
 package com.hubspot.singularity.scheduler;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -9,6 +10,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.hubspot.singularity.MachineState;
+import com.hubspot.singularity.SingularityKilledTaskIdRecord;
 import com.hubspot.singularity.SingularityPendingTask;
 import com.hubspot.singularity.SingularityRack;
 import com.hubspot.singularity.SingularitySlave;
@@ -30,6 +32,7 @@ public class SingularitySchedulerStateCache {
   private Optional<Collection<SingularityTaskId>> activeTaskIds;
   private Optional<Collection<SingularityPendingTask>> scheduledTasks;
   private Optional<Collection<SingularityTaskId>> cleaningTasks;
+  private Optional<Collection<SingularityKilledTaskIdRecord>> killedTasks;
   private Optional<Integer> numActiveRacks;
   private Optional<Integer> numActiveSlaves;
 
@@ -42,6 +45,7 @@ public class SingularitySchedulerStateCache {
     activeTaskIds = Optional.absent();
     scheduledTasks = Optional.absent();
     cleaningTasks = Optional.absent();
+    killedTasks = Optional.absent();
     numActiveRacks = Optional.absent();
     numActiveSlaves = Optional.absent();
 
@@ -76,6 +80,17 @@ public class SingularitySchedulerStateCache {
     }
 
     return cleaningTasks.get();
+  }
+
+  public Collection<SingularityTaskId> getKilledTasks() {
+    if (!killedTasks.isPresent()) {
+      killedTasks = getMutableCollection(taskManager.getKilledTaskIdRecords());
+    }
+    Collection<SingularityTaskId> taskIds = new ArrayList<>();
+    for (SingularityKilledTaskIdRecord record : killedTasks.get()) {
+      taskIds.add(record.getTaskId());
+    }
+    return taskIds;
   }
 
   public int getNumActiveRacks() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularitySchedulerStateCache.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularitySchedulerStateCache.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
@@ -32,7 +33,7 @@ public class SingularitySchedulerStateCache {
   private Optional<Collection<SingularityTaskId>> activeTaskIds;
   private Optional<Collection<SingularityPendingTask>> scheduledTasks;
   private Optional<Collection<SingularityTaskId>> cleaningTasks;
-  private Optional<Collection<SingularityKilledTaskIdRecord>> killedTasks;
+  private Optional<Collection<SingularityTaskId>> killedTasks;
   private Optional<Integer> numActiveRacks;
   private Optional<Integer> numActiveSlaves;
 
@@ -84,13 +85,14 @@ public class SingularitySchedulerStateCache {
 
   public Collection<SingularityTaskId> getKilledTasks() {
     if (!killedTasks.isPresent()) {
-      killedTasks = getMutableCollection(taskManager.getKilledTaskIdRecords());
+      List<SingularityKilledTaskIdRecord> killedTaskRecords = taskManager.getKilledTaskIdRecords();
+      Collection<SingularityTaskId> taskIds = new ArrayList<>();
+      for (SingularityKilledTaskIdRecord record : killedTaskRecords) {
+        taskIds.add(record.getTaskId());
+      }
+      killedTasks = Optional.of(taskIds);
     }
-    Collection<SingularityTaskId> taskIds = new ArrayList<>();
-    for (SingularityKilledTaskIdRecord record : killedTasks.get()) {
-      taskIds.add(record.getTaskId());
-    }
-    return taskIds;
+    return killedTasks.get();
   }
 
   public int getNumActiveRacks() {

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -941,7 +941,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     SingularityTask taskTwo = startTask(firstDeploy, 2);
     SingularityTask taskThree = startTask(firstDeploy, 3);
 
-    requestResource.bounce(requestId, user);
+    requestResource.bounce(requestId, user, Optional.of(false));
 
     Assert.assertTrue(requestManager.cleanupRequestExists(requestId));
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -6,8 +6,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import javax.ws.rs.HEAD;
-
 import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.SlaveID;
 import org.apache.mesos.Protos.TaskID;
@@ -946,7 +944,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     SingularityTask taskTwo = startTask(firstDeploy, 2);
     SingularityTask taskThree = startTask(firstDeploy, 3);
 
-    requestResource.bounce(requestId, Optional.of(false));
+    requestResource.bounce(requestId, false);
 
     Assert.assertTrue(requestManager.cleanupRequestExists(requestId));
 

--- a/SingularityUI/app/models/Request.coffee
+++ b/SingularityUI/app/models/Request.coffee
@@ -90,9 +90,9 @@ class Request extends Model
               id:      @get "id"
               instances: confirmedOrPromptData
 
-    bounce: =>
+    bounce: (incremental) =>
         $.ajax
-            url:  "#{ @url() }/bounce?user=#{ app.getUsername() }"
+            url:  "#{ @url() }/bounce?user=#{ app.getUsername() }&incremental=#{ incremental }"
             type: "POST"
 
     exitCooldown: =>
@@ -249,7 +249,8 @@ class Request extends Model
             message: bounceTemplate id: @get "id"
             callback: (confirmed) =>
                 return if not confirmed
-                @bounce().done callback
+                incremental = $('.vex #incremental-bounce').is ':checked'
+                @bounce(incremental).done callback
 
     promptExitCooldown: (callback) =>
         vex.dialog.confirm

--- a/SingularityUI/app/templates/vex/requestBounce.hbs
+++ b/SingularityUI/app/templates/vex/requestBounce.hbs
@@ -2,6 +2,9 @@
 <pre>{{ id }}</pre>
 <p>
 	Bouncing a request will cause replacement tasks to be scheduled
-	(and under normal conditions) executed immediately. Existing
-	tasks will be killed once replacement tasks are deemed healthy.
+	(and under normal conditions) executed immediately.
 </p>
+<label for="incremental-bounce" id="incremental-bounce-label">
+    <input type="radio" name="incremental" value="false" checked> Kill old tasks once ALL new tasks are healthy<br>
+    <input type="radio" name="incremental" id="incremental-bounce" value="true"> Kill old tasks as new tasks become healthy
+</label>


### PR DESCRIPTION
Currently, in order to bounce a request which has `SEPARATE*` placement, you need to be running instance_count * 2 slaves. This can be quite a pain for requests with many instances. This PR creates a new type of bounce where we shut down old tasks as new ones are spun up (vs waiting for all new tasks to be ready first). Using this, you only need a minimum of instance_count + 1 slaves to bounce the same request