### PR TITLE
Upgrade Horizon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,12 @@ git:
 
 sudo: false
 
+before_install:
+  - wget https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip
+  - unzip -qq apache-maven-3.3.9-bin.zip
+  - export M2_HOME=$PWD/apache-maven-3.3.9
+  - export PATH=$M2_HOME/bin:$PATH
+
 cache:
   directories:
   - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ jdk:
   - oraclejdk7
   - openjdk7
   - oraclejdk8
-install: mvn -Pbuild-swagger-documentation -DskipTests=true -B -q -fae install
-script: mvn -B -q -fae verify
+install: mvn -Pbuild-swagger-documentation -DskipTests=true -DskipSingularityWebUI -B -q -fae install
+script: mvn -DskipSingularityWebUI -B -q -fae verify
 
 git:
   depth: 100
@@ -20,5 +20,3 @@ before_install:
 cache:
   directories:
   - $HOME/.m2
-  - SingularityUI/bower_components
-  - SingularityUI/node_modules

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>12.6</version>
+    <version>15.1</version>
   </parent>
 
   <artifactId>Singularity</artifactId>
@@ -38,7 +38,7 @@
 
     <dropwizard.guicier.version>0.7.1.2</dropwizard.guicier.version>
     <baragon.version>0.1.8</baragon.version>
-    <horizon.version>0.0.20</horizon.version>
+    <horizon.version>0.0.22</horizon.version>
     <mesos.docker.tag>0.23.0-1.0.ubuntu1404</mesos.docker.tag>
     <mesos.version>0.23.0</mesos.version>
     <singularitybase.image.revision>1</singularitybase.image.revision>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>15.1</version>
+    <version>12.8</version>
   </parent>
 
   <artifactId>Singularity</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
 
     <dropwizard.guicier.version>0.7.1.2</dropwizard.guicier.version>
     <baragon.version>0.1.8</baragon.version>
+    <horizon.version>0.0.20</horizon.version>
     <mesos.docker.tag>0.23.0-1.0.ubuntu1404</mesos.docker.tag>
     <mesos.version>0.23.0</mesos.version>
     <singularitybase.image.revision>1</singularitybase.image.revision>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>12.8</version>
+    <version>12.9</version>
   </parent>
 
   <artifactId>Singularity</artifactId>


### PR DESCRIPTION
The new version of Horizon makes the async client use daemon threads which helps to ensure the JVM shuts down gracefully

@tpetr @ssalinas @wsorenson 