### PR TITLE
Include message with emails

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/helpers/RequestHelper.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/helpers/RequestHelper.java
@@ -32,7 +32,7 @@ public class RequestHelper {
   }
 
   public long unpause(SingularityRequest request, Optional<String> user, Optional<String> message, Optional<Boolean> skipHealthchecks) {
-    mailer.sendRequestUnpausedMail(request, user);
+    mailer.sendRequestUnpausedMail(request, user, message);
 
     Optional<String> maybeDeployId = deployManager.getInUseDeployId(request.getId());
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -519,7 +519,7 @@ public class RequestResource extends AbstractRequestResource {
 
     requestManager.deleteRequest(request, JavaUtils.getUserEmail(user), actionId, message);
 
-    mailer.sendRequestRemovedMail(request, JavaUtils.getUserEmail(user));
+    mailer.sendRequestRemovedMail(request, JavaUtils.getUserEmail(user), message);
 
     return request;
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/smtp/SingularityMailer.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/smtp/SingularityMailer.java
@@ -73,6 +73,10 @@ public class SingularityMailer implements Managed {
 
   private static final Pattern TASK_STATUS_BY_PATTERN = Pattern.compile("(\\w+) by \\w+");
 
+  /// Set this to true to log emails being sent. This allows testing locally without setting up an SMTP server
+  /// To find the email html, grep the logs: "grep TheMail -A 10" (change 10 depending on how many lines you need)
+  private static final Boolean LOG_EMAILS_FOR_DEBUG = false;
+
   @Inject
   public SingularityMailer(
       SingularitySmtpSender smtpSender,
@@ -287,6 +291,10 @@ public class SingularityMailer implements Managed {
 
     final String body = Jade4J.render(taskTemplate, templateProperties);
 
+    if (LOG_EMAILS_FOR_DEBUG) {
+      LOG.debug("TheMail: " + body);
+    }
+
     final Optional<String> user = task.isPresent() ? task.get().getTaskRequest().getPendingTask().getUser() : Optional.<String> absent();
 
     queueMail(emailDestination, request, emailType, user, subject, body);
@@ -333,7 +341,7 @@ public class SingularityMailer implements Managed {
 
   }
 
-  private void sendRequestMail(final SingularityRequest request, final RequestMailType type, final Optional<String> user, final Optional<Map<String, Object>> additionalProperties) {
+  private void sendRequestMail(final SingularityRequest request, final RequestMailType type, final Optional<String> user, final Optional<String> message, final Optional<Map<String, Object>> additionalProperties) {
     if (!maybeSmtpConfiguration.isPresent()) {
       LOG.debug("Not sending request mail - no SMTP configuration is present");
       return;
@@ -344,7 +352,7 @@ public class SingularityMailer implements Managed {
       @Override
       public void run() {
         try {
-          prepareRequestMail(request, type, user, additionalProperties);
+          prepareRequestMail(request, type, user, message, additionalProperties);
         } catch (Throwable t) {
           LOG.error("While preparing request mail for {} / {}", request, type, t);
           exceptionNotifier.notify(t, ImmutableMap.of("requestId", request.getId()));
@@ -353,7 +361,7 @@ public class SingularityMailer implements Managed {
     });
   }
 
-  private void prepareRequestMail(SingularityRequest request, RequestMailType type, Optional<String> user, Optional<Map<String, Object>> additionalProperties) {
+  private void prepareRequestMail(SingularityRequest request, RequestMailType type, Optional<String> user, Optional<String> message, Optional<Map<String, Object>> additionalProperties) {
     final List<SingularityEmailDestination> emailDestination = getDestination(request, type.getEmailType());
 
     if (emailDestination.isEmpty()) {
@@ -371,9 +379,14 @@ public class SingularityMailer implements Managed {
     templateProperties.put("requestScaled", type == RequestMailType.SCALED);
     templateProperties.put("action", type.name().toLowerCase());
     templateProperties.put("hasUser", user.isPresent());
+    templateProperties.put("hasMessage", message.isPresent());
 
     if (user.isPresent()) {
       templateProperties.put("user", user.get());
+    }
+
+    if (message.isPresent()) {
+      templateProperties.put("message", message.get());
     }
 
     if (additionalProperties.isPresent()) {
@@ -381,6 +394,10 @@ public class SingularityMailer implements Managed {
     }
 
     final String body = Jade4J.render(requestModifiedTemplate, templateProperties);
+
+    if (LOG_EMAILS_FOR_DEBUG) {
+      LOG.debug("TheMail: " + body);
+    }
 
     queueMail(emailDestination, request, type.getEmailType(), user, subject, body);
   }
@@ -403,38 +420,45 @@ public class SingularityMailer implements Managed {
 
     Boolean killTasks = Boolean.TRUE;
 
+    Optional<String> message = Optional.absent();
+
     if (pauseRequest.isPresent()) {
       setupExpireFormat(additionalProperties, pauseRequest.get().getDurationMillis());
 
       if (pauseRequest.get().getKillTasks().isPresent()) {
         killTasks = pauseRequest.get().getKillTasks().get();
       }
+
+      message = pauseRequest.get().getMessage();
     }
 
     additionalProperties.put("killTasks", killTasks);
 
-    sendRequestMail(request, RequestMailType.PAUSED, user, Optional.of(additionalProperties));
+    sendRequestMail(request, RequestMailType.PAUSED, user, message, Optional.of(additionalProperties));
   }
 
-  public void sendRequestUnpausedMail(SingularityRequest request, Optional<String> user) {
-    sendRequestMail(request, RequestMailType.UNPAUSED, user, Optional.<Map<String, Object>> absent());
+  public void sendRequestUnpausedMail(SingularityRequest request, Optional<String> user, Optional<String> message) {
+    sendRequestMail(request, RequestMailType.UNPAUSED, user, message, Optional.<Map<String, Object>> absent());
   }
 
   public void sendRequestScaledMail(SingularityRequest request, Optional<SingularityScaleRequest> newScaleRequest, Optional<Integer> formerInstances, Optional<String> user) {
     Map<String, Object> additionalProperties = new HashMap<>();
 
+    Optional<String> message = Optional.absent();
+
     if (newScaleRequest.isPresent()) {
       setupExpireFormat(additionalProperties, newScaleRequest.get().getDurationMillis());
+      message = newScaleRequest.get().getMessage();
     }
 
     additionalProperties.put("newInstances", request.getInstancesSafe());
     additionalProperties.put("oldInstances", formerInstances.or(1));
 
-    sendRequestMail(request, RequestMailType.SCALED, user, Optional.of(additionalProperties));
+    sendRequestMail(request, RequestMailType.SCALED, user, message, Optional.of(additionalProperties));
   }
 
-  public void sendRequestRemovedMail(SingularityRequest request, Optional<String> user) {
-    sendRequestMail(request, RequestMailType.REMOVED, user, Optional.<Map<String, Object>> absent());
+  public void sendRequestRemovedMail(SingularityRequest request, Optional<String> user, Optional<String> message) {
+    sendRequestMail(request, RequestMailType.REMOVED, user, message, Optional.<Map<String, Object>> absent());
   }
 
   public void sendRequestInCooldownMail(final SingularityRequest request) {
@@ -475,6 +499,10 @@ public class SingularityMailer implements Managed {
     templateProperties.put("cooldownExpiresFormat", DurationFormatUtils.formatDurationHMS(TimeUnit.MINUTES.toMillis(configuration.getCooldownExpiresAfterMinutes())));
 
     final String body = Jade4J.render(requestInCooldownTemplate, templateProperties);
+
+    if (LOG_EMAILS_FOR_DEBUG) {
+      LOG.debug("TheMail: " + body);
+    }
 
     queueMail(emailDestination, request, SingularityEmailType.REQUEST_IN_COOLDOWN, Optional.<String> absent(), subject, body);
   }
@@ -595,6 +623,10 @@ public class SingularityMailer implements Managed {
           }
         }
       }
+    }
+
+    if (LOG_EMAILS_FOR_DEBUG) {
+      LOG.debug("TheMail: " + body);
     }
 
     smtpSender.queueMail(toList, ccList, subject, body);

--- a/SingularityService/src/main/java/com/hubspot/singularity/smtp/SingularityMailer.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/smtp/SingularityMailer.java
@@ -73,10 +73,6 @@ public class SingularityMailer implements Managed {
 
   private static final Pattern TASK_STATUS_BY_PATTERN = Pattern.compile("(\\w+) by \\w+");
 
-  /// Set this to true to log emails being sent. This allows testing locally without setting up an SMTP server
-  /// To find the email html, grep the logs: "grep TheMail -A 10" (change 10 depending on how many lines you need)
-  private static final Boolean LOG_EMAILS_FOR_DEBUG = false;
-
   @Inject
   public SingularityMailer(
       SingularitySmtpSender smtpSender,
@@ -291,10 +287,6 @@ public class SingularityMailer implements Managed {
 
     final String body = Jade4J.render(taskTemplate, templateProperties);
 
-    if (LOG_EMAILS_FOR_DEBUG) {
-      LOG.debug("TheMail: " + body);
-    }
-
     final Optional<String> user = task.isPresent() ? task.get().getTaskRequest().getPendingTask().getUser() : Optional.<String> absent();
 
     queueMail(emailDestination, request, emailType, user, subject, body);
@@ -394,10 +386,6 @@ public class SingularityMailer implements Managed {
     }
 
     final String body = Jade4J.render(requestModifiedTemplate, templateProperties);
-
-    if (LOG_EMAILS_FOR_DEBUG) {
-      LOG.debug("TheMail: " + body);
-    }
 
     queueMail(emailDestination, request, type.getEmailType(), user, subject, body);
   }
@@ -499,10 +487,6 @@ public class SingularityMailer implements Managed {
     templateProperties.put("cooldownExpiresFormat", DurationFormatUtils.formatDurationHMS(TimeUnit.MINUTES.toMillis(configuration.getCooldownExpiresAfterMinutes())));
 
     final String body = Jade4J.render(requestInCooldownTemplate, templateProperties);
-
-    if (LOG_EMAILS_FOR_DEBUG) {
-      LOG.debug("TheMail: " + body);
-    }
 
     queueMail(emailDestination, request, SingularityEmailType.REQUEST_IN_COOLDOWN, Optional.<String> absent(), subject, body);
   }
@@ -623,10 +607,6 @@ public class SingularityMailer implements Managed {
           }
         }
       }
-    }
-
-    if (LOG_EMAILS_FOR_DEBUG) {
-      LOG.debug("TheMail: " + body);
     }
 
     smtpSender.queueMail(toList, ccList, subject, body);

--- a/SingularityService/src/main/java/com/hubspot/singularity/smtp/SingularitySmtpSender.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/smtp/SingularitySmtpSender.java
@@ -69,7 +69,7 @@ public class SingularitySmtpSender implements Managed {
 
   public void queueMail(final List<String> toList, final List<String> ccList, final String subject, final String body) {
     if (LOG_EMAILS_FOR_DEBUG) {
-      LOG.debug("TheMail: " + body);
+      LOG.trace("TheMail: " + body);
     }
 
     if (toList.isEmpty()) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/smtp/SingularitySmtpSender.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/smtp/SingularitySmtpSender.java
@@ -37,10 +37,6 @@ public class SingularitySmtpSender implements Managed {
 
   private static final Logger LOG = LoggerFactory.getLogger(SingularitySmtpSender.class);
 
-  /// Set this to true to log emails being sent. This allows testing locally without setting up an SMTP server
-  /// To find the email html, grep the logs: "grep TheMail -A 10" (change 10 depending on how many lines you need)
-  private static final Boolean LOG_EMAILS_FOR_DEBUG = false;
-
   private final Optional<SMTPConfiguration> maybeSmtpConfiguration;
   private final Optional<ThreadPoolExecutor> mailSenderExecutorService;
   private final SingularityExceptionNotifier exceptionNotifier;
@@ -68,9 +64,9 @@ public class SingularitySmtpSender implements Managed {
   }
 
   public void queueMail(final List<String> toList, final List<String> ccList, final String subject, final String body) {
-    if (LOG_EMAILS_FOR_DEBUG) {
-      LOG.trace("TheMail: " + body);
-    }
+
+    LOG.trace("Sending email to: {}, cc: {}, body: {}", toList, ccList, body); // Log the email for viewing without SMTP server
+
 
     if (toList.isEmpty()) {
       LOG.warn("Couldn't queue email {} because no to address is present", subject);

--- a/SingularityService/src/main/java/com/hubspot/singularity/smtp/SingularitySmtpSender.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/smtp/SingularitySmtpSender.java
@@ -30,8 +30,6 @@ import com.hubspot.singularity.sentry.SingularityExceptionNotifier;
 
 import io.dropwizard.lifecycle.Managed;
 
-
-
 @Singleton
 public class SingularitySmtpSender implements Managed {
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/smtp/SingularitySmtpSender.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/smtp/SingularitySmtpSender.java
@@ -30,10 +30,16 @@ import com.hubspot.singularity.sentry.SingularityExceptionNotifier;
 
 import io.dropwizard.lifecycle.Managed;
 
+
+
 @Singleton
 public class SingularitySmtpSender implements Managed {
 
   private static final Logger LOG = LoggerFactory.getLogger(SingularitySmtpSender.class);
+
+  /// Set this to true to log emails being sent. This allows testing locally without setting up an SMTP server
+  /// To find the email html, grep the logs: "grep TheMail -A 10" (change 10 depending on how many lines you need)
+  private static final Boolean LOG_EMAILS_FOR_DEBUG = false;
 
   private final Optional<SMTPConfiguration> maybeSmtpConfiguration;
   private final Optional<ThreadPoolExecutor> mailSenderExecutorService;
@@ -62,6 +68,10 @@ public class SingularitySmtpSender implements Managed {
   }
 
   public void queueMail(final List<String> toList, final List<String> ccList, final String subject, final String body) {
+    if (LOG_EMAILS_FOR_DEBUG) {
+      LOG.debug("TheMail: " + body);
+    }
+
     if (toList.isEmpty()) {
       LOG.warn("Couldn't queue email {} because no to address is present", subject);
       return;

--- a/SingularityService/src/main/resources/templates/request_modified.jade
+++ b/SingularityService/src/main/resources/templates/request_modified.jade
@@ -28,6 +28,8 @@ html
               h2(style="font-weight: normal; margin: 0 0 21px; line-height: 1") has been #{ action } by #{ user }
             else
               h2(style="font-weight: normal; margin: 0 0 21px; line-height: 1") has been #{ action }
+            if hasMessage
+              h2(style="font-weight: normal; margin: 0 0 21px; line-height: 1") Message: #{ message }
             if singularityRequestLink
               a(style="background: #08c; color: #fff; padding: 10px 20px; display: inline-block; text-decoration: none; font-size: 13px; letter-spacing: .08em; text-transform: uppercase; border-radius: 3px", href="#{ singularityRequestLink }") View request
 


### PR DESCRIPTION
Now that Singularity has the capability to accept optional user messages for tasks, these messages can be included in any emails sent because of user actions with messages. This commit includes that ability.
It also includes the ability to set a variable, LOG_EMAILS_FOR_DEBUG - If this variable is set to true, all emails sent will be logged in the debug logs. This allows local testing of emails without an SMTP server.