### PR TITLE
Less ui build magic

### DIFF
--- a/SingularityService/pom.xml
+++ b/SingularityService/pom.xml
@@ -539,9 +539,18 @@
                 <goals>
                   <goal>npm</goal>
                 </goals>
-                <configuration>
-                  <arguments>install</arguments>
-                </configuration>
+              </execution>
+              <execution>
+                <id>bower install</id>
+                <goals>
+                  <goal>bower</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>gulp build</id>
+                <goals>
+                  <goal>gulp</goal>
+                </goals>
               </execution>
             </executions>
           </plugin>

--- a/SingularityUI/gulpfile.js
+++ b/SingularityUI/gulpfile.js
@@ -1,18 +1,39 @@
 var gulp = require('gulp');
 var path = require('path');
-var brunch = require('brunch');
 var del = require('del');
+var child_process = require('child_process');
+
+var dest = path.resolve(__dirname, '../SingularityService/target/generated-resources/assets');
 
 gulp.task("clean", function() {
   return del([
-    path.resolve(__dirname, '../SingularityService/target/generated-resources/assets/static/**'),
-    path.resolve(__dirname, '../SingularityService/target/generated-resources/assets/index.html')], {force: true});
+    path.resolve(dest, 'static/**'),
+    path.resolve(dest, 'index.html')], {force: true});
 });
 
 gulp.task("build", function(cb) {
-  brunch.build({}, function () {
-    cb();
+  var brunch = child_process.execFile('node_modules/brunch/bin/brunch', ['build', '--production']);
+
+  var hasStderrOutput = false;
+
+  brunch.stdout.pipe(process.stdout);
+  brunch.stderr.pipe(process.stderr);
+
+  brunch.stderr.on('data', function () {
+    hasStderrOutput = true;
+  });
+
+  brunch.on('error', cb);
+
+  brunch.on('exit', function (code) {
+    if (hasStderrOutput) {
+      cb(new Error("Brunch build failed"));
+    } else if (code != 0) {
+      cb(new Error("Brunch exited with code " + code));
+    } else {
+      cb();
+    }
   });
 });
 
-gulp.task("default", ["clean", "build"])
+gulp.task("default", ["clean", "build"]);

--- a/SingularityUI/gulpfile.js
+++ b/SingularityUI/gulpfile.js
@@ -1,0 +1,18 @@
+var gulp = require('gulp');
+var path = require('path');
+var brunch = require('brunch');
+var del = require('del');
+
+gulp.task("clean", function() {
+  return del([
+    path.resolve(__dirname, '../SingularityService/target/generated-resources/assets/static/**'),
+    path.resolve(__dirname, '../SingularityService/target/generated-resources/assets/index.html')], {force: true});
+});
+
+gulp.task("build", function(cb) {
+  brunch.build({}, function () {
+    cb();
+  });
+});
+
+gulp.task("default", ["clean", "build"])

--- a/SingularityUI/package.json
+++ b/SingularityUI/package.json
@@ -16,8 +16,7 @@
     "brunch": "./node_modules/brunch/bin/brunch"
   },
   "scripts": {
-    "start": "brunch watch --server",
-    "postinstall": "bower install --allow-root && brunch build --production"
+    "start": "brunch watch --server"
   },
   "dependencies": {
     "bower": "^1.7.6",
@@ -32,5 +31,10 @@
     "react-coffee-brunch": "^1.7.2",
     "stylus-brunch": "^2.0.0",
     "uglify-js-brunch": "^2.0.0"
+  },
+  "license": "Apache 2.0",
+  "devDependencies": {
+    "del": "^2.2.0",
+    "gulp": "^3.9.1"
   }
 }


### PR DESCRIPTION
This PR addresses build issues we've experienced with Bower + Brunch lately:
- Remove sketchy postinstall actions from `package.json`
- Update `maven-frontend-plugin` config to explicitly launch `npm install`, `bower install`, `brunch build`
- Launch brunch via a gulpfile. This is necessary due to how the `maven-frontend-plugin` works (no Brunch support), and also makes it easier for us to transition off of Brunch in the future.
- Explicitly clean assets folder before each UI build.