### PR TITLE
generate swagger json alongside docs

### DIFF
--- a/SingularityService/pom.xml
+++ b/SingularityService/pom.xml
@@ -403,6 +403,7 @@
                   <mustacheFileRoot>${basedir}/../SingularityUI/app/assets/api-docs</mustacheFileRoot>
                   <outputPath>${project.build.directory}/classes/assets/api-docs/index.html</outputPath>
                   <apiSortComparator>com.hubspot.singularity.swagger.ApiSortComparator</apiSortComparator>
+                  <swaggerDirectory>${project.build.directory}/classes/assets/api-docs</swaggerDirectory>
                 </apiSource>
               </apiSources>
             </configuration>


### PR DESCRIPTION
Realized we weren't outputting swagger json files for the endpoints since `swaggerDirectory` wasn't set.
/fixes #956