### PR TITLE
Add link to finished service.log to failed healthcheck notification

### DIFF
--- a/SingularityUI/app/templates/taskDetail/taskHealthcheckNotification.hbs
+++ b/SingularityUI/app/templates/taskDetail/taskHealthcheckNotification.hbs
@@ -53,7 +53,7 @@
     {{#if lastHealthcheckFailed}}
         {{#with data.healthcheckResults.[0]}}
         <div class="alert alert-warning" role="alert">
-            <b>Task failed due to no passing healthchecks:</b> Last healthcheck {{#if statusCode}}responded with <span class="label label-danger">HTTP {{statusCode}}</span>{{else}}did not respond{{/if}}{{#if durationMillis}} in {{durationMillis}}ms{{/if}} at {{timestampFormattedWithSeconds timestamp}}. <a href="#health-checks" data-action="viewHealthchecks">View all healthchecks.</a> <a href="{{ appRoot }}/task/{{ ../data.taskId }}/tail/{{ substituteTaskId ../config.finishedTaskLogPath ../data.taskId }}">View Logs.</a>
+            <b>Task failed due to no passing healthchecks:</b> Last healthcheck {{#if statusCode}}responded with <span class="label label-danger">HTTP {{statusCode}}</span>{{else}}did not respond{{/if}}{{#if durationMillis}} in {{durationMillis}}ms{{/if}} at {{timestampFormattedWithSeconds timestamp}}. <a href="#health-checks" data-action="viewHealthchecks">View all healthchecks.</a> <a href="{{ appRoot }}/task/{{ ../data.taskId }}/tail/{{ substituteTaskId ../config.finishedTaskLogPath ../data.taskId }}">View service logs.</a>
         </div>
         {{/with}}
     {{/if}}

--- a/SingularityUI/app/templates/taskDetail/taskHealthcheckNotification.hbs
+++ b/SingularityUI/app/templates/taskDetail/taskHealthcheckNotification.hbs
@@ -53,7 +53,7 @@
     {{#if lastHealthcheckFailed}}
         {{#with data.healthcheckResults.[0]}}
         <div class="alert alert-warning" role="alert">
-            <b>Task failed due to no passing healthchecks:</b> Last healthcheck {{#if statusCode}}responded with <span class="label label-danger">HTTP {{statusCode}}</span>{{else}}did not respond{{/if}}{{#if durationMillis}} in {{durationMillis}}ms{{/if}} at {{timestampFormattedWithSeconds timestamp}}. <a href="#health-checks" data-action="viewHealthchecks">View all healthchecks.</a>
+            <b>Task failed due to no passing healthchecks:</b> Last healthcheck {{#if statusCode}}responded with <span class="label label-danger">HTTP {{statusCode}}</span>{{else}}did not respond{{/if}}{{#if durationMillis}} in {{durationMillis}}ms{{/if}} at {{timestampFormattedWithSeconds timestamp}}. <a href="#health-checks" data-action="viewHealthchecks">View all healthchecks.</a> <a href="{{ appRoot }}/task/{{ ../data.taskId }}/tail/{{ substituteTaskId ../config.finishedTaskLogPath ../data.taskId }}">View Logs.</a>
         </div>
         {{/with}}
     {{/if}}

--- a/SingularityUI/app/views/taskHealthcheckNotificationSubview.coffee
+++ b/SingularityUI/app/views/taskHealthcheckNotificationSubview.coffee
@@ -26,6 +26,7 @@ class taskHealthcheckNotificationSubview extends View
         hasSuccessfulHealthcheck: @model.get('healthcheckResults')?.length > 0 and _.find(@model.get('healthcheckResults'), (item) -> item.statusCode is 200)
         lastHealthcheckFailed: @model.get('healthcheckResults')?.length > 0 and @model.get('healthcheckResults')[0].statusCode isnt 200
         synced:           @model.synced
+        config:           config
 
     triggerToggleHealthchecks: ->
         @trigger 'toggleHealthchecks'


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/3221272/11824178/2c699be4-a346-11e5-848a-a9b332933071.png)

I'll add the compatible version of this link to the new log tail branch as well.