### PR TITLE
bake user query params into authentication system

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/mesos/JavaUtils.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/JavaUtils.java
@@ -37,6 +37,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.hubspot.jackson.datatype.protobuf.ProtobufModule;
+import com.hubspot.singularity.SingularityUser;
 
 public final class JavaUtils {
 
@@ -196,5 +197,11 @@ public final class JavaUtils {
     return string.replace("-", "_");
   }
 
-
+  public static final Optional<String> getUserEmail(Optional<SingularityUser> user) {
+    if (user.isPresent()) {
+      return user.get().getEmail();
+    } else {
+      return Optional.absent();
+    }
+  }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAuthDatastoreClass.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAuthDatastoreClass.java
@@ -2,11 +2,13 @@ package com.hubspot.singularity.auth;
 
 import com.hubspot.singularity.auth.datastore.SingularityAuthDatastore;
 import com.hubspot.singularity.auth.datastore.SingularityDisabledAuthDatastore;
+import com.hubspot.singularity.auth.datastore.SingularityDummyDatastore;
 import com.hubspot.singularity.auth.datastore.SingularityLDAPDatastore;
 
 public enum SingularityAuthDatastoreClass {
   LDAP(SingularityLDAPDatastore.class),
-  DISABLED(SingularityDisabledAuthDatastore.class);
+  DISABLED(SingularityDisabledAuthDatastore.class),
+  DUMMY(SingularityDummyDatastore.class);
 
   private final Class<? extends SingularityAuthDatastore> authDatastoreClass;
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAuthenticatorClass.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAuthenticatorClass.java
@@ -3,10 +3,12 @@ package com.hubspot.singularity.auth;
 import com.hubspot.singularity.auth.authenticator.SingularityAuthenticator;
 import com.hubspot.singularity.auth.authenticator.SingularityDisabledAuthenticator;
 import com.hubspot.singularity.auth.authenticator.SingularityHeaderPassthroughAuthenticator;
+import com.hubspot.singularity.auth.authenticator.SingularityQueryParamAuthenticator;
 
 public enum SingularityAuthenticatorClass {
   DISABLED(SingularityDisabledAuthenticator.class),
-  HEADER_PASSTHROUGH(SingularityHeaderPassthroughAuthenticator.class);
+  HEADER_PASSTHROUGH(SingularityHeaderPassthroughAuthenticator.class),
+  QUERYPARAM_PASSTHROUGH(SingularityQueryParamAuthenticator.class);
 
   private final Class<? extends SingularityAuthenticator> authenticatorClass;
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/authenticator/SingularityQueryParamAuthenticator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/authenticator/SingularityQueryParamAuthenticator.java
@@ -1,0 +1,33 @@
+package com.hubspot.singularity.auth.authenticator;
+
+import javax.servlet.http.HttpServletRequest;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Strings;
+import com.google.inject.Inject;
+import com.google.inject.servlet.RequestScoped;
+import com.hubspot.singularity.SingularityUser;
+import com.hubspot.singularity.auth.datastore.SingularityAuthDatastore;
+
+@RequestScoped
+public class SingularityQueryParamAuthenticator implements SingularityAuthenticator {
+  private final HttpServletRequest request;
+  private final SingularityAuthDatastore authDatastore;
+
+  @Inject
+  public SingularityQueryParamAuthenticator(HttpServletRequest request, SingularityAuthDatastore authDatastore) {
+    this.request = request;
+    this.authDatastore = authDatastore;
+  }
+
+  @Override
+  public Optional<SingularityUser> get() {
+    final Optional<String> maybeUser = Optional.fromNullable(Strings.emptyToNull(request.getParameter("user")));
+
+    if (maybeUser.isPresent()) {
+      return authDatastore.getUser(maybeUser.get());
+    } else {
+      return Optional.absent();
+    }
+  }
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/datastore/SingularityDummyDatastore.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/datastore/SingularityDummyDatastore.java
@@ -1,0 +1,25 @@
+package com.hubspot.singularity.auth.datastore;
+
+import java.util.Collections;
+
+import com.google.common.base.Optional;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.hubspot.singularity.SingularityUser;
+
+@Singleton
+public class SingularityDummyDatastore implements SingularityAuthDatastore {
+  @Inject
+  public SingularityDummyDatastore() {
+  }
+
+  @Override
+  public Optional<SingularityUser> getUser(String username) {
+    return Optional.of(new SingularityUser(username, Optional.of(username), Optional.of(username), Collections.<String>emptySet()));
+  }
+
+  @Override
+  public Optional<Boolean> isHealthy() {
+    return Optional.of(true);
+  }
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/AuthConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/AuthConfiguration.java
@@ -15,7 +15,7 @@ public class AuthConfiguration {
 
   @JsonProperty
   @NotNull
-  private SingularityAuthenticatorClass authenticator = SingularityAuthenticatorClass.DISABLED;
+  private SingularityAuthenticatorClass authenticator = SingularityAuthenticatorClass.QUERYPARAM_PASSTHROUGH;
 
   @JsonProperty
   @NotNull

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/AuthConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/AuthConfiguration.java
@@ -19,7 +19,7 @@ public class AuthConfiguration {
 
   @JsonProperty
   @NotNull
-  private SingularityAuthDatastoreClass datastore = SingularityAuthDatastoreClass.DISABLED;
+  private SingularityAuthDatastoreClass datastore = SingularityAuthDatastoreClass.DUMMY;
 
   @JsonProperty
   @NotNull

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/DeployResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/DeployResource.java
@@ -11,12 +11,12 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.hubspot.jackson.jaxrs.PropertyFiltering;
+import com.hubspot.mesos.JavaUtils;
 import com.hubspot.singularity.DeployState;
 import com.hubspot.singularity.RequestState;
 import com.hubspot.singularity.SingularityAuthorizationScope;
@@ -119,8 +119,7 @@ public class DeployResource extends AbstractRequestResource {
   })
   public SingularityRequestParent cancelDeploy(
       @ApiParam(required=true,  value="The Singularity Request Id from which the deployment is removed.") @PathParam("requestId") String requestId,
-      @ApiParam(required=true,  value="The Singularity Deploy Id that should be removed.") @PathParam("deployId") String deployId,
-      @ApiParam(required=false, value="The user which executes the delete request.") @QueryParam("user") Optional<String> queryUser) {
+      @ApiParam(required=true,  value="The Singularity Deploy Id that should be removed.") @PathParam("deployId") String deployId) {
     SingularityRequestWithState requestWithState = fetchRequestWithState(requestId);
 
     authorizationHelper.checkForAuthorization(requestWithState.getRequest(), user, SingularityAuthorizationScope.WRITE);
@@ -131,7 +130,7 @@ public class DeployResource extends AbstractRequestResource {
       throw badRequest("Request %s does not have a pending deploy %s", requestId, deployId);
     }
 
-    deployManager.createCancelDeployRequest(new SingularityDeployMarker(requestId, deployId, System.currentTimeMillis(), queryUser));
+    deployManager.createCancelDeployRequest(new SingularityDeployMarker(requestId, deployId, System.currentTimeMillis(), JavaUtils.getUserEmail(user)));
 
     return fillEntireRequest(requestWithState);
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RackResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RackResource.java
@@ -13,6 +13,7 @@ import javax.ws.rs.core.MediaType;
 
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
+import com.hubspot.mesos.JavaUtils;
 import com.hubspot.singularity.MachineState;
 import com.hubspot.singularity.SingularityMachineStateHistoryUpdate;
 import com.hubspot.singularity.SingularityRack;
@@ -59,40 +60,36 @@ public class RackResource extends AbstractMachineResource<SingularityRack> {
   @DELETE
   @Path("/rack/{rackId}")
   @ApiOperation("Remove a known rack, erasing history. This operation will cancel decomissioning of racks")
-  public void removeRack(@ApiParam("Rack ID") @PathParam("rackId") String rackId, @QueryParam("user") Optional<String> queryUser) {
+  public void removeRack(@ApiParam("Rack ID") @PathParam("rackId") String rackId) {
     super.remove(rackId);
   }
 
   @POST
   @Path("/rack/{rackId}/decomission")
   @Deprecated
-  public void decomissionRack(@ApiParam("Active rack ID") @PathParam("rackId") String rackId,
-      @ApiParam("User requesting the decommisioning") @QueryParam("user") Optional<String> queryUser) {
-    super.decommission(rackId, queryUser);
+  public void decomissionRack(@ApiParam("Active rack ID") @PathParam("rackId") String rackId) {
+    super.decommission(rackId, JavaUtils.getUserEmail(user));
   }
 
   @POST
   @Path("/rack/{rackId}/decommission")
   @ApiOperation("Begin decommissioning a specific active rack")
-  public void decommissionRack(@ApiParam("Active rack ID") @PathParam("rackId") String rackId,
-      @ApiParam("User requesting the decommisioning") @QueryParam("user") Optional<String> queryUser) {
-    super.decommission(rackId, queryUser);
+  public void decommissionRack(@ApiParam("Active rack ID") @PathParam("rackId") String rackId) {
+    super.decommission(rackId, JavaUtils.getUserEmail(user));
   }
 
   @POST
   @Path("/rack/{rackId}/freeze")
   @ApiOperation("Freeze a specific rack")
-  public void freezeRack(@ApiParam("Rack ID") @PathParam("rackId") String rackId,
-                               @ApiParam("User requesting the freeze") @QueryParam("user") Optional<String> user) {
-    super.freeze(rackId, user);
+  public void freezeRack(@ApiParam("Rack ID") @PathParam("rackId") String rackId) {
+    super.freeze(rackId, JavaUtils.getUserEmail(user));
   }
 
   @POST
   @Path("/rack/{rackId}/activate")
   @ApiOperation("Activate a decomissioning rack, canceling decomission without erasing history")
-  public void activateSlave(@ApiParam("Active rackId") @PathParam("rackId") String rackId,
-      @ApiParam("User requesting the activate") @QueryParam("user") Optional<String> queryUser) {
-    super.activate(rackId, queryUser);
+  public void activateSlave(@ApiParam("Active rackId") @PathParam("rackId") String rackId) {
+    super.activate(rackId, JavaUtils.getUserEmail(user));
   }
 
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/SlaveResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/SlaveResource.java
@@ -13,6 +13,7 @@ import javax.ws.rs.core.MediaType;
 
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
+import com.hubspot.mesos.JavaUtils;
 import com.hubspot.singularity.MachineState;
 import com.hubspot.singularity.SingularityMachineStateHistoryUpdate;
 import com.hubspot.singularity.SingularityService;
@@ -57,40 +58,36 @@ public class SlaveResource extends AbstractMachineResource<SingularitySlave> {
   @DELETE
   @Path("/slave/{slaveId}")
   @ApiOperation("Remove a known slave, erasing history. This operation will cancel decomissioning of the slave")
-  public void removeSlave(@ApiParam("Active SlaveId") @PathParam("slaveId") String slaveId, @QueryParam("user") Optional<String> queryUser) {
+  public void removeSlave(@ApiParam("Active SlaveId") @PathParam("slaveId") String slaveId) {
     super.remove(slaveId);
   }
 
   @POST
   @Path("/slave/{slaveId}/decomission")
   @Deprecated
-  public void decomissionSlave(@ApiParam("Active slaveId") @PathParam("slaveId") String slaveId,
-      @ApiParam("User requesting the decommisioning") @QueryParam("user") Optional<String> queryUser) {
-    super.decommission(slaveId, queryUser);
+  public void decomissionSlave(@ApiParam("Active slaveId") @PathParam("slaveId") String slaveId) {
+    super.decommission(slaveId, JavaUtils.getUserEmail(user));
   }
 
   @POST
   @Path("/slave/{slaveId}/decommission")
   @ApiOperation("Begin decommissioning a specific active slave")
-  public void decommissionSlave(@ApiParam("Active slaveId") @PathParam("slaveId") String slaveId,
-      @ApiParam("User requesting the decommisioning") @QueryParam("user") Optional<String> queryUser) {
-    super.decommission(slaveId, queryUser);
+  public void decommissionSlave(@ApiParam("Active slaveId") @PathParam("slaveId") String slaveId) {
+    super.decommission(slaveId, JavaUtils.getUserEmail(user));
   }
 
   @POST
   @Path("/slave/{slaveId}/freeze")
   @ApiOperation("Freeze tasks on a specific slave")
-  public void freezeSlave(@ApiParam("Slave ID") @PathParam("slaveId") String slaveId,
-                          @ApiParam("User requesting the freeze") @QueryParam("user") Optional<String> user) {
-    super.freeze(slaveId, user);
+  public void freezeSlave(@ApiParam("Slave ID") @PathParam("slaveId") String slaveId) {
+    super.freeze(slaveId, JavaUtils.getUserEmail(user));
   }
 
   @POST
   @Path("/slave/{slaveId}/activate")
   @ApiOperation("Activate a decomissioning slave, canceling decomission without erasing history")
-  public void activateSlave(@ApiParam("Active slaveId") @PathParam("slaveId") String slaveId,
-      @ApiParam("User requesting the activate") @QueryParam("user") Optional<String> queryUser) {
-    super.activate(slaveId, queryUser);
+  public void activateSlave(@ApiParam("Active slaveId") @PathParam("slaveId") String slaveId) {
+    super.activate(slaveId, JavaUtils.getUserEmail(user));
   }
 
 }

--- a/SingularityService/src/test/java/com/hubspot/singularity/SingularityHistoryPurgerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/SingularityHistoryPurgerTest.java
@@ -174,18 +174,14 @@ public class SingularityHistoryPurgerTest extends SingularitySchedulerTestBase {
     initFirstDeploy();
 
     String runId = "my-run-id";
-    String user = "my-user";
-    testAuthenticator.setUser(Optional.of(new SingularityUser("", Optional.<String>absent(), Optional.of(user), Collections.<String>emptySet())));
 
     SingularityPendingRequestParent parent = requestResource.scheduleImmediately(requestId, Optional.of(runId), Collections.<String> emptyList());
 
     Assert.assertEquals(runId, parent.getPendingRequest().getRunId().get());
-    Assert.assertEquals(user, parent.getPendingRequest().getUser().get());
 
     resourceOffers();
 
     Assert.assertEquals(runId, taskManager.getActiveTasks().get(0).getTaskRequest().getPendingTask().getRunId().get());
-    Assert.assertEquals(user, taskManager.getActiveTasks().get(0).getTaskRequest().getPendingTask().getUser().get());
 
     SingularityTaskId taskId = taskManager.getActiveTaskIds().get(0);
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/SingularityHistoryPurgerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/SingularityHistoryPurgerTest.java
@@ -45,6 +45,9 @@ public class SingularityHistoryPurgerTest extends SingularitySchedulerTestBase {
   @Inject
   protected SingularityTaskHistoryPersister taskHistoryPersister;
 
+  @Inject
+  protected SingularityTestAuthenticator testAuthenticator;
+
   public SingularityHistoryPurgerTest() {
     super(true);
   }
@@ -172,8 +175,9 @@ public class SingularityHistoryPurgerTest extends SingularitySchedulerTestBase {
 
     String runId = "my-run-id";
     String user = "my-user";
+    testAuthenticator.setUser(Optional.of(new SingularityUser("", Optional.<String>absent(), Optional.of(user), Collections.<String>emptySet())));
 
-    SingularityPendingRequestParent parent = requestResource.scheduleImmediately(requestId, Optional.of(user), Optional.of(runId), Collections.<String> emptyList());
+    SingularityPendingRequestParent parent = requestResource.scheduleImmediately(requestId, Optional.of(runId), Collections.<String> emptyList());
 
     Assert.assertEquals(runId, parent.getPendingRequest().getRunId().get());
     Assert.assertEquals(user, parent.getPendingRequest().getUser().get());
@@ -192,7 +196,7 @@ public class SingularityHistoryPurgerTest extends SingularitySchedulerTestBase {
     Assert.assertEquals(runId, historyManager.getTaskHistory(taskId.getId()).get().getTask().getTaskRequest().getPendingTask().getRunId().get());
     Assert.assertEquals(runId, historyManager.getTaskHistoryForRequest(requestId, 0, 10).get(0).getRunId().get());
 
-    parent = requestResource.scheduleImmediately(requestId, Optional.<String> absent(), Optional.<String> absent(), Collections.<String> emptyList());
+    parent = requestResource.scheduleImmediately(requestId, Optional.<String> absent(), Collections.<String> emptyList());
 
     Assert.assertTrue(parent.getPendingRequest().getRunId().isPresent());
   }
@@ -205,7 +209,7 @@ public class SingularityHistoryPurgerTest extends SingularitySchedulerTestBase {
     initScheduledRequest();
     initFirstDeploy();
 
-    requestResource.scheduleImmediately(requestId, Optional.<String>absent(), Optional.<String>absent(), Collections.<String>emptyList());
+    requestResource.scheduleImmediately(requestId, Optional.<String>absent(), Collections.<String>emptyList());
 
     resourceOffers();
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/SingularityTestAuthenticator.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/SingularityTestAuthenticator.java
@@ -1,0 +1,23 @@
+package com.hubspot.singularity;
+
+import com.google.common.base.Optional;
+import com.google.inject.Inject;
+import com.hubspot.singularity.auth.authenticator.SingularityAuthenticator;
+
+public class SingularityTestAuthenticator implements SingularityAuthenticator {
+  private Optional<SingularityUser> user = Optional.absent();
+
+  @Inject
+  public SingularityTestAuthenticator() {
+
+  }
+
+  @Override
+  public Optional<SingularityUser> get() {
+    return user;
+  }
+
+  public void setUser(Optional<SingularityUser> user) {
+    this.user = user;
+  }
+}

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityStartupTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityStartupTest.java
@@ -111,7 +111,7 @@ public class SingularityStartupTest extends SingularitySchedulerTestBase {
     boolean caughtException = false;
 
     try {
-      requestResource.scheduleImmediately(requestId,  Optional.<String> absent(), Optional.<String> absent(), null);
+      requestResource.scheduleImmediately(requestId, Optional.<String> absent(), null);
     } catch (Exception e) {
       caughtException = true;
     }

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityTaskShellCommandTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityTaskShellCommandTest.java
@@ -71,19 +71,19 @@ public class SingularityTaskShellCommandTest extends SingularitySchedulerTestBas
 
     // bad shell cmd
     try {
-      taskResource.runShellCommand(task.getTaskId().getId(), user, new SingularityShellCommand("test-cmd", Optional.of(Arrays.asList("one", "two")), user));
+      taskResource.runShellCommand(task.getTaskId().getId(), new SingularityShellCommand("test-cmd", Optional.of(Arrays.asList("one", "two")), user));
     } catch (WebApplicationException exception) {
       assertEquals(403, exception.getResponse().getStatus());
     }
 
     // bad option
     try {
-      taskResource.runShellCommand(task.getTaskId().getId(), user, new SingularityShellCommand("d1", Optional.of(Arrays.asList("one", "two")), user));
+      taskResource.runShellCommand(task.getTaskId().getId(), new SingularityShellCommand("d1", Optional.of(Arrays.asList("one", "two")), user));
     } catch (WebApplicationException exception) {
       assertEquals(400, exception.getResponse().getStatus());
     }
 
-    SingularityTaskShellCommandRequest firstShellRequest = taskResource.runShellCommand(task.getTaskId().getId(), user, new SingularityShellCommand("d1", Optional.of(Arrays.asList("o1", "o2")), user));
+    SingularityTaskShellCommandRequest firstShellRequest = taskResource.runShellCommand(task.getTaskId().getId(), new SingularityShellCommand("d1", Optional.of(Arrays.asList("o1", "o2")), user));
 
     try {
       Thread.sleep(3);
@@ -91,7 +91,7 @@ public class SingularityTaskShellCommandTest extends SingularitySchedulerTestBas
 
     }
 
-    SingularityTaskShellCommandRequest secondShellRequest = taskResource.runShellCommand(task.getTaskId().getId(), user, new SingularityShellCommand("d2", Optional.<List<String>> absent(), user));
+    SingularityTaskShellCommandRequest secondShellRequest = taskResource.runShellCommand(task.getTaskId().getId(), new SingularityShellCommand("d2", Optional.<List<String>> absent(), user));
 
     assertEquals(2, taskManager.getAllQueuedTaskShellCommandRequests().size());
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -209,7 +209,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     SingularityTask firstTask = launchTask(request, firstDeploy, 1, TaskState.TASK_RUNNING);
     createAndSchedulePendingTask(firstDeployId);
 
-    requestResource.pause(requestId, Optional.<String> absent(), Optional.of(new SingularityPauseRequest(Optional.of("testuser"), Optional.of(false))));
+    requestResource.pause(requestId, Optional.of(new SingularityPauseRequest(Optional.of("testuser"), Optional.of(false))));
 
     cleaner.drainCleanupQueue();
 
@@ -230,7 +230,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
 
     SingularityTask firstTask = launchTask(request, firstDeploy, 1, TaskState.TASK_RUNNING);
 
-    requestResource.deleteRequest(requestId, Optional.<String> absent());
+    requestResource.deleteRequest(requestId);
 
     Assert.assertTrue(requestManager.getCleanupRequests().size() == 1);
 
@@ -279,7 +279,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     initRequest();
     initFirstDeploy();
 
-    requestResource.submit(request.toBuilder().setInstances(Optional.of(3)).build(), Optional.<String>absent());
+    requestResource.submit(request.toBuilder().setInstances(Optional.of(3)).build());
     scheduler.drainPendingQueue(stateCacheProvider.get());
 
     List<Offer> oneOffer = Arrays.asList(createOffer(12, 1024));
@@ -295,7 +295,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     initRequest();
     initFirstDeploy();
 
-    requestResource.submit(request.toBuilder().setInstances(Optional.of(10)).build(), Optional.<String>absent());
+    requestResource.submit(request.toBuilder().setInstances(Optional.of(10)).build());
     scheduler.drainPendingQueue(stateCacheProvider.get());
 
     sms.resourceOffers(driver, Arrays.asList(createOffer(2, 1024), createOffer(1, 1024)));
@@ -309,7 +309,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     initRequest();
     initFirstDeploy();
 
-    requestResource.submit(request.toBuilder().setInstances(Optional.of(15)).build(), Optional.<String> absent());
+    requestResource.submit(request.toBuilder().setInstances(Optional.of(15)).build());
     scheduler.drainPendingQueue(stateCacheProvider.get());
 
     sms.resourceOffers(driver, Arrays.asList(createOffer(20, 1024), createOffer(20, 1024)));
@@ -333,7 +333,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     schedule = "*/1 * * * * ? 1995";
 
     // cause it to be pending
-    requestResource.submit(request.toBuilder().setQuartzSchedule(Optional.of(schedule)).build(), Optional.<String> absent());
+    requestResource.submit(request.toBuilder().setQuartzSchedule(Optional.of(schedule)).build());
     scheduler.drainPendingQueue(stateCacheProvider.get());
 
     Assert.assertTrue(requestResource.getActiveRequests().isEmpty());
@@ -341,7 +341,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     Assert.assertTrue(taskManager.getPendingTaskIds().isEmpty());
 
     schedule = "*/1 * * * * ?";
-    requestResource.submit(request.toBuilder().setQuartzSchedule(Optional.of(schedule)).build(), Optional.<String>absent());
+    requestResource.submit(request.toBuilder().setQuartzSchedule(Optional.of(schedule)).build());
     scheduler.drainPendingQueue(stateCacheProvider.get());
 
     Assert.assertTrue(!requestResource.getActiveRequests().isEmpty());
@@ -372,7 +372,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
   @Test
   public void testOneOffsDontRunByThemselves() {
     SingularityRequestBuilder bldr = new SingularityRequestBuilder(requestId, RequestType.ON_DEMAND);
-    requestResource.submit(bldr.build(), Optional.<String> absent());
+    requestResource.submit(bldr.build());
     Assert.assertTrue(requestManager.getPendingRequests().isEmpty());
 
     deploy("d2");
@@ -382,7 +382,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
 
     Assert.assertTrue(requestManager.getPendingRequests().isEmpty());
 
-    requestResource.scheduleImmediately(requestId, user, Optional.<String> absent(), Collections.<String> emptyList());
+    requestResource.scheduleImmediately(requestId, Optional.<String> absent(), Collections.<String> emptyList());
 
     resourceOffers();
 
@@ -394,7 +394,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     Assert.assertEquals(0, taskManager.getActiveTaskIds().size());
     Assert.assertEquals(0, taskManager.getPendingTaskIds().size());
 
-    requestResource.scheduleImmediately(requestId, user, Optional.<String> absent(), Collections.<String> emptyList());
+    requestResource.scheduleImmediately(requestId, Optional.<String> absent(), Collections.<String> emptyList());
 
     resourceOffers();
 
@@ -410,10 +410,10 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
   @Test
   public void testOneOffsDontMoveDuringDecomission() {
     SingularityRequestBuilder bldr = new SingularityRequestBuilder(requestId, RequestType.ON_DEMAND);
-    requestResource.submit(bldr.build(), Optional.<String> absent());
+    requestResource.submit(bldr.build());
     deploy("d2");
 
-    requestResource.scheduleImmediately(requestId, user, Optional.<String> absent(), Collections.<String> emptyList());
+    requestResource.scheduleImmediately(requestId, Optional.<String> absent(), Collections.<String> emptyList());
 
     validateTaskDoesntMoveDuringDecommission();
   }
@@ -933,7 +933,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
   public void testBounce() {
     initRequest();
 
-    requestResource.updateInstances(requestId, Optional.<String> absent(), new SingularityRequestInstances(requestId, Optional.of(3)));
+    requestResource.updateInstances(requestId, new SingularityRequestInstances(requestId, Optional.of(3)));
 
     initFirstDeploy();
 
@@ -941,7 +941,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     SingularityTask taskTwo = startTask(firstDeploy, 2);
     SingularityTask taskThree = startTask(firstDeploy, 3);
 
-    requestResource.bounce(requestId, user);
+    requestResource.bounce(requestId);
 
     Assert.assertTrue(requestManager.cleanupRequestExists(requestId));
 
@@ -1185,7 +1185,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
 
     Assert.assertEquals(0, taskManager.getTasksOnSlave(taskManager.getActiveTaskIds(), slaveManager.getObject("slave1").get()).size());
 
-    slaveResource.activateSlave("slave1", Optional.of("user2"));
+    slaveResource.activateSlave("slave1");
 
     sms.resourceOffers(driver, Arrays.asList(createOffer(1, 129, "slave1", "host1", Optional.of("rack1"))));
 
@@ -1246,25 +1246,25 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
   @Test
   public void testOnDemandTasksPersist() {
     SingularityRequestBuilder bldr = new SingularityRequestBuilder(requestId, RequestType.ON_DEMAND);
-    requestResource.submit(bldr.build(), Optional.<String> absent());
+    requestResource.submit(bldr.build());
     deploy("d2");
     deployChecker.checkDeploys();
 
-    requestResource.scheduleImmediately(requestId, user, Optional.<String> absent(), Collections.<String> emptyList());
+    requestResource.scheduleImmediately(requestId, Optional.<String> absent(), Collections.<String> emptyList());
 
     resourceOffers();
 
-    requestResource.scheduleImmediately(requestId, user, Optional.<String> absent(), Collections.<String> emptyList());
+    requestResource.scheduleImmediately(requestId, Optional.<String> absent(), Collections.<String> emptyList());
 
     resourceOffers();
 
     Assert.assertEquals(2, taskManager.getActiveTaskIds().size());
 
-    requestResource.scheduleImmediately(requestId, user, Optional.<String> absent(), Collections.<String> emptyList());
+    requestResource.scheduleImmediately(requestId, Optional.<String> absent(), Collections.<String> emptyList());
 
     scheduler.drainPendingQueue(stateCacheProvider.get());
 
-    requestResource.scheduleImmediately(requestId, user, Optional.<String> absent(), Collections.<String> emptyList());
+    requestResource.scheduleImmediately(requestId, Optional.<String> absent(), Collections.<String> emptyList());
 
     scheduler.drainPendingQueue(stateCacheProvider.get());
 
@@ -1318,7 +1318,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
 
     Assert.assertEquals(5, taskManager.getActiveTaskIds().size());
 
-    requestResource.updateInstances(requestId, Optional.of("user1"), new SingularityRequestInstances(requestId, Optional.of(2)));
+    requestResource.updateInstances(requestId, new SingularityRequestInstances(requestId, Optional.of(2)));
 
     resourceOffers();
     cleaner.drainCleanupQueue();
@@ -1602,7 +1602,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     initRequest();
     initFirstDeploy();
 
-    requestResource.submit(request.toBuilder().setInstances(Optional.of(20)).build(), Optional.<String> absent());
+    requestResource.submit(request.toBuilder().setInstances(Optional.of(20)).build());
     scheduler.drainPendingQueue(stateCacheProvider.get());
 
     sms.resourceOffers(driver, Arrays.asList(createOffer(36, 12024)));

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityTestModule.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityTestModule.java
@@ -26,6 +26,7 @@ import com.google.inject.Binder;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
+import com.google.inject.Scopes;
 import com.google.inject.Stage;
 import com.google.inject.TypeLiteral;
 import com.google.inject.util.Modules;
@@ -36,6 +37,8 @@ import com.hubspot.singularity.SingularityAbort;
 import com.hubspot.singularity.SingularityAuthModule;
 import com.hubspot.singularity.SingularityMainModule;
 import com.hubspot.singularity.SingularityTaskId;
+import com.hubspot.singularity.SingularityTestAuthenticator;
+import com.hubspot.singularity.auth.authenticator.SingularityAuthenticator;
 import com.hubspot.singularity.config.MesosConfiguration;
 import com.hubspot.singularity.config.SMTPConfiguration;
 import com.hubspot.singularity.config.SentryConfiguration;
@@ -189,7 +192,14 @@ public class SingularityTestModule implements Module {
     mainBinder.install(new SingularityZkMigrationsModule());
     mainBinder.install(new SingularityMesosClientModule());
     mainBinder.install(new SingularityEventModule(configuration));
-    mainBinder.install(new SingularityAuthModule(configuration));
+    mainBinder.install(Modules.override(new SingularityAuthModule(configuration))
+            .with(new Module() {
+              @Override
+              public void configure(Binder binder) {
+                binder.bind(SingularityAuthenticator.class).to(SingularityTestAuthenticator.class);
+                binder.bind(SingularityTestAuthenticator.class).in(Scopes.SINGLETON);
+              }
+            }));
 
     mainBinder.bind(DeployResource.class);
     mainBinder.bind(RequestResource.class);


### PR DESCRIPTION
the `?user=email` authentication scheme is good for when people are trying Singularity out (i.e. they want to record that user X did an action, but dont want to set up LDAP yet), but required littering all our resource methods with `@QueryParam("user")`, which began to get nasty.

At the same time, many of our resource methods just record the action taker based on the `?user=` field, and ignore the injected `Optional<SingularityUser>` completely, which can be completely wrong!

This PR:
 - Adds `SingularityQueryParamAuthenticator`, which keys off of the `user` query param
 - Adds `SingularityDummyDatastore`, which always yields a user based off a username with no groups defined for it
 - Removed all usage of `@QueryParam("user")` in favor of using the injected `Optional<SingularityUser>`

Once this is merged, #759 will function properly.