### PR TITLE
add a default bounce expiration

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityBounceRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityBounceRequest.java
@@ -1,5 +1,7 @@
 package com.hubspot.singularity.api;
 
+import java.util.UUID;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
@@ -16,6 +18,10 @@ public class SingularityBounceRequest extends SingularityExpiringRequestParent {
     super(durationMillis, actionId, message);
     this.incremental = incremental;
     this.skipHealthchecks = skipHealthchecks;
+  }
+
+  public static SingularityBounceRequest defaultRequest() {
+    return new SingularityBounceRequest(Optional.<Boolean>absent(), Optional.<Boolean>absent(), Optional.<Long>absent(), Optional.of(UUID.randomUUID().toString()), Optional.<String>absent());
   }
 
   @ApiModelProperty(required=false, value="If present and set to true, old tasks will be killed as soon as replacement tasks are available, instead of waiting for all replacement tasks to be healthy")

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -73,6 +73,8 @@ public class SingularityConfiguration extends Configuration {
   @JsonProperty("database")
   private DataSourceFactory databaseConfiguration;
 
+  private int defaultBounceExpirationMinutes = 60;
+
   @NotNull
   private SlavePlacement defaultSlavePlacement = SlavePlacement.GREEDY;
 
@@ -337,6 +339,14 @@ public class SingularityConfiguration extends Configuration {
 
   public Optional<DataSourceFactory> getDatabaseConfiguration() {
     return Optional.fromNullable(databaseConfiguration);
+  }
+
+  public int getDefaultBounceExpirationMinutes() {
+    return defaultBounceExpirationMinutes;
+  }
+
+  public void setDefaultBounceExpirationMinutes(int defaultBounceExpirationMinutes) {
+    this.defaultBounceExpirationMinutes = defaultBounceExpirationMinutes;
   }
 
   public SlavePlacement getDefaultSlavePlacement() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -73,6 +73,7 @@ public class SingularityConfiguration extends Configuration {
   @JsonProperty("database")
   private DataSourceFactory databaseConfiguration;
 
+  @Min(value = 1, message = "Must be positive and non-zero")
   private int defaultBounceExpirationMinutes = 60;
 
   @NotNull

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -181,6 +181,10 @@ public class RequestResource extends AbstractRequestResource {
       message = bounceRequest.get().getMessage();
     }
 
+    if (!actionId.isPresent()) {
+      actionId = Optional.of(UUID.randomUUID().toString());
+    }
+
     final String deployId = getAndCheckDeployId(requestId);
 
     SingularityCreateResult createResult = requestManager.createCleanupRequest(
@@ -192,7 +196,7 @@ public class RequestResource extends AbstractRequestResource {
     requestManager.bounce(requestWithState.getRequest(), System.currentTimeMillis(), JavaUtils.getUserEmail(user), message);
 
     requestManager.saveExpiringObject(new SingularityExpiringBounce(requestId, deployId, JavaUtils.getUserEmail(user),
-        System.currentTimeMillis(), bounceRequest.or(SingularityBounceRequest.defaultRequest()), actionId.or(UUID.randomUUID().toString())));
+        System.currentTimeMillis(), bounceRequest.or(SingularityBounceRequest.defaultRequest()), actionId.get()));
 
     return fillEntireRequest(requestWithState);
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -8,6 +8,7 @@ import static com.hubspot.singularity.WebExceptions.checkNotNullBadRequest;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -151,7 +152,7 @@ public class RequestResource extends AbstractRequestResource {
   @ApiOperation(value="Bounce a specific Singularity request. A bounce launches replacement task(s), and then kills the original task(s) if the replacement(s) are healthy.",
   response=SingularityRequestParent.class)
   public SingularityRequestParent bounce(@ApiParam("The request ID to bounce") @PathParam("requestId") String requestId,
-      @ApiParam("Bounce request options") Optional<SingularityBounceRequest> bounceRequest) {
+      @ApiParam("Bounce request options") Optional<SingularityBounceRequest> maybeBounceRequest) {
     SingularityRequestWithState requestWithState = fetchRequestWithState(requestId);
 
     authorizationHelper.checkForAuthorization(requestWithState.getRequest(), user, SingularityAuthorizationScope.WRITE);
@@ -162,7 +163,25 @@ public class RequestResource extends AbstractRequestResource {
 
     SlavePlacement placement = requestWithState.getRequest().getSlavePlacement().or(configuration.getDefaultSlavePlacement());
 
-    final boolean isIncrementalBounce = bounceRequest.isPresent() && bounceRequest.get().getIncremental().or(false);
+    SingularityBounceRequest bounceRequest;
+
+    if (maybeBounceRequest.isPresent()) {
+      bounceRequest = new SingularityBounceRequest(
+        maybeBounceRequest.get().getIncremental(),
+        maybeBounceRequest.get().getSkipHealthchecks(),
+        maybeBounceRequest.get().getDurationMillis().or(Optional.of(TimeUnit.MINUTES.toMillis(configuration.getDefaultBounceExpirationMinutes()))),
+        maybeBounceRequest.get().getActionId().or(Optional.of(UUID.randomUUID().toString())),
+        maybeBounceRequest.get().getMessage());
+    } else {
+      bounceRequest = new SingularityBounceRequest(
+        Optional.<Boolean>absent(),
+        Optional.<Boolean>absent(),
+        Optional.of(TimeUnit.MINUTES.toMillis(configuration.getDefaultBounceExpirationMinutes())),
+        Optional.of(UUID.randomUUID().toString()),
+        Optional.<String>absent());
+    }
+
+    final boolean isIncrementalBounce = bounceRequest.getIncremental().or(false);
 
     if (placement != SlavePlacement.GREEDY && placement != SlavePlacement.OPTIMISTIC) {
       int currentActiveSlaveCount = slaveManager.getNumObjectsAtState(MachineState.ACTIVE);
@@ -171,34 +190,18 @@ public class RequestResource extends AbstractRequestResource {
       checkBadRequest(currentActiveSlaveCount >= requiredSlaveCount, "Not enough active slaves to successfully complete a bounce of request %s (minimum required: %s, current: %s). Consider deploying, or changing the slave placement strategy instead.", requestId, requiredSlaveCount, currentActiveSlaveCount);
     }
 
-    final Optional<Boolean> skipHealthchecks = bounceRequest.isPresent() ? bounceRequest.get().getSkipHealthchecks() : Optional.<Boolean> absent();
-
-    Optional<String> message = Optional.absent();
-    Optional<String> actionId = Optional.absent();
-
-    if (bounceRequest.isPresent()) {
-      actionId = bounceRequest.get().getActionId();
-      message = bounceRequest.get().getMessage();
-
-      if (bounceRequest.get().getDurationMillis().isPresent() && !actionId.isPresent()) {
-        actionId = Optional.of(UUID.randomUUID().toString());
-      }
-    }
-
     final String deployId = getAndCheckDeployId(requestId);
 
     SingularityCreateResult createResult = requestManager.createCleanupRequest(
         new SingularityRequestCleanup(JavaUtils.getUserEmail(user), isIncrementalBounce ? RequestCleanupType.INCREMENTAL_BOUNCE : RequestCleanupType.BOUNCE,
-            System.currentTimeMillis(), Optional.<Boolean> absent(), requestId, Optional.of(deployId), skipHealthchecks, message, actionId));
+            System.currentTimeMillis(), Optional.<Boolean> absent(), requestId, Optional.of(deployId), bounceRequest.getSkipHealthchecks(), bounceRequest.getMessage(), bounceRequest.getActionId()));
 
     checkConflict(createResult != SingularityCreateResult.EXISTED, "%s is already bouncing", requestId);
 
-    requestManager.bounce(requestWithState.getRequest(), System.currentTimeMillis(), JavaUtils.getUserEmail(user), message);
+    requestManager.bounce(requestWithState.getRequest(), System.currentTimeMillis(), JavaUtils.getUserEmail(user), bounceRequest.getMessage());
 
-    if (bounceRequest.isPresent() && bounceRequest.get().getDurationMillis().isPresent()) {
-      requestManager.saveExpiringObject(new SingularityExpiringBounce(requestId, deployId, JavaUtils.getUserEmail(user),
-          System.currentTimeMillis(), bounceRequest.get(), actionId.get()));
-    }
+    requestManager.saveExpiringObject(new SingularityExpiringBounce(requestId, deployId, JavaUtils.getUserEmail(user),
+        System.currentTimeMillis(), bounceRequest, bounceRequest.getActionId().get()));
 
     return fillEntireRequest(requestWithState);
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/views/IndexView.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/views/IndexView.java
@@ -32,6 +32,7 @@ public class IndexView extends View {
   private final Integer slaveHttpPort;
   private final Integer slaveHttpsPort;
 
+  private final int defaultBounceExpirationMinutes;
   private final long defaultHealthcheckIntervalSeconds;
   private final long defaultHealthcheckTimeoutSeconds;
   private final long defaultDeployHealthTimeoutSeconds;
@@ -77,6 +78,7 @@ public class IndexView extends View {
 
     this.navColor = configuration.getUiConfiguration().getNavColor();
 
+    this.defaultBounceExpirationMinutes = configuration.getDefaultBounceExpirationMinutes();
     this.defaultHealthcheckIntervalSeconds = configuration.getHealthcheckIntervalSeconds();
     this.defaultHealthcheckTimeoutSeconds = configuration.getHealthcheckTimeoutSeconds();
     this.defaultDeployHealthTimeoutSeconds = configuration.getDeployHealthyBySeconds();
@@ -154,6 +156,10 @@ public class IndexView extends View {
     return loadBalancingEnabled;
   }
 
+  public int getDefaultBounceExpirationMinutes() {
+    return defaultBounceExpirationMinutes;
+  }
+
   public long getDefaultHealthcheckIntervalSeconds() {
     return defaultHealthcheckIntervalSeconds;
   }
@@ -213,6 +219,7 @@ public class IndexView extends View {
             ", title='" + title + '\'' +
             ", slaveHttpPort=" + slaveHttpPort +
             ", slaveHttpsPort=" + slaveHttpsPort +
+            ", defaultBounceExpirationMinutes=" + defaultBounceExpirationMinutes +
             ", defaultHealthcheckIntervalSeconds=" + defaultHealthcheckIntervalSeconds +
             ", defaultHealthcheckTimeoutSeconds=" + defaultHealthcheckTimeoutSeconds +
             ", defaultDeployHealthTimeoutSeconds=" + defaultDeployHealthTimeoutSeconds +

--- a/SingularityUI/app/assets/_index.mustache
+++ b/SingularityUI/app/assets/_index.mustache
@@ -23,6 +23,7 @@
             loadBalancingEnabled: {{{loadBalancingEnabled}}},
             defaultCpus: {{{defaultCpus}}},
             defaultMemory: {{{defaultMemory}}},
+            defaultBounceExpirationMinutes: {{{defaultBounceExpirationMinutes}}},
             defaultHealthcheckIntervalSeconds: {{{defaultHealthcheckIntervalSeconds}}},
             defaultHealthcheckTimeoutSeconds: {{{defaultHealthcheckTimeoutSeconds}}},
             defaultDeployHealthTimeoutSeconds: {{{defaultDeployHealthTimeoutSeconds}}},

--- a/SingularityUI/app/models/Request.coffee
+++ b/SingularityUI/app/models/Request.coffee
@@ -432,7 +432,9 @@ class Request extends Model
 
     promptBounce: (callback) =>
         vex.dialog.confirm
-            message: bounceTemplate id: @get "id"
+            message: bounceTemplate
+                id: @get "id"
+                config: config
             input: """
                 <input name="message" id="bounce-message" type="text" placeholder="Message (optional)" />
             """

--- a/SingularityUI/app/templates/vex/requestBounce.hbs
+++ b/SingularityUI/app/templates/vex/requestBounce.hbs
@@ -12,6 +12,6 @@
 	<input type="checkbox" name="skip-healthchecks" id="skip-healthchecks"> Skip healthchecks during bounce
 </label>
 <div class="vex-dialog-input expiration-input">
-		<input name="duration" id="bounce-expiration" type="text" placeholder="Expiration (optional)" />
+		<input name="duration" id="bounce-expiration" type="text" placeholder="Expiration (optional - default {{ config.defaultBounceExpirationMinutes }}m)" />
 </div>
 <span class="help">If an expiration duration is specified, this bounce will be aborted if not finished. Accepts any english time duration. (Days, Hr, Min...)</span>

--- a/SingularityUI/app/views/requestActionExpirations.coffee
+++ b/SingularityUI/app/views/requestActionExpirations.coffee
@@ -29,15 +29,20 @@ class requestActionExpirations extends View
                 revertParam: request.expiringScale.revertToInstances
                 message: request.expiringScale.expiringAPIRequestObject.message
 
-        if request.expiringBounce and (request.expiringBounce.startMillis + request.expiringBounce.expiringAPIRequestObject.durationMillis) > new Date().getTime()
-            expirations.push
-                action: 'Bounce'
-                user: if request.expiringBounce.user then request.expiringBounce.user.split('@')[0] else ""
-                endMillis: request.expiringBounce.startMillis + request.expiringBounce.expiringAPIRequestObject.durationMillis
-                canRevert: false
-                cancelText: 'Cancel'
-                cancelAction: 'cancelBounce'
-                message: request.expiringBounce.expiringAPIRequestObject.message
+        if request.expiringBounce
+            if request.expiringBounce.expiringAPIRequestObject.durationMillis
+                endMillis = request.expiringBounce.startMillis + request.expiringBounce.expiringAPIRequestObject.durationMillis
+            else
+                endMillis = request.expiringBounce.startMillis + (config.defaultBounceExpirationMinutes * 60 * 1000)
+            if endMillis > new Date().getTime()
+                expirations.push
+                    action: 'Bounce'
+                    user: if request.expiringBounce.user then request.expiringBounce.user.split('@')[0] else ""
+                    endMillis: endMillis
+                    canRevert: false
+                    cancelText: 'Cancel'
+                    cancelAction: 'cancelBounce'
+                    message: request.expiringBounce.expiringAPIRequestObject.message
 
         if request.expiringPause and (request.expiringPause.startMillis + request.expiringPause.expiringAPIRequestObject.durationMillis) > new Date().getTime()
             expirations.push

--- a/SingularityUI/config.coffee
+++ b/SingularityUI/config.coffee
@@ -45,6 +45,7 @@ exports.config =
             navColor: process.env.SINGULARITY_NAV_COLOR
             defaultCpus: process.env.SINGUALRITY_DEFAULT_CPUS ? 1
             defaultMemory: process.env.SINGULARITY_DEFAULT_MEMORY ? 128
+            defaultBounceExpirationMinutes: process.env.SINGULARITY_DEFAULT_BOUNCE_EXPIRATION_MINUTES ? 60
             defaultHealthcheckIntervalSeconds: process.env.SINGULARITY_DEFAULT_HEALTHCHECK_INTERVAL_SECONDS ? 5
             defaultHealthcheckTimeoutSeconds: process.env.SINGULARITY_HEALTHCHECK_TIMEOUT_SECONDS ? 5
             defaultDeployHealthTimeoutSeconds: process.env.SINGULARITY_DEPLOY_HEALTH_TIMEOUT_SECONDS ? 120


### PR DESCRIPTION
Don't allow a bounce that will go on forever. Defaults to 60 minutes and shows in the ui as:
![screen shot 2016-01-28 at 9 14 55 am](https://cloud.githubusercontent.com/assets/6034439/12646702/9fe22d36-c59f-11e5-99b0-cea1cfa947f9.png)
