### PR TITLE
Store status update reason field in SingularityTaskHistoryUpdate

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskHistoryUpdate.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskHistoryUpdate.java
@@ -2,8 +2,6 @@ package com.hubspot.singularity;
 
 import javax.annotation.Nonnull;
 
-import org.apache.mesos.Protos;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Objects;
@@ -17,8 +15,7 @@ public class SingularityTaskHistoryUpdate extends SingularityTaskIdHolder implem
   private final long timestamp;
   private final ExtendedTaskState taskState;
   private final Optional<String> statusMessage;
-  private final Optional<Protos.TaskStatus.Source> mesosSource;
-  private final Optional<Protos.TaskStatus.Reason> mesosReason;
+  private final Optional<String> statusReason;
 
   public enum SimplifiedTaskState {
     UNKNOWN, WAITING, RUNNING, DONE
@@ -54,14 +51,13 @@ public class SingularityTaskHistoryUpdate extends SingularityTaskIdHolder implem
   }
 
   @JsonCreator
-  public SingularityTaskHistoryUpdate(@JsonProperty("taskId") SingularityTaskId taskId, @JsonProperty("timestamp") long timestamp, @JsonProperty("taskState") ExtendedTaskState taskState, @JsonProperty("statusMessage") Optional<String> statusMessage, @JsonProperty("mesosSource") Optional<Protos.TaskStatus.Source> mesosSource, @JsonProperty("mesosReason") Optional<Protos.TaskStatus.Reason> mesosReason) {
+  public SingularityTaskHistoryUpdate(@JsonProperty("taskId") SingularityTaskId taskId, @JsonProperty("timestamp") long timestamp, @JsonProperty("taskState") ExtendedTaskState taskState, @JsonProperty("statusMessage") Optional<String> statusMessage, @JsonProperty("statusReason") Optional<String> statusReason) {
     super(taskId);
 
     this.timestamp = timestamp;
     this.taskState = taskState;
     this.statusMessage = statusMessage;
-    this.mesosSource = mesosSource;
-    this.mesosReason = mesosReason;
+    this.statusReason = statusReason;
   }
 
   @Override
@@ -75,7 +71,7 @@ public class SingularityTaskHistoryUpdate extends SingularityTaskIdHolder implem
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(getTaskId(), timestamp, taskState, statusMessage);
+    return Objects.hashCode(getTaskId(), timestamp, taskState, statusMessage, statusReason);
   }
 
   @Override
@@ -92,7 +88,8 @@ public class SingularityTaskHistoryUpdate extends SingularityTaskIdHolder implem
     return Objects.equal(this.getTaskId(), that.getTaskId())
         && Objects.equal(this.timestamp, that.timestamp)
         && Objects.equal(this.taskState, that.taskState)
-        && Objects.equal(statusMessage, statusMessage);
+        && Objects.equal(this.statusMessage, that.statusMessage)
+        && Objects.equal(this.statusReason, that.statusReason);
   }
 
   public long getTimestamp() {
@@ -107,17 +104,16 @@ public class SingularityTaskHistoryUpdate extends SingularityTaskIdHolder implem
     return statusMessage;
   }
 
-  public Optional<Protos.TaskStatus.Source> getMesosSource() {
-    return mesosSource;
+  public Optional<String> getStatusReason() {
+    return statusReason;
   }
 
-  public Optional<Protos.TaskStatus.Reason> getMesosReason() {
-    return mesosReason;
+  @Override public String toString() {
+    return "SingularityTaskHistoryUpdate[" +
+        "timestamp=" + timestamp +
+        ", taskState=" + taskState +
+        ", statusMessage=" + statusMessage +
+        ", statusReason=" + statusReason +
+        ']';
   }
-
-  @Override
-  public String toString() {
-    return "SingularityTaskHistoryUpdate [taskId=" + getTaskId() + ", timestamp=" + timestamp + ", taskState=" + taskState + ", statusMessage=" + statusMessage + "]";
-  }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskHistoryUpdate.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskHistoryUpdate.java
@@ -2,6 +2,8 @@ package com.hubspot.singularity;
 
 import javax.annotation.Nonnull;
 
+import org.apache.mesos.Protos;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Objects;
@@ -15,6 +17,8 @@ public class SingularityTaskHistoryUpdate extends SingularityTaskIdHolder implem
   private final long timestamp;
   private final ExtendedTaskState taskState;
   private final Optional<String> statusMessage;
+  private final Optional<Protos.TaskStatus.Source> mesosSource;
+  private final Optional<Protos.TaskStatus.Reason> mesosReason;
 
   public enum SimplifiedTaskState {
     UNKNOWN, WAITING, RUNNING, DONE
@@ -50,12 +54,14 @@ public class SingularityTaskHistoryUpdate extends SingularityTaskIdHolder implem
   }
 
   @JsonCreator
-  public SingularityTaskHistoryUpdate(@JsonProperty("taskId") SingularityTaskId taskId, @JsonProperty("timestamp") long timestamp, @JsonProperty("taskState") ExtendedTaskState taskState, @JsonProperty("statusMessage") Optional<String> statusMessage) {
+  public SingularityTaskHistoryUpdate(@JsonProperty("taskId") SingularityTaskId taskId, @JsonProperty("timestamp") long timestamp, @JsonProperty("taskState") ExtendedTaskState taskState, @JsonProperty("statusMessage") Optional<String> statusMessage, @JsonProperty("mesosSource") Optional<Protos.TaskStatus.Source> mesosSource, @JsonProperty("mesosReason") Optional<Protos.TaskStatus.Reason> mesosReason) {
     super(taskId);
 
     this.timestamp = timestamp;
     this.taskState = taskState;
     this.statusMessage = statusMessage;
+    this.mesosSource = mesosSource;
+    this.mesosReason = mesosReason;
   }
 
   @Override
@@ -99,6 +105,14 @@ public class SingularityTaskHistoryUpdate extends SingularityTaskIdHolder implem
 
   public Optional<String> getStatusMessage() {
     return statusMessage;
+  }
+
+  public Optional<Protos.TaskStatus.Source> getMesosSource() {
+    return mesosSource;
+  }
+
+  public Optional<Protos.TaskStatus.Reason> getMesosReason() {
+    return mesosReason;
   }
 
   @Override

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -574,7 +574,7 @@ public class TaskManager extends CuratorAsyncManager {
       msg = String.format("%s (%s)", msg, task.getTaskRequest().getPendingTask().getMessage().get());
     }
 
-    saveTaskHistoryUpdate(new SingularityTaskHistoryUpdate(task.getTaskId(), now, ExtendedTaskState.TASK_LAUNCHED, Optional.of(msg)));
+    saveTaskHistoryUpdate(new SingularityTaskHistoryUpdate(task.getTaskId(), now, ExtendedTaskState.TASK_LAUNCHED, Optional.of(msg), Optional.<String>absent()));
     saveLastActiveTaskStatus(new SingularityTaskStatusHolder(task.getTaskId(), Optional.<TaskStatus>absent(), now, serverId, Optional.of(task.getOffer().getSlaveId().getValue())));
 
     try {
@@ -686,7 +686,7 @@ public class TaskManager extends CuratorAsyncManager {
       msg.append(cleanup.getMessage().get());
     }
 
-    saveTaskHistoryUpdate(new SingularityTaskHistoryUpdate(cleanup.getTaskId(), cleanup.getTimestamp(), ExtendedTaskState.TASK_CLEANING, Optional.of(msg.toString())));
+    saveTaskHistoryUpdate(new SingularityTaskHistoryUpdate(cleanup.getTaskId(), cleanup.getTimestamp(), ExtendedTaskState.TASK_CLEANING, Optional.of(msg.toString()), Optional.<String>absent()));
   }
 
   public SingularityCreateResult createTaskCleanup(SingularityTaskCleanup cleanup) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
@@ -358,7 +358,7 @@ public class SingularityMesosScheduler implements Scheduler {
     }
 
     final SingularityTaskHistoryUpdate taskUpdate =
-        new SingularityTaskHistoryUpdate(taskIdObj, timestamp, taskState, status.hasMessage() ? Optional.of(status.getMessage()) : Optional.<String>absent());
+        new SingularityTaskHistoryUpdate(taskIdObj, timestamp, taskState, status.hasMessage() ? Optional.of(status.getMessage()) : Optional.<String>absent(), status.hasSource() ? Optional.of(status.getSource()) : Optional.<Protos.TaskStatus.Source>absent(), status.hasReason() ? Optional.of(status.getReason()) : Optional.<Protos.TaskStatus.Reason>absent());
     final SingularityCreateResult taskHistoryUpdateCreateResult = taskManager.saveTaskHistoryUpdate(taskUpdate);
 
     logSupport.checkDirectory(taskIdObj);

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
@@ -358,7 +358,7 @@ public class SingularityMesosScheduler implements Scheduler {
     }
 
     final SingularityTaskHistoryUpdate taskUpdate =
-        new SingularityTaskHistoryUpdate(taskIdObj, timestamp, taskState, status.hasMessage() ? Optional.of(status.getMessage()) : Optional.<String>absent(), status.hasSource() ? Optional.of(status.getSource()) : Optional.<Protos.TaskStatus.Source>absent(), status.hasReason() ? Optional.of(status.getReason()) : Optional.<Protos.TaskStatus.Reason>absent());
+        new SingularityTaskHistoryUpdate(taskIdObj, timestamp, taskState, status.hasMessage() ? Optional.of(status.getMessage()) : Optional.<String>absent(), status.hasReason() ? Optional.of(status.getReason().name()) : Optional.<String>absent());
     final SingularityCreateResult taskHistoryUpdateCreateResult = taskManager.saveTaskHistoryUpdate(taskUpdate);
 
     logSupport.checkDirectory(taskIdObj);

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.annotation.Timed;
 import com.google.common.base.Optional;
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
@@ -298,6 +299,22 @@ public class SingularityMesosScheduler implements Scheduler {
     }
   }
 
+  private Optional<String> getStatusMessage(Protos.TaskStatus status, Optional<SingularityTask> task) {
+    if (status.hasMessage() && !Strings.isNullOrEmpty(status.getMessage())) {
+      return Optional.of(status.getMessage());
+    } else if (status.hasReason() && status.getReason() == Protos.TaskStatus.Reason.REASON_MEMORY_LIMIT) {
+      if (task.isPresent()) {
+        final double memory = MesosUtils.getMemory(task.get().getMesosTask().getResourcesList());
+        if (memory > 0) {
+          return Optional.of(String.format("Task exceeded memory limit of %s MB", MesosUtils.getMemory(task.get().getMesosTask().getResourcesList())));
+        }
+      }
+      return Optional.of("Task exceeded memory limit");
+    }
+
+    return Optional.absent();
+  }
+
   @Override
   @Timed
   public void statusUpdate(SchedulerDriver driver, Protos.TaskStatus status) {
@@ -357,8 +374,10 @@ public class SingularityMesosScheduler implements Scheduler {
       }
     }
 
+    final Optional<String> statusMessage = getStatusMessage(status, task);
+
     final SingularityTaskHistoryUpdate taskUpdate =
-        new SingularityTaskHistoryUpdate(taskIdObj, timestamp, taskState, status.hasMessage() ? Optional.of(status.getMessage()) : Optional.<String>absent(), status.hasReason() ? Optional.of(status.getReason().name()) : Optional.<String>absent());
+        new SingularityTaskHistoryUpdate(taskIdObj, timestamp, taskState, statusMessage, status.hasReason() ? Optional.of(status.getReason().name()) : Optional.<String>absent());
     final SingularityCreateResult taskHistoryUpdateCreateResult = taskManager.saveTaskHistoryUpdate(taskUpdate);
 
     logSupport.checkDirectory(taskIdObj);

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/MesosUtilsTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/MesosUtilsTest.java
@@ -36,9 +36,9 @@ public class MesosUtilsTest {
     final SingularityTaskId taskId = new SingularityTaskId("r", "d", System.currentTimeMillis(), 1, "h", "r");
     final Optional<String> msg = Optional.absent();
 
-    SingularityTaskHistoryUpdate update1 = new SingularityTaskHistoryUpdate(taskId, 1L, ExtendedTaskState.TASK_LAUNCHED, msg);
-    SingularityTaskHistoryUpdate update2 = new SingularityTaskHistoryUpdate(taskId, 2L, ExtendedTaskState.TASK_RUNNING, msg);
-    SingularityTaskHistoryUpdate update3 = new SingularityTaskHistoryUpdate(taskId, 2L, ExtendedTaskState.TASK_FAILED, msg);
+    SingularityTaskHistoryUpdate update1 = new SingularityTaskHistoryUpdate(taskId, 1L, ExtendedTaskState.TASK_LAUNCHED, msg, Optional.<String>absent());
+    SingularityTaskHistoryUpdate update2 = new SingularityTaskHistoryUpdate(taskId, 2L, ExtendedTaskState.TASK_RUNNING, msg, Optional.<String>absent());
+    SingularityTaskHistoryUpdate update3 = new SingularityTaskHistoryUpdate(taskId, 2L, ExtendedTaskState.TASK_FAILED, msg, Optional.<String>absent());
 
     List<SingularityTaskHistoryUpdate> list = Arrays.asList(update2, update1, update3);
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -797,7 +797,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     Assert.assertTrue(taskManager.getPendingTaskIds().size() == 1);
     Assert.assertTrue(taskManager.getActiveTaskIds().size() == 1);
 
-    eventListener.taskHistoryUpdateEvent(new SingularityTaskHistoryUpdate(taskManager.getActiveTaskIds().get(0), System.currentTimeMillis(), ExtendedTaskState.TASK_CLEANING, Optional.<String>absent()));
+    eventListener.taskHistoryUpdateEvent(new SingularityTaskHistoryUpdate(taskManager.getActiveTaskIds().get(0), System.currentTimeMillis(), ExtendedTaskState.TASK_CLEANING, Optional.<String>absent(), Optional.<String>absent()));
 
     sms.resourceOffers(driver, Arrays.asList(createOffer(20, 20000, "slave1", "host1")));
 
@@ -829,7 +829,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
 
     sms.resourceOffers(driver, Arrays.asList(createOffer(20, 20000, "slave2", "host2")));
 
-    eventListener.taskHistoryUpdateEvent(new SingularityTaskHistoryUpdate(taskManager.getActiveTaskIds().get(0), System.currentTimeMillis(), ExtendedTaskState.TASK_CLEANING, Optional.<String>absent()));
+    eventListener.taskHistoryUpdateEvent(new SingularityTaskHistoryUpdate(taskManager.getActiveTaskIds().get(0), System.currentTimeMillis(), ExtendedTaskState.TASK_CLEANING, Optional.<String>absent(), Optional.<String>absent()));
 
     Assert.assertTrue(taskManager.getPendingTaskIds().isEmpty());
     Assert.assertTrue(taskManager.getActiveTaskIds().size() == 3);
@@ -844,7 +844,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
 
     sms.resourceOffers(driver, Arrays.asList(createOffer(20, 20000, "slave1", "host1"), createOffer(20, 20000, "slave2", "host2")));
 
-    eventListener.taskHistoryUpdateEvent(new SingularityTaskHistoryUpdate(taskManager.getActiveTaskIds().get(0), System.currentTimeMillis(), ExtendedTaskState.TASK_CLEANING, Optional.<String>absent()));
+    eventListener.taskHistoryUpdateEvent(new SingularityTaskHistoryUpdate(taskManager.getActiveTaskIds().get(0), System.currentTimeMillis(), ExtendedTaskState.TASK_CLEANING, Optional.<String>absent(), Optional.<String>absent()));
 
     Assert.assertTrue(taskManager.getPendingTaskIds().isEmpty());
     Assert.assertTrue(taskManager.getActiveTaskIds().size() == 3);


### PR DESCRIPTION
This will allow us to determine whether or not a task was killed due to a mesos OOM kill. Also sets `statusMessage` to `Task exceeded memory limit of XXX MB` if no message was set in the status update from Mesos.