### PR TITLE
Page Now Automatically Refreshes Even After Invalid Duration Entered

### DIFF
--- a/SingularityUI/app/models/Request.coffee
+++ b/SingularityUI/app/models/Request.coffee
@@ -202,7 +202,7 @@ class Request extends Model
             contentType: 'application/json'
             data: JSON.stringify(data)
 
-    _validateDuration: (duration, action) =>
+    _validateDuration: (duration, action, callback) =>
         if @_parseDuration(duration)
             return true
         else
@@ -210,7 +210,7 @@ class Request extends Model
                 message: 'Invalid duration specified, please try again.'
                 callback: (data) ->
                   if data
-                      action()
+                      action(callback)
             return false
 
     _parseDuration: (duration) =>
@@ -237,7 +237,7 @@ class Request extends Model
                 duration = $('.vex #pause-expiration').val()
                 message = $('.vex #pause-message').val()
 
-                if !duration or (duration and @_validateDuration(duration, @promptPause))
+                if !duration or (duration and @_validateDuration(duration, @promptPause, callback))
                     @pause(killTasks, duration, message).done callback
 
     promptScale: (callback) =>
@@ -265,7 +265,7 @@ class Request extends Model
                 incremental = $('.vex #incremental-bounce').is ':checked'
                 message = $('.vex #scale-message').val()
                 duration = $('.vex #scale-expiration').val()
-                if !duration or (duration and @_validateDuration(duration, @promptScale))
+                if !duration or (duration and @_validateDuration(duration, @promptScale, callback))
                     @scale(data).done =>
                         if bounce
                             @bounce({incremental}).done callback
@@ -288,7 +288,7 @@ class Request extends Model
                 return unless data
                 duration = $('.vex #disable-healthchecks-expiration').val()
                 message = $('.vex #disable-healthchecks-message').val()
-                if !duration or (duration and @_validateDuration(duration, @promptDisableHealthchecks))
+                if !duration or (duration and @_validateDuration(duration, @promptDisableHealthchecks, callback))
                     @disableHealthchecks(message, duration).done callback
 
     promptEnableHealthchecks: (callback) =>
@@ -307,7 +307,7 @@ class Request extends Model
                 return unless data
                 duration = $('.vex #disable-healthchecks-expiration').val()
                 message = $('.vex #disable-healthchecks-message').val()
-                if !duration or (duration and @_validateDuration(duration, @promptEnableHealthchecks))
+                if !duration or (duration and @_validateDuration(duration, @promptEnableHealthchecks, callback))
                     @enableHealthchecks(message, duration).done callback
 
     promptUnpause: (callback) =>
@@ -442,7 +442,7 @@ class Request extends Model
                 confirmed.skipHealthchecks = $('.vex #skip-healthchecks').is ':checked'
                 confirmed.duration = $('.vex #bounce-expiration').val()
 
-                if !confirmed.duration or (confirmed.duration and @_validateDuration(confirmed.duration, @promptBounce))
+                if !confirmed.duration or (confirmed.duration and @_validateDuration(confirmed.duration, @promptBounce, callback))
                     @bounce(confirmed).done callback
 
     promptExitCooldown: (callback) =>


### PR DESCRIPTION
This could potentially create a merge conflict with #851 - if so, resolve by adding the callback argument to any @_validateDuration calls.