### PR TITLE
Warning to Disable Healthchecks for < 1 Hour

### DIFF
--- a/SingularityUI/app/models/Request.coffee
+++ b/SingularityUI/app/models/Request.coffee
@@ -272,6 +272,21 @@ class Request extends Model
                         else
                             callback()
 
+    promptDisableHealthchecksDuration: (message, duration, callback) =>
+        durationMillis = @_parseDuration(duration)
+        if durationMillis < 3600000
+            vex.dialog.confirm
+                message: '
+                    <strong>We strongly recommend against disabling healthchecks for less than an hour.</strong>
+                    Your task may not have enough time to get into a stable state.
+                    Are you sure you want to do this?
+                '
+                callback: (data) =>
+                    if data
+                        @disableHealthchecks(message, duration).done callback
+        else
+            @disableHealthchecks(message, duration).done callback
+
     promptDisableHealthchecks: (callback) =>
         vex.dialog.open
             message: "Turn <strong>off</strong> healthchecks for this request."
@@ -288,8 +303,11 @@ class Request extends Model
                 return unless data
                 duration = $('.vex #disable-healthchecks-expiration').val()
                 message = $('.vex #disable-healthchecks-message').val()
-                if !duration or (duration and @_validateDuration(duration, @promptDisableHealthchecks))
+                if !duration
                     @disableHealthchecks(message, duration).done callback
+                else if @_validateDuration(duration, @promptDisableHealthchecks)
+                    @promptDisableHealthchecksDuration(message, duration, callback)
+
 
     promptEnableHealthchecks: (callback) =>
         vex.dialog.open

--- a/SingularityUI/app/models/Request.coffee
+++ b/SingularityUI/app/models/Request.coffee
@@ -277,10 +277,13 @@ class Request extends Model
         if durationMillis < 3600000
             vex.dialog.confirm
                 message: '
-                    <strong>We strongly recommend against disabling healthchecks for less than an hour.</strong>
-                    Your task may not have enough time to get into a stable state.
-                    Are you sure you want to do this?
+                    <strong>Are you sure you want to disable healthchecks for less than an hour?</strong>
+                    This may not be enough time for your service to get into a stable state.
                 '
+                buttons: [
+                    $.extend _.clone(vex.dialog.buttons.YES), text: 'Disable Healthchecks'
+                    vex.dialog.buttons.NO
+                ]
                 callback: (data) =>
                     if data
                         @disableHealthchecks(message, duration).done callback


### PR DESCRIPTION
Some processes need a decent chunk of time to go from zero to healthy.
If the healthchecks run before the process is healthy, which may happen when tasks are in a bad state, problems could occur.
This change posts a warning and requires a second confirmation to disable healthchecks for less than one hour.