### PR TITLE
Fix Duplicates in Fuzzy Search

### DIFF
--- a/SingularityUI/app/views/requests.coffee
+++ b/SingularityUI/app/views/requests.coffee
@@ -64,7 +64,7 @@ class RequestsView extends View
                 o.requestDeployState?.activeDeploy?.user or ''
         res1 = fuzzy.filter(filter, requests, id)
         res2 = fuzzy.filter(filter, requests, user)
-        _.pluck(_.sortBy(_.union(res2, res1), (r) => Utils.fuzzyAdjustScore(filter, r)), 'original').reverse()
+        _.uniq(_.pluck(_.sortBy(_.union(res2, res1), (r) => Utils.fuzzyAdjustScore(filter, r)), 'original').reverse())
 
     # Returns the array of requests that need to be rendered
     filterCollection: =>

--- a/SingularityUI/app/views/tasks.coffee
+++ b/SingularityUI/app/views/tasks.coffee
@@ -57,7 +57,7 @@ class TasksView extends View
                 "#{o.id}"
         res1 = fuzzy.filter(filter, tasks, host)
         res2 = fuzzy.filter(filter, tasks, id)
-        _.pluck(_.sortBy(_.union(res1, res2), (t) => Utils.fuzzyAdjustScore(filter, t)), 'original').reverse()
+        _.uniq(_.pluck(_.sortBy(_.union(res1, res2), (t) => Utils.fuzzyAdjustScore(filter, t)), 'original').reverse())
 
     # Returns the array of tasks that need to be rendered
     filterCollection: =>


### PR DESCRIPTION
Fuzzy Search gave duplicates in certain situations. This is because there are two searches done, one based on task id and one based on host. Fuzzy returns an object containing the string it searched on. If both the task id and host match the filter, two non-equal fuzzy objects representing the same task are returned, and _.union doesn't see them as the same thing.

This fixes that problem by calling _.uniq after extracting the original object.