### PR TITLE
tweaks to make grepping a file easier

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosFileChunkObject.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosFileChunkObject.java
@@ -4,15 +4,18 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Optional;
 
 public class MesosFileChunkObject {
   private final String data;
   private final long offset;
+  private final Optional<Long> nextOffset;
 
   @JsonCreator
-  public MesosFileChunkObject(@JsonProperty("data") String data, @JsonProperty("offset") long offset) {
+  public MesosFileChunkObject(@JsonProperty("data") String data, @JsonProperty("offset") long offset, @JsonProperty("nextOffset") Optional<Long> nextOffset) {
     this.data = data;
     this.offset = offset;
+    this.nextOffset = nextOffset;
   }
 
   public String getData() {
@@ -23,11 +26,16 @@ public class MesosFileChunkObject {
     return offset;
   }
 
+  public Optional<Long> getNextOffset() {
+    return nextOffset;
+  }
+
   @Override
   public String toString() {
     return "MesosFileChunkObject[" +
             "data='" + data + '\'' +
             ", offset=" + offset +
+            ", nextOffset=" + nextOffset +
             ']';
   }
 
@@ -41,11 +49,12 @@ public class MesosFileChunkObject {
     }
     MesosFileChunkObject that = (MesosFileChunkObject) o;
     return Objects.equals(offset, that.offset) &&
-            Objects.equals(data, that.data);
+            Objects.equals(data, that.data) &&
+            Objects.equals(nextOffset, that.nextOffset);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(data, offset);
+    return Objects.hash(data, offset, nextOffset);
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/SandboxResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/SandboxResource.java
@@ -19,6 +19,7 @@ import javax.ws.rs.core.MediaType;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
@@ -139,7 +140,7 @@ public class SandboxResource extends AbstractHistoryResource {
 
       checkNotFound(maybeChunk.isPresent(), "File %s does not exist for task ID %s", fullPath, taskId);
 
-      if (grep.isPresent()) {
+      if (grep.isPresent() && !Strings.isNullOrEmpty(grep.get())) {
         final Pattern grepPattern = Pattern.compile(grep.get());
         final StringBuilder strBuilder = new StringBuilder(maybeChunk.get().getData().length());
 
@@ -150,7 +151,7 @@ public class SandboxResource extends AbstractHistoryResource {
           }
         }
 
-        return new MesosFileChunkObject(strBuilder.toString(), maybeChunk.get().getOffset());
+        return new MesosFileChunkObject(strBuilder.toString(), maybeChunk.get().getOffset(), Optional.of(maybeChunk.get().getOffset() + maybeChunk.get().getData().length()));
       }
 
       return maybeChunk.get();


### PR DESCRIPTION
- Don't grep if the grep query param is empty
- Add optional `nextOffset` field to `MesosFileChunkObject`, and if grepping, relay what the next file offset should be (needed for the UI). If `nextOffset` is not set, it's safe to assume the next offset you should grab is `offset + data.length`.

/cc @kwm4385 