### PR TITLE
After submitting or editing a request, redirect to that request's page

### DIFF
--- a/SingularityUI/app/views/requestFormEdit.coffee
+++ b/SingularityUI/app/views/requestFormEdit.coffee
@@ -67,6 +67,7 @@ class RequestFormEdit extends RequestFormBaseView
         serverRequest.done  (response) =>
             @lockdown = false
             @alert "Your Request <a href='#{ config.appRoot }/request/#{ response.id }'>#{ response.id }</a> has been updated"
+            Backbone.history.navigate "/request/#{ response.id }", {trigger: true}
 
         serverRequest.error (response) =>
             @postSave()

--- a/SingularityUI/app/views/requestFormNew.coffee
+++ b/SingularityUI/app/views/requestFormNew.coffee
@@ -14,6 +14,7 @@ class RequestFormNew extends RequestFormBaseView
         serverRequest.done  (response) =>
             @lockdown = false
             @alert "Your Request <a href='#{ config.appRoot }/request/#{ response.id }'>#{ response.id }</a> has been created"
+            Backbone.history.navigate "/request/#{ response.id }", {trigger: true}
 
         serverRequest.error (response) =>
             @postSave()


### PR DESCRIPTION
Rather than simply display a note saying the request was created, for most use cases it would probably be better to redirect back to that request's page. This implements that.