### PR TITLE
Clean tasks on decommissioned hosts

### DIFF
--- a/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/SingularityExecutorCleanup.java
+++ b/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/SingularityExecutorCleanup.java
@@ -107,15 +107,19 @@ public class SingularityExecutorCleanup {
     statisticsBldr.setMesosRunningTasks(runningTaskIds.size());
 
     if (runningTaskIds.isEmpty()) {
-      if (cleanupConfiguration.isSafeModeWontRunWithNoTasks()) {
-        if (!isDecommissioned()) {
+      if (!isDecommissioned()) {
+        if (cleanupConfiguration.isSafeModeWontRunWithNoTasks()) {
           final String errorMessage = String.format("Running in safe mode and found 0 running tasks - aborting cleanup");
           LOG.error(errorMessage);
           statisticsBldr.setErrorMessage(errorMessage);
+          return statisticsBldr.build();
+        } else {
+          LOG.warn("Found 0 running tasks - proceeding with cleanup as we are not in safe mode");
         }
-        return statisticsBldr.build();
       } else {
-        LOG.warn("Found 0 running tasks - proceeding with cleanup as we are not in safe mode");
+        if (!cleanupConfiguration.isCleanTasksWhenDecommissioned()) {
+          return statisticsBldr.build();
+        }
       }
     }
 

--- a/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/SingularityExecutorCleanup.java
+++ b/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/SingularityExecutorCleanup.java
@@ -26,6 +26,8 @@ import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.hubspot.mesos.JavaUtils;
 import com.hubspot.mesos.client.MesosClient;
+import com.hubspot.singularity.MachineState;
+import com.hubspot.singularity.SingularitySlave;
 import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.SingularityTaskHistory;
 import com.hubspot.singularity.SingularityTaskHistoryUpdate;
@@ -106,9 +108,11 @@ public class SingularityExecutorCleanup {
 
     if (runningTaskIds.isEmpty()) {
       if (cleanupConfiguration.isSafeModeWontRunWithNoTasks()) {
-        final String errorMessage = String.format("Running in safe mode and found 0 running tasks - aborting cleanup");
-        LOG.error(errorMessage);
-        statisticsBldr.setErrorMessage(errorMessage);
+        if (!isDecommissioned()) {
+          final String errorMessage = String.format("Running in safe mode and found 0 running tasks - aborting cleanup");
+          LOG.error(errorMessage);
+          statisticsBldr.setErrorMessage(errorMessage);
+        }
         return statisticsBldr.build();
       } else {
         LOG.warn("Found 0 running tasks - proceeding with cleanup as we are not in safe mode");
@@ -182,6 +186,17 @@ public class SingularityExecutorCleanup {
     }
 
     return statisticsBldr.build();
+  }
+
+  private boolean isDecommissioned() {
+    Collection<SingularitySlave> slaves = singularityClient.getSlaves(Optional.of(MachineState.DECOMMISSIONED));
+    boolean decommissioned = false;
+    for (SingularitySlave slave : slaves) {
+      if (slave.getHost().equals(hostname)) {
+        decommissioned = true;
+      }
+    }
+    return decommissioned;
   }
 
   private Set<String> getRunningTaskIds() {

--- a/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/config/SingularityExecutorCleanupConfiguration.java
+++ b/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/config/SingularityExecutorCleanupConfiguration.java
@@ -48,6 +48,9 @@ public class SingularityExecutorCleanupConfiguration extends BaseRunnerConfigura
   @JsonProperty
   private Optional<SingularityClientCredentials> singularityClientCredentials = Optional.absent();
 
+  @JsonProperty
+  private boolean cleanTasksWhenDecommissioned = true;
+
   public SingularityExecutorCleanupConfiguration() {
     super(Optional.of("singularity-executor-cleanup.log"));
   }
@@ -114,6 +117,14 @@ public class SingularityExecutorCleanupConfiguration extends BaseRunnerConfigura
 
   public void setSingularityClientCredentials(Optional<SingularityClientCredentials> singularityClientCredentials) {
     this.singularityClientCredentials = singularityClientCredentials;
+  }
+
+  public boolean isCleanTasksWhenDecommissioned() {
+    return cleanTasksWhenDecommissioned;
+  }
+
+  public void setCleanTasksWhenDecommissioned(boolean cleanTasksWhenDecommissioned) {
+    this.cleanTasksWhenDecommissioned = cleanTasksWhenDecommissioned;
   }
 
   @Override


### PR DESCRIPTION
- If we find no tasks, also check if we are decommissioned
- If we are, then either continue with cleanup (default setting) or just return without error since we would expect to find no tasks in decom state
- If we are not decommissioned, go the normal safe mode/error route that we normally would