### PR TITLE
Add a buffer to task history persistence

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -191,6 +191,8 @@ public class SingularityConfiguration extends Configuration {
 
   private long threadpoolShutdownDelayInSeconds = 1;
 
+  private long taskPersistAfterStartupBufferMillis = TimeUnit.MINUTES.toMillis(1);
+
   @Valid
   @JsonProperty("customExecutor")
   @NotNull
@@ -837,6 +839,14 @@ public class SingularityConfiguration extends Configuration {
 
   public void setCacheTasksForMillis(long cacheTasksForMillis) {
     this.cacheTasksForMillis = cacheTasksForMillis;
+  }
+
+  public long getTaskPersistAfterStartupBufferMillis() {
+    return taskPersistAfterStartupBufferMillis;
+  }
+
+  public void setTaskPersistAfterStartupBufferMillis(long taskPersistAfterStartupBufferMillis) {
+    this.taskPersistAfterStartupBufferMillis = taskPersistAfterStartupBufferMillis;
   }
 
   public Optional<LDAPConfiguration> getLdapConfiguration() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityTaskHistoryPersister.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityTaskHistoryPersister.java
@@ -59,7 +59,7 @@ public class SingularityTaskHistoryPersister extends SingularityHistoryPersister
         continue;
       }
 
-      final long age = System.currentTimeMillis() - taskId.getStartedAt();
+      final long age = start - taskId.getStartedAt();
 
       if (age < configuration.getTaskPersistAfterStartupBufferMillis()) {
         LOG.debug("Not persisting {}, it has started up too recently {} (buffer: {}) - this prevents race conditions with ZK tx", taskId, JavaUtils.durationFromMillis(age),

--- a/SingularityService/src/test/java/com/hubspot/singularity/SingularityHistoryTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/SingularityHistoryTest.java
@@ -29,11 +29,11 @@ import com.hubspot.singularity.config.HistoryPurgingConfiguration;
 import com.hubspot.singularity.data.TaskManager;
 import com.hubspot.singularity.data.history.HistoryManager;
 import com.hubspot.singularity.data.history.HistoryManager.OrderDirection;
-import com.hubspot.singularity.scheduler.SingularitySchedulerTestBase;
 import com.hubspot.singularity.data.history.SingularityHistoryPurger;
 import com.hubspot.singularity.data.history.SingularityRequestHistoryPersister;
 import com.hubspot.singularity.data.history.SingularityTaskHistoryPersister;
 import com.hubspot.singularity.data.history.TaskHistoryHelper;
+import com.hubspot.singularity.scheduler.SingularitySchedulerTestBase;
 
 import liquibase.Liquibase;
 import liquibase.database.Database;
@@ -198,6 +198,8 @@ public class SingularityHistoryTest extends SingularitySchedulerTestBase {
 
     statusUpdate(taskManager.getTask(taskId).get(), TaskState.TASK_FINISHED);
 
+    configuration.setTaskPersistAfterStartupBufferMillis(0);
+
     taskHistoryPersister.runActionOnPoll();
 
     Assert.assertEquals(runId, historyManager.getTaskHistory(taskId.getId()).get().getTask().getTaskRequest().getPendingTask().getRunId().get());
@@ -206,6 +208,20 @@ public class SingularityHistoryTest extends SingularitySchedulerTestBase {
     parent = requestResource.scheduleImmediately(requestId);
 
     Assert.assertTrue(parent.getPendingRequest().getRunId().isPresent());
+  }
+
+  @Test
+  public void testTaskBufferPersist() {
+    initRequest();
+    initFirstDeploy();
+
+    SingularityTask task = startTask(firstDeploy);
+
+    statusUpdate(task, TaskState.TASK_FINISHED);
+
+    taskHistoryPersister.runActionOnPoll();
+
+    Assert.assertEquals(1, taskManager.getAllTaskIds().size());
   }
 
   @Test


### PR DESCRIPTION
Resolves the edge case where we see partial read data from a ZK transaction, and persist the task history too quickly.

(Fixes #599)




