### PR TITLE
better request sort for exact matches

### DIFF
--- a/SingularityUI/app/views/requests.coffee
+++ b/SingularityUI/app/views/requests.coffee
@@ -63,7 +63,7 @@ class RequestsView extends View
                 o.requestDeployState?.activeDeploy?.user or ''
         res1 = fuzzy.filter(filter, requests, id)
         res2 = fuzzy.filter(filter, requests, user)
-        _.pluck(_.sortBy(_.union(res1, res2), (r) => r.score), 'original')
+        _.pluck(_.sortBy(_.union(res2, res1), (r) => r.score), 'original')
 
     # Returns the array of requests that need to be rendered
     filterCollection: =>

--- a/SingularityUI/app/views/requests.coffee
+++ b/SingularityUI/app/views/requests.coffee
@@ -54,6 +54,12 @@ class RequestsView extends View
 
         @fuzzySearch = _.memoize(@fuzzySearch)
 
+    adjustedScore: (filter, req) ->
+        if req.original.id.toLowerCase().startsWith(filter.toLowerCase())
+            req.score * 10
+        else
+            req.score
+
     fuzzySearch: (filter, requests) =>
         id =
             extract: (o) ->
@@ -63,7 +69,7 @@ class RequestsView extends View
                 o.requestDeployState?.activeDeploy?.user or ''
         res1 = fuzzy.filter(filter, requests, id)
         res2 = fuzzy.filter(filter, requests, user)
-        _.pluck(_.sortBy(_.union(res2, res1), (r) => r.score), 'original')
+        _.pluck(_.sortBy(_.union(res2, res1), (r) => @adjustedScore(filter, r)), 'original').reverse()
 
     # Returns the array of requests that need to be rendered
     filterCollection: =>

--- a/SingularityUI/app/views/requests.coffee
+++ b/SingularityUI/app/views/requests.coffee
@@ -122,6 +122,9 @@ class RequestsView extends View
             if not @sortAscending
                 requests = requests.reverse()
 
+        if not @sortAttribute? and not @searchFilter?
+            requests.reverse()
+
         if @state in ['all', 'active', 'activeDeploy', 'noDeploy']
             for request in requests
                 request.starred = @collection.isStarred request.id

--- a/SingularityUI/app/views/requests.coffee
+++ b/SingularityUI/app/views/requests.coffee
@@ -121,9 +121,9 @@ class RequestsView extends View
 
             if not @sortAscending
                 requests = requests.reverse()
-
-        if not @sortAttribute? and not @searchFilter?
-            requests.reverse()
+        else
+            if not @searchFilter
+                requests.reverse()
 
         if @state in ['all', 'active', 'activeDeploy', 'noDeploy']
             for request in requests

--- a/SingularityUI/app/views/requests.coffee
+++ b/SingularityUI/app/views/requests.coffee
@@ -115,8 +115,6 @@ class RequestsView extends View
 
             if not @sortAscending
                 requests = requests.reverse()
-        else
-            requests.reverse()
 
         if @state in ['all', 'active', 'activeDeploy', 'noDeploy']
             for request in requests


### PR DESCRIPTION
`_.union` will take the second occurrence of an object if two similar objects are passed to it. We would get the match score from the fuzzy filter by active deploy user instead of the one form the request id if both were found. This caused some things to be out of order even when they were an exact match