### PR TITLE
add support for override defaults file

### DIFF
--- a/SingularityService/pom.xml
+++ b/SingularityService/pom.xml
@@ -179,6 +179,11 @@
 
     <dependency>
       <groupId>io.dropwizard</groupId>
+      <artifactId>dropwizard-configuration</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-db</artifactId>
     </dependency>
 
@@ -251,6 +256,11 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
     </dependency>
 
     <dependency>

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityService.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityService.java
@@ -4,12 +4,15 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Module;
 import com.hubspot.dropwizard.guicier.GuiceBundle;
 import com.hubspot.jackson.datatype.protobuf.ProtobufModule;
 import com.hubspot.singularity.bundles.CorsBundle;
+import com.hubspot.singularity.config.MergingSourceProvider;
 import com.hubspot.singularity.config.SingularityConfiguration;
 
 import io.dropwizard.Application;
@@ -23,11 +26,15 @@ import io.dropwizard.setup.Environment;
 import io.dropwizard.views.ViewBundle;
 
 public class SingularityService<T extends SingularityConfiguration> extends Application<T> {
+  private static final String SINGULARITY_OVERRIDE_CONFIGURATION_PROPERTY = "singularityOverrideConfiguration";
 
   public static final String API_BASE_PATH = "/api";
 
   @Override
   public void initialize(final Bootstrap<T> bootstrap) {
+    if (!Strings.isNullOrEmpty(System.getProperty(SINGULARITY_OVERRIDE_CONFIGURATION_PROPERTY))) {
+      bootstrap.setConfigurationSourceProvider(new MergingSourceProvider(bootstrap.getConfigurationSourceProvider(), System.getProperty(SINGULARITY_OVERRIDE_CONFIGURATION_PROPERTY), bootstrap.getObjectMapper(), new YAMLFactory()));
+    }
 
     final Iterable<? extends Module> additionalModules = checkNotNull(getGuiceModules(bootstrap), "getGuiceModules() returned null");
     final Iterable<? extends Bundle> additionalBundles = checkNotNull(getDropwizardBundles(bootstrap), "getDropwizardBundles() returned null");

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityService.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityService.java
@@ -26,14 +26,14 @@ import io.dropwizard.setup.Environment;
 import io.dropwizard.views.ViewBundle;
 
 public class SingularityService<T extends SingularityConfiguration> extends Application<T> {
-  private static final String SINGULARITY_OVERRIDE_CONFIGURATION_PROPERTY = "singularityOverrideConfiguration";
+  private static final String SINGULARITY_DEFAULT_CONFIGURATION_PROPERTY = "singularityDefaultConfiguration";
 
   public static final String API_BASE_PATH = "/api";
 
   @Override
   public void initialize(final Bootstrap<T> bootstrap) {
-    if (!Strings.isNullOrEmpty(System.getProperty(SINGULARITY_OVERRIDE_CONFIGURATION_PROPERTY))) {
-      bootstrap.setConfigurationSourceProvider(new MergingSourceProvider(bootstrap.getConfigurationSourceProvider(), System.getProperty(SINGULARITY_OVERRIDE_CONFIGURATION_PROPERTY), bootstrap.getObjectMapper(), new YAMLFactory()));
+    if (!Strings.isNullOrEmpty(System.getProperty(SINGULARITY_DEFAULT_CONFIGURATION_PROPERTY))) {
+      bootstrap.setConfigurationSourceProvider(new MergingSourceProvider(bootstrap.getConfigurationSourceProvider(), System.getProperty(SINGULARITY_DEFAULT_CONFIGURATION_PROPERTY), bootstrap.getObjectMapper(), new YAMLFactory()));
     }
 
     final Iterable<? extends Module> additionalModules = checkNotNull(getGuiceModules(bootstrap), "getGuiceModules() returned null");

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/MergingSourceProvider.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/MergingSourceProvider.java
@@ -1,0 +1,66 @@
+package com.hubspot.singularity.config;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Iterator;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import io.dropwizard.configuration.ConfigurationSourceProvider;
+
+public class MergingSourceProvider implements ConfigurationSourceProvider {
+    private final ConfigurationSourceProvider delegate;
+    private final String overridePath;
+    private final ObjectMapper objectMapper;
+    private final YAMLFactory yamlFactory;
+
+    public MergingSourceProvider(ConfigurationSourceProvider delegate, String overridePath, ObjectMapper objectMapper, YAMLFactory yamlFactory) {
+        this.delegate = delegate;
+        this.overridePath = overridePath;
+        this.objectMapper = objectMapper;
+        this.yamlFactory = yamlFactory;
+    }
+
+    @Override
+    public InputStream open(String path) throws IOException {
+        final JsonNode originalNode = objectMapper.readTree(yamlFactory.createParser(delegate.open(path)));
+        final JsonNode overrideNode = objectMapper.readTree(yamlFactory.createParser(delegate.open(overridePath)));
+
+        if (!(originalNode instanceof ObjectNode && overrideNode instanceof ObjectNode)) {
+            throw new RuntimeException(String.format("Both %s and %s need to be objects", path, overridePath));
+        }
+
+        merge((ObjectNode)originalNode, (ObjectNode)overrideNode);
+
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        objectMapper.writeTree(yamlFactory.createGenerator(baos), originalNode);
+
+        return new ByteArrayInputStream(baos.toByteArray());
+    }
+
+    private static void merge(ObjectNode to, ObjectNode from) {
+        Iterator<String> newFieldNames = from.fieldNames();
+
+        while (newFieldNames.hasNext()) {
+            String newFieldName = newFieldNames.next();
+            JsonNode oldVal = to.get(newFieldName);
+            JsonNode newVal = from.get(newFieldName);
+
+            if (oldVal == null || oldVal.isNull()) {
+                to.put(newFieldName, newVal);
+            } else if (oldVal.isArray() && newVal.isArray()) {
+                ((ArrayNode) oldVal).addAll((ArrayNode) newVal);
+            } else if (oldVal.isObject() && newVal.isObject()) {
+                merge((ObjectNode) oldVal, (ObjectNode) newVal);
+            } else if (!(newVal == null || newVal.isNull())) {
+                to.put(newFieldName, newVal);
+            }
+        }
+    }
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/MergingSourceProvider.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/MergingSourceProvider.java
@@ -33,7 +33,7 @@ public class MergingSourceProvider implements ConfigurationSourceProvider {
         final JsonNode overrideNode = objectMapper.readTree(yamlFactory.createParser(delegate.open(path)));
 
         if (!(originalNode instanceof ObjectNode && overrideNode instanceof ObjectNode)) {
-            throw new RuntimeException(String.format("Both %s and %s need to be YAML objects", defaultConfigurationPath, path));
+            throw new SingularityConfigurationMergeException(String.format("Both %s and %s need to be YAML objects", defaultConfigurationPath, path));
         }
 
         merge((ObjectNode)originalNode, (ObjectNode)overrideNode);

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfigurationMergeException.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfigurationMergeException.java
@@ -1,0 +1,7 @@
+package com.hubspot.singularity.config;
+
+public class SingularityConfigurationMergeException extends RuntimeException {
+    public SingularityConfigurationMergeException(String message) {
+        super(message);
+    }
+}

--- a/SingularityService/src/test/java/com/hubspot/singularity/config/MergingSourceProviderTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/config/MergingSourceProviderTest.java
@@ -1,0 +1,53 @@
+package com.hubspot.singularity.config;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.google.common.base.Charsets;
+import com.google.inject.Inject;
+import com.hubspot.singularity.SingularityTestBaseNoDb;
+
+import io.dropwizard.configuration.ConfigurationSourceProvider;
+
+public class MergingSourceProviderTest extends SingularityTestBaseNoDb {
+    private static final String OVERRIDE_PATH = "override.yaml";
+
+    private static final YAMLFactory YAML_FACTORY = new YAMLFactory();
+
+    @Inject
+    private ObjectMapper objectMapper;
+
+    @Test
+    public void testMergedConfigs() throws Exception {
+        final String base = "s3: {s3AccessKey: test-access-key}";
+        final String override = "s3: {s3SecretKey: test-secret-key}";
+        final ConfigurationSourceProvider mergedProvider = new MergingSourceProvider(new TestSourceProvider(base, override), OVERRIDE_PATH, objectMapper, YAML_FACTORY);
+
+        final SingularityConfiguration mergedConfig = objectMapper.readValue(YAML_FACTORY.createParser(mergedProvider.open("config.yaml")), SingularityConfiguration.class);
+
+        assertEquals("test-access-key", mergedConfig.getS3Configuration().get().getS3AccessKey());
+        assertEquals("test-secret-key", mergedConfig.getS3Configuration().get().getS3SecretKey());
+    }
+
+    private static class TestSourceProvider implements ConfigurationSourceProvider {
+        private final String defaultValue;
+        private final String overrideValue;
+
+        public TestSourceProvider(String defaultValue, String overrideValue) {
+            this.defaultValue = defaultValue;
+            this.overrideValue = overrideValue;
+        }
+
+        @Override
+        public InputStream open(String path) throws IOException {
+            return new ByteArrayInputStream((path.equals(OVERRIDE_PATH) ? overrideValue : defaultValue).getBytes(Charsets.UTF_8));
+        }
+    }
+}

--- a/SingularityService/src/test/resources/configs/default.yaml
+++ b/SingularityService/src/test/resources/configs/default.yaml
@@ -1,0 +1,6 @@
+cacheTasksMaxSize: 10000  # override.yaml will not touch this
+cacheTasksInitialSize: 200  # override.yaml will override this to 500
+# override.yaml will override checkDeploysEverySeconds to 100
+
+database:  # override.yaml will override some of this
+  user: "baseuser"

--- a/SingularityService/src/test/resources/configs/just_a_string.yaml
+++ b/SingularityService/src/test/resources/configs/just_a_string.yaml
@@ -1,0 +1,1 @@
+"this is just a string!"

--- a/SingularityService/src/test/resources/configs/override.yaml
+++ b/SingularityService/src/test/resources/configs/override.yaml
@@ -1,0 +1,5 @@
+cacheTasksInitialSize: 500
+checkDeploysEverySeconds: 100
+
+database:
+  password: "overridepassword"


### PR DESCRIPTION
This PR adds support for pulling in an additional Singularity configuration file which overrides values from the default one. This is useful if you need to lock down S3 / database / LDAP credentials but would like the other settings to have looser read/write permissions.