### PR TITLE
smarter ordering for queries that don't use zk first

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -240,6 +240,8 @@ public class SingularityConfiguration extends Configuration {
   @Valid
   private GraphiteConfiguration graphiteConfiguration = new GraphiteConfiguration();
 
+  private boolean taskHistoryQueryUsesZkFirst = false;
+
   public long getAskDriverToKillTasksAgainAfterMillis() {
     return askDriverToKillTasksAgainAfterMillis;
   }
@@ -974,5 +976,13 @@ public class SingularityConfiguration extends Configuration {
 
   public void setMaxStaleTasksPerRequestInZkWhenNoDatabase(Optional<Integer> maxStaleTasksPerRequestInZkWhenNoDatabase) {
     this.maxStaleTasksPerRequestInZkWhenNoDatabase = maxStaleTasksPerRequestInZkWhenNoDatabase;
+  }
+
+  public boolean isTaskHistoryQueryUsesZkFirst() {
+    return taskHistoryQueryUsesZkFirst;
+  }
+
+  public void setTaskHistoryQueryUsesZkFirst(boolean taskHistoryQueryUsesZkFirst) {
+    this.taskHistoryQueryUsesZkFirst = taskHistoryQueryUsesZkFirst;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/BlendedHistoryHelper.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/BlendedHistoryHelper.java
@@ -4,15 +4,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-import org.apache.commons.collections.ArrayStack;
-
-import com.google.common.collect.BoundType;
 import com.google.common.collect.Lists;
 import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.SingularityTaskHistoryUpdate;

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/BlendedHistoryHelper.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/BlendedHistoryHelper.java
@@ -9,6 +9,9 @@ import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.collect.Lists;
 import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.SingularityTaskHistoryUpdate;
@@ -18,6 +21,7 @@ import com.hubspot.singularity.data.TaskManager;
 
 public abstract class BlendedHistoryHelper<T, Q> {
 
+  private static final Logger LOG = LoggerFactory.getLogger(BlendedHistoryHelper.class);
   protected abstract List<T> getFromZk(Q id);
   protected abstract List<T> getFromHistory(Q id, int historyStart, int numFromHistory);
 
@@ -127,6 +131,10 @@ public abstract class BlendedHistoryHelper<T, Q> {
     }
     for (T item : toRemove) {
       returnedMap.remove(item);
+    }
+
+    if (!foundAllFromHistory) {
+      LOG.trace("Current start index is {}, querying for more history", currentStartIndex);
     }
 
     return foundAllFromHistory;

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/TaskHistoryHelper.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/TaskHistoryHelper.java
@@ -15,6 +15,7 @@ import com.hubspot.singularity.SingularityTaskHistory;
 import com.hubspot.singularity.SingularityTaskHistoryQuery;
 import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.SingularityTaskIdHistory;
+import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.RequestManager;
 import com.hubspot.singularity.data.TaskManager;
 
@@ -24,12 +25,14 @@ public class TaskHistoryHelper extends BlendedHistoryHelper<SingularityTaskIdHis
   private final TaskManager taskManager;
   private final RequestManager requestManager;
   private final HistoryManager historyManager;
+  private final SingularityConfiguration configuration;
 
   @Inject
-  public TaskHistoryHelper(TaskManager taskManager, HistoryManager historyManager, RequestManager requestManager) {
+  public TaskHistoryHelper(TaskManager taskManager, HistoryManager historyManager, RequestManager requestManager, SingularityConfiguration configuration) {
     this.taskManager = taskManager;
     this.historyManager = historyManager;
     this.requestManager = requestManager;
+    this.configuration = configuration;
   }
 
   private List<SingularityTaskIdHistory> getFromZk(List<String> requestIds) {
@@ -95,6 +98,9 @@ public class TaskHistoryHelper extends BlendedHistoryHelper<SingularityTaskIdHis
 
   @Override
   protected boolean queryUsesZkFirst(SingularityTaskHistoryQuery query) {
+    if (configuration.isTaskHistoryQueryUsesZkFirst()) {
+      return true;
+    }
     if (!query.getRequestId().isPresent()) {
       return false;
     }

--- a/SingularityService/src/test/java/com/hubspot/singularity/SingularityHistoryTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/SingularityHistoryTest.java
@@ -247,7 +247,7 @@ public class SingularityHistoryTest extends SingularitySchedulerTestBase {
   @Test
   public void testPersisterRaceCondition() {
     final TaskManager taskManagerSpy = spy(taskManager);
-    final TaskHistoryHelper taskHistoryHelperWithMockedTaskManager = new TaskHistoryHelper(taskManagerSpy, historyManager, requestManager);
+    final TaskHistoryHelper taskHistoryHelperWithMockedTaskManager = new TaskHistoryHelper(taskManagerSpy, historyManager, requestManager, configuration);
 
     initScheduledRequest();
     initFirstDeploy();
@@ -356,6 +356,10 @@ public class SingularityHistoryTest extends SingularitySchedulerTestBase {
     match(taskHistoryHelper.getBlendedHistory(new SingularityTaskHistoryQuery(Optional.of(requestId), Optional.<String> absent(), Optional.<String> absent(),
         Optional.<ExtendedTaskState> absent(), Optional.of(7L), Optional.of(2L), Optional.of(OrderDirection.ASC)), 0, 3), 3,
         taskThree, taskFour, taskFive);
+
+    match(taskHistoryHelper.getBlendedHistory(new SingularityTaskHistoryQuery(Optional.of(requestId), Optional.<String> absent(), Optional.<String> absent(),
+        Optional.<ExtendedTaskState> absent(), Optional.of(7L), Optional.of(2L), Optional.of(OrderDirection.ASC)), 1, 3), 3,
+        taskFour, taskFive, taskSix);
   }
 
   @Test
@@ -408,6 +412,10 @@ public class SingularityHistoryTest extends SingularitySchedulerTestBase {
         Optional.<ExtendedTaskState> absent(), Optional.<Long> absent(), Optional.<Long> absent(), Optional.<OrderDirection> absent()), 0, 3), 3,
         taskSeven, taskSix, taskFive);
 
+    match(taskHistoryHelper.getBlendedHistory(new SingularityTaskHistoryQuery(Optional.of(requestId), Optional.<String> absent(), Optional.<String> absent(),
+        Optional.<ExtendedTaskState> absent(), Optional.<Long> absent(), Optional.<Long> absent(), Optional.<OrderDirection> absent()), 2, 1), 1,
+        taskFive);
+
     match(taskHistoryHelper.getBlendedHistory(new SingularityTaskHistoryQuery(Optional.of(requestId), Optional.of(secondDeployId), Optional.of("host4"),
         Optional.<ExtendedTaskState> absent(), Optional.<Long> absent(), Optional.<Long> absent(), Optional.<OrderDirection> absent()), 0, 3), 1,
         taskFour);
@@ -423,6 +431,10 @@ public class SingularityHistoryTest extends SingularitySchedulerTestBase {
     match(taskHistoryHelper.getBlendedHistory(new SingularityTaskHistoryQuery(Optional.of(requestId), Optional.<String> absent(), Optional.<String> absent(),
         Optional.<ExtendedTaskState> absent(), Optional.of(70000L), Optional.of(20000L), Optional.of(OrderDirection.ASC)), 0, 3), 3,
         taskThree, taskFour, taskFive);
+
+    match(taskHistoryHelper.getBlendedHistory(new SingularityTaskHistoryQuery(Optional.of(requestId), Optional.<String> absent(), Optional.<String> absent(),
+        Optional.<ExtendedTaskState> absent(), Optional.of(70000L), Optional.of(20000L), Optional.of(OrderDirection.ASC)), 1, 3), 3,
+        taskFour, taskFive, taskSix);
   }
 
   private void match(List<SingularityTaskIdHistory> history, int num, SingularityTask... tasks) {


### PR DESCRIPTION
Currently, when searching anything where `queryUsesZkFirst` returns `false`, all results from zk are still initially in our list of returned items before fetching from history. So, after sorting, regardless of page, the zk results will likely be on the page and much of the persisted history will not be shown. In short, anything that hasn't been persisted yet will likely show up on every page of task search results.

This PR implements two things:
- `taskHistoryQueryUsesZkFirst` option -> if `true` this would have every query for task history use zk items first. This will only require a single history query, and thus be much faster, with the caveat that anything not persisted will always appear before anything that has already persisted in the general order (but paging will be correct)
- If `taskHistoryQueryUsesZkFirst` is `false` we will make similar initial queries for items from zk and from persisted history. But, after ordering them, we will check that we have fetched all relevant items from the history. If we have not (i.e. some non-persisted items in the limitStart/limitCount range are beyond the range of all persisted items we have fetched), then we will fetch additional items to ensure correct ordering of all items, but at the added cost of additional queries needed.

My overall thought on this was that we can at least give the user the choice of efficiency/speed vs ensuring correct ordering.

Only other thing I wasn't sure on was whether to make `taskHistoryQueryUsesZkFirst` available on the query as well to give each individual user making a query the option as well as being abel to set the system-wide default.

/cc @wsorenson @tpetr @Calvinp 