### PR TITLE
Don't Lose Currently Typed Owner/Rack Affinity When Losing Focus

### DIFF
--- a/SingularityUI/app/views/requestFormBase.coffee
+++ b/SingularityUI/app/views/requestFormBase.coffee
@@ -17,13 +17,16 @@ class RequestFormBase extends FormBaseView
             { 
                 name: 'owners', selector: '#owners'
                 options:
-                    tags: true
+                    tags: []
                     containerCssClass: 'select-owners hide-select2-spinner'
                     dropdownCssClass: 'hidden'
+                    selectOnBlur: true
             }
             { 
                 name: 'rackAffinity', selector: "#rackAffinity-#{type}"
-                options: tags: racks
+                options:
+                    tags: racks
+                    selectOnBlur: true
             }
         ]
 


### PR DESCRIPTION
This fixes the bug where, on the request edit or create form an owner or rack (for rack affinity) is being typed, then the user clicks or tabs causing the form to lose focus, the in-progress owner or rack would be lost.