### PR TITLE
Task kill checkbox label

### DIFF
--- a/SingularityUI/app/templates/vex/requestBounce.hbs
+++ b/SingularityUI/app/templates/vex/requestBounce.hbs
@@ -4,8 +4,10 @@
 	Bouncing a request will cause replacement tasks to be scheduled
 	(and under normal conditions) executed immediately.
 </p>
+<label for="no-incremental-bounce" id="no-incremental-bounce-label">
+    <input type="radio" name="incremental" id="no-incremental-bounce" value="false" checked> Kill old tasks once ALL new tasks are healthy<br>
+</label>
 <label for="incremental-bounce" id="incremental-bounce-label">
-    <input type="radio" name="incremental" value="false" checked> Kill old tasks once ALL new tasks are healthy<br>
     <input type="radio" name="incremental" id="incremental-bounce" value="true"> Kill old tasks as new tasks become healthy
 </label>
 <label for="skip-healthchecks" id="skip-healthchecks-label">

--- a/SingularityUI/app/views/taskOverviewSubview.coffee
+++ b/SingularityUI/app/views/taskOverviewSubview.coffee
@@ -72,7 +72,10 @@ class taskOverviewSubview extends View
                             vex.dialog.buttons.NO
                         ]
                         input: """
-                            <input name="wait-for-replacement-task" id="wait-for-replacement-task" type="checkbox" #{checked} /> Wait for replacement task to start before killing this task
+                            <label name="wait-for-replacement-task-label" id="wait-for-replacement-task-label" for="wait-for-replacement-task">
+                                <input name="wait-for-replacement-task" id="wait-for-replacement-task" type="checkbox" #{checked} /> 
+                                Wait for replacement task to start before killing this task
+                            </label>
                             <input name="message" type="text" placeholder="Message (optional)" />
                         """
                         message: templ id: @model.taskId

--- a/SingularityUI/app/views/taskOverviewSubview.coffee
+++ b/SingularityUI/app/views/taskOverviewSubview.coffee
@@ -74,7 +74,7 @@ class taskOverviewSubview extends View
                         input: """
                             <label name="wait-for-replacement-task-label" id="wait-for-replacement-task-label" for="wait-for-replacement-task">
                                 <input name="wait-for-replacement-task" id="wait-for-replacement-task" type="checkbox" #{checked} /> 
-                                Wait for replacement task to start before killing this task
+                                Wait for replacement task to start before killing task
                             </label>
                             <input name="message" type="text" placeholder="Message (optional)" />
                         """


### PR DESCRIPTION
The message for when you killed a task was not a label, so could not be clicked to select the corresponding checkbox.
On bounce, the label that should have been for incremental bounce = false was applying to incremental bounce = true.
This fixes both of those bugs.