### PR TITLE
validation constraints for config classes

### DIFF
--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
@@ -143,6 +143,7 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
   @JsonProperty
   private String s3UploaderBucket;
 
+  @NotEmpty
   @JsonProperty
   private boolean useLocalDownloadService = false;
 
@@ -157,6 +158,7 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
   @JsonProperty
   private String dockerPrefix = "se-";
 
+  @NotNull
   @JsonProperty
   private int dockerStopTimeout = 15;
 
@@ -186,15 +188,19 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
   @JsonProperty
   public List<SingularityExecutorShellCommandDescriptor> shellCommands = Collections.emptyList();
 
+  @NotEmpty
   @JsonProperty
   public String shellCommandOutFile = "executor.commands.{TIMESTAMP}.log";
 
+  @NotEmpty
   @JsonProperty
   private String shellCommandPidPlaceholder = "{PID}";
 
+  @NotEmpty
   @JsonProperty
   private String shellCommandUserPlaceholder = "{USER}";
 
+  @NotEmpty
   @JsonProperty
   private String shellCommandPidFile = ".task-pid";
 

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
@@ -143,7 +143,6 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
   @JsonProperty
   private String s3UploaderBucket;
 
-  @NotEmpty
   @JsonProperty
   private boolean useLocalDownloadService = false;
 
@@ -158,7 +157,7 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
   @JsonProperty
   private String dockerPrefix = "se-";
 
-  @NotNull
+  @Min(5)
   @JsonProperty
   private int dockerStopTimeout = 15;
 

--- a/SingularityOOMKiller/src/main/java/com/hubspot/singularity/oomkiller/config/SingularityOOMKillerConfiguration.java
+++ b/SingularityOOMKiller/src/main/java/com/hubspot/singularity/oomkiller/config/SingularityOOMKillerConfiguration.java
@@ -1,6 +1,7 @@
 package com.hubspot.singularity.oomkiller.config;
 
 import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
 
 import org.hibernate.validator.constraints.NotEmpty;
 
@@ -11,9 +12,11 @@ import com.hubspot.singularity.runner.base.configuration.Configuration;
 
 @Configuration(filename = "/etc/singularity.oomkiller.yaml", consolidatedField = "oomkiller")
 public class SingularityOOMKillerConfiguration extends BaseRunnerConfiguration {
+  @NotNull
   @JsonProperty
   private double requestKillThresholdRatio = 1.0;
 
+  @NotNull
   @JsonProperty
   private double killProcessDirectlyThresholdRatio = 1.2;
 

--- a/SingularityOOMKiller/src/main/java/com/hubspot/singularity/oomkiller/config/SingularityOOMKillerConfiguration.java
+++ b/SingularityOOMKiller/src/main/java/com/hubspot/singularity/oomkiller/config/SingularityOOMKillerConfiguration.java
@@ -12,11 +12,11 @@ import com.hubspot.singularity.runner.base.configuration.Configuration;
 
 @Configuration(filename = "/etc/singularity.oomkiller.yaml", consolidatedField = "oomkiller")
 public class SingularityOOMKillerConfiguration extends BaseRunnerConfiguration {
-  @NotNull
+  @Min(1)
   @JsonProperty
   private double requestKillThresholdRatio = 1.0;
 
-  @NotNull
+  @Min(1)
   @JsonProperty
   private double killProcessDirectlyThresholdRatio = 1.2;
 

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/config/SingularityS3UploaderConfiguration.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/config/SingularityS3UploaderConfiguration.java
@@ -42,15 +42,19 @@ public class SingularityS3UploaderConfiguration extends BaseRunnerConfiguration 
   @Obfuscate
   private Optional<String> s3SecretKey = Optional.absent();
 
+  @NotNull
   @JsonProperty
   private long maxSingleUploadSizeBytes = 5368709120L;
 
+  @NotNull
   @JsonProperty
   private long uploadPartSize = 20971520L;
 
+  @NotNull
   @JsonProperty
   private int retryWaitMs = 1000;
 
+  @NotNull
   @JsonProperty
   private int retryCount = 2;
 

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/config/SingularityS3UploaderConfiguration.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/config/SingularityS3UploaderConfiguration.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
@@ -42,19 +43,19 @@ public class SingularityS3UploaderConfiguration extends BaseRunnerConfiguration 
   @Obfuscate
   private Optional<String> s3SecretKey = Optional.absent();
 
-  @NotNull
+  @Max(5368709120L)
   @JsonProperty
   private long maxSingleUploadSizeBytes = 5368709120L;
 
-  @NotNull
+  @Min(5242880L)
   @JsonProperty
   private long uploadPartSize = 20971520L;
 
-  @NotNull
+  @Min(500)
   @JsonProperty
   private int retryWaitMs = 1000;
 
-  @NotNull
+  @Min(0)
   @JsonProperty
   private int retryCount = 2;
 

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/config/SingularityS3UploaderConfiguration.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/config/SingularityS3UploaderConfiguration.java
@@ -44,7 +44,7 @@ public class SingularityS3UploaderConfiguration extends BaseRunnerConfiguration 
   private Optional<String> s3SecretKey = Optional.absent();
 
   @Max(5368709120L)
-  @Min(0)
+  @Min(5242880L)
   @JsonProperty
   private long maxSingleUploadSizeBytes = 5368709120L;
 

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/config/SingularityS3UploaderConfiguration.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/config/SingularityS3UploaderConfiguration.java
@@ -44,6 +44,7 @@ public class SingularityS3UploaderConfiguration extends BaseRunnerConfiguration 
   private Optional<String> s3SecretKey = Optional.absent();
 
   @Max(5368709120L)
+  @Min(0)
   @JsonProperty
   private long maxSingleUploadSizeBytes = 5368709120L;
 
@@ -51,7 +52,7 @@ public class SingularityS3UploaderConfiguration extends BaseRunnerConfiguration 
   @JsonProperty
   private long uploadPartSize = 20971520L;
 
-  @Min(500)
+  @Min(0)
   @JsonProperty
   private int retryWaitMs = 1000;
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/GraphiteConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/GraphiteConfiguration.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import javax.validation.constraints.NotNull;
 
+import org.hibernate.validator.constraints.NotEmpty;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class GraphiteConfiguration {
@@ -12,6 +14,7 @@ public class GraphiteConfiguration {
   @JsonProperty
   private boolean enabled = false;
 
+  @NotEmpty
   @JsonProperty
   private String hostname;
 
@@ -26,6 +29,7 @@ public class GraphiteConfiguration {
   @NotNull
   private String hostnameOmitSuffix = "";
 
+  @NotNull
   @JsonProperty
   private int periodSeconds = 60;
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/GraphiteConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/GraphiteConfiguration.java
@@ -5,8 +5,6 @@ import java.util.List;
 
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class GraphiteConfiguration {

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/GraphiteConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/GraphiteConfiguration.java
@@ -3,6 +3,7 @@ package com.hubspot.singularity.config;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -26,7 +27,7 @@ public class GraphiteConfiguration {
   @NotNull
   private String hostnameOmitSuffix = "";
 
-  @NotNull
+  @Min(15)
   @JsonProperty
   private int periodSeconds = 60;
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/GraphiteConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/GraphiteConfiguration.java
@@ -14,7 +14,6 @@ public class GraphiteConfiguration {
   @JsonProperty
   private boolean enabled = false;
 
-  @NotEmpty
   @JsonProperty
   private String hostname;
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -161,9 +161,11 @@ public class SingularityConfiguration extends Configuration {
   private long saveStateEverySeconds = 60;
 
   @JsonProperty("sentry")
+  @Valid
   private SentryConfiguration sentryConfiguration;
 
   @JsonProperty("smtp")
+  @Valid
   private SMTPConfiguration smtpConfiguration;
 
   private long startNewReconcileEverySeconds = TimeUnit.MINUTES.toSeconds(10);
@@ -206,10 +208,12 @@ public class SingularityConfiguration extends Configuration {
 
   @JsonProperty("auth")
   @NotNull
+  @Valid
   private AuthConfiguration authConfiguration = new AuthConfiguration();
 
   @JsonProperty("graphite")
   @NotNull
+  @Valid
   private GraphiteConfiguration graphiteConfiguration = new GraphiteConfiguration();
 
   public long getAskDriverToKillTasksAgainAfterMillis() {


### PR DESCRIPTION
Some are probably overkill, but adding in the extra `@NotNull` and `@NotEmpty` to be consistent with what we are doing elsewhere. Will take one more pass at this before I move it up through the branches