### PR TITLE
if a task failed due to healthchecks, always show info on last healthcheck

### DIFF
--- a/SingularityUI/app/templates/taskDetail/taskHealthcheckNotification.hbs
+++ b/SingularityUI/app/templates/taskDetail/taskHealthcheckNotification.hbs
@@ -49,4 +49,12 @@
             {{/ifGT}}
             {{/if}}
         </div>
+    {{else}}
+    {{#if lastHealthcheckFailed}}
+        {{#with data.healthcheckResults.[0]}}
+        <div class="alert alert-warning" role="alert">
+            <b>Task failed due to no passing healthchecks:</b> Last healthcheck {{#if statusCode}}responded with <span class="label label-danger">HTTP {{statusCode}}</span>{{else}}did not respond{{/if}}{{#if durationMillis}} in {{durationMillis}}ms{{/if}} at {{timestampFormattedWithSeconds timestamp}}. <a href="#health-checks" data-action="viewHealthchecks">View all healthchecks.</a>
+        </div>
+        {{/with}}
+    {{/if}}
     {{/if}}

--- a/SingularityUI/app/views/taskHealthcheckNotificationSubview.coffee
+++ b/SingularityUI/app/views/taskHealthcheckNotificationSubview.coffee
@@ -24,6 +24,7 @@ class taskHealthcheckNotificationSubview extends View
         data:             @model.toJSON()
         isDeployPending:  !!deployStatus
         hasSuccessfulHealthcheck: @model.get('healthcheckResults')?.length > 0 and _.find(@model.get('healthcheckResults'), (item) -> item.statusCode is 200)
+        lastHealthcheckFailed: @model.get('healthcheckResults')?.length > 0 and @model.get('healthcheckResults')[0].statusCode isnt 200
         synced:           @model.synced
 
     triggerToggleHealthchecks: ->


### PR DESCRIPTION
It's sometimes hard to diagnose why a deploy fails -- making it obvious when a task failed due to healthchecks should help.