### PR TITLE
time-box the docker client to avoid ever getting stuck

### DIFF
--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorThreadChecker.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorThreadChecker.java
@@ -18,6 +18,7 @@ import com.google.common.base.Charsets;
 import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.common.util.concurrent.UncheckedTimeoutException;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.hubspot.mesos.JavaUtils;
@@ -124,6 +125,8 @@ public class SingularityExecutorThreadChecker {
         }
       } catch (DockerException e) {
         throw new ProcessFailedException(String.format("Could not get docker root pid due to error: %s", e));
+      } catch (UncheckedTimeoutException te) {
+        throw new ProcessFailedException("Timed out trying to reach docker daemon");
       }
     }
 

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorThreadChecker.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorThreadChecker.java
@@ -126,7 +126,7 @@ public class SingularityExecutorThreadChecker {
       } catch (DockerException e) {
         throw new ProcessFailedException(String.format("Could not get docker root pid due to error: %s", e));
       } catch (UncheckedTimeoutException te) {
-        throw new ProcessFailedException("Timed out trying to reach docker daemon");
+        throw new ProcessFailedException(String.format("Timed out trying to reach docker daemon after %s seconds", configuration.getDockerClientTimeLimitSeconds()));
       }
     }
 

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
@@ -200,6 +200,9 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
   @JsonProperty
   private List<String> shellCommandPrefix = Collections.emptyList();
 
+  @JsonProperty
+  private Optional<Integer> dockerClientTimeLimitMs = Optional.absent();
+
   public SingularityExecutorConfiguration() {
     super(Optional.of("singularity-executor.log"));
   }
@@ -576,6 +579,14 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
     this.shellCommandPrefix = shellCommandPrefix;
   }
 
+  public Optional<Integer> getDockerClientTimeLimitMs() {
+    return dockerClientTimeLimitMs;
+  }
+
+  public void setDockerClientTimeLimitMs(Optional<Integer> dockerClientTimeLimitMs) {
+    this.dockerClientTimeLimitMs = dockerClientTimeLimitMs;
+  }
+
   @Override
   public String toString() {
     return "SingularityExecutorConfiguration[" +
@@ -625,6 +636,7 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
             ", shellCommandUserPlaceholder='" + shellCommandUserPlaceholder + '\'' +
             ", shellCommandPidFile='" + shellCommandPidFile + '\'' +
             ", shellCommandPrefix='" + shellCommandPrefix + '\'' +
+            ", dockerClientTimeLimitMs='" + dockerClientTimeLimitMs + '\'' +
             ']';
   }
 }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
@@ -201,7 +201,7 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
   private List<String> shellCommandPrefix = Collections.emptyList();
 
   @JsonProperty
-  private Optional<Integer> dockerClientTimeLimitMs = Optional.absent();
+  private Optional<Integer> dockerClientTimeLimitSeconds = Optional.absent();
 
   public SingularityExecutorConfiguration() {
     super(Optional.of("singularity-executor.log"));
@@ -579,12 +579,12 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
     this.shellCommandPrefix = shellCommandPrefix;
   }
 
-  public Optional<Integer> getDockerClientTimeLimitMs() {
-    return dockerClientTimeLimitMs;
+  public Optional<Integer> getDockerClientTimeLimitSeconds() {
+    return dockerClientTimeLimitSeconds;
   }
 
-  public void setDockerClientTimeLimitMs(Optional<Integer> dockerClientTimeLimitMs) {
-    this.dockerClientTimeLimitMs = dockerClientTimeLimitMs;
+  public void setDockerClientTimeLimitSeconds(Optional<Integer> dockerClientTimeLimitMs) {
+    this.dockerClientTimeLimitSeconds = dockerClientTimeLimitMs;
   }
 
   @Override
@@ -636,7 +636,7 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
             ", shellCommandUserPlaceholder='" + shellCommandUserPlaceholder + '\'' +
             ", shellCommandPidFile='" + shellCommandPidFile + '\'' +
             ", shellCommandPrefix='" + shellCommandPrefix + '\'' +
-            ", dockerClientTimeLimitMs='" + dockerClientTimeLimitMs + '\'' +
+            ", dockerClientTimeLimitMs='" + dockerClientTimeLimitSeconds + '\'' +
             ']';
   }
 }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorModule.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorModule.java
@@ -88,9 +88,9 @@ public class SingularityExecutorModule extends AbstractModule {
   @Provides
   @Singleton
   public DockerClient providesDockerClient(SingularityExecutorConfiguration configuration) {
-    if (configuration.getDockerClientTimeLimitMs().isPresent()) {
+    if (configuration.getDockerClientTimeLimitSeconds().isPresent()) {
       TimeLimiter limiter = new SimpleTimeLimiter();
-      return limiter.newProxy(new DefaultDockerClient("unix:///var/run/docker.sock"), DockerClient.class, configuration.getDockerClientTimeLimitMs().get(), TimeUnit.MILLISECONDS);
+      return limiter.newProxy(new DefaultDockerClient("unix:///var/run/docker.sock"), DockerClient.class, configuration.getDockerClientTimeLimitSeconds().get(), TimeUnit.SECONDS);
     } else {
       return new DefaultDockerClient("unix:///var/run/docker.sock");
     }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorModule.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorModule.java
@@ -1,10 +1,13 @@
 package com.hubspot.singularity.executor.config;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Template;
+import com.google.common.util.concurrent.SimpleTimeLimiter;
+import com.google.common.util.concurrent.TimeLimiter;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
@@ -84,8 +87,13 @@ public class SingularityExecutorModule extends AbstractModule {
 
   @Provides
   @Singleton
-  public DockerClient providesDockerClient() {
-    return new DefaultDockerClient("unix:///var/run/docker.sock");
+  public DockerClient providesDockerClient(SingularityExecutorConfiguration configuration) {
+    if (configuration.getDockerClientTimeLimitMs().isPresent()) {
+      TimeLimiter limiter = new SimpleTimeLimiter();
+      return limiter.newProxy(new DefaultDockerClient("unix:///var/run/docker.sock"), DockerClient.class, configuration.getDockerClientTimeLimitMs().get(), TimeUnit.MILLISECONDS);
+    } else {
+      return new DefaultDockerClient("unix:///var/run/docker.sock");
+    }
   }
 
   @Provides

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskCleanup.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskCleanup.java
@@ -121,15 +121,15 @@ public class SingularityExecutorTaskCleanup {
         dockerClient.stopContainer(containerName, configuration.getDockerStopTimeout());
       }
       dockerClient.removeContainer(containerName);
-      log.info(String.format("Removed container %s", containerName));
+      log.info("Removed container {}", containerName);
       return true;
     } catch (ContainerNotFoundException e) {
-      log.info(String.format("Container %s was already removed", containerName));
+      log.info("Container {} was already removed", containerName);
       return true;
     } catch (UncheckedTimeoutException te) {
-      log.error(String.format("Timed out trying to reach docker daemon after %s seconds", configuration.getDockerClientTimeLimitSeconds()), te);
+      log.error("Timed out trying to reach docker daemon after {} seconds", configuration.getDockerClientTimeLimitSeconds(), te);
     } catch (Exception e) {
-      log.info(String.format("Could not ensure removal of docker container due to error %s", e));
+      log.info("Could not ensure removal of docker container", e);
     }
     return false;
   }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskCleanup.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskCleanup.java
@@ -127,7 +127,7 @@ public class SingularityExecutorTaskCleanup {
       log.info(String.format("Container %s was already removed", containerName));
       return true;
     } catch (UncheckedTimeoutException te) {
-      log.error("Timed out trying to reach docker daemon", te);
+      log.error(String.format("Timed out trying to reach docker daemon after %s seconds", configuration.getDockerClientTimeLimitSeconds()), te);
     } catch (Exception e) {
       log.info(String.format("Could not ensure removal of docker container due to error %s", e));
     }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskCleanup.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskCleanup.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.slf4j.Logger;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.UncheckedTimeoutException;
 import com.hubspot.singularity.executor.config.SingularityExecutorConfiguration;
 import com.hubspot.singularity.runner.base.shared.SimpleProcessManager;
 import com.spotify.docker.client.ContainerNotFoundException;
@@ -125,6 +126,8 @@ public class SingularityExecutorTaskCleanup {
     } catch (ContainerNotFoundException e) {
       log.info(String.format("Container %s was already removed", containerName));
       return true;
+    } catch (UncheckedTimeoutException te) {
+      log.error("Timed out trying to reach docker daemon", te);
     } catch (Exception e) {
       log.info(String.format("Could not ensure removal of docker container due to error %s", e));
     }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskProcessBuilder.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskProcessBuilder.java
@@ -9,6 +9,7 @@ import org.apache.mesos.Protos.TaskState;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.UncheckedTimeoutException;
 import com.hubspot.deploy.ExecutorData;
 import com.hubspot.singularity.executor.TemplateManager;
 import com.hubspot.singularity.executor.config.SingularityExecutorConfiguration;
@@ -17,6 +18,7 @@ import com.hubspot.singularity.executor.models.EnvironmentContext;
 import com.hubspot.singularity.executor.models.RunnerContext;
 import com.hubspot.singularity.executor.task.SingularityExecutorArtifactFetcher.SingularityExecutorTaskArtifactFetcher;
 import com.hubspot.singularity.executor.utils.ExecutorUtils;
+import com.hubspot.singularity.runner.base.shared.ProcessFailedException;
 import com.spotify.docker.client.DockerClient;
 
 public class SingularityExecutorTaskProcessBuilder implements Callable<ProcessBuilder> {
@@ -60,7 +62,11 @@ public class SingularityExecutorTaskProcessBuilder implements Callable<ProcessBu
   public ProcessBuilder call() throws Exception {
     if (task.getTaskInfo().hasContainer() && task.getTaskInfo().getContainer().hasDocker()) {
       executorUtils.sendStatusUpdate(task.getDriver(), task.getTaskInfo(), TaskState.TASK_STARTING, String.format("Pulling image... (executor pid: %s)", executorPid), task.getLog());
-      dockerClient.pull(task.getTaskInfo().getContainer().getDocker().getImage());
+      try {
+        dockerClient.pull(task.getTaskInfo().getContainer().getDocker().getImage());
+      } catch (UncheckedTimeoutException te) {
+        throw new ProcessFailedException(String.format("Timed out trying to reach docker daemon after %s seconds", configuration.getDockerClientTimeLimitSeconds()));
+      }
     }
 
     executorUtils.sendStatusUpdate(task.getDriver(), task.getTaskInfo(), TaskState.TASK_STARTING, String.format("Staging files... (executor pid: %s)", executorPid), task.getLog());


### PR DESCRIPTION
It seems that we can get into an odd state when contacting the docker daemon. Even with the appropriate timeouts (default apache client in this case) set, we can still get into a situation where we try to contact the docker daemon then hang there forever. While the root problem lies in the docker daemon, it shouldn't stop the executor from being able to shut down properly.

This optionally creates a time limit for all calls using the docker daemon to avoid things hanging and causing an executor process that will simply wait forever doing nothing.