### PR TITLE
Opt out of even number across racks.

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
@@ -47,6 +47,8 @@ public class SingularityRequest {
 
   private final Optional<Map<SingularityEmailType, List<SingularityEmailDestination>>> emailConfigurationOverrides;
 
+  private final Optional<Boolean> hideEvenNumberAcrossRacksHint;
+
   @JsonCreator
   public SingularityRequest(@JsonProperty("id") String id, @JsonProperty("requestType") RequestType requestType, @JsonProperty("owners") Optional<List<String>> owners,
       @JsonProperty("numRetriesOnFailure") Optional<Integer> numRetriesOnFailure, @JsonProperty("schedule") Optional<String> schedule, @JsonProperty("instances") Optional<Integer> instances,
@@ -58,7 +60,8 @@ public class SingularityRequest {
       @JsonProperty("waitAtLeastMillisAfterTaskFinishesForReschedule") Optional<Long> waitAtLeastMillisAfterTaskFinishesForReschedule, @JsonProperty("group") Optional<String> group,
       @JsonProperty("readOnlyGroups") Optional<Set<String>> readOnlyGroups, @JsonProperty("bounceAfterScale") Optional<Boolean> bounceAfterScale,
       @JsonProperty("skipHealthchecks") Optional<Boolean> skipHealthchecks,
-      @JsonProperty("emailConfigurationOverrides") Optional<Map<SingularityEmailType, List<SingularityEmailDestination>>> emailConfigurationOverrides, @JsonProperty("daemon") @Deprecated Optional<Boolean> daemon) {
+      @JsonProperty("emailConfigurationOverrides") Optional<Map<SingularityEmailType, List<SingularityEmailDestination>>> emailConfigurationOverrides,
+      @JsonProperty("daemon") @Deprecated Optional<Boolean> daemon, @JsonProperty("hideEvenNumberAcrossRacks") Optional<Boolean> hideEvenNumberAcrossRacksHint) {
     this.id = checkNotNull(id, "id cannot be null");
     this.owners = owners;
     this.numRetriesOnFailure = numRetriesOnFailure;
@@ -80,6 +83,7 @@ public class SingularityRequest {
     this.bounceAfterScale = bounceAfterScale;
     this.emailConfigurationOverrides = emailConfigurationOverrides;
     this.skipHealthchecks = skipHealthchecks;
+    this.hideEvenNumberAcrossRacksHint = hideEvenNumberAcrossRacksHint;
     if (requestType == null) {
       this.requestType = RequestType.fromDaemonAndScheduleAndLoadBalanced(schedule, daemon, loadBalanced);
     } else {
@@ -108,7 +112,8 @@ public class SingularityRequest {
     .setReadOnlyGroups(readOnlyGroups)
     .setBounceAfterScale(bounceAfterScale)
     .setEmailConfigurationOverrides(emailConfigurationOverrides)
-    .setSkipHealthchecks(skipHealthchecks);
+    .setSkipHealthchecks(skipHealthchecks)
+    .setHideEvenNumberAcrossRacksHint(hideEvenNumberAcrossRacksHint);
   }
 
   public String getId() {
@@ -252,6 +257,8 @@ public class SingularityRequest {
     return skipHealthchecks;
   }
 
+  public Optional<Boolean> getHideEvenNumberAcrossRacksHint() { return hideEvenNumberAcrossRacksHint; }
+
   @Override
   public String toString() {
     return "SingularityRequest[" +
@@ -276,6 +283,7 @@ public class SingularityRequest {
             ", readOnlyGroups=" + readOnlyGroups +
             ", bounceAfterScale=" + bounceAfterScale +
             ", emailConfigurationOverrides=" + emailConfigurationOverrides +
+            ", hideEvenNumberAcrossRacksHint=" + hideEvenNumberAcrossRacksHint +
             ']';
   }
 
@@ -308,11 +316,12 @@ public class SingularityRequest {
             Objects.equals(group, request.group) &&
             Objects.equals(readOnlyGroups, request.readOnlyGroups) &&
             Objects.equals(bounceAfterScale, request.bounceAfterScale) &&
-            Objects.equals(emailConfigurationOverrides, request.emailConfigurationOverrides);
+            Objects.equals(emailConfigurationOverrides, request.emailConfigurationOverrides) &&
+            Objects.equals(hideEvenNumberAcrossRacksHint, request.hideEvenNumberAcrossRacksHint);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, requestType, owners, numRetriesOnFailure, schedule, quartzSchedule, scheduleType, killOldNonLongRunningTasksAfterMillis, scheduledExpectedRuntimeMillis, waitAtLeastMillisAfterTaskFinishesForReschedule, instances, rackSensitive, rackAffinity, slavePlacement, requiredSlaveAttributes, allowedSlaveAttributes, loadBalanced, group, readOnlyGroups, bounceAfterScale, emailConfigurationOverrides);
+    return Objects.hash(id, requestType, owners, numRetriesOnFailure, schedule, quartzSchedule, scheduleType, killOldNonLongRunningTasksAfterMillis, scheduledExpectedRuntimeMillis, waitAtLeastMillisAfterTaskFinishesForReschedule, instances, rackSensitive, rackAffinity, slavePlacement, requiredSlaveAttributes, allowedSlaveAttributes, loadBalanced, group, readOnlyGroups, bounceAfterScale, emailConfigurationOverrides, hideEvenNumberAcrossRacksHint);
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestBuilder.java
@@ -41,6 +41,7 @@ public class SingularityRequestBuilder {
   private Optional<Set<String>> readOnlyGroups;
   private Optional<Boolean> bounceAfterScale;
   private Optional<Map<SingularityEmailType, List<SingularityEmailDestination>>> emailConfigurationOverrides;
+  private Optional<Boolean> hideEvenNumberAcrossRacksHint;
 
   public SingularityRequestBuilder(String id, RequestType requestType) {
     this.id = checkNotNull(id, "id cannot be null");
@@ -65,12 +66,13 @@ public class SingularityRequestBuilder {
     this.bounceAfterScale = Optional.absent();
     this.emailConfigurationOverrides = Optional.absent();
     this.skipHealthchecks = Optional.absent();
+    this.hideEvenNumberAcrossRacksHint = Optional.absent();
   }
 
   public SingularityRequest build() {
     return new SingularityRequest(id, requestType, owners, numRetriesOnFailure, schedule, instances, rackSensitive, loadBalanced, killOldNonLongRunningTasksAfterMillis, scheduleType, quartzSchedule,
         rackAffinity, slavePlacement, requiredSlaveAttributes, allowedSlaveAttributes, scheduledExpectedRuntimeMillis, waitAtLeastMillisAfterTaskFinishesForReschedule, group, readOnlyGroups,
-        bounceAfterScale, skipHealthchecks, emailConfigurationOverrides, Optional.<Boolean>absent());
+        bounceAfterScale, skipHealthchecks, emailConfigurationOverrides, Optional.<Boolean>absent(), hideEvenNumberAcrossRacksHint);
   }
 
   public Optional<Boolean> getSkipHealthchecks() {
@@ -253,6 +255,13 @@ public class SingularityRequestBuilder {
     return this;
   }
 
+  public Optional<Boolean> getHideEvenNumberAcrossRacksHint() { return hideEvenNumberAcrossRacksHint; }
+
+  public SingularityRequestBuilder setHideEvenNumberAcrossRacksHint(Optional<Boolean> hideEvenNumberAcrossRacksHint) {
+    this.hideEvenNumberAcrossRacksHint = hideEvenNumberAcrossRacksHint;
+    return this;
+  }
+
   @Override
   public String toString() {
     return "SingularityRequestBuilder[" +
@@ -278,6 +287,7 @@ public class SingularityRequestBuilder {
             ", bounceAfterScale=" + bounceAfterScale +
             ", emailConfigurationOverrides=" + emailConfigurationOverrides +
             ", skipHealthchecks=" + skipHealthchecks +
+            ", hideEvenNumberAcrossRacksHint=" + hideEvenNumberAcrossRacksHint +
             ']';
   }
 
@@ -311,14 +321,15 @@ public class SingularityRequestBuilder {
             Objects.equals(readOnlyGroups, that.readOnlyGroups) &&
             Objects.equals(bounceAfterScale, that.bounceAfterScale) &&
             Objects.equals(skipHealthchecks, that.skipHealthchecks) &&
-            Objects.equals(emailConfigurationOverrides, that.emailConfigurationOverrides);
+            Objects.equals(emailConfigurationOverrides, that.emailConfigurationOverrides) &&
+            Objects.equals(hideEvenNumberAcrossRacksHint, that.hideEvenNumberAcrossRacksHint);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(id, requestType, owners, numRetriesOnFailure, schedule, quartzSchedule, scheduleType, killOldNonLongRunningTasksAfterMillis,
         scheduledExpectedRuntimeMillis, waitAtLeastMillisAfterTaskFinishesForReschedule, instances, rackSensitive, rackAffinity, slavePlacement,
-        requiredSlaveAttributes, allowedSlaveAttributes, loadBalanced, group, readOnlyGroups, bounceAfterScale, skipHealthchecks, emailConfigurationOverrides);
+        requiredSlaveAttributes, allowedSlaveAttributes, loadBalanced, group, readOnlyGroups, bounceAfterScale, skipHealthchecks, emailConfigurationOverrides, hideEvenNumberAcrossRacksHint);
   }
 
 }

--- a/SingularityUI/app/models/Request.coffee
+++ b/SingularityUI/app/models/Request.coffee
@@ -289,7 +289,7 @@ class Request extends Model
                 
 
     checkScaleEvenNumberRacks: (data, bounce, incremental, message, duration, callback) =>
-        mod = data.instances %% 2
+        mod = data.instances %% @racks.length
         if mod
             @promptScaleEvenNumberRacks 
                 callback: callback

--- a/SingularityUI/app/models/Request.coffee
+++ b/SingularityUI/app/models/Request.coffee
@@ -61,6 +61,16 @@ class Request extends Model
                 message: data.message
             )
 
+    hideEvenNumberAcrossRacksHint: (callback) ->
+        @attributes.request.hideEvenNumberAcrossRacksHint = true
+        ajaxPromise = $.ajax(
+            type: 'POST'
+            url: "#{ config.apiRoot }/requests"
+            contentType: 'application/json'
+            data: JSON.stringify @attributes.request
+        )
+        ajaxPromise.then callback
+
     pause: (killTasks, duration, message) =>
         data =
             user:      app.getUsername()
@@ -238,9 +248,16 @@ class Request extends Model
                 if !duration or (duration and @_validateDuration(duration, @promptPause, callback))
                     @pause(killTasks, duration, message).done callback
 
-    callScale: (data, bounce, incremental, message, duration, callback) =>
+    callScale: (data, bounce, incremental, message, duration, callback, setHideEvenNumberAcrossRacksHintTrue) =>
         @scale(data).done =>
-            if bounce
+            if setHideEvenNumberAcrossRacksHintTrue
+                @attributes.request.instances = data.instances
+                @hideEvenNumberAcrossRacksHint () =>
+                    if bounce 
+                        @bounce({incremental}).done callback
+                    else
+                        callback()
+            else if bounce 
                 @bounce({incremental}).done callback
             else
                 callback()
@@ -268,10 +285,11 @@ class Request extends Model
             callback: (data) =>
                 return unless data
                 scaleData.data.instances = data.instances
-                @callScale scaleData.data, scaleData.bounce, scaleData.incremental, scaleData.message, scaleData.duration, scaleData.callback
+                @callScale scaleData.data, scaleData.bounce, scaleData.incremental, scaleData.message, scaleData.duration, scaleData.callback, data.optOut
+                
 
     checkScaleEvenNumberRacks: (data, bounce, incremental, message, duration, callback) =>
-        mod = data.instances %% @racks.length
+        mod = data.instances %% 2
         if mod
             @promptScaleEvenNumberRacks 
                 callback: callback
@@ -282,7 +300,7 @@ class Request extends Model
                 message: message
                 duration: duration
         else
-            @callScale data, bounce, incremental, message, duration, callback
+            @callScale data, bounce, incremental, message, duration, callback, false
 
     promptScale: (callback) =>
         vex.dialog.open
@@ -319,9 +337,9 @@ class Request extends Model
                                 success: () => @checkScaleEvenNumberRacks data, bounce, incremental, message, duration, callback
                                 error: () => 
                                     app.caughtError() # Since we scale anyway, don't show the error
-                                    @callScale data, bounce, incremental, message, duration, callback
+                                    @callScale data, bounce, incremental, message, duration, callback, false
                     else
-                        @callScale data, bounce, incremental, message, duration, callback
+                        @callScale data, bounce, incremental, message, duration, callback, false
                     
 
     promptDisableHealthchecksDuration: (message, duration, callback) =>

--- a/SingularityUI/app/models/Request.coffee
+++ b/SingularityUI/app/models/Request.coffee
@@ -310,7 +310,7 @@ class Request extends Model
                 message = $('.vex #scale-message').val()
                 duration = $('.vex #scale-expiration').val()
                 if !duration or (duration and @_validateDuration(duration, @promptScale, callback))
-                    if @attributes.request.rackSensitive
+                    if @attributes.request.rackSensitive and not @attributes.request.hideEvenNumberAcrossRacksHint
                         if @racks
                             @checkScaleEvenNumberRacks data, bounce, incremental, message, duration, callback
                         else

--- a/SingularityUI/app/templates/requestForm.hbs
+++ b/SingularityUI/app/templates/requestForm.hbs
@@ -74,6 +74,14 @@
               </label>
             </div>
           </div>
+          <div class="col-sm-4">
+            <div class="form-group">
+              <label for="hide-distribute-across-racks-hint-SERVICE" data-tooltip='hide-distribute-across-racks-hint'>
+                <input type="checkbox" id="hide-distribute-across-racks-hint-SERVICE">
+                Hide Distribute Evenly Across Racks Hint
+              </label>
+            </div>
+          </div>
           {{#if config.loadBalancingEnabled }}
             <div class="col-sm-4">
               <div class="form-group">
@@ -106,6 +114,14 @@
               <label for="rack-sensitive-WORKER" data-tooltip='rack-sensitive'>
                 <input type="checkbox" id="rack-sensitive-WORKER" checked>
                 Rack sensitive
+              </label>
+            </div>
+          </div>
+          <div class="col-sm-4">
+            <div class="form-group">
+              <label for="hide-distribute-across-racks-hint-WORKER" data-tooltip='hide-distribute-across-racks-hint'>
+                <input type="checkbox" id="hide-distribute-across-racks-hint-WORKER">
+                Hide Distribute Evenly Across Racks Hint
               </label>
             </div>
           </div>

--- a/SingularityUI/app/templates/vex/requestBounce.hbs
+++ b/SingularityUI/app/templates/vex/requestBounce.hbs
@@ -9,7 +9,7 @@
     <input type="radio" name="incremental" id="incremental-bounce" value="true"> Kill old tasks as new tasks become healthy
 </label>
 <label for="skip-healthchecks" id="skip-healthchecks-label">
-	<input type="checkbox" name="skip-healthchecks" id="skip-healthchecks"> Skip healthchecks during bounce
+	<input type="checkbox" name="skip-healthchecks" id="skip-healthchecks">
 </label>
 <div class="vex-dialog-input expiration-input">
 		<input name="duration" id="bounce-expiration" type="text" placeholder="Expiration (optional - default {{ config.defaultBounceExpirationMinutes }}m)" />

--- a/SingularityUI/app/templates/vex/requestScaleConfirmRacks.hbs
+++ b/SingularityUI/app/templates/vex/requestScaleConfirmRacks.hbs
@@ -39,3 +39,10 @@
     </label><br/>
     <input type="radio" name="instances" id="higher" value="{{ higher }}"> <label for="higher" id="higher-label">{{ higher }} instances</label><br/>
 </div>
+<br />
+<div id="opt-out">
+    <label for='opt-out-box' id='opt-out-box-label'>
+        <input type='checkbox' name='optOut' id='opt-out-box' value='opt-out'>
+        Don't ask again for this request, for any user
+    </label>
+</div>

--- a/SingularityUI/app/views/requestFormBase.coffee
+++ b/SingularityUI/app/views/requestFormBase.coffee
@@ -97,8 +97,6 @@ class RequestFormBase extends FormBaseView
             
             requestObject.rackAffinity = @getSelect2Val "#rackAffinity-#{ type }"
 
-            debugger
-
         if type in ['SCHEDULED', 'ON_DEMAND', 'RUN_ONCE']
             killOld = parseInt @$("#killOldNRL-#{ type }").val()
             requestObject.killOldNonLongRunningTasksAfterMillis = killOld if killOld

--- a/SingularityUI/app/views/requestFormBase.coffee
+++ b/SingularityUI/app/views/requestFormBase.coffee
@@ -92,8 +92,12 @@ class RequestFormBase extends FormBaseView
             requestObject.waitAtLeastMillisAfterTaskFinishesForReschedule = waitAtLeast if waitAtLeast
 
             requestObject.rackSensitive = @$("#rack-sensitive-#{ type }").is ':checked'
+
+            requestObject.hideEvenNumberAcrossRacksHint = @$("#hide-distribute-across-racks-hint-#{ type }").is ':checked'
             
             requestObject.rackAffinity = @getSelect2Val "#rackAffinity-#{ type }"
+
+            debugger
 
         if type in ['SCHEDULED', 'ON_DEMAND', 'RUN_ONCE']
             killOld = parseInt @$("#killOldNRL-#{ type }").val()

--- a/SingularityUI/app/views/requestFormEdit.coffee
+++ b/SingularityUI/app/views/requestFormEdit.coffee
@@ -28,6 +28,7 @@ class RequestFormEdit extends RequestFormBaseView
         if @requestType is 'SERVICE' or 'WORKER'
             @$("#instances-#{@requestType}").val request.request.instances
             @$("#rack-sensitive-#{@requestType}").prop 'checked', request.request.rackSensitive
+            @$("#hide-distribute-across-racks-hint-#{@requestType}").prop 'checked', request.request.hideEvenNumberAcrossRacksHint
             @$("#load-balanced").prop 'checked', request.request.loadBalanced
 
         if @requestType in ['SCHEDULED','ON_DEMAND','RUN_ONCE']


### PR DESCRIPTION
Adds a parameter to SingularityRequest to opt out of suggesting even numbers across racks, and the UI listens to this.
Also when creating or updating requests through the UI, there is a checkbox to toggle this.