### PR TITLE
make rack sensitive placement more even

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
@@ -193,12 +193,12 @@ class SingularitySlaveAndRackManager {
   }
 
   public int getInstanceCountForRack(Multiset<String> countPerRack, int numActiveRacks) {
-    for (int i = numActiveRacks - countPerRack.size(); i > 0; i--) {
-      countPerRack.add(String.format("RackWithNoMatchingTasks-%s", i));
-    }
-
     int maxOnRack = 0;
     boolean allRacksEqual = true;
+
+    if (countPerRack.size() != 0 && countPerRack.size() < numActiveRacks) {
+      allRacksEqual = false;
+    }
 
     Optional<Integer> previousValue = Optional.absent();
     for (Multiset.Entry entry : countPerRack.entrySet()) {
@@ -210,6 +210,7 @@ class SingularitySlaveAndRackManager {
       }
       previousValue = Optional.of(entry.getCount());
     }
+
     if (allRacksEqual) {
       return maxOnRack + 1;
     } else {


### PR DESCRIPTION
Had an idea for a (possibly) simple way to ensure more even distribution across different racks, based on two things:
- We sort tasks to be scheduled such that lower instance number tasks will be scheduled first
- On a scale down we kill highest numbered instances first

This PR will calculate the number allowed on a certain rack so that we make sure we are evenly distributed among all racks before adding additional instances to a rack. For example, if we have 3 active racks and a request with 5 instances. It will first ensure that each rack gets 1 instance before allowing any rack to get 2.

Then, when scaling down, because we added them in this order, we will still have even distribution when killing highest instance numbers first.

The one drawback is it might take more runs of the scheduler to schedule all of the tasks for a request.

@tpetr @wsorenson would love some opinions on this