### PR TITLE
Fuzzy sort better adjusted score

### DIFF
--- a/SingularityUI/app/utils.coffee
+++ b/SingularityUI/app/utils.coffee
@@ -198,5 +198,13 @@ class Utils
         else
           {}
 
+    @fuzzyAdjustScore: (filter, fuzzyObject) ->
+        if fuzzyObject.original.id.toLowerCase().startsWith(filter.toLowerCase())
+            fuzzyObject.score * 10
+        else if fuzzyObject.original.id.toLowerCase().indexOf(filter.toLowerCase()) > -1
+            fuzzyObject.score * 5
+        else
+            fuzzyObject.score
+
 
 module.exports = Utils

--- a/SingularityUI/app/views/requests.coffee
+++ b/SingularityUI/app/views/requests.coffee
@@ -1,6 +1,7 @@
 View = require './view'
 AutoTailer = require './AutoTailer'
 Request = require '../models/Request'
+Utils = require '../utils'
 
 class RequestsView extends View
 
@@ -54,14 +55,6 @@ class RequestsView extends View
 
         @fuzzySearch = _.memoize(@fuzzySearch)
 
-    adjustedScore: (filter, req) ->
-        if req.original.id.toLowerCase().startsWith(filter.toLowerCase())
-            req.score * 10
-        else if req.original.id.toLowerCase().indexOf(filter.toLowerCase()) > -1
-            req.score * 5
-        else
-            req.score
-
     fuzzySearch: (filter, requests) =>
         id =
             extract: (o) ->
@@ -71,7 +64,7 @@ class RequestsView extends View
                 o.requestDeployState?.activeDeploy?.user or ''
         res1 = fuzzy.filter(filter, requests, id)
         res2 = fuzzy.filter(filter, requests, user)
-        _.pluck(_.sortBy(_.union(res2, res1), (r) => @adjustedScore(filter, r)), 'original').reverse()
+        _.pluck(_.sortBy(_.union(res2, res1), (r) => Utils.fuzzyAdjustScore(filter, r)), 'original').reverse()
 
     # Returns the array of requests that need to be rendered
     filterCollection: =>

--- a/SingularityUI/app/views/requests.coffee
+++ b/SingularityUI/app/views/requests.coffee
@@ -57,6 +57,8 @@ class RequestsView extends View
     adjustedScore: (filter, req) ->
         if req.original.id.toLowerCase().startsWith(filter.toLowerCase())
             req.score * 10
+        else if req.original.id.toLowerCase().indexOf(filter.toLowerCase()) > -1
+            req.score * 5
         else
             req.score
 

--- a/SingularityUI/app/views/tasks.coffee
+++ b/SingularityUI/app/views/tasks.coffee
@@ -81,7 +81,7 @@ class TasksView extends View
                 return value
             if not @sortAscending
                 tasks = tasks.reverse()
-        else
+        else if not @searchFilter
             tasks.reverse() unless @state is 'scheduled'
 
         @currentTasks = tasks

--- a/SingularityUI/app/views/tasks.coffee
+++ b/SingularityUI/app/views/tasks.coffee
@@ -5,6 +5,8 @@ Slaves = require '../collections/Slaves'
 
 killTemplate = require '../templates/vex/taskKill'
 
+Utils = require '../utils'
+
 class TasksView extends View
 
     isSorted: false
@@ -46,14 +48,6 @@ class TasksView extends View
 
         @fuzzySearch = _.memoize(@fuzzySearch)
 
-    adjustedScore: (filter, task) ->
-        if task.original.id.toLowerCase().startsWith(filter.toLowerCase())
-            task.score * 10
-        else if task.original.id.toLowerCase().indexOf(filter.toLowerCase()) > -1
-            task.score * 5
-        else
-            task.score
-
     fuzzySearch: (filter, tasks) =>
         host =
             extract: (o) ->
@@ -63,7 +57,7 @@ class TasksView extends View
                 "#{o.id}"
         res1 = fuzzy.filter(filter, tasks, host)
         res2 = fuzzy.filter(filter, tasks, id)
-        _.pluck(_.sortBy(_.union(res1, res2), (t) => @adjustedScore(filter, t)), 'original')
+        _.pluck(_.sortBy(_.union(res1, res2), (t) => Utils.fuzzyAdjustScore(filter, t)), 'original')
 
     # Returns the array of tasks that need to be rendered
     filterCollection: =>

--- a/SingularityUI/app/views/tasks.coffee
+++ b/SingularityUI/app/views/tasks.coffee
@@ -57,7 +57,7 @@ class TasksView extends View
                 "#{o.id}"
         res1 = fuzzy.filter(filter, tasks, host)
         res2 = fuzzy.filter(filter, tasks, id)
-        _.pluck(_.sortBy(_.union(res1, res2), (t) => Utils.fuzzyAdjustScore(filter, t)), 'original')
+        _.pluck(_.sortBy(_.union(res1, res2), (t) => Utils.fuzzyAdjustScore(filter, t)), 'original').reverse()
 
     # Returns the array of tasks that need to be rendered
     filterCollection: =>

--- a/SingularityUI/app/views/tasks.coffee
+++ b/SingularityUI/app/views/tasks.coffee
@@ -46,6 +46,14 @@ class TasksView extends View
 
         @fuzzySearch = _.memoize(@fuzzySearch)
 
+    adjustedScore: (filter, task) ->
+        if task.original.id.toLowerCase().startsWith(filter.toLowerCase())
+            task.score * 10
+        else if task.original.id.toLowerCase().indexOf(filter.toLowerCase()) > -1
+            task.score * 5
+        else
+            task.score
+
     fuzzySearch: (filter, tasks) =>
         host =
             extract: (o) ->
@@ -55,7 +63,7 @@ class TasksView extends View
                 "#{o.id}"
         res1 = fuzzy.filter(filter, tasks, host)
         res2 = fuzzy.filter(filter, tasks, id)
-        _.pluck(_.sortBy(_.union(res1, res2), (r) => r.score), 'original')
+        _.pluck(_.sortBy(_.union(res1, res2), (t) => @adjustedScore(filter, t)), 'original')
 
     # Returns the array of tasks that need to be rendered
     filterCollection: =>


### PR DESCRIPTION
Requests and tasks that were searched from the requests (or tasks) page would sometimes filter to the bottom of search results despite containing the search term. This is because the fuzzy search algorithm only favored requests that started with the term (and not even that for tasks).
This fixes that, giving the highest score to requests or tasks that start with the search term, a medium score to requests or tasks that contain the search term, and a low score to others.