### PR TITLE
missing an early return for numPorts == 0

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/mesos/MesosUtils.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/MesosUtils.java
@@ -80,6 +80,10 @@ public final class MesosUtils {
 
   public static long[] getPorts(Resource portsResource, int numPorts) {
     long[] ports = new long[numPorts];
+    if (numPorts == 0) {
+      return ports;
+    }
+
     int idx = 0;
 
     for (Range r : portsResource.getRanges().getRangeList()) {

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/MesosUtilsTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/MesosUtilsTest.java
@@ -111,6 +111,15 @@ public class MesosUtilsTest {
     Assert.assertEquals(numPorts + requestedPorts.size(), MesosUtils.getNumPorts(Collections.singletonList(resource)));
   }
 
+  @Test
+  public void testGetZeroPortsFromResource() {
+    String[] rangesOverlappingRequestPorts = {"23:28"};
+    int numPorts = 0;
+    List<Long> requestedPorts = Arrays.asList(25L, 27L);
+    Resource resource = MesosUtils.getPortsResource(numPorts, buildOffer(rangesOverlappingRequestPorts).getResourcesList(), requestedPorts);
+    Assert.assertEquals(0, MesosUtils.getPorts(resource, numPorts).length);
+  }
+
   public static Resource buildPortRanges(String... ranges) {
     Resource.Builder resources = Resource.newBuilder()
         .setType(Type.RANGES)


### PR DESCRIPTION
/fixes #926

Before I added support for literal port mappings we skipped this section entirely when `numPorts` was 0. Needed to add a check for it now that we can hit this code path with `numPorts` of 0.
/cc @tpetr