### PR TITLE
ensure run once tasks don't get launched at startup

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
@@ -206,7 +206,7 @@ public class SingularityRequest {
 
   @JsonIgnore
   public boolean isOneOff() {
-    return requestType == RequestType.ON_DEMAND || requestType == RequestType.RUN_ONCE;
+    return requestType == RequestType.ON_DEMAND;
   }
 
   @JsonIgnore

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
@@ -206,7 +206,7 @@ public class SingularityRequest {
 
   @JsonIgnore
   public boolean isOneOff() {
-    return requestType == RequestType.ON_DEMAND;
+    return requestType == RequestType.ON_DEMAND || requestType == RequestType.RUN_ONCE;
   }
 
   @JsonIgnore

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityStartup.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityStartup.java
@@ -18,6 +18,7 @@ import com.hubspot.mesos.JavaUtils;
 import com.hubspot.mesos.MesosUtils;
 import com.hubspot.mesos.client.MesosClient;
 import com.hubspot.mesos.json.MesosMasterStateObject;
+import com.hubspot.singularity.RequestType;
 import com.hubspot.singularity.SingularityDeployKey;
 import com.hubspot.singularity.SingularityPendingDeploy;
 import com.hubspot.singularity.SingularityPendingRequest;
@@ -135,8 +136,8 @@ class SingularityStartup {
   private void checkActiveRequest(SingularityRequestWithState requestWithState, Map<SingularityDeployKey, SingularityPendingTaskId> deployKeyToPendingTaskId, final long timestamp) {
     final SingularityRequest request = requestWithState.getRequest();
 
-    if (request.isOneOff()) {
-      return;
+    if (request.getRequestType() == RequestType.ON_DEMAND || request.getRequestType() == RequestType.RUN_ONCE) {
+      return;  // There's no situation where we'd want to schedule an On Demand or Run Once request at startup, so don't even bother with them.
     }
 
     Optional<SingularityRequestDeployState> requestDeployState = deployManager.getRequestDeployState(request.getId());

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityStartupTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityStartupTest.java
@@ -148,18 +148,15 @@ public class SingularityStartupTest extends SingularitySchedulerTestBase {
     deploy(firstDeployId);
     deployChecker.checkDeploys();
 
+    scheduler.drainPendingQueue(stateCacheProvider.get());
+    resourceOffers();
+
     Assert.assertTrue(requestManager.getPendingRequests().isEmpty());
     Assert.assertTrue(taskManager.getPendingTaskIds().isEmpty());
 
     startup.checkSchedulerForInconsistentState();
 
+    // assert that SingularityStartup does not enqueue a SingularityPendingRequest (pendingType=STARTUP) for the RUN_ONCE request
     Assert.assertTrue(requestManager.getPendingRequests().isEmpty());
-    Assert.assertTrue(taskManager.getPendingTaskIds().isEmpty());
-
-    requestManager.addToPendingQueue(new SingularityPendingRequest(requestId, firstDeployId, System.currentTimeMillis(), Optional.<String> absent(), PendingType.ONEOFF, Optional.<Boolean> absent(), Optional.<String> absent()));
-
-    startup.checkSchedulerForInconsistentState();
-
-    Assert.assertTrue(requestManager.getPendingRequests().get(0).getPendingType() == PendingType.ONEOFF);
   }
 }

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityStartupTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityStartupTest.java
@@ -122,7 +122,7 @@ public class SingularityStartupTest extends SingularitySchedulerTestBase {
   }
 
   @Test
-  public void testOneOffDoesntGetRescheduled() {
+  public void testOnDemandDoesntGetRescheduled() {
     saveRequest(new SingularityRequestBuilder(requestId, RequestType.ON_DEMAND).build());
     deploy(firstDeployId);
     deployChecker.checkDeploys();
@@ -142,4 +142,24 @@ public class SingularityStartupTest extends SingularitySchedulerTestBase {
     Assert.assertTrue(requestManager.getPendingRequests().get(0).getPendingType() == PendingType.ONEOFF);
   }
 
+  @Test
+  public void testRunOnceDoesntGetRescheduled() {
+    saveRequest(new SingularityRequestBuilder(requestId, RequestType.RUN_ONCE).build());
+    deploy(firstDeployId);
+    deployChecker.checkDeploys();
+
+    Assert.assertTrue(requestManager.getPendingRequests().isEmpty());
+    Assert.assertTrue(taskManager.getPendingTaskIds().isEmpty());
+
+    startup.checkSchedulerForInconsistentState();
+
+    Assert.assertTrue(requestManager.getPendingRequests().isEmpty());
+    Assert.assertTrue(taskManager.getPendingTaskIds().isEmpty());
+
+    requestManager.addToPendingQueue(new SingularityPendingRequest(requestId, firstDeployId, System.currentTimeMillis(), Optional.<String> absent(), PendingType.ONEOFF, Optional.<Boolean> absent(), Optional.<String> absent()));
+
+    startup.checkSchedulerForInconsistentState();
+
+    Assert.assertTrue(requestManager.getPendingRequests().get(0).getPendingType() == PendingType.ONEOFF);
+  }
 }


### PR DESCRIPTION
- Update SingularityStartup logic to ignore both `ON_DEMAND` and `RUN_ONCE` requests.
- Add unit test to assert that `RUN_ONCE` requests aren't launched at startup