### PR TITLE
Don't capture ctrl-t

### DIFF
--- a/SingularityUI/app/views/globalSearch.coffee
+++ b/SingularityUI/app/views/globalSearch.coffee
@@ -20,7 +20,7 @@ class GlobalSearchView extends View
             focusBody = $(event.target).is 'body'
             focusInput = $(event.target).is @$ 'input[type="search"]'
 
-            modifierKey = event.metaKey or event.shiftKey
+            modifierKey = event.metaKey or event.shiftKey or event.ctrlKey
             sPressed = event.keyCode in [83, 84] and not modifierKey
             escPressed = event.keyCode is 27
 


### PR DESCRIPTION
Capturing ctrl-t prevents someone on a Linux or Windows machine from using the common keyboard shortcut to open a new tab.