### PR TITLE
show paused requests in dashboard view

### DIFF
--- a/SingularityUI/app/templates/dashboard.hbs
+++ b/SingularityUI/app/templates/dashboard.hbs
@@ -89,6 +89,16 @@
                 </div>
             </div>
         </div>
+        <div class="row">
+            <div class="col-md-12">
+                <div class="page-header">
+                    <h2>My paused requests</h2>
+                </div>
+                {{#with pausedRequests}}
+                {{> requestsPausedBody}}
+                {{/with}}
+            </div>
+        </div>
     {{/if}}
     <div class="row">
         <div class="col-md-12 table-staged">

--- a/SingularityUI/app/views/dashboard.coffee
+++ b/SingularityUI/app/views/dashboard.coffee
@@ -38,6 +38,7 @@ class DashboardView extends View
                 requests: pausedRequests
                 haveRequests: pausedRequests.length > 0
                 requestsSubFilter: ''
+                collectionSynced: @collection.synced
 
         @$el.html @templateBase context, partials
         @renderTable()

--- a/SingularityUI/app/views/dashboard.coffee
+++ b/SingularityUI/app/views/dashboard.coffee
@@ -4,6 +4,7 @@ class DashboardView extends View
 
     templateBase: require '../templates/dashboard'
     templateRequestsTable: require '../templates/dashboardTable/dashboardStarred'
+    templateRequestsPausedBody: require '../templates/requestsTable/requestsPausedBody'
 
     events: ->
         _.extend super,
@@ -21,15 +22,22 @@ class DashboardView extends View
         partials =
             partials:
                 requestsBody: @templateRequestsTable
+                requestsPausedBody: @templateRequestsPausedBody
 
         # Count up the Requests for the clicky boxes
         userRequestTotals = @collection.getUserRequestTotals deployUser
+
+        pausedRequests = _.map(_.filter(@collection.getUserRequests(app.getUsername()), (r) -> r.get('state') is 'PAUSED'), (r) -> r.toJSON())
 
         context =
             deployUser: deployUser
             collectionSynced: @collection.synced
             userRequestTotals: userRequestTotals or { }
             haveStarredRequests: @collection.getStarredOnly().length
+            pausedRequests:
+                requests: pausedRequests
+                haveRequests: pausedRequests.length > 0
+                requestsSubFilter: ''
 
         @$el.html @templateBase context, partials
         @renderTable()


### PR DESCRIPTION
Makes it easier to keep an eye on old paused requests that could be deleted.