### PR TITLE
Request type zk migration

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
@@ -29,6 +29,10 @@ public class SingularityRequest {
 
   private final Optional<Long> waitAtLeastMillisAfterTaskFinishesForReschedule;
 
+  //"use requestType instead"
+  @Deprecated
+  private final Optional<Boolean> daemon;
+
   private final Optional<Integer> instances;
   private final Optional<Boolean> skipHealthchecks;
 
@@ -48,7 +52,7 @@ public class SingularityRequest {
 
   @JsonCreator
   public SingularityRequest(@JsonProperty("id") String id, @JsonProperty("requestType") RequestType requestType, @JsonProperty("owners") Optional<List<String>> owners,
-      @JsonProperty("numRetriesOnFailure") Optional<Integer> numRetriesOnFailure, @JsonProperty("schedule") Optional<String> schedule, @JsonProperty("instances") Optional<Integer> instances,
+      @JsonProperty("numRetriesOnFailure") Optional<Integer> numRetriesOnFailure, @JsonProperty("schedule") Optional<String> schedule, @JsonProperty("daemon") Optional<Boolean> daemon, @JsonProperty("instances") Optional<Integer> instances,
       @JsonProperty("rackSensitive") Optional<Boolean> rackSensitive, @JsonProperty("loadBalanced") Optional<Boolean> loadBalanced,
       @JsonProperty("killOldNonLongRunningTasksAfterMillis") Optional<Long> killOldNonLongRunningTasksAfterMillis, @JsonProperty("scheduleType") Optional<ScheduleType> scheduleType,
       @JsonProperty("quartzSchedule") Optional<String> quartzSchedule, @JsonProperty("rackAffinity") Optional<List<String>> rackAffinity,
@@ -62,6 +66,7 @@ public class SingularityRequest {
     this.owners = owners;
     this.numRetriesOnFailure = numRetriesOnFailure;
     this.schedule = schedule;
+    this.daemon = daemon;
     this.rackSensitive = rackSensitive;
     this.instances = instances;
     this.loadBalanced = loadBalanced;
@@ -79,7 +84,11 @@ public class SingularityRequest {
     this.bounceAfterScale = bounceAfterScale;
     this.emailConfigurationOverrides = emailConfigurationOverrides;
     this.skipHealthchecks = skipHealthchecks;
-    this.requestType = requestType;
+    if (requestType == null) {
+      this.requestType = RequestType.fromDaemonAndScheduleAndLoadBalanced(schedule, daemon, loadBalanced);
+    } else {
+      this.requestType = requestType;
+    }
   }
 
   public SingularityRequestBuilder toBuilder() {
@@ -124,6 +133,11 @@ public class SingularityRequest {
 
   public Optional<String> getQuartzSchedule() {
     return quartzSchedule;
+  }
+
+  @Deprecated
+  public Optional<Boolean> getDaemon() {
+    return daemon;
   }
 
   public Optional<Integer> getInstances() {

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
@@ -1,5 +1,6 @@
 package com.hubspot.singularity;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.hubspot.singularity.JsonHelpers.copyOfList;
 
 import java.util.List;
@@ -29,10 +30,6 @@ public class SingularityRequest {
 
   private final Optional<Long> waitAtLeastMillisAfterTaskFinishesForReschedule;
 
-  //"use requestType instead"
-  @Deprecated
-  private final Optional<Boolean> daemon;
-
   private final Optional<Integer> instances;
   private final Optional<Boolean> skipHealthchecks;
 
@@ -52,7 +49,7 @@ public class SingularityRequest {
 
   @JsonCreator
   public SingularityRequest(@JsonProperty("id") String id, @JsonProperty("requestType") RequestType requestType, @JsonProperty("owners") Optional<List<String>> owners,
-      @JsonProperty("numRetriesOnFailure") Optional<Integer> numRetriesOnFailure, @JsonProperty("schedule") Optional<String> schedule, @JsonProperty("daemon") Optional<Boolean> daemon, @JsonProperty("instances") Optional<Integer> instances,
+      @JsonProperty("numRetriesOnFailure") Optional<Integer> numRetriesOnFailure, @JsonProperty("schedule") Optional<String> schedule, @JsonProperty("instances") Optional<Integer> instances,
       @JsonProperty("rackSensitive") Optional<Boolean> rackSensitive, @JsonProperty("loadBalanced") Optional<Boolean> loadBalanced,
       @JsonProperty("killOldNonLongRunningTasksAfterMillis") Optional<Long> killOldNonLongRunningTasksAfterMillis, @JsonProperty("scheduleType") Optional<ScheduleType> scheduleType,
       @JsonProperty("quartzSchedule") Optional<String> quartzSchedule, @JsonProperty("rackAffinity") Optional<List<String>> rackAffinity,
@@ -66,7 +63,6 @@ public class SingularityRequest {
     this.owners = owners;
     this.numRetriesOnFailure = numRetriesOnFailure;
     this.schedule = schedule;
-    this.daemon = daemon;
     this.rackSensitive = rackSensitive;
     this.instances = instances;
     this.loadBalanced = loadBalanced;
@@ -84,11 +80,7 @@ public class SingularityRequest {
     this.bounceAfterScale = bounceAfterScale;
     this.emailConfigurationOverrides = emailConfigurationOverrides;
     this.skipHealthchecks = skipHealthchecks;
-    if (requestType == null) {
-      this.requestType = RequestType.fromDaemonAndScheduleAndLoadBalanced(schedule, daemon, loadBalanced);
-    } else {
-      this.requestType = requestType;
-    }
+    this.requestType = checkNotNull(requestType, "requestType cannot be null");
   }
 
   public SingularityRequestBuilder toBuilder() {
@@ -133,11 +125,6 @@ public class SingularityRequest {
 
   public Optional<String> getQuartzSchedule() {
     return quartzSchedule;
-  }
-
-  @Deprecated
-  public Optional<Boolean> getDaemon() {
-    return daemon;
   }
 
   public Optional<Integer> getInstances() {

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
@@ -59,7 +59,7 @@ public class SingularityRequest {
       @JsonProperty("readOnlyGroups") Optional<Set<String>> readOnlyGroups, @JsonProperty("bounceAfterScale") Optional<Boolean> bounceAfterScale,
       @JsonProperty("skipHealthchecks") Optional<Boolean> skipHealthchecks,
       @JsonProperty("emailConfigurationOverrides") Optional<Map<SingularityEmailType, List<SingularityEmailDestination>>> emailConfigurationOverrides) {
-    this.id = id;
+    this.id = checkNotNull(id, "id cannot be null");
     this.owners = owners;
     this.numRetriesOnFailure = numRetriesOnFailure;
     this.schedule = schedule;

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestBuilder.java
@@ -24,10 +24,6 @@ public class SingularityRequestBuilder {
 
   private Optional<Long> waitAtLeastMillisAfterTaskFinishesForReschedule;
 
-  @Deprecated
-  // use requestType
-  private Optional<Boolean> daemon;
-
   private Optional<Integer> instances;
   private Optional<Boolean> skipHealthchecks;
 
@@ -61,7 +57,6 @@ public class SingularityRequestBuilder {
     this.requiredSlaveAttributes = Optional.absent();
     this.allowedSlaveAttributes = Optional.absent();
     this.scheduledExpectedRuntimeMillis = Optional.absent();
-    this.daemon = Optional.absent();
     this.waitAtLeastMillisAfterTaskFinishesForReschedule = Optional.absent();
     this.group = Optional.absent();
     this.readOnlyGroups = Optional.absent();
@@ -71,7 +66,7 @@ public class SingularityRequestBuilder {
   }
 
   public SingularityRequest build() {
-    return new SingularityRequest(id, requestType, owners, numRetriesOnFailure, schedule, daemon, instances, rackSensitive, loadBalanced, killOldNonLongRunningTasksAfterMillis, scheduleType, quartzSchedule,
+    return new SingularityRequest(id, requestType, owners, numRetriesOnFailure, schedule, instances, rackSensitive, loadBalanced, killOldNonLongRunningTasksAfterMillis, scheduleType, quartzSchedule,
         rackAffinity, slavePlacement, requiredSlaveAttributes, allowedSlaveAttributes, scheduledExpectedRuntimeMillis, waitAtLeastMillisAfterTaskFinishesForReschedule, group, readOnlyGroups,
         bounceAfterScale, skipHealthchecks, emailConfigurationOverrides);
   }
@@ -122,17 +117,6 @@ public class SingularityRequestBuilder {
 
   public SingularityRequestBuilder setSchedule(Optional<String> schedule) {
     this.schedule = schedule;
-    return this;
-  }
-
-  @Deprecated
-  public Optional<Boolean> getDaemon() {
-    return daemon;
-  }
-
-  @Deprecated
-  public SingularityRequestBuilder setDaemon(Optional<Boolean> daemon) {
-    this.daemon = daemon;
     return this;
   }
 

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestBuilder.java
@@ -1,5 +1,7 @@
 package com.hubspot.singularity;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -41,8 +43,8 @@ public class SingularityRequestBuilder {
   private Optional<Map<SingularityEmailType, List<SingularityEmailDestination>>> emailConfigurationOverrides;
 
   public SingularityRequestBuilder(String id, RequestType requestType) {
-    this.id = id;
-    this.requestType = requestType;
+    this.id = checkNotNull(id, "id cannot be null");
+    this.requestType = checkNotNull(requestType, "requestType cannot be null");
     this.owners = Optional.absent();
     this.numRetriesOnFailure = Optional.absent();
     this.schedule = Optional.absent();

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestBuilder.java
@@ -24,6 +24,10 @@ public class SingularityRequestBuilder {
 
   private Optional<Long> waitAtLeastMillisAfterTaskFinishesForReschedule;
 
+  @Deprecated
+  // use requestType
+  private Optional<Boolean> daemon;
+
   private Optional<Integer> instances;
   private Optional<Boolean> skipHealthchecks;
 
@@ -57,6 +61,7 @@ public class SingularityRequestBuilder {
     this.requiredSlaveAttributes = Optional.absent();
     this.allowedSlaveAttributes = Optional.absent();
     this.scheduledExpectedRuntimeMillis = Optional.absent();
+    this.daemon = Optional.absent();
     this.waitAtLeastMillisAfterTaskFinishesForReschedule = Optional.absent();
     this.group = Optional.absent();
     this.readOnlyGroups = Optional.absent();
@@ -66,7 +71,7 @@ public class SingularityRequestBuilder {
   }
 
   public SingularityRequest build() {
-    return new SingularityRequest(id, requestType, owners, numRetriesOnFailure, schedule, instances, rackSensitive, loadBalanced, killOldNonLongRunningTasksAfterMillis, scheduleType, quartzSchedule,
+    return new SingularityRequest(id, requestType, owners, numRetriesOnFailure, schedule, daemon, instances, rackSensitive, loadBalanced, killOldNonLongRunningTasksAfterMillis, scheduleType, quartzSchedule,
         rackAffinity, slavePlacement, requiredSlaveAttributes, allowedSlaveAttributes, scheduledExpectedRuntimeMillis, waitAtLeastMillisAfterTaskFinishesForReschedule, group, readOnlyGroups,
         bounceAfterScale, skipHealthchecks, emailConfigurationOverrides);
   }
@@ -117,6 +122,17 @@ public class SingularityRequestBuilder {
 
   public SingularityRequestBuilder setSchedule(Optional<String> schedule) {
     this.schedule = schedule;
+    return this;
+  }
+
+  @Deprecated
+  public Optional<Boolean> getDaemon() {
+    return daemon;
+  }
+
+  @Deprecated
+  public SingularityRequestBuilder setDaemon(Optional<Boolean> daemon) {
+    this.daemon = daemon;
     return this;
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
@@ -100,6 +100,7 @@ public class SingularityValidator {
       Optional<SingularityDeploy> pendingDeploy) {
 
     checkBadRequest(request.getId() != null && !request.getId().contains("/"), "Id can not be null or contain / characters");
+    checkBadRequest(request.getRequestType() != null, "RequestType cannot be null or missing");
 
     if (!allowRequestsWithoutOwners) {
       checkBadRequest(request.getOwners().isPresent() && !request.getOwners().get().isEmpty(), "Request must have owners defined (this can be turned off in Singularity configuration)");

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/transcoders/JsonTranscoder.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/transcoders/JsonTranscoder.java
@@ -14,7 +14,7 @@ public class JsonTranscoder<T> implements Transcoder<T> {
   private final ObjectMapper objectMapper;
   private final Class<T> clazz;
 
-  JsonTranscoder(final ObjectMapper objectMapper, final Class<T> clazz) {
+  public JsonTranscoder(final ObjectMapper objectMapper, final Class<T> clazz) {
     this.objectMapper = checkNotNull(objectMapper, "objectMapper is null");
     this.clazz = checkNotNull(clazz, "clazz is null");
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/SingularityRequestTypeMigration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/SingularityRequestTypeMigration.java
@@ -76,7 +76,7 @@ public class SingularityRequestTypeMigration extends ZkDataMigration {
         private final Optional<Boolean> daemon;
         private final Optional<Boolean> loadBalanced;
 
-        private Map<String, Object> unknownFields = new HashMap<>();
+        private final Map<String, Object> unknownFields = new HashMap<>();
 
         @JsonCreator
         public OldSingularityRequest(@JsonProperty("id") String id,

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/SingularityRequestTypeMigration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/SingularityRequestTypeMigration.java
@@ -1,32 +1,155 @@
 package com.hubspot.singularity.data.zkmigrations;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
+import com.google.common.base.Throwables;
 import com.google.inject.Inject;
-import com.hubspot.singularity.SingularityRequest;
-import com.hubspot.singularity.SingularityRequestWithState;
+import com.hubspot.mesos.JavaUtils;
+import com.hubspot.singularity.RequestState;
+import com.hubspot.singularity.RequestType;
 import com.hubspot.singularity.data.RequestManager;
+import com.hubspot.singularity.data.transcoders.JsonTranscoder;
+import com.hubspot.singularity.data.transcoders.Transcoder;
 
 public class SingularityRequestTypeMigration extends ZkDataMigration {
+    private static final Logger LOG = LoggerFactory.getLogger(ScheduleMigration.class);
+
     private final RequestManager requestManager;
+    private final CuratorFramework curator;
+    private final Transcoder<OldSingularityRequestWithState> oldSingularityRequestTranscoder;
 
     @Inject
-    public SingularityRequestTypeMigration(RequestManager requestManager) {
+    public SingularityRequestTypeMigration(ObjectMapper objectMapper, CuratorFramework curator, RequestManager requestManager) {
         super(9);
+
+        this.curator = curator;
         this.requestManager = requestManager;
+        this.oldSingularityRequestTranscoder = new JsonTranscoder<>(objectMapper, OldSingularityRequestWithState.class);
+
     }
 
     @Override
     public void applyMigration() {
-        for (SingularityRequestWithState requestWithState : requestManager.getRequests()) {
-            if (!requestWithState.getRequest().getDaemon().isPresent()) {
-                continue;
+        LOG.info("Starting migration to ensure all Requests have a value for requestType field");
+
+        final long start = System.currentTimeMillis();
+        int num = 0;
+
+        for (String requestId : requestManager.getAllRequestIds()) {
+            try {
+                OldSingularityRequestWithState requestWithState = oldSingularityRequestTranscoder.fromBytes(curator.getData().forPath("/requests/all/" + requestId));
+
+                if (!requestWithState.getRequest().getDaemon().isPresent()) {
+                    LOG.info("Skipping {}, already already has requestType set", requestId);
+                    continue;
+                }
+
+                LOG.info("Saving request {}", requestId);
+                curator.setData().forPath("/requests/all/" + requestId, oldSingularityRequestTranscoder.toBytes(requestWithState));
+                num++;
+            } catch (Throwable t) {
+                LOG.error("Failed to read {}", requestId, t);
+                throw Throwables.propagate(t);
             }
+        }
 
-            final SingularityRequest requestWithoutDaemon = requestWithState.getRequest().toBuilder()
-                .setDaemon(Optional.<Boolean>absent())
-                .build();
+        LOG.info("Applied {} in {}", num, JavaUtils.duration(start));
+    }
 
-            requestManager.update(requestWithoutDaemon, System.currentTimeMillis(), Optional.of("migration"), Optional.of("SingularityRequestTypeMigration"));
+    private static class OldSingularityRequest {
+
+        private final String id;
+        private final RequestType requestType;
+
+        private final Optional<String> schedule;
+        private final Optional<Boolean> daemon;
+        private final Optional<Boolean> loadBalanced;
+
+        private Map<String, Object> unknownFields = new HashMap<>();
+
+        @JsonCreator
+        public OldSingularityRequest(@JsonProperty("id") String id,
+            @JsonProperty("requestType") RequestType requestType,
+            @JsonProperty("schedule") Optional<String> schedule,
+            @JsonProperty("daemon") Optional<Boolean> daemon,
+            @JsonProperty("loadBalanced") Optional<Boolean> loadBalanced) {
+            this.id = id;
+            this.schedule = schedule;
+            this.daemon = daemon;
+            this.loadBalanced = loadBalanced;
+            if (requestType == null) {
+                this.requestType = RequestType.fromDaemonAndScheduleAndLoadBalanced(schedule, daemon, loadBalanced);
+            } else {
+                this.requestType = requestType;
+            }
+        }
+
+        @JsonAnySetter
+        public void setUnknownField(String name, Object value) {
+            unknownFields.put(name, value);
+        }
+
+        @JsonAnyGetter
+        public Map<String, Object> getUnknownFields() {
+            return unknownFields;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public RequestType getRequestType() {
+            return requestType;
+        }
+
+        public Optional<String> getSchedule() {
+            return schedule;
+        }
+
+        public Optional<Boolean> getDaemon() {
+            return daemon;
+        }
+
+        public Optional<Boolean> getLoadBalanced() {
+            return loadBalanced;
+        }
+    }
+
+    private static class OldSingularityRequestWithState {
+        private final OldSingularityRequest request;
+        private final RequestState state;
+        private final long timestamp;
+
+        @JsonCreator
+        public OldSingularityRequestWithState(@JsonProperty("request") OldSingularityRequest request,
+            @JsonProperty("state") RequestState state,
+            @JsonProperty("timestamp") long timestamp) {
+            this.request = request;
+            this.state = state;
+            this.timestamp = timestamp;
+        }
+
+        public OldSingularityRequest getRequest() {
+            return request;
+        }
+
+        public RequestState getState() {
+            return state;
+        }
+
+        public long getTimestamp() {
+            return timestamp;
         }
     }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/SingularityRequestTypeMigration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/SingularityRequestTypeMigration.java
@@ -67,7 +67,7 @@ public class SingularityRequestTypeMigration extends ZkDataMigration {
         LOG.info("Applied {} in {}", num, JavaUtils.duration(start));
     }
 
-    private static class OldSingularityRequest {
+    static class OldSingularityRequest {
 
         private final String id;
         private final RequestType requestType;
@@ -126,7 +126,7 @@ public class SingularityRequestTypeMigration extends ZkDataMigration {
         }
     }
 
-    private static class OldSingularityRequestWithState {
+    static class OldSingularityRequestWithState {
         private final OldSingularityRequest request;
         private final RequestState state;
         private final long timestamp;

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/SingularityRequestTypeMigration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/SingularityRequestTypeMigration.java
@@ -1,0 +1,32 @@
+package com.hubspot.singularity.data.zkmigrations;
+
+import com.google.common.base.Optional;
+import com.google.inject.Inject;
+import com.hubspot.singularity.SingularityRequest;
+import com.hubspot.singularity.SingularityRequestWithState;
+import com.hubspot.singularity.data.RequestManager;
+
+public class SingularityRequestTypeMigration extends ZkDataMigration {
+    private final RequestManager requestManager;
+
+    @Inject
+    public SingularityRequestTypeMigration(RequestManager requestManager) {
+        super(9);
+        this.requestManager = requestManager;
+    }
+
+    @Override
+    public void applyMigration() {
+        for (SingularityRequestWithState requestWithState : requestManager.getRequests()) {
+            if (!requestWithState.getRequest().getDaemon().isPresent()) {
+                continue;
+            }
+
+            final SingularityRequest requestWithoutDaemon = requestWithState.getRequest().toBuilder()
+                .setDaemon(Optional.<Boolean>absent())
+                .build();
+
+            requestManager.update(requestWithoutDaemon, System.currentTimeMillis(), Optional.of("migration"), Optional.of("SingularityRequestTypeMigration"));
+        }
+    }
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/SingularityZkMigrationsModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/SingularityZkMigrationsModule.java
@@ -25,6 +25,7 @@ public class SingularityZkMigrationsModule implements Module {
     dataMigrations.addBinding().to(TaskManagerRequiredParentsForTransactionsMigration.class);
     dataMigrations.addBinding().to(SlaveAndRackMigration2.class);
     dataMigrations.addBinding().to(ScheduleMigration.class);
+    dataMigrations.addBinding().to(SingularityRequestTypeMigration.class);
   }
 
   @Provides

--- a/SingularityService/src/test/java/com/hubspot/singularity/data/zkmigrations/ZkMigrationTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/data/zkmigrations/ZkMigrationTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.hubspot.singularity.RequestState;
 import com.hubspot.singularity.RequestType;
@@ -18,8 +19,6 @@ import com.hubspot.singularity.SingularityPendingRequest;
 import com.hubspot.singularity.SingularityPendingRequest.PendingType;
 import com.hubspot.singularity.SingularityPendingTaskId;
 import com.hubspot.singularity.SingularityRequest;
-import com.hubspot.singularity.SingularityRequestBuilder;
-import com.hubspot.singularity.SingularityRequestHistory;
 import com.hubspot.singularity.SingularityTestBaseNoDb;
 import com.hubspot.singularity.data.MetadataManager;
 import com.hubspot.singularity.data.RequestManager;
@@ -122,19 +121,14 @@ public class ZkMigrationTest extends SingularityTestBaseNoDb {
   public void testSingularityRequestTypeMigration() throws Exception {
     metadataManager.setZkDataVersion("8");
 
-    final SingularityRequest deprecatedOnDemandRequest = new SingularityRequestBuilder("old-on-demand", null).setDaemon(Optional.of(false)).build();
-
-    Assert.assertEquals(RequestType.ON_DEMAND, deprecatedOnDemandRequest.getRequestType());
-    Assert.assertEquals(Optional.of(false), deprecatedOnDemandRequest.getDaemon());
-
-    requestManager.save(deprecatedOnDemandRequest, RequestState.ACTIVE, SingularityRequestHistory.RequestHistoryType.CREATED, 0, Optional.<String>absent(), Optional.<String>absent());
+    curator.create().creatingParentsIfNeeded().forPath("/requests/all/old-on-demand", objectMapper.writeValueAsBytes(ImmutableMap.of("state", RequestState.ACTIVE, "request", ImmutableMap.of("id", "old-on-demand", "daemon", false), "timestamp", 0)));
 
     migrationRunner.checkMigrations();
 
-    final SingularityRequest request = requestManager.getRequest(deprecatedOnDemandRequest.getId()).get().getRequest();
+    final SingularityRequest request = requestManager.getRequest("old-on-demand").get().getRequest();
 
+    Assert.assertEquals("old-on-demand", request.getId());
     Assert.assertEquals(RequestType.ON_DEMAND, request.getRequestType());
-    Assert.assertEquals(Optional.absent(), request.getDaemon());
   }
 
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/data/zkmigrations/ZkMigrationTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/data/zkmigrations/ZkMigrationTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import com.hubspot.singularity.RequestState;
 import com.hubspot.singularity.RequestType;
@@ -119,22 +120,32 @@ public class ZkMigrationTest extends SingularityTestBaseNoDb {
   public void testSingularityRequestTypeMigration() throws Exception {
     metadataManager.setZkDataVersion("8");
 
+    final List<String> owners = ImmutableList.of("foo1@bar.com", "foo2@bar.com");
+
     final SingularityRequestTypeMigration.OldSingularityRequest oldOnDemandRequest = new SingularityRequestTypeMigration.OldSingularityRequest("old-on-demand", null, Optional.<String>absent(), Optional.of(false), Optional.<Boolean>absent());
     final SingularityRequestTypeMigration.OldSingularityRequest oldWorkerRequest = new SingularityRequestTypeMigration.OldSingularityRequest("old-worker", null, Optional.<String>absent(), Optional.of(true), Optional.<Boolean>absent());
     final SingularityRequestTypeMigration.OldSingularityRequest oldScheduledRequest = new SingularityRequestTypeMigration.OldSingularityRequest("old-scheduled", null, Optional.of("0 0 0 0 0"), Optional.<Boolean>absent(), Optional.<Boolean>absent());
     final SingularityRequestTypeMigration.OldSingularityRequest oldServiceRequest = new SingularityRequestTypeMigration.OldSingularityRequest("old-service", null, Optional.<String>absent(), Optional.of(true), Optional.of(true));
 
+    oldOnDemandRequest.setUnknownField("owners", owners);
+
+    // save old-style requests to ZK
     curator.create().creatingParentsIfNeeded().forPath("/requests/all/" + oldOnDemandRequest.getId(), objectMapper.writeValueAsBytes(new SingularityRequestTypeMigration.OldSingularityRequestWithState(oldOnDemandRequest, RequestState.ACTIVE, System.currentTimeMillis())));
     curator.create().creatingParentsIfNeeded().forPath("/requests/all/" + oldWorkerRequest.getId(), objectMapper.writeValueAsBytes(new SingularityRequestTypeMigration.OldSingularityRequestWithState(oldWorkerRequest, RequestState.ACTIVE, System.currentTimeMillis())));
     curator.create().creatingParentsIfNeeded().forPath("/requests/all/" + oldScheduledRequest.getId(), objectMapper.writeValueAsBytes(new SingularityRequestTypeMigration.OldSingularityRequestWithState(oldScheduledRequest, RequestState.ACTIVE, System.currentTimeMillis())));
     curator.create().creatingParentsIfNeeded().forPath("/requests/all/" + oldServiceRequest.getId(), objectMapper.writeValueAsBytes(new SingularityRequestTypeMigration.OldSingularityRequestWithState(oldServiceRequest, RequestState.ACTIVE, System.currentTimeMillis())));
 
+    // run ZK migration
     migrationRunner.checkMigrations();
 
+    // assert that the migration properly set the requestType field
     Assert.assertEquals(RequestType.ON_DEMAND, requestManager.getRequest(oldOnDemandRequest.getId()).get().getRequest().getRequestType());
     Assert.assertEquals(RequestType.WORKER, requestManager.getRequest(oldWorkerRequest.getId()).get().getRequest().getRequestType());
     Assert.assertEquals(RequestType.SCHEDULED, requestManager.getRequest(oldScheduledRequest.getId()).get().getRequest().getRequestType());
     Assert.assertEquals(RequestType.SERVICE, requestManager.getRequest(oldServiceRequest.getId()).get().getRequest().getRequestType());
+
+    // assert that the migration properly carried over any additional fields on the request
+    Assert.assertEquals(Optional.of(owners), requestManager.getRequest(oldOnDemandRequest.getId()).get().getRequest().getOwners());
   }
 
 


### PR DESCRIPTION
- bring back deprecated `daemon` field
- add ZK migration to ensure that all requests have `requestType` set
- add null check to `SingularityValidator` for `requestType`

/cc @wsorenson 