### PR TITLE
(logfetch) make a silent mode, activate if not a tty

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -46,6 +46,7 @@ Two commands exist for downloading logs.
 |-U, --use-cache|Don't redownload live logs, prefer the cached version|false|
 |--search|Run logsearch on the cache of local files (no downloading)|false|
 |-V, --verbose|More verbose output|false|
+|--silent|No output except for log content, overrides -V|false|
 
 ##Grep and Log Files
 When the `-g` option is set, the log fetcher will grep the downloaded files for the provided regex.
@@ -109,7 +110,8 @@ You can also provide the `-g` option which will provide the grep string to the s
 |-u, --singularity-uri-base|Base url for singularity (e.g. `localhost:8080/singularity/v2/api`)|Must be set!|
 |-g, --grep|Grep string or full command for searching output||
 |-l, --logfile|Log file path to tail (ie logs/access.log)|Must be set!|
-|-v, --verbose|Extra output about the task id associated with logs in the output|False|
+|-V, --verbose|Extra output about the task id associated with logs in the output|False|
+|--silent|No output except for log content, overrides -V|false|
 
 #Logsearch
 
@@ -130,7 +132,8 @@ An offline version of `logfetch` that will aid in searching through your directo
 |-p, --file-pattern|Should match the executor.s3.uploader.pattern setting, determines if we can match on file name for s3 logs|`%requestId/%Y/%m/%taskId_%index-%s-%filename`|
 |-g, --grep|Grep string for searching log files(Only for `logfetch`)||
 |-l, --logtype|Glob matcher for type of log file to download| None (match all)|
-|-V, --verbose|More verbose output||
+|-V, --verbose|More verbose output|false|
+|--silent|No output except for log content, overrides -V|false|
 
 example:
 

--- a/scripts/logfetch/callbacks.py
+++ b/scripts/logfetch/callbacks.py
@@ -6,7 +6,7 @@ goal = 0
 
 CALLBACK_FORMAT = '{0}/{1}'
 
-def update_progress_bar(progress):
+def update_progress_bar(silent, progress):
   bar_length = 30
   global goal
   percent = float(progress) / goal
@@ -20,11 +20,12 @@ def update_progress_bar(progress):
     color = 'yellow'
   else:
     color = 'blue'
-  sys.stderr.write("\rDownload Progress: [" + colored("{0}".format(hashes + spaces), color) + "] {0}%".format(int(round(percent * 100))))
-  sys.stderr.flush()
+  if not silent: 
+    sys.stderr.write("\rDownload Progress: [" + colored("{0}".format(hashes + spaces), color) + "] {0}%".format(int(round(percent * 100))))
+    sys.stderr.flush()
 
 
-def generate_callback(request, destination, filename, chunk_size, verbose):
+def generate_callback(request, destination, filename, chunk_size, verbose, silent):
   path = CALLBACK_FORMAT.format(destination, filename) if destination else filename
 
   def callback(response, **kwargs):
@@ -34,9 +35,9 @@ def generate_callback(request, destination, filename, chunk_size, verbose):
       for chunk in response.iter_content(chunk_size):
         f.write(chunk)
       progress += 1
-      if verbose:
+      if verbose and not silent:
         sys.stderr.write(colored('Downloaded log {0}/{1} '.format(progress, goal), 'green') + colored(path, 'white') + '\n')
       else:
-        update_progress_bar(progress)
+        update_progress_bar(silent, progress)
 
   return callback

--- a/scripts/logfetch/cat.py
+++ b/scripts/logfetch/cat.py
@@ -6,10 +6,10 @@ def cat_files(args, all_logs):
     if all_logs:
         all_logs.sort()
         for log in all_logs:
-        	if not args.silent:
-            	sys.stderr.write(colored(log, 'cyan') + '\n')
-            command = 'cat {0}'.format(log)
-            sys.stdout.write(os.popen(command).read() + '\n')
+          if not args.silent:
+            sys.stderr.write(colored(log, 'cyan') + '\n')
+          command = 'cat {0}'.format(log)
+          sys.stdout.write(os.popen(command).read() + '\n')
     else:
         if not args.silent:
-        	sys.stderr.write(colored('No log files found\n', 'magenta'))
+          sys.stderr.write(colored('No log files found\n', 'magenta'))

--- a/scripts/logfetch/cat.py
+++ b/scripts/logfetch/cat.py
@@ -6,8 +6,10 @@ def cat_files(args, all_logs):
     if all_logs:
         all_logs.sort()
         for log in all_logs:
-            sys.stderr.write(colored(log, 'cyan') + '\n')
+        	if not args.silent:
+            	sys.stderr.write(colored(log, 'cyan') + '\n')
             command = 'cat {0}'.format(log)
             sys.stdout.write(os.popen(command).read() + '\n')
     else:
-        sys.stderr.write(colored('No log files found\n', 'magenta'))
+        if not args.silent:
+        	sys.stderr.write(colored('No log files found\n', 'magenta'))

--- a/scripts/logfetch/entrypoint.py
+++ b/scripts/logfetch/entrypoint.py
@@ -25,6 +25,8 @@ DEFAULT_TASK_COUNT = 20
 DEFAULT_DAYS = 7
 DEFAULT_S3_PATTERN = '%requestId/%%Y/%m/%taskId_%index-%s-%filename'
 
+IS_A_TTY = sys.stdout.isatty()
+
 def exit(reason, color='red'):
   sys.stderr.write(colored(reason, color) + '\n')
   sys.exit(1)
@@ -145,8 +147,12 @@ def fetch():
   parser.add_argument("-U", "--use-cache", dest="use_cache", help="Use cache for live logs, don't re-download them", action='store_true')
   parser.add_argument("--search", dest="search", help="run logsearch on the local cache of downloaded files", action='store_true')
   parser.add_argument("-V", "--verbose", dest="verbose", help="Print more verbose output", action='store_true')
+  parser.add_argument("--silent", dest="silent", help="No stderr (progress, file names, etc) output", action='store_true')
 
   args = parser.parse_args(remaining_argv)
+
+  if not IS_A_TTY:
+    args.silent = True
 
   check_args(args)
   args.start = convert_to_date(args, args.start, True)
@@ -156,7 +162,8 @@ def fetch():
   try:
     setattr(args, 'headers', dict(config.items("Request Headers")))
   except:
-    sys.stderr.write('No additional request headers found\n')
+    if not args.silent:
+      sys.stderr.write('No additional request headers found\n')
     setattr(args, 'headers', {})
 
   if args.search:
@@ -202,11 +209,16 @@ def search():
   parser.add_argument("-g", "--grep", dest="grep", help="Regex to grep for (normal grep syntax) or a full grep command")
   parser.add_argument("-z", "--local-zone", dest="zone", help="If specified, input times in the local time zone and convert to UTC, if not specified inputs are assumed to be UTC", action="store_true")
   parser.add_argument("-V", "--verbose", dest="verbose", help="Print more verbose output", action='store_true')
+  parser.add_argument("--silent", dest="silent", help="No stderr (progress, file names, etc) output", action='store_true')
 
   args, unknown = parser.parse_known_args(remaining_argv)
 
+  if not IS_A_TTY:
+    args.silent = True
+
   if args.verbose and unknown:
-    sys.stderr.write(colored('Found unknown args {0}'.format(unknown), 'magenta'))
+    if not args.silent:
+      sys.stderr.write(colored('Found unknown args {0}'.format(unknown), 'magenta'))
 
   check_args(args)
   args.start = convert_to_date(args, args.start, True)
@@ -264,8 +276,12 @@ def cat():
   parser.add_argument("-L", "--skip-live", dest="skip_live", help="Don't download/search live logs", action='store_true')
   parser.add_argument("-U", "--use-cache", dest="use_cache", help="Use cache for live logs, don't re-download them", action='store_true')
   parser.add_argument("-V", "--verbose", dest="verbose", help="Print more verbose output", action='store_true')
+  parser.add_argument("--silent", dest="silent", help="No stderr (progress, file names, etc) output", action='store_true')
 
   args = parser.parse_args(remaining_argv)
+
+  if not IS_A_TTY:
+    args.silent = True
 
   check_args(args)
   args.start = convert_to_date(args, args.start, True)
@@ -275,7 +291,8 @@ def cat():
   try:
     setattr(args, 'headers', dict(config.items("Request Headers")))
   except:
-    sys.stderr.write('No additional request headers found\n')
+    if not args.silent:
+      sys.stderr.write('No additional request headers found\n')
     setattr(args, 'headers', {})
 
 
@@ -310,8 +327,12 @@ def tail():
   parser.add_argument("-g", "--grep", dest="grep", help="String to grep for")
   parser.add_argument("-l", "--logfile", dest="logfile", help="Logfile path/name to tail (ie 'logs/access.log')")
   parser.add_argument("-V", "--verbose", dest="verbose", help="more verbose output", action='store_true')
+  parser.add_argument("--silent", dest="silent", help="No stderr (progress, file names, etc) output", action='store_true')
 
   args = parser.parse_args(remaining_argv)
+
+  if not IS_A_TTY:
+    args.silent = True
 
   if not args.logfile:
     exit("Must specify logfile to tail (-l)")
@@ -321,7 +342,8 @@ def tail():
   try:
     setattr(args, 'headers', dict(config.items("Request Headers")))
   except:
-    sys.stderr.write('No additional request headers found\n')
+    if not args.silent:
+      sys.stderr.write('No additional request headers found\n')
     setattr(args, 'headers', {})
 
 

--- a/scripts/logfetch/grep.py
+++ b/scripts/logfetch/grep.py
@@ -14,10 +14,12 @@ def grep_files(args, all_logs):
         command = grep_command(args, log)
         output = os.popen(command).read()
         if output is not None and output != '':
-          sys.stderr.write(colored(log, 'cyan') + '\n')
+          if not args.silent:
+            sys.stderr.write(colored(log, 'cyan') + '\n')
           sys.stdout.write(output)
 
-      sys.stderr.write(colored('Finished grep, exiting', 'green') + '\n')
+      if not args.silent:
+        sys.stderr.write(colored('Finished grep, exiting', 'green') + '\n')
     else:
       sys.stderr.write(colored('No logs found\n', 'magenta'))
 

--- a/scripts/logfetch/grep.py
+++ b/scripts/logfetch/grep.py
@@ -6,7 +6,8 @@ GREP_COMMAND_FORMAT = '{0} {1}'
 DEFAULT_GREP_COMMAND = 'grep --color=always \'{0}\''
 
 def grep_files(args, all_logs):
-  sys.stderr.write('\n')
+  if not args.silent:
+    sys.stderr.write('\n')
   if args.grep:
     if all_logs:
       all_logs.sort()

--- a/scripts/logfetch/logfetch_base.py
+++ b/scripts/logfetch/logfetch_base.py
@@ -31,11 +31,11 @@ def unpack_logs(args, logs):
         if args.verbose and not args.silent:
           sys.stderr.write(colored('Unpacked log {0}/{1}'.format(progress, goal), 'green') + colored(zipped_file, 'white') + '\n')
         else:
-          update_progress_bar(progress, goal, 'Unpack')
+          update_progress_bar(progress, goal, 'Unpack', args.silent)
         successful.append(unzipped)
       else:
         progress += 1
-        update_progress_bar(progress, goal, 'Unpack')
+        update_progress_bar(progress, goal, 'Unpack', args.silent)
     except Exception as e:
       print e
       if os.path.isfile(zipped_file):

--- a/scripts/logfetch/logfetch_base.py
+++ b/scripts/logfetch/logfetch_base.py
@@ -18,7 +18,7 @@ def unpack_logs(args, logs):
   for zipped_file in logs:
     try:
       if os.path.isfile(zipped_file):
-        if args.verbose:
+        if args.verbose and not args.silent:
           sys.stderr.write(colored('Starting unpack of {0}'.format(zipped_file), 'magenta') + '\n')
         file_in = gzip.open(zipped_file, 'rb')
         unzipped = zipped_file.replace('.gz', '.log')
@@ -28,7 +28,7 @@ def unpack_logs(args, logs):
         file_in.close
         os.remove(zipped_file)
         progress += 1
-        if args.verbose:
+        if args.verbose and not args.silent:
           sys.stderr.write(colored('Unpacked log {0}/{1}'.format(progress, goal), 'green') + colored(zipped_file, 'white') + '\n')
         else:
           update_progress_bar(progress, goal, 'Unpack')
@@ -42,7 +42,8 @@ def unpack_logs(args, logs):
         os.remove(zipped_file)
       sys.stderr.write(colored('Could not unpack {0}'.format(zipped_file), 'red') + '\n')
       continue
-  sys.stderr.write('\n')
+  if not args.silent:
+    sys.stderr.write('\n')
   return successful
 
 def base_uri(args):
@@ -99,7 +100,7 @@ def is_in_date_range(args, timestamp):
   else:
     return False if timedelta.days < args.start else True
 
-def update_progress_bar(progress, goal, progress_type):
+def update_progress_bar(progress, goal, progress_type, silent):
   bar_length = 30
   percent = float(progress) / goal
   hashes = '#' * int(round(percent * bar_length))
@@ -112,5 +113,6 @@ def update_progress_bar(progress, goal, progress_type):
     color = 'yellow'
   else:
     color = 'blue'
-  sys.stderr.write("\r{0} Progress: [".format(progress_type) + colored("{0}".format(hashes + spaces), color) + "] {0}%".format(int(round(percent * 100))))
-  sys.stderr.flush()
+  if not silent:
+    sys.stderr.write("\r{0} Progress: [".format(progress_type) + colored("{0}".format(hashes + spaces), color) + "] {0}%".format(int(round(percent * 100))))
+    sys.stderr.flush()

--- a/scripts/logfetch/s3_logs.py
+++ b/scripts/logfetch/s3_logs.py
@@ -32,7 +32,7 @@ def download_s3_logs(args):
           sys.stderr.write(colored('Including log {0}'.format(filename), 'blue') + '\n')
         if not already_downloaded(args.dest, filename):
           async_requests.append(
-            grequests.AsyncRequest('GET', log_file['getUrl'], callback=callbacks.generate_callback(log_file['getUrl'], args.dest, filename, args.chunk_size, args.verbose), headers=args.headers)
+            grequests.AsyncRequest('GET', log_file['getUrl'], callback=callbacks.generate_callback(log_file['getUrl'], args.dest, filename, args.chunk_size, args.verbose, args.silent), headers=args.headers)
           )
         else:
           if args.verbose and not args.silent:

--- a/scripts/logfetch/search.py
+++ b/scripts/logfetch/search.py
@@ -10,11 +10,11 @@ def find_cached_logs(args):
     log_fn_match = get_matcher(args)
     for filename in os.listdir(args.dest):
         if fnmatch.fnmatch(filename, log_fn_match) and in_date_range(args, filename):
-            if args.verbose:
+            if args.verbose and not args.silent:
                 sys.stderr.write(colored('Including log {0}\n'.format(filename), 'blue'))
             matching_logs.append('{0}/{1}'.format(args.dest, filename))
         else:
-            if args.verbose:
+            if args.verbose and not args.silent:
                 sys.stderr.write(colored('Excluding log {0}, not in date range\n'.format(filename), 'magenta'))
     return matching_logs
             

--- a/scripts/logfetch/singularity_request.py
+++ b/scripts/logfetch/singularity_request.py
@@ -7,11 +7,11 @@ ERROR_STATUS_FORMAT = 'Singularity responded with an invalid status code ({0})'
 def get_json_response(uri, args, params={}):
   singularity_response = requests.get(uri, params=params, headers=args.headers)
   if singularity_response.status_code < 199 or singularity_response.status_code > 299:
-  	if not args.silent:
-    	sys.stderr.write('{0} params:{1}\n'.format(uri, str(params)))
+    if not args.silent:
+      sys.stderr.write('{0} params:{1}\n'.format(uri, str(params)))
     sys.stderr.write(colored(ERROR_STATUS_FORMAT.format(singularity_response.status_code), 'red') + '\n')
     if not args.silent:
-    	sys.stderr.write(colored(singularity_response.text, 'red') + '\n')
+      sys.stderr.write(colored(singularity_response.text, 'red') + '\n')
     return {}
   return singularity_response.json()
 

--- a/scripts/logfetch/singularity_request.py
+++ b/scripts/logfetch/singularity_request.py
@@ -7,9 +7,11 @@ ERROR_STATUS_FORMAT = 'Singularity responded with an invalid status code ({0})'
 def get_json_response(uri, args, params={}):
   singularity_response = requests.get(uri, params=params, headers=args.headers)
   if singularity_response.status_code < 199 or singularity_response.status_code > 299:
-    sys.stderr.write('{0} params:{1}\n'.format(uri, str(params)))
+  	if not args.silent:
+    	sys.stderr.write('{0} params:{1}\n'.format(uri, str(params)))
     sys.stderr.write(colored(ERROR_STATUS_FORMAT.format(singularity_response.status_code), 'red') + '\n')
-    sys.stderr.write(colored(singularity_response.text, 'red') + '\n')
+    if not args.silent:
+    	sys.stderr.write(colored(singularity_response.text, 'red') + '\n')
     return {}
   return singularity_response.json()
 

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -11,7 +11,7 @@ requirements = [
 
 setup(
     name='singularity-logfetch',
-    version='0.21.0',
+    version='0.22.0',
     description='Singularity log fetching and searching',
     author="HubSpot",
     author_email='singularity-users@googlegroups.com',


### PR DESCRIPTION
Behave more like curl where if we realize output is being redirected, we do not output stderr/progress messages. There is a `--silent` option that will do this, and it is automatically on when output is being redirected. The only stderr that will still write is for error messages (i.e. when the stdout output would not be useful/complete anyways)

/cc @mjball 