### PR TITLE
Fix the sorting in the wrong order bug.

### DIFF
--- a/SingularityUI/app/collections/TaskFiles.coffee
+++ b/SingularityUI/app/collections/TaskFiles.coffee
@@ -58,7 +58,7 @@ class TaskFiles extends Collection
             return -1
         else if not a.get('isDirectory') and b.get('isDirectory')
             return 1
-        return a.get('path') - b.get('path')
+        return a.get('name') > b.get('name')
 
     testSandbox: ->
         $.ajax

--- a/SingularityUI/app/collections/TaskFiles.coffee
+++ b/SingularityUI/app/collections/TaskFiles.coffee
@@ -54,11 +54,19 @@ class TaskFiles extends Collection
         taskFiles
 
     comparator: (a, b) ->
+        return @nameComparator(a, b)
+
+    nameComparator: (a, b) ->
         if a.get('isDirectory') and not b.get('isDirectory')
             return -1
         else if not a.get('isDirectory') and b.get('isDirectory')
             return 1
-        return a.get('name') > b.get('name')
+        else if a.get('name') > b.get('name')
+            return 1
+        else if a.get('name') < b.get('name')
+            return -1
+        else
+            return 0
 
     testSandbox: ->
         $.ajax


### PR DESCRIPTION
When more than 10 files were present in a task, the sort order became very wrong in Chrome. Manually overriding the sort order would cause files to jump around.
This fixes the wrong initial sort order. Unfortunately files will still jump around, but that can be avoided by not manually sorting the table.