### PR TITLE
Don't show deleted request message if not deleted

### DIFF
--- a/SingularityUI/app/controllers/RequestDetail.coffee
+++ b/SingularityUI/app/controllers/RequestDetail.coffee
@@ -77,6 +77,8 @@ class RequestDetailController extends Controller
         @subviews.requestHistoryMsg = new SimpleSubview
             collection: @collections.requestHistory
             template:   @templates.requestHistoryMsg
+            extraRenderData: (subView) =>
+                { request: @models.request.toJSON() }
 
         @subviews.stats = new SimpleSubview
             model:      @models.activeDeployStats

--- a/SingularityUI/app/templates/requestDetail/requestHistoryMsg.hbs
+++ b/SingularityUI/app/templates/requestDetail/requestHistoryMsg.hbs
@@ -1,23 +1,25 @@
 {{! Part of requestBase }}
 
-{{#ifEqual data.[0].eventType 'DELETED'}}
-    <div class="row detail-header">
-        <div class="col-md-12">
-            <h4>
-                <span class="request-state" data-state="DELETED">
-                    Deleted
-                </span>
-                <span class="request-type">
-                    {{humanizeText data.[0].request.requestType }} 
-                </span>                
-            </h4>
-            <h2>
-                {{ data.[0].request.id }} 
-            </h2>
+{{#unless request}}
+    {{#ifEqual data.[0].eventType 'DELETED'}}
+        <div class="row detail-header">
+            <div class="col-md-12">
+                <h4>
+                    <span class="request-state" data-state="DELETED">
+                        Deleted
+                    </span>
+                    <span class="request-type">
+                        {{humanizeText data.[0].request.requestType }} 
+                    </span>                
+                </h4>
+                <h2>
+                    {{ data.[0].request.id }} 
+                </h2>
+            </div>
         </div>
-    </div>
-    <div class='alert alert-warning'>
-        <strong>Note: </strong>This request was deleted {{timestampFromNow data.[0].createdAt}}{{#if data.[0].user}}, by {{data.[0].user}}{{/if}}. All active and scheduled tasks will not run again unless it is reposted to Singularity.
-    </div>
-{{/ifEqual}}
+        <div class='alert alert-warning'>
+            <strong>Note: </strong>This request was deleted {{timestampFromNow data.[0].createdAt}}{{#if data.[0].user}}, by {{data.[0].user}}{{/if}}. All active and scheduled tasks will not run again unless it is reposted to Singularity.
+        </div>
+    {{/ifEqual}}
+{{/unless}}
 


### PR DESCRIPTION
It only checks the last history event to see if it is deleted. In the case things might be out of order there, we shouldn't keep showing the deleted message if the request is actually still active