### PR TITLE
Healthcheck notification won't display if task state is TASK_FAILED

### DIFF
--- a/SingularityUI/app/views/taskHealthcheckNotificationSubview.coffee
+++ b/SingularityUI/app/views/taskHealthcheckNotificationSubview.coffee
@@ -14,6 +14,7 @@ class taskHealthcheckNotificationSubview extends View
 
     render: =>
         return if not @model.synced
+        return if _.last(@model.attributes.taskUpdates).taskState is "TASK_FAILED" # This is unfortunately the only place last state is stored.
         @$el.html @template @renderData()
 
     renderData: =>


### PR DESCRIPTION
The notification that the task failed due to no passing healthchecks was being displayed even for tasks that failed on their own for other reasons.

This fixes that.