### PR TITLE
get memory info from deploy object instead of mesos task resources

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
@@ -303,11 +303,8 @@ public class SingularityMesosScheduler implements Scheduler {
     if (status.hasMessage() && !Strings.isNullOrEmpty(status.getMessage())) {
       return Optional.of(status.getMessage());
     } else if (status.hasReason() && status.getReason() == Protos.TaskStatus.Reason.REASON_MEMORY_LIMIT) {
-      if (task.isPresent()) {
-        final double memory = MesosUtils.getMemory(task.get().getMesosTask().getResourcesList());
-        if (memory > 0) {
-          return Optional.of(String.format("Task exceeded memory limit of %s MB", MesosUtils.getMemory(task.get().getMesosTask().getResourcesList())));
-        }
+      if (task.isPresent() && task.get().getTaskRequest().getDeploy().getResources().isPresent()) {
+          return Optional.of(String.format("Task exceeded memory limit of %s MB", task.get().getTaskRequest().getDeploy().getResources().get().getMemoryMb()));
       }
       return Optional.of("Task exceeded memory limit");
     }


### PR DESCRIPTION
#900 set a meaningful status message when a task dies from an OOM kill, but it depended on Mesos task data being available, which may not always be true (see #892). This PR grabs the allocated memory from the `SingularityDeploy` object instead.