### PR TITLE
Task is cleaning default msg fix

### DIFF
--- a/SingularityUI/app/templates/taskDetail/taskOverview.hbs
+++ b/SingularityUI/app/templates/taskDetail/taskOverview.hbs
@@ -2,7 +2,10 @@
     {{! If there's a TaskCleanup object associated with this task, display its info }}
     {{#if data.cleanup}}
         <div class="alert alert-warning" role="alert">
-            <b>Task is cleaning:</b> {{data.cleanup.message}}
+            <b>Task is cleaning:</b> {{ data.cleanup.cleanupType }}
+            {{#if data.cleanup.message}}
+                ({{ data.cleanup.message }})
+            {{/if}}
         </div>
     {{else}}
         {{#if data.isCleaning}}


### PR DESCRIPTION
Pull request to solve an issue where the message field for a bounced task would be blank.

Added a default message which will appear when a task is being cleaned up after a bounce