### PR TITLE
Lock brunch to version 2.2.x

### DIFF
--- a/SingularityUI/package.json
+++ b/SingularityUI/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "bower": "^1.7.6",
-    "brunch": "^2.2.2",
+    "brunch": "~2.2.2",
     "clean-css-brunch": "^2.0.0",
     "coffee-script-brunch": "^2.0.0",
     "css-brunch": "^2.0.0",


### PR DESCRIPTION
The new version released this morning breaks the build, so until we can bring the build in line with the new version's change we must lock brunch to the old version.