### PR TITLE
Upgrade basepom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>15.2</version>
+    <version>15.3</version>
   </parent>
 
   <artifactId>Singularity</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -290,14 +290,6 @@
             </dependency>
           </dependencies>
         </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-shade-plugin</artifactId>
-          <configuration>
-            <createDependencyReducedPom>true</createDependencyReducedPom>
-            <finalName>${singularity.jar.name.format}</finalName>
-          </configuration>
-        </plugin>
         <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
         <plugin>
         	<groupId>org.eclipse.m2e</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>12.9</version>
+    <version>15.2</version>
   </parent>
 
   <artifactId>Singularity</artifactId>
@@ -31,7 +31,8 @@
   </developers>
 
   <properties>
-    <singularity.jar.name.format>${project.artifactId}-${project.version}</singularity.jar.name.format>
+    <singularity.jar.name.format>${project.artifactId}-${project.version}-shaded</singularity.jar.name.format>
+    <basepom.jar.name.format>${singularity.jar.name.format}</basepom.jar.name.format>
 
     <!-- build the docs for releases -->
     <basepom.release.profiles>oss-release,build-swagger-documentation</basepom.release.profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
   </developers>
 
   <properties>
-    <singularity.jar.name.format>${project.artifactId}-${project.version}-shaded</singularity.jar.name.format>
+    <singularity.jar.name.format>${project.artifactId}-${project.version}</singularity.jar.name.format>
     <basepom.jar.name.format>${singularity.jar.name.format}</basepom.jar.name.format>
 
     <!-- build the docs for releases -->


### PR DESCRIPTION
This prevents the shaded JAR from getting attached as an artifact (and therefore uploaded to repository manager like Nexus). It will get uploaded when `basepom.oss-release` profile is active though, so it will still go to maven central

@tpetr @wsorenson @ssalinas 