### PR TITLE
(logfetch) don't print 404 errors for slaves where directory isn't available

### DIFF
--- a/scripts/logfetch/live_logs.py
+++ b/scripts/logfetch/live_logs.py
@@ -97,11 +97,11 @@ def task_still_running(args, task, history):
 
 def files_json(args, task):
   uri = BROWSE_FOLDER_FORMAT.format(logfetch_base.base_uri(args), task)
-  return get_json_response(uri, args)
+  return get_json_response(uri, args, {}, True)
 
 def logs_folder_files(args, task):
   uri = BROWSE_FOLDER_FORMAT.format(logfetch_base.base_uri(args), task)
-  files_json = get_json_response(uri, args, {'path' : '{0}/logs'.format(task)})
+  files_json = get_json_response(uri, args, {'path' : '{0}/logs'.format(task)}, True)
   if 'files' in files_json:
     files = files_json['files']
     return [f['name'] for f in files if logfetch_base.is_in_date_range(args, f['mtime'])]

--- a/scripts/logfetch/singularity_request.py
+++ b/scripts/logfetch/singularity_request.py
@@ -4,13 +4,14 @@ from termcolor import colored
 
 ERROR_STATUS_FORMAT = 'Singularity responded with an invalid status code ({0})'
 
-def get_json_response(uri, args, params={}):
+def get_json_response(uri, args, params={}, skip404ErrMessage=False):
   singularity_response = requests.get(uri, params=params, headers=args.headers)
   if singularity_response.status_code < 199 or singularity_response.status_code > 299:
-    if not args.silent:
+    if not args.silent and not (skip404ErrMessage and singularity_response.status_code == 404):
       sys.stderr.write('{0} params:{1}\n'.format(uri, str(params)))
-    sys.stderr.write(colored(ERROR_STATUS_FORMAT.format(singularity_response.status_code), 'red') + '\n')
-    if not args.silent:
+    if not (skip404ErrMessage and singularity_response.status_code == 404):
+    	sys.stderr.write(colored(ERROR_STATUS_FORMAT.format(singularity_response.status_code), 'red') + '\n')
+    if not args.silent and not (skip404ErrMessage and singularity_response.status_code == 404):
       sys.stderr.write(colored(singularity_response.text, 'red') + '\n')
     return {}
   return singularity_response.json()

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -11,7 +11,7 @@ requirements = [
 
 setup(
     name='singularity-logfetch',
-    version='0.22.0',
+    version='0.22.1',
     description='Singularity log fetching and searching',
     author="HubSpot",
     author_email='singularity-users@googlegroups.com',


### PR DESCRIPTION
Comes up when slave is decommissioned and Singularity can't see the files. No need to spam with errors here. Makes it seem like something went wrong when these files are instead in the s3 logs