### PR TITLE
File error fix

### DIFF
--- a/SingularityUI/app/controllers/Controller.coffee
+++ b/SingularityUI/app/controllers/Controller.coffee
@@ -35,4 +35,7 @@ class Controller
     # e.g. `myModel.fetch().error @ignore404`
     ignore404: (response) -> app.caughtError() if response.status is 404
 
+    # e.g. `myModel.fetch().error @ignore400`
+    ignore400: (response) -> app.caughtError() if response.status is 400
+
 module.exports = Controller

--- a/SingularityUI/app/controllers/TaskDetail.coffee
+++ b/SingularityUI/app/controllers/TaskDetail.coffee
@@ -192,6 +192,7 @@ class TaskDetailController extends Controller
             @collections.alerts.reset(alerts)
 
     refresh: ->
+        console.log "Refresh"
         @resourcesFetched = false
 
         @collections.taskCleanups.fetch()
@@ -199,14 +200,14 @@ class TaskDetailController extends Controller
         @collections.pendingDeploys.fetch()
 
         @models.task.fetch()
-            .done =>
+           .done =>
                 @collections.files.fetch().error @ignore404
                 @fetchResourceUsage() if @models.task.get('isStillRunning')
                 logPath = if @models.task.get('isStillRunning') then config.runningTaskLogPath else config.finishedTaskLogPath
                 logPath = logPath.replace('$TASK_ID', @taskId)
                 logPath = _.initial(logPath.split('/')).join('/')
                 @collections.logDirectory.path = logPath
-                @collections.logDirectory.fetch()
+                @collections.logDirectory.fetch().error @ignore404
             .success =>
                 @getAlerts()
             .error =>

--- a/SingularityUI/app/controllers/TaskDetail.coffee
+++ b/SingularityUI/app/controllers/TaskDetail.coffee
@@ -192,7 +192,6 @@ class TaskDetailController extends Controller
             @collections.alerts.reset(alerts)
 
     refresh: ->
-        console.log "Refresh"
         @resourcesFetched = false
 
         @collections.taskCleanups.fetch()
@@ -200,14 +199,14 @@ class TaskDetailController extends Controller
         @collections.pendingDeploys.fetch()
 
         @models.task.fetch()
-           .done =>
+            .done =>
                 @collections.files.fetch().error @ignore404
                 @fetchResourceUsage() if @models.task.get('isStillRunning')
                 logPath = if @models.task.get('isStillRunning') then config.runningTaskLogPath else config.finishedTaskLogPath
                 logPath = logPath.replace('$TASK_ID', @taskId)
                 logPath = _.initial(logPath.split('/')).join('/')
                 @collections.logDirectory.path = logPath
-                @collections.logDirectory.fetch().error @ignore404
+                @collections.logDirectory.fetch().error @ignore400
             .success =>
                 @getAlerts()
             .error =>


### PR DESCRIPTION
When a new task starts up, logs aren't generated right away.
An error notification would pop up with an opaque error message telling you that there was a problem, but not quite telling you what.
This fixes that - now the error message doesn't pop up at all. A new ignore400 function is added to allow ignoring 400 errors, and that function is called when the logs are fetched.