### PR TITLE
More Descriptive Error Message On Http 200 But No JSON

### DIFF
--- a/SingularityUI/app/application.coffee
+++ b/SingularityUI/app/application.coffee
@@ -116,13 +116,12 @@ class Application
                     serverMessage = JSON.parse(jqxhr.responseText).message or jqxhr.responseText
                 catch
                     if jqxhr.status is 200
-                        console.error jqxhr
+                        console.error jqxhr.responseText
                         Messenger().error
-                            message:    '''
-                                            <p>Expected JSON but received something else (possibly html). The response has been saved to your js console.</p>
-                                            <p>One possible cause is an http redirect to an html web page.</p>
-                                        '''
-                        throw new Error "Expected JSON in response but received something else"
+                            message:    """
+                                            <p>Expected JSON but received #{if jqxhr.responseText.startsWith '<!DOCTYPE html>' then 'html' else 'something else'}. The response has been saved to your js console.</p>
+                                        """
+                        throw new Error "Expected JSON in response but received #{if jqxhr.responseText.startsWith '<!DOCTYPE html>' then 'html' else 'something else'}"
                     serverMessage = jqxhr.responseText
 
                 serverMessage = _.escape serverMessage

--- a/SingularityUI/app/application.coffee
+++ b/SingularityUI/app/application.coffee
@@ -120,8 +120,7 @@ class Application
                         Messenger().error
                             message:    '''
                                             <p>Expected JSON but received something else (possibly html). The response has been saved to your js console.</p>
-                                            <p>One possible cause is an http redirect to an html web page, which could happen if your session has expired.</p>
-                                            <p>Please log in again, then repeat this request.</p>
+                                            <p>One possible cause is an http redirect to an html web page.</p>
                                         '''
                         throw new Error "Expected JSON in response but received something else"
                     serverMessage = jqxhr.responseText

--- a/SingularityUI/app/application.coffee
+++ b/SingularityUI/app/application.coffee
@@ -113,9 +113,18 @@ class Application
                     message:   "<p>Could not reach the Singularity API. Please make sure SingularityUI is properly set up.</p><p>If running through Brunch, this might be your browser blocking cross-domain requests.</p>"
             else
                 try
-                  serverMessage = JSON.parse(jqxhr.responseText).message or jqxhr.responseText
+                    serverMessage = JSON.parse(jqxhr.responseText).message or jqxhr.responseText
                 catch
-                  serverMessage = jqxhr.responseText
+                    if jqxhr.status is 200
+                        console.error jqxhr
+                        Messenger().error
+                            message:    '''
+                                            <p>Expected JSON but received something else (possibly html). The response has been saved to your js console.</p>
+                                            <p>One possible cause is an http redirect to an html web page, which could happen if your session has expired.</p>
+                                            <p>Please log in again, then repeat this request.</p>
+                                        '''
+                        throw new Error "Expected JSON in response but received something else"
+                    serverMessage = jqxhr.responseText
 
                 serverMessage = _.escape serverMessage
                 id = "message_" + Date.now()


### PR DESCRIPTION
When a user's session expires, we send an http 302 redirect to the login page. However, the browser catches this and follows it without passing it off to the application. Then the application receives html when it was expecting JSON. This handles that problem by advising the user of the situation and that one possible cause is an expired session.