### PR TITLE
Instantly overdue tasks

### DIFF
--- a/SingularityUI/app/assets/_index.mustache
+++ b/SingularityUI/app/assets/_index.mustache
@@ -26,6 +26,7 @@
             defaultHealthcheckIntervalSeconds: {{{defaultHealthcheckIntervalSeconds}}},
             defaultHealthcheckTimeoutSeconds: {{{defaultHealthcheckTimeoutSeconds}}},
             defaultDeployHealthTimeoutSeconds: {{{defaultDeployHealthTimeoutSeconds}}},
+            pendingWithinSeconds: 60,
             runningTaskLogPath: "{{{ runningTaskLogPath }}}",
             finishedTaskLogPath: "{{{ finishedTaskLogPath }}}",
             commonHostnameSuffixToOmit: "{{{ commonHostnameSuffixToOmit }}}",

--- a/SingularityUI/app/handlebarsHelpers.coffee
+++ b/SingularityUI/app/handlebarsHelpers.coffee
@@ -77,6 +77,15 @@ Handlebars.registerHelper 'ifTimestampInPast', (timestamp, options) ->
     else
         options.inverse @
 
+Handlebars.registerHelper 'ifTimestampMinuteInPast', (timestamp, options) ->
+    return options.inverse @ if not timestamp
+    timeObject = moment timestamp
+    past = moment().subtract(1, "second")
+    if timeObject.isBefore(past)
+        options.fn @
+    else
+        options.inverse @
+
 # 12345 => 12 seconds
 Handlebars.registerHelper 'timestampDuration', (timestamp) ->
     return '' if not timestamp

--- a/SingularityUI/app/handlebarsHelpers.coffee
+++ b/SingularityUI/app/handlebarsHelpers.coffee
@@ -77,11 +77,20 @@ Handlebars.registerHelper 'ifTimestampInPast', (timestamp, options) ->
     else
         options.inverse @
 
-Handlebars.registerHelper 'ifTimestampMinuteInPast', (timestamp, options) ->
+Handlebars.registerHelper 'ifTimestampSecondsInPast', (timestamp, seconds, options) ->
     return options.inverse @ if not timestamp
     timeObject = moment timestamp
-    past = moment().subtract(1, "second")
+    past = moment().subtract(seconds, "seconds")
     if timeObject.isBefore(past)
+        options.fn @
+    else
+        options.inverse @
+
+Handlebars.registerHelper 'ifTimestampSecondsInFuture', (timestamp, seconds, options) ->
+    return options.inverse @ if not timestamp
+    timeObject = moment timestamp
+    future = moment().add(seconds, "seconds")
+    if timeObject.isAfter(future)
         options.fn @
     else
         options.inverse @

--- a/SingularityUI/app/templates/requestDetail/requestScheduledTasks.hbs
+++ b/SingularityUI/app/templates/requestDetail/requestScheduledTasks.hbs
@@ -24,9 +24,9 @@
                     </td>
                     <td data-value="{{ pendingTask.pendingTaskId.nextRunAt }}">
                         {{timestampFromNow pendingTask.pendingTaskId.nextRunAt}}
-                        {{#ifTimestampInPast pendingTask.pendingTaskId.nextRunAt}}
+                        {{#ifTimestampMinuteInPast pendingTask.pendingTaskId.nextRunAt}}
                             <span class="label label-danger">OVERDUE</span>
-                        {{/ifTimestampInPast}}
+                        {{/ifTimestampMinuteInPast}}
                     </td>
                     <td class="hidden-xs actions-column">
                         {{#unless ../request.attributes.daemon}}

--- a/SingularityUI/app/templates/requestDetail/requestScheduledTasks.hbs
+++ b/SingularityUI/app/templates/requestDetail/requestScheduledTasks.hbs
@@ -24,9 +24,15 @@
                     </td>
                     <td data-value="{{ pendingTask.pendingTaskId.nextRunAt }}">
                         {{timestampFromNow pendingTask.pendingTaskId.nextRunAt}}
-                        {{#ifTimestampMinuteInPast pendingTask.pendingTaskId.nextRunAt}}
+                        {{#ifTimestampSecondsInPast pendingTask.pendingTaskId.nextRunAt ../config.pendingWithinSeconds }}
                             <span class="label label-danger">OVERDUE</span>
-                        {{/ifTimestampMinuteInPast}}
+                        {{else}}
+                            {{#ifTimestampSecondsInFuture pendingTask.pendingTaskId.nextRunAt ../config.pendingWithinSeconds }}
+                                <span class="label label-default">SCHEDULED</span>
+                            {{else}}
+                                <span class="label label-info">PENDING</span>
+                            {{/ifTimestampSecondsInFuture}}
+                        {{/ifTimestampSecondsInPast}}
                     </td>
                     <td class="hidden-xs actions-column">
                         {{#unless ../request.attributes.daemon}}

--- a/SingularityUI/app/templates/tasksTable/tasksScheduledBody.hbs
+++ b/SingularityUI/app/templates/tasksTable/tasksScheduledBody.hbs
@@ -30,11 +30,15 @@
                     </td>
                     <td class="hidden-xs">
                         {{timestampFromNow pendingTask.pendingTaskId.nextRunAt}}
-                        {{#if pendingTask.pendingTaskId}}
-                            {{#ifTimestampInPast pendingTask.pendingTaskId.nextRunAt}}
-                                <span class="label label-danger">OVERDUE</span>
-                            {{/ifTimestampInPast}}
-                        {{/if}}
+                        {{#ifTimestampSecondsInPast pendingTask.pendingTaskId.nextRunAt ../config.pendingWithinSeconds }}
+                            <span class="label label-danger">OVERDUE</span>
+                        {{else}}
+                            {{#ifTimestampSecondsInFuture pendingTask.pendingTaskId.nextRunAt ../config.pendingWithinSeconds }}
+                                <span class="label label-default">SCHEDULED</span>
+                            {{else}}
+                                <span class="label label-info">PENDING</span>
+                            {{/ifTimestampSecondsInFuture}}
+                        {{/ifTimestampSecondsInPast}}
                     </td>
                     <td>
                         {{humanizeText pendingTask.pendingTaskId.pendingType}}

--- a/SingularityUI/app/views/tasks.coffee
+++ b/SingularityUI/app/views/tasks.coffee
@@ -148,6 +148,7 @@ class TasksView extends View
             tasks: tasks
             rowsOnly: true
             decomissioning_tasks: decomTasks
+            config: config
 
         $table = @$ ".table-staged table"
         $tableBody = $table.find "tbody"


### PR DESCRIPTION
Scheduled tasks are shown as overdue the second after they were supposed to start up.
That is fine for most use cases, but when a task is bounced the replacement tasks are scheduled to start right away. Since it takes them a few seconds to start up, they're instantly marked as overdue.
With this pull request, tasks will show as scheduled if they're scheduled to start up more than a minute in the future. They'll show as pending if they're scheduled to start within a minute of now. And they'll only show as overdue if they are scheduled to start more than a minute ago.