### PR TITLE
Fix time display emails

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SMTPConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SMTPConfiguration.java
@@ -1,8 +1,9 @@
 package com.hubspot.singularity.config;
 
+import java.util.List;
+import java.util.TimeZone;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -39,6 +40,9 @@ public class SMTPConfiguration {
   private String from = "singularity-no-reply@example.com";
 
   @JsonProperty
+  private String mailerDatePattern = "MMM dd h:mm:ss a zzz";
+
+  @JsonProperty
   private int mailMaxThreads = 3;
 
   @NotNull
@@ -65,6 +69,9 @@ public class SMTPConfiguration {
   // Files to tail when sending a task email.
   @JsonProperty
   private List<String> taskEmailTailFiles = Arrays.asList("stdout", "stderr");
+
+  @JsonProperty
+  private TimeZone mailerTimeZone = TimeZone.getTimeZone("UTC");
 
   @JsonProperty("emails")
   private Map<SingularityEmailType, List<SingularityEmailDestination>> emailConfiguration = Maps.newHashMap(ImmutableMap.<SingularityEmailType, List<SingularityEmailDestination>>builder()
@@ -200,5 +207,21 @@ public class SMTPConfiguration {
 
   public void setTaskEmailTailFiles(List<String> taskEmailTailFiles) {
     this.taskEmailTailFiles = taskEmailTailFiles;
+  }
+
+  public String getMailerDatePattern() {
+    return mailerDatePattern;
+  }
+
+  public void setMailerDatePattern(String mailerDatePattern) {
+    this.mailerDatePattern = mailerDatePattern;
+  }
+
+  public TimeZone getMailerTimeZone() {
+    return mailerTimeZone;
+  }
+
+  public void setMailerTimeZone(TimeZone mailerTimeZone) {
+    this.mailerTimeZone = mailerTimeZone;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -77,7 +77,7 @@ public class SingularityConfiguration extends Configuration {
   @Min(value = 1, message = "Must be positive and non-zero")
   private int defaultBounceExpirationMinutes = 60;
 
-  private String defaultDatePattern = "MMM dd h:mm:ss a zzz";
+  private String mailerDatePattern = "MMM dd h:mm:ss a zzz";
 
   @NotNull
   private SlavePlacement defaultSlavePlacement = SlavePlacement.GREEDY;
@@ -188,7 +188,7 @@ public class SingularityConfiguration extends Configuration {
 
   private long startNewReconcileEverySeconds = TimeUnit.MINUTES.toSeconds(10);
 
-  private TimeZone timeZone = TimeZone.getTimeZone("UTC");
+  private TimeZone mailerTimeZone = TimeZone.getTimeZone("UTC");
 
   @JsonProperty("ui")
   @Valid
@@ -961,19 +961,19 @@ public class SingularityConfiguration extends Configuration {
     this.maxStaleTasksPerRequestInZkWhenNoDatabase = maxStaleTasksPerRequestInZkWhenNoDatabase;
   }
 
-  public String getDefaultDatePattern() {
-    return defaultDatePattern;
+  public String getMailerDatePattern() {
+    return mailerDatePattern;
   }
 
-  public void setDefaultDatePattern(String defaultDatePattern) {
-    this.defaultDatePattern = defaultDatePattern;
+  public void setMailerDatePattern(String mailerDatePattern) {
+    this.mailerDatePattern = mailerDatePattern;
   }
 
-  public TimeZone getTimeZone() {
-    return timeZone;
+  public TimeZone getMailerTimeZone() {
+    return mailerTimeZone;
   }
 
-  public void setTimeZone(TimeZone timeZone) {
-    this.timeZone = timeZone;
+  public void setMailerTimeZone(TimeZone mailerTimeZone) {
+    this.mailerTimeZone = mailerTimeZone;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.TimeZone;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Max;
@@ -75,6 +76,8 @@ public class SingularityConfiguration extends Configuration {
 
   @Min(value = 1, message = "Must be positive and non-zero")
   private int defaultBounceExpirationMinutes = 60;
+
+  private String defaultDatePattern = "MMM dd h:mm:ss a";
 
   @NotNull
   private SlavePlacement defaultSlavePlacement = SlavePlacement.GREEDY;
@@ -184,6 +187,8 @@ public class SingularityConfiguration extends Configuration {
   private SMTPConfiguration smtpConfiguration;
 
   private long startNewReconcileEverySeconds = TimeUnit.MINUTES.toSeconds(10);
+
+  private TimeZone timeZone = TimeZone.getTimeZone("UTC");
 
   @JsonProperty("ui")
   @Valid
@@ -954,5 +959,21 @@ public class SingularityConfiguration extends Configuration {
 
   public void setMaxStaleTasksPerRequestInZkWhenNoDatabase(Optional<Integer> maxStaleTasksPerRequestInZkWhenNoDatabase) {
     this.maxStaleTasksPerRequestInZkWhenNoDatabase = maxStaleTasksPerRequestInZkWhenNoDatabase;
+  }
+
+  public String getDefaultDatePattern() {
+    return defaultDatePattern;
+  }
+
+  public void setDefaultDatePattern(String defaultDatePattern) {
+    this.defaultDatePattern = defaultDatePattern;
+  }
+
+  public TimeZone getTimeZone() {
+    return timeZone;
+  }
+
+  public void setTimeZone(TimeZone timeZone) {
+    this.timeZone = timeZone;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -77,8 +77,6 @@ public class SingularityConfiguration extends Configuration {
   @Min(value = 1, message = "Must be positive and non-zero")
   private int defaultBounceExpirationMinutes = 60;
 
-  private String mailerDatePattern = "MMM dd h:mm:ss a zzz";
-
   @NotNull
   private SlavePlacement defaultSlavePlacement = SlavePlacement.GREEDY;
 
@@ -187,8 +185,6 @@ public class SingularityConfiguration extends Configuration {
   private SMTPConfiguration smtpConfiguration;
 
   private long startNewReconcileEverySeconds = TimeUnit.MINUTES.toSeconds(10);
-
-  private TimeZone mailerTimeZone = TimeZone.getTimeZone("UTC");
 
   @JsonProperty("ui")
   @Valid
@@ -959,21 +955,5 @@ public class SingularityConfiguration extends Configuration {
 
   public void setMaxStaleTasksPerRequestInZkWhenNoDatabase(Optional<Integer> maxStaleTasksPerRequestInZkWhenNoDatabase) {
     this.maxStaleTasksPerRequestInZkWhenNoDatabase = maxStaleTasksPerRequestInZkWhenNoDatabase;
-  }
-
-  public String getMailerDatePattern() {
-    return mailerDatePattern;
-  }
-
-  public void setMailerDatePattern(String mailerDatePattern) {
-    this.mailerDatePattern = mailerDatePattern;
-  }
-
-  public TimeZone getMailerTimeZone() {
-    return mailerTimeZone;
-  }
-
-  public void setMailerTimeZone(TimeZone mailerTimeZone) {
-    this.mailerTimeZone = mailerTimeZone;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -77,7 +77,7 @@ public class SingularityConfiguration extends Configuration {
   @Min(value = 1, message = "Must be positive and non-zero")
   private int defaultBounceExpirationMinutes = 60;
 
-  private String defaultDatePattern = "MMM dd h:mm:ss a";
+  private String defaultDatePattern = "MMM dd h:mm:ss a zzz";
 
   @NotNull
   private SlavePlacement defaultSlavePlacement = SlavePlacement.GREEDY;

--- a/SingularityService/src/main/java/com/hubspot/singularity/smtp/MailTemplateHelpers.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/smtp/MailTemplateHelpers.java
@@ -3,6 +3,7 @@ package com.hubspot.singularity.smtp;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.TimeZone;
 
 import org.apache.commons.lang3.text.WordUtils;
 import org.apache.commons.lang3.time.DateFormatUtils;
@@ -29,7 +30,6 @@ public class MailTemplateHelpers {
 
   private static final Logger LOG = LoggerFactory.getLogger(MailTemplateHelpers.class);
 
-  private static final String TASK_DATE_PATTERN = "MMM dd HH:mm:ss";
   private static final String TASK_LINK_FORMAT = "%s/task/%s";
   private static final String REQUEST_LINK_FORMAT = "%s/request/%s";
   private static final String LOG_LINK_FORMAT = "%s/task/%s/tail/%s";
@@ -38,9 +38,13 @@ public class MailTemplateHelpers {
 
   private final Optional<String> uiBaseUrl;
   private final Optional<SMTPConfiguration> smtpConfiguration;
+  private String taskDatePattern;
+  private TimeZone timeZone;
 
   @Inject
   public MailTemplateHelpers(SandboxManager sandboxManager, SingularityConfiguration singularityConfiguration) {
+    taskDatePattern = singularityConfiguration.getDefaultDatePattern();
+    timeZone = singularityConfiguration.getTimeZone();
     this.uiBaseUrl = singularityConfiguration.getUiConfiguration().getBaseUrl();
     this.sandboxManager = sandboxManager;
     this.smtpConfiguration = singularityConfiguration.getSmtpConfiguration();
@@ -52,7 +56,7 @@ public class MailTemplateHelpers {
     for (SingularityTaskHistoryUpdate taskUpdate : taskHistory) {
       output.add(
           new SingularityMailTaskHistoryUpdate(
-              DateFormatUtils.formatUTC(taskUpdate.getTimestamp(), TASK_DATE_PATTERN),
+              DateFormatUtils.format(taskUpdate.getTimestamp(), taskDatePattern, timeZone),
               WordUtils.capitalize(taskUpdate.getTaskState().getDisplayName()),
               taskUpdate.getStatusMessage().or("")));
     }

--- a/SingularityService/src/main/java/com/hubspot/singularity/smtp/MailTemplateHelpers.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/smtp/MailTemplateHelpers.java
@@ -43,8 +43,8 @@ public class MailTemplateHelpers {
 
   @Inject
   public MailTemplateHelpers(SandboxManager sandboxManager, SingularityConfiguration singularityConfiguration) {
-    taskDatePattern = singularityConfiguration.getDefaultDatePattern();
-    timeZone = singularityConfiguration.getTimeZone();
+    this.taskDatePattern = singularityConfiguration.getMailerDatePattern();
+    this.timeZone = singularityConfiguration.getMailerTimeZone();
     this.uiBaseUrl = singularityConfiguration.getUiConfiguration().getBaseUrl();
     this.sandboxManager = sandboxManager;
     this.smtpConfiguration = singularityConfiguration.getSmtpConfiguration();

--- a/SingularityService/src/main/java/com/hubspot/singularity/smtp/MailTemplateHelpers.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/smtp/MailTemplateHelpers.java
@@ -38,8 +38,8 @@ public class MailTemplateHelpers {
 
   private final Optional<String> uiBaseUrl;
   private final Optional<SMTPConfiguration> smtpConfiguration;
-  private String taskDatePattern;
-  private TimeZone timeZone;
+  private final String taskDatePattern;
+  private final TimeZone timeZone;
 
   @Inject
   public MailTemplateHelpers(SandboxManager sandboxManager, SingularityConfiguration singularityConfiguration) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/smtp/MailTemplateHelpers.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/smtp/MailTemplateHelpers.java
@@ -7,7 +7,6 @@ import java.util.TimeZone;
 
 import org.apache.commons.lang3.text.WordUtils;
 import org.apache.commons.lang3.time.DateFormatUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/smtp/SingularityMailer.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/smtp/SingularityMailer.java
@@ -401,7 +401,7 @@ public class SingularityMailer implements Managed {
     final long now = System.currentTimeMillis();
     final long future = now + durationMillis.get();
 
-    additionalProperties.put("expireFormat", DateFormatUtils.format(new Date(future), configuration.getDefaultDatePattern(), configuration.getTimeZone()));
+    additionalProperties.put("expireFormat", DateFormatUtils.format(new Date(future), configuration.getMailerDatePattern(), configuration.getMailerTimeZone()));
   }
 
   public void sendRequestPausedMail(SingularityRequest request, Optional<SingularityPauseRequest> pauseRequest, Optional<String> user) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/smtp/SingularityMailer.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/smtp/SingularityMailer.java
@@ -12,6 +12,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.time.DateFormatUtils;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -400,7 +401,7 @@ public class SingularityMailer implements Managed {
     final long now = System.currentTimeMillis();
     final long future = now + durationMillis.get();
 
-    additionalProperties.put("expireFormat", new Date(future));
+    additionalProperties.put("expireFormat", DateFormatUtils.format(new Date(future), configuration.getDefaultDatePattern(), configuration.getTimeZone()));
   }
 
   public void sendRequestPausedMail(SingularityRequest request, Optional<SingularityPauseRequest> pauseRequest, Optional<String> user) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/smtp/SingularityMailer.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/smtp/SingularityMailer.java
@@ -400,8 +400,10 @@ public class SingularityMailer implements Managed {
 
     final long now = System.currentTimeMillis();
     final long future = now + durationMillis.get();
-
-    additionalProperties.put("expireFormat", DateFormatUtils.format(new Date(future), configuration.getMailerDatePattern(), configuration.getMailerTimeZone()));
+    if (maybeSmtpConfiguration.isPresent()) {
+      SMTPConfiguration smtpConfiguration = maybeSmtpConfiguration.get();
+      additionalProperties.put("expireFormat", DateFormatUtils.format(new Date(future), smtpConfiguration.getMailerDatePattern(), smtpConfiguration.getMailerTimeZone()));
+    }
   }
 
   public void sendRequestPausedMail(SingularityRequest request, Optional<SingularityPauseRequest> pauseRequest, Optional<String> user) {

--- a/SingularityService/src/main/resources/templates/request_modified.jade
+++ b/SingularityService/src/main/resources/templates/request_modified.jade
@@ -43,9 +43,9 @@ html
             else
               | #{ requestId } will not run again until it is manually unpaused.
             if killTasks
-              | Existing tasks will be killed.
+              |  Existing tasks will be killed.
             else
-              | Existing tasks will not be killed.
+              |  Existing tasks will not be killed.
           else if requestUnpaused
             | #{ requestId } will begin scheduling and executing tasks immediately.
           else if requestScaled


### PR DESCRIPTION
In pause emails, when an expiration time was set:
- The timestamp displayed in a confusing way (24h clock always UTC). Now the format and timezone are configurable, and it defaults to 12h clock (but still UTC).
- A space was missing after the timestamp. This is fixed.