### PR TITLE
add mailhog to compose dev

### DIFF
--- a/compose-dev.yml
+++ b/compose-dev.yml
@@ -36,6 +36,8 @@ scheduler:
   environment:
     - DOCKER_HOST
     - LOAD_BALANCER_URI=http://localhost:8080/baragon/v2/request
+    - SINGULARITY_SMTP_HOST=localhost
+    - SINGULARITY_SMTP_PORT=1025
 
 baragonservice:
   image: hubspot/baragonservice:0.1.11
@@ -52,3 +54,7 @@ baragonagent:
     NGINX_PORT: 80
     BARAGON_PORT: 8882
     BARAGON_AGENT_GROUP: test
+
+mailhog:
+  image: mailhog/mailhog
+  net: host


### PR DESCRIPTION
@Calvinp this will add mailhog to the docker compose setup (controlled with the `./dev` script). Once an email is sent, you should be able to go to the mailhog ui and see any emails at `$DOCKER_HOST:8025`