### PR TITLE
better handling of Docker timeouts

### DIFF
--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
@@ -207,7 +207,10 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
   private List<String> shellCommandPrefix = Collections.emptyList();
 
   @JsonProperty
-  private Optional<Integer> dockerClientTimeLimitSeconds = Optional.absent();
+  private int dockerClientTimeLimitSeconds = 600;
+
+  @JsonProperty
+  private int dockerClientConnectionPoolSize = 5;
 
   public SingularityExecutorConfiguration() {
     super(Optional.of("singularity-executor.log"));
@@ -585,12 +588,20 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
     this.shellCommandPrefix = shellCommandPrefix;
   }
 
-  public Optional<Integer> getDockerClientTimeLimitSeconds() {
+  public int getDockerClientTimeLimitSeconds() {
     return dockerClientTimeLimitSeconds;
   }
 
-  public void setDockerClientTimeLimitSeconds(Optional<Integer> dockerClientTimeLimitMs) {
+  public void setDockerClientTimeLimitSeconds(int dockerClientTimeLimitMs) {
     this.dockerClientTimeLimitSeconds = dockerClientTimeLimitMs;
+  }
+
+  public int getDockerClientConnectionPoolSize() {
+    return dockerClientConnectionPoolSize;
+  }
+
+  public void setDockerClientConnectionPoolSize(int dockerClientConnectionPoolSize) {
+    this.dockerClientConnectionPoolSize = dockerClientConnectionPoolSize;
   }
 
   @Override
@@ -643,6 +654,7 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
             ", shellCommandPidFile='" + shellCommandPidFile + '\'' +
             ", shellCommandPrefix='" + shellCommandPrefix + '\'' +
             ", dockerClientTimeLimitMs='" + dockerClientTimeLimitSeconds + '\'' +
+            ", dockerClientConnectionPoolSize='" + dockerClientConnectionPoolSize + '\'' +
             ']';
   }
 }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
@@ -207,7 +207,7 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
   private List<String> shellCommandPrefix = Collections.emptyList();
 
   @JsonProperty
-  private int dockerClientTimeLimitSeconds = 600;
+  private int dockerClientTimeLimitSeconds = 300;
 
   @JsonProperty
   private int dockerClientConnectionPoolSize = 5;

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorModule.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorModule.java
@@ -1,13 +1,11 @@
 package com.hubspot.singularity.executor.config;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
+import java.net.URI;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Template;
-import com.google.common.util.concurrent.SimpleTimeLimiter;
-import com.google.common.util.concurrent.TimeLimiter;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
@@ -88,12 +86,10 @@ public class SingularityExecutorModule extends AbstractModule {
   @Provides
   @Singleton
   public DockerClient providesDockerClient(SingularityExecutorConfiguration configuration) {
-    if (configuration.getDockerClientTimeLimitSeconds().isPresent()) {
-      TimeLimiter limiter = new SimpleTimeLimiter();
-      return limiter.newProxy(new DefaultDockerClient("unix:///var/run/docker.sock"), DockerClient.class, configuration.getDockerClientTimeLimitSeconds().get(), TimeUnit.SECONDS);
-    } else {
-      return new DefaultDockerClient("unix:///var/run/docker.sock");
-    }
+    return DefaultDockerClient.builder()
+      .uri(URI.create("unix://localhost/var/run/docker.sock"))
+      .connectionPoolSize(configuration.getDockerClientConnectionPoolSize())
+      .build();
   }
 
   @Provides

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorTaskBuilder.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorTaskBuilder.java
@@ -19,12 +19,12 @@ import com.hubspot.singularity.executor.TemplateManager;
 import com.hubspot.singularity.executor.task.SingularityExecutorArtifactFetcher;
 import com.hubspot.singularity.executor.task.SingularityExecutorTask;
 import com.hubspot.singularity.executor.task.SingularityExecutorTaskDefinition;
+import com.hubspot.singularity.executor.utils.DockerUtils;
 import com.hubspot.singularity.executor.utils.ExecutorUtils;
 import com.hubspot.singularity.runner.base.config.SingularityRunnerBaseModule;
 import com.hubspot.singularity.runner.base.configuration.SingularityRunnerBaseConfiguration;
 import com.hubspot.singularity.runner.base.shared.JsonObjectFileHelper;
 import com.hubspot.singularity.s3.base.config.SingularityS3Configuration;
-import com.spotify.docker.client.DockerClient;
 
 import ch.qos.logback.classic.Logger;
 
@@ -39,7 +39,7 @@ public class SingularityExecutorTaskBuilder {
   private final SingularityExecutorConfiguration executorConfiguration;
   private final SingularityS3Configuration s3Configuration;
   private final SingularityExecutorArtifactFetcher artifactFetcher;
-  private final DockerClient dockerClient;
+  private final DockerUtils dockerUtils;
 
   private final SingularityExecutorLogging executorLogging;
   private final ExecutorUtils executorUtils;
@@ -51,7 +51,7 @@ public class SingularityExecutorTaskBuilder {
   @Inject
   public SingularityExecutorTaskBuilder(ObjectMapper jsonObjectMapper, JsonObjectFileHelper jsonObjectFileHelper, TemplateManager templateManager,
       SingularityExecutorLogging executorLogging, SingularityRunnerBaseConfiguration baseConfiguration, SingularityExecutorConfiguration executorConfiguration, @Named(SingularityRunnerBaseModule.PROCESS_NAME) String executorPid,
-      ExecutorUtils executorUtils, SingularityExecutorArtifactFetcher artifactFetcher, DockerClient dockerClient, SingularityS3Configuration s3Configuration) {
+      ExecutorUtils executorUtils, SingularityExecutorArtifactFetcher artifactFetcher, DockerUtils dockerUtils, SingularityS3Configuration s3Configuration) {
     this.jsonObjectFileHelper = jsonObjectFileHelper;
     this.jsonObjectMapper = jsonObjectMapper;
     this.templateManager = templateManager;
@@ -59,7 +59,7 @@ public class SingularityExecutorTaskBuilder {
     this.baseConfiguration = baseConfiguration;
     this.executorConfiguration = executorConfiguration;
     this.artifactFetcher = artifactFetcher;
-    this.dockerClient = dockerClient;
+    this.dockerUtils = dockerUtils;
     this.executorPid = executorPid;
     this.executorUtils = executorUtils;
     this.s3Configuration = s3Configuration;
@@ -79,7 +79,7 @@ public class SingularityExecutorTaskBuilder {
 
     jsonObjectFileHelper.writeObject(taskDefinition, executorConfiguration.getTaskDefinitionPath(taskId), log);
 
-    return new SingularityExecutorTask(driver, executorUtils, baseConfiguration, executorConfiguration, taskDefinition, executorPid, artifactFetcher, taskInfo, templateManager, jsonObjectMapper, log, jsonObjectFileHelper, dockerClient, s3Configuration);
+    return new SingularityExecutorTask(driver, executorUtils, baseConfiguration, executorConfiguration, taskDefinition, executorPid, artifactFetcher, taskInfo, templateManager, jsonObjectMapper, log, jsonObjectFileHelper, dockerUtils, s3Configuration);
   }
 
   private ExecutorData readExecutorData(ObjectMapper objectMapper, Protos.TaskInfo taskInfo) {

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTask.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTask.java
@@ -13,11 +13,11 @@ import com.hubspot.deploy.ExecutorData;
 import com.hubspot.singularity.ExtendedTaskState;
 import com.hubspot.singularity.executor.TemplateManager;
 import com.hubspot.singularity.executor.config.SingularityExecutorConfiguration;
+import com.hubspot.singularity.executor.utils.DockerUtils;
 import com.hubspot.singularity.executor.utils.ExecutorUtils;
 import com.hubspot.singularity.runner.base.configuration.SingularityRunnerBaseConfiguration;
 import com.hubspot.singularity.runner.base.shared.JsonObjectFileHelper;
 import com.hubspot.singularity.s3.base.config.SingularityS3Configuration;
-import com.spotify.docker.client.DockerClient;
 
 import ch.qos.logback.classic.Logger;
 
@@ -39,7 +39,7 @@ public class SingularityExecutorTask {
   private final SingularityExecutorArtifactVerifier artifactVerifier;
 
   public SingularityExecutorTask(ExecutorDriver driver, ExecutorUtils executorUtils, SingularityRunnerBaseConfiguration baseConfiguration, SingularityExecutorConfiguration executorConfiguration, SingularityExecutorTaskDefinition taskDefinition, String executorPid,
-      SingularityExecutorArtifactFetcher artifactFetcher, Protos.TaskInfo taskInfo, TemplateManager templateManager, ObjectMapper objectMapper, Logger log, JsonObjectFileHelper jsonObjectFileHelper, DockerClient dockerClient, SingularityS3Configuration s3Configuration) {
+      SingularityExecutorArtifactFetcher artifactFetcher, Protos.TaskInfo taskInfo, TemplateManager templateManager, ObjectMapper objectMapper, Logger log, JsonObjectFileHelper jsonObjectFileHelper, DockerUtils dockerUtils, SingularityS3Configuration s3Configuration) {
     this.driver = driver;
     this.taskInfo = taskInfo;
     this.log = log;
@@ -54,8 +54,8 @@ public class SingularityExecutorTask {
     this.taskDefinition = taskDefinition;
 
     this.taskLogManager = new SingularityExecutorTaskLogManager(taskDefinition, templateManager, baseConfiguration, executorConfiguration, log, jsonObjectFileHelper);
-    this.taskCleanup = new SingularityExecutorTaskCleanup(taskLogManager, executorConfiguration, taskDefinition, log, dockerClient);
-    this.processBuilder = new SingularityExecutorTaskProcessBuilder(this, executorUtils, artifactFetcher, templateManager, executorConfiguration, taskDefinition.getExecutorData(), executorPid, dockerClient);
+    this.taskCleanup = new SingularityExecutorTaskCleanup(taskLogManager, executorConfiguration, taskDefinition, log, dockerUtils);
+    this.processBuilder = new SingularityExecutorTaskProcessBuilder(this, executorUtils, artifactFetcher, templateManager, executorConfiguration, taskDefinition.getExecutorData(), executorPid, dockerUtils);
     this.artifactVerifier = new SingularityExecutorArtifactVerifier(taskDefinition, log, executorConfiguration, s3Configuration);
   }
 

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskCleanup.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskCleanup.java
@@ -9,12 +9,9 @@ import java.util.List;
 import org.slf4j.Logger;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.util.concurrent.UncheckedTimeoutException;
 import com.hubspot.singularity.executor.config.SingularityExecutorConfiguration;
+import com.hubspot.singularity.executor.utils.DockerUtils;
 import com.hubspot.singularity.runner.base.shared.SimpleProcessManager;
-import com.spotify.docker.client.ContainerNotFoundException;
-import com.spotify.docker.client.DockerClient;
-import com.spotify.docker.client.messages.ContainerInfo;
 
 public class SingularityExecutorTaskCleanup {
 
@@ -22,14 +19,14 @@ public class SingularityExecutorTaskCleanup {
   private final SingularityExecutorTaskLogManager taskLogManager;
   private final SingularityExecutorConfiguration configuration;
   private final Logger log;
-  private final DockerClient dockerClient;
+  private final DockerUtils dockerUtils;
 
-  public SingularityExecutorTaskCleanup(SingularityExecutorTaskLogManager taskLogManager, SingularityExecutorConfiguration configuration, SingularityExecutorTaskDefinition taskDefinition, Logger log, DockerClient dockerClient) {
+  public SingularityExecutorTaskCleanup(SingularityExecutorTaskLogManager taskLogManager, SingularityExecutorConfiguration configuration, SingularityExecutorTaskDefinition taskDefinition, Logger log, DockerUtils dockerUtils) {
     this.configuration = configuration;
     this.taskLogManager = taskLogManager;
     this.taskDefinition = taskDefinition;
     this.log = log;
-    this.dockerClient = dockerClient;
+    this.dockerUtils = dockerUtils;
   }
 
   public TaskCleanupResult cleanup(boolean cleanupTaskAppDirectory, boolean isDocker) {
@@ -37,7 +34,7 @@ public class SingularityExecutorTaskCleanup {
 
     boolean dockerCleanSuccess = true;
     if (isDocker) {
-      dockerCleanSuccess = cleanDocker();
+      dockerCleanSuccess = dockerUtils.cleanDocker();
     }
 
     if (!Files.exists(taskDirectory)) {
@@ -112,26 +109,4 @@ public class SingularityExecutorTaskCleanup {
 
     return false;
   }
-
-  private boolean cleanDocker() {
-    String containerName = String.format("%s%s", configuration.getDockerPrefix(), taskDefinition.getTaskId());
-    try {
-      ContainerInfo containerInfo = dockerClient.inspectContainer(containerName);
-      if (containerInfo.state().running()) {
-        dockerClient.stopContainer(containerName, configuration.getDockerStopTimeout());
-      }
-      dockerClient.removeContainer(containerName);
-      log.info("Removed container {}", containerName);
-      return true;
-    } catch (ContainerNotFoundException e) {
-      log.info("Container {} was already removed", containerName);
-      return true;
-    } catch (UncheckedTimeoutException te) {
-      log.error("Timed out trying to reach docker daemon after {} seconds", configuration.getDockerClientTimeLimitSeconds(), te);
-    } catch (Exception e) {
-      log.info("Could not ensure removal of docker container", e);
-    }
-    return false;
-  }
-
 }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskProcessBuilder.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskProcessBuilder.java
@@ -65,7 +65,7 @@ public class SingularityExecutorTaskProcessBuilder implements Callable<ProcessBu
       try {
         dockerUtils.pull(task.getTaskInfo().getContainer().getDocker().getImage());
       } catch (DockerException e) {
-        throw new ProcessFailedException(String.format("Could not pull docker image due to error: %s", e));
+        throw new ProcessFailedException("Could not pull docker image", e);
       }
     }
 

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskProcessBuilder.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskProcessBuilder.java
@@ -9,7 +9,6 @@ import org.apache.mesos.Protos.TaskState;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
-import com.google.common.util.concurrent.UncheckedTimeoutException;
 import com.hubspot.deploy.ExecutorData;
 import com.hubspot.singularity.executor.TemplateManager;
 import com.hubspot.singularity.executor.config.SingularityExecutorConfiguration;
@@ -17,9 +16,10 @@ import com.hubspot.singularity.executor.models.DockerContext;
 import com.hubspot.singularity.executor.models.EnvironmentContext;
 import com.hubspot.singularity.executor.models.RunnerContext;
 import com.hubspot.singularity.executor.task.SingularityExecutorArtifactFetcher.SingularityExecutorTaskArtifactFetcher;
+import com.hubspot.singularity.executor.utils.DockerUtils;
 import com.hubspot.singularity.executor.utils.ExecutorUtils;
 import com.hubspot.singularity.runner.base.shared.ProcessFailedException;
-import com.spotify.docker.client.DockerClient;
+import com.spotify.docker.client.DockerException;
 
 public class SingularityExecutorTaskProcessBuilder implements Callable<ProcessBuilder> {
 
@@ -38,7 +38,7 @@ public class SingularityExecutorTaskProcessBuilder implements Callable<ProcessBu
 
   private Optional<SingularityExecutorTaskArtifactFetcher> taskArtifactFetcher;
 
-  private DockerClient dockerClient;
+  private DockerUtils dockerUtils;
 
   public SingularityExecutorTaskProcessBuilder(SingularityExecutorTask task,
                                                ExecutorUtils executorUtils,
@@ -46,7 +46,7 @@ public class SingularityExecutorTaskProcessBuilder implements Callable<ProcessBu
                                                TemplateManager templateManager,
                                                SingularityExecutorConfiguration configuration,
                                                ExecutorData executorData, String executorPid,
-                                               DockerClient dockerClient) {
+                                               DockerUtils dockerUtils) {
     this.executorData = executorData;
     this.task = task;
     this.executorUtils = executorUtils;
@@ -55,7 +55,7 @@ public class SingularityExecutorTaskProcessBuilder implements Callable<ProcessBu
     this.configuration = configuration;
     this.executorPid = executorPid;
     this.taskArtifactFetcher = Optional.absent();
-    this.dockerClient = dockerClient;
+    this.dockerUtils = dockerUtils;
   }
 
   @Override
@@ -63,9 +63,9 @@ public class SingularityExecutorTaskProcessBuilder implements Callable<ProcessBu
     if (task.getTaskInfo().hasContainer() && task.getTaskInfo().getContainer().hasDocker()) {
       executorUtils.sendStatusUpdate(task.getDriver(), task.getTaskInfo(), TaskState.TASK_STARTING, String.format("Pulling image... (executor pid: %s)", executorPid), task.getLog());
       try {
-        dockerClient.pull(task.getTaskInfo().getContainer().getDocker().getImage());
-      } catch (UncheckedTimeoutException te) {
-        throw new ProcessFailedException(String.format("Timed out trying to reach docker daemon after %s seconds", configuration.getDockerClientTimeLimitSeconds()));
+        dockerUtils.pull(task.getTaskInfo().getContainer().getDocker().getImage());
+      } catch (DockerException e) {
+        throw new ProcessFailedException(String.format("Could not pull docker image due to error: %s", e));
       }
     }
 

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/utils/DockerUtils.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/utils/DockerUtils.java
@@ -1,0 +1,166 @@
+package com.hubspot.singularity.executor.utils;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+
+import javax.print.Doc;
+
+import jdk.nashorn.internal.codegen.CompilerConstants.Call;
+
+import org.apache.mesos.Protos.Parameter;
+import org.slf4j.Logger;
+
+import com.google.common.util.concurrent.UncheckedTimeoutException;
+import com.google.inject.Inject;
+import com.hubspot.singularity.executor.config.SingularityExecutorConfiguration;
+import com.hubspot.singularity.executor.task.SingularityExecutorTaskDefinition;
+import com.spotify.docker.client.ContainerNotFoundException;
+import com.spotify.docker.client.DockerClient;
+import com.spotify.docker.client.DockerException;
+import com.spotify.docker.client.messages.Container;
+import com.spotify.docker.client.messages.ContainerInfo;
+
+public class DockerUtils {
+  private final SingularityExecutorTaskDefinition taskDefinition;
+  private final Logger log;
+  private final SingularityExecutorConfiguration configuration;
+  private final DockerClient dockerClient;
+  private final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+  @Inject
+  public DockerUtils(SingularityExecutorTaskDefinition taskDefinition, Logger log, SingularityExecutorConfiguration configuration, DockerClient dockerClient) {
+    this.taskDefinition = taskDefinition;
+    this.log = log;
+    this.configuration = configuration;
+    this.dockerClient = dockerClient;
+  }
+
+
+  public boolean cleanDocker() {
+    Callable<Boolean> callable = new Callable<Boolean>() {
+      @Override public Boolean call() throws Exception {
+        String containerName = String.format("%s%s", configuration.getDockerPrefix(), taskDefinition.getTaskId());
+        try {
+          ContainerInfo containerInfo = dockerClient.inspectContainer(containerName);
+          if (containerInfo.state().running()) {
+            dockerClient.stopContainer(containerName, configuration.getDockerStopTimeout());
+          }
+          dockerClient.removeContainer(containerName);
+          log.info("Removed container {}", containerName);
+          return true;
+        } catch (ContainerNotFoundException e) {
+          log.info("Container {} was already removed", containerName);
+          return true;
+        } catch (UncheckedTimeoutException te) {
+          log.error("Timed out trying to reach docker daemon after {} seconds", configuration.getDockerClientTimeLimitSeconds(), te);
+        } catch (Exception e) {
+          log.info("Could not ensure removal of docker container", e);
+        }
+        return false;
+      }
+    };
+
+    try {
+      return callWithTimeout(callable);
+    } catch (Exception e) {
+      log.error("Caught exception while cleaning docker containers", e);
+      return false;
+    }
+  }
+
+  public int getPid(final String containerName) throws DockerException {
+    return inspectContainer(containerName).state().pid();
+  }
+
+  public boolean isContainerRunning(final String containerName) throws DockerException {
+    return inspectContainer(containerName).state().running();
+  }
+
+  public ContainerInfo inspectContainer(final String containerName) throws DockerException {
+    Callable<ContainerInfo> callable = new Callable<ContainerInfo>() {
+      @Override public ContainerInfo call() throws Exception {
+        return dockerClient.inspectContainer(containerName);
+      }
+    };
+
+    try {
+      return callWithTimeout(callable);
+    } catch (Exception e) {
+      log.error("Caught exception while getting container status", e);
+      throw new DockerException(e);
+    }
+  }
+
+  public void pull(final String imageName) throws DockerException {
+    Callable<Void> callable = new Callable<Void>() {
+      @Override public Void call() throws Exception {
+        dockerClient.pull(imageName);
+        return null;
+      }
+    };
+
+    try {
+      callWithTimeout(callable);
+    } catch (Exception e) {
+      log.error("Could not pull image due to error", e);
+      throw new DockerException(e);
+    }
+  }
+
+  public List<Container> listContainers() throws DockerException {
+    Callable<List<Container>> callable = new Callable<List<Container>>() {
+      @Override public List<Container> call() throws Exception {
+        return dockerClient.listContainers();
+      }
+    };
+
+    try {
+      return callWithTimeout(callable);
+    } catch (Exception e) {
+      log.error("Caught exception attempting to list containers", e);
+      throw new DockerException(e);
+    }
+  }
+
+  public void stopContainer(final String containerId, final int timeout) throws DockerException {
+    Callable<Void> callable = new Callable<Void>() {
+      @Override public Void call() throws Exception {
+        dockerClient.stopContainer(containerId, timeout);
+        return null;
+      }
+    };
+
+    try {
+      callWithTimeout(callable);
+    } catch (Exception e) {
+      log.error("Caught exception attempting to stop container", e);
+      throw new DockerException(e);
+    }
+  }
+
+  public void removeContainer(final String containerId, final boolean removeRunning) throws DockerException {
+    Callable<Void> callable = new Callable<Void>() {
+      @Override public Void call() throws Exception {
+        dockerClient.removeContainer(containerId, removeRunning);
+        return null;
+      }
+    };
+
+    try {
+      callWithTimeout(callable);
+    } catch (Exception e) {
+      log.error("Caught exception attempting to stop container", e);
+      throw new DockerException(e);
+    }
+  }
+
+  private <T> T callWithTimeout(Callable<T> callable) throws Exception {
+    FutureTask<T> task = new FutureTask<T>(callable);
+    executor.execute(task);
+    return task.get(configuration.getDockerClientTimeLimitSeconds(), TimeUnit.SECONDS);
+  }
+}

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/utils/DockerUtils.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/utils/DockerUtils.java
@@ -7,9 +7,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.inject.Inject;
 import com.hubspot.singularity.executor.config.SingularityExecutorConfiguration;
 import com.spotify.docker.client.DockerClient;
@@ -18,9 +15,6 @@ import com.spotify.docker.client.messages.Container;
 import com.spotify.docker.client.messages.ContainerInfo;
 
 public class DockerUtils {
-  private static final Logger LOG = LoggerFactory.getLogger(DockerUtils.class);
-
-
   private final SingularityExecutorConfiguration configuration;
   private final DockerClient dockerClient;
   private final ExecutorService executor = Executors.newSingleThreadExecutor();
@@ -49,7 +43,6 @@ public class DockerUtils {
     try {
       return callWithTimeout(callable);
     } catch (Exception e) {
-      LOG.error("Caught exception while getting container status", e);
       throw new DockerException(e);
     }
   }
@@ -65,7 +58,6 @@ public class DockerUtils {
     try {
       callWithTimeout(callable);
     } catch (Exception e) {
-      LOG.error("Could not pull image due to error", e);
       throw new DockerException(e);
     }
   }
@@ -80,7 +72,6 @@ public class DockerUtils {
     try {
       return callWithTimeout(callable);
     } catch (Exception e) {
-      LOG.error("Caught exception attempting to list containers", e);
       throw new DockerException(e);
     }
   }
@@ -96,7 +87,6 @@ public class DockerUtils {
     try {
       callWithTimeout(callable);
     } catch (Exception e) {
-      LOG.error("Caught exception attempting to stop container", e);
       throw new DockerException(e);
     }
   }
@@ -112,7 +102,6 @@ public class DockerUtils {
     try {
       callWithTimeout(callable);
     } catch (Exception e) {
-      LOG.error("Caught exception attempting to stop container", e);
       throw new DockerException(e);
     }
   }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/utils/DockerUtils.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/utils/DockerUtils.java
@@ -39,39 +39,6 @@ public class DockerUtils {
     this.dockerClient = dockerClient;
   }
 
-
-  public boolean cleanDocker() {
-    Callable<Boolean> callable = new Callable<Boolean>() {
-      @Override public Boolean call() throws Exception {
-        String containerName = String.format("%s%s", configuration.getDockerPrefix(), taskDefinition.getTaskId());
-        try {
-          ContainerInfo containerInfo = dockerClient.inspectContainer(containerName);
-          if (containerInfo.state().running()) {
-            dockerClient.stopContainer(containerName, configuration.getDockerStopTimeout());
-          }
-          dockerClient.removeContainer(containerName);
-          log.info("Removed container {}", containerName);
-          return true;
-        } catch (ContainerNotFoundException e) {
-          log.info("Container {} was already removed", containerName);
-          return true;
-        } catch (UncheckedTimeoutException te) {
-          log.error("Timed out trying to reach docker daemon after {} seconds", configuration.getDockerClientTimeLimitSeconds(), te);
-        } catch (Exception e) {
-          log.info("Could not ensure removal of docker container", e);
-        }
-        return false;
-      }
-    };
-
-    try {
-      return callWithTimeout(callable);
-    } catch (Exception e) {
-      log.error("Caught exception while cleaning docker containers", e);
-      return false;
-    }
-  }
-
   public int getPid(final String containerName) throws DockerException {
     return inspectContainer(containerName).state().pid();
   }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/utils/DockerUtils.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/utils/DockerUtils.java
@@ -7,34 +7,26 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 
-import javax.print.Doc;
-
-import jdk.nashorn.internal.codegen.CompilerConstants.Call;
-
-import org.apache.mesos.Protos.Parameter;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import com.google.common.util.concurrent.UncheckedTimeoutException;
 import com.google.inject.Inject;
 import com.hubspot.singularity.executor.config.SingularityExecutorConfiguration;
-import com.hubspot.singularity.executor.task.SingularityExecutorTaskDefinition;
-import com.spotify.docker.client.ContainerNotFoundException;
 import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.DockerException;
 import com.spotify.docker.client.messages.Container;
 import com.spotify.docker.client.messages.ContainerInfo;
 
 public class DockerUtils {
-  private final SingularityExecutorTaskDefinition taskDefinition;
-  private final Logger log;
+  private static final Logger LOG = LoggerFactory.getLogger(DockerUtils.class);
+
+
   private final SingularityExecutorConfiguration configuration;
   private final DockerClient dockerClient;
   private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
   @Inject
-  public DockerUtils(SingularityExecutorTaskDefinition taskDefinition, Logger log, SingularityExecutorConfiguration configuration, DockerClient dockerClient) {
-    this.taskDefinition = taskDefinition;
-    this.log = log;
+  public DockerUtils(SingularityExecutorConfiguration configuration, DockerClient dockerClient) {
     this.configuration = configuration;
     this.dockerClient = dockerClient;
   }
@@ -57,7 +49,7 @@ public class DockerUtils {
     try {
       return callWithTimeout(callable);
     } catch (Exception e) {
-      log.error("Caught exception while getting container status", e);
+      LOG.error("Caught exception while getting container status", e);
       throw new DockerException(e);
     }
   }
@@ -73,7 +65,7 @@ public class DockerUtils {
     try {
       callWithTimeout(callable);
     } catch (Exception e) {
-      log.error("Could not pull image due to error", e);
+      LOG.error("Could not pull image due to error", e);
       throw new DockerException(e);
     }
   }
@@ -88,7 +80,7 @@ public class DockerUtils {
     try {
       return callWithTimeout(callable);
     } catch (Exception e) {
-      log.error("Caught exception attempting to list containers", e);
+      LOG.error("Caught exception attempting to list containers", e);
       throw new DockerException(e);
     }
   }
@@ -104,7 +96,7 @@ public class DockerUtils {
     try {
       callWithTimeout(callable);
     } catch (Exception e) {
-      log.error("Caught exception attempting to stop container", e);
+      LOG.error("Caught exception attempting to stop container", e);
       throw new DockerException(e);
     }
   }
@@ -120,7 +112,7 @@ public class DockerUtils {
     try {
       callWithTimeout(callable);
     } catch (Exception e) {
-      log.error("Caught exception attempting to stop container", e);
+      LOG.error("Caught exception attempting to stop container", e);
       throw new DockerException(e);
     }
   }

--- a/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/shared/ProcessFailedException.java
+++ b/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/shared/ProcessFailedException.java
@@ -8,4 +8,8 @@ public class ProcessFailedException extends Exception {
     super(message);
   }
 
+  public ProcessFailedException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
 }


### PR DESCRIPTION
@wsorenson this was my addition to #864

`DockerUtils` has a single threaded `ExecutorService` (we only need one call at a time right now anyways) that will execute each with a timeout. So, anything docker is not executed on the main thread that needs to keep going in order for the Executor to communicate with mesos.

Also adds a default thread pool of 5 for the docker client. The initial client was meant for managing large numbers of containers concurrently, thus the limit of 100.