### PR TITLE
Thread check types

### DIFF
--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorThreadChecker.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorThreadChecker.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -13,19 +14,23 @@ import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.NOPLogger;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.hubspot.mesos.JavaUtils;
 import com.hubspot.singularity.executor.SingularityExecutorMonitor.KillState;
 import com.hubspot.singularity.executor.config.SingularityExecutorConfiguration;
+import com.hubspot.singularity.executor.models.ThreadCheckerType;
 import com.hubspot.singularity.executor.task.SingularityExecutorTaskProcessCallable;
 import com.hubspot.singularity.executor.utils.DockerUtils;
 import com.hubspot.singularity.runner.base.shared.ProcessFailedException;
+import com.hubspot.singularity.runner.base.shared.SimpleProcessManager;
 import com.spotify.docker.client.DockerException;
 
 @Singleton
@@ -34,6 +39,7 @@ public class SingularityExecutorThreadChecker {
   private static final Logger LOG = LoggerFactory.getLogger(SingularityExecutorThreadChecker.class);
 
   private static Pattern CGROUP_CPU_REGEX = Pattern.compile("^\\d+:cpu:/(.*)$");
+  private static Pattern PROC_STATUS_THREADS_REGEX = Pattern.compile("Threads:\\s*(\\d+)\\s*$");
 
   private final SingularityExecutorConfiguration configuration;
   private final ScheduledExecutorService scheduledExecutorService;
@@ -128,20 +134,78 @@ public class SingularityExecutorThreadChecker {
     }
 
     try {
-      final Path procCgroupPath = Paths.get(String.format(configuration.getProcCgroupFormat(), dockerPid.or(taskProcess.getCurrentPid().get())));
-      if (Files.exists(procCgroupPath)) {
-        for (String line : Files.readAllLines(procCgroupPath, Charsets.UTF_8)) {
-          final Matcher matcher = CGROUP_CPU_REGEX.matcher(line);
-          if (matcher.matches()) {
-            return Files.readAllLines(Paths.get(String.format(configuration.getCgroupsMesosCpuTasksFormat(), matcher.group(1))), Charsets.UTF_8).size();
-          }
-        }
-        throw new RuntimeException("Unable to parse cgroup container from " + procCgroupPath.toString());
+      Optional<Integer> numThreads = getNumThreads(configuration.getThreadCheckerType(), taskProcess, dockerPid);
+      if (numThreads.isPresent()) {
+        return numThreads.get();
       } else {
-        throw new RuntimeException(procCgroupPath.toString() + " does not exist");
+        LOG.warn("Could not get num threads using {} thread checker", configuration.getThreadCheckerType());
+        return 0;
       }
     } catch (IOException e) {
       throw Throwables.propagate(e);
+    }
+  }
+
+  private Optional<Integer> getNumThreads(ThreadCheckerType type, SingularityExecutorTaskProcessCallable taskProcess, Optional<Integer> dockerPid) throws InterruptedException, ProcessFailedException, IOException {
+    Optional<Integer> numThreads;
+    switch (type) {
+      case CGROUP:
+        numThreads = getNumThreadsFromCgroup(taskProcess, dockerPid);
+        break;
+      case PS:
+        numThreads = getNumThreadsFromCommand(taskProcess, dockerPid, "ps hH p %s | wc -l");
+        break;
+      case PROC_STATUS:
+      default:
+        numThreads = getNumThreadsFromProcStatus(taskProcess, dockerPid);
+        break;
+    }
+    return numThreads;
+  }
+
+  private Optional<Integer> getNumThreadsFromCommand(SingularityExecutorTaskProcessCallable taskProcess, Optional<Integer> dockerPid, String commandFormat) throws InterruptedException, ProcessFailedException {
+    SimpleProcessManager checkThreadsProcessManager = new SimpleProcessManager(NOPLogger.NOP_LOGGER);
+    List<String> cmd = ImmutableList.of("/bin/sh", "-c", String.format(commandFormat, dockerPid.or(taskProcess.getCurrentPid().get())));
+    List<String> output = checkThreadsProcessManager.runCommandWithOutput(cmd);
+    if (output.isEmpty()) {
+      LOG.warn("Output from ls was empty ({})", cmd);
+      return Optional.absent();
+    } else {
+      return Optional.of(Integer.parseInt(output.get(0)));
+    }
+  }
+
+  private Optional<Integer> getNumThreadsFromProcStatus(SingularityExecutorTaskProcessCallable taskProcess, Optional<Integer> dockerPid) throws InterruptedException, IOException {
+    final Path procStatusPath = Paths.get(String.format("/proc/%s/status", dockerPid.or(taskProcess.getCurrentPid().get())));
+    if (Files.exists(procStatusPath)) {
+      for (String line : Files.readAllLines(procStatusPath, Charsets.UTF_8)) {
+        final Matcher matcher = PROC_STATUS_THREADS_REGEX.matcher(line);
+        if (matcher.matches()) {
+          return Optional.of(Integer.parseInt(matcher.group(1)));
+        }
+      }
+      LOG.warn("Unable to parse threads from proc status file {}", procStatusPath);
+      return Optional.absent();
+    } else {
+      LOG.warn("Proc status file does not exist for pid {}", dockerPid.or(taskProcess.getCurrentPid().get()));
+      return Optional.absent();
+    }
+  }
+
+  private Optional<Integer> getNumThreadsFromCgroup(SingularityExecutorTaskProcessCallable taskProcess, Optional<Integer> dockerPid) throws InterruptedException, IOException {
+    final Path procCgroupPath = Paths.get(String.format(configuration.getProcCgroupFormat(), dockerPid.or(taskProcess.getCurrentPid().get())));
+    if (Files.exists(procCgroupPath)) {
+      for (String line : Files.readAllLines(procCgroupPath, Charsets.UTF_8)) {
+        final Matcher matcher = CGROUP_CPU_REGEX.matcher(line);
+        if (matcher.matches()) {
+          return Optional.of(Files.readAllLines(Paths.get(String.format(configuration.getCgroupsMesosCpuTasksFormat(), matcher.group(1))), Charsets.UTF_8).size());
+        }
+      }
+      LOG.warn("Unable to parse cgroup container from {}", procCgroupPath.toString());
+      return Optional.absent();
+    } else {
+      LOG.warn("cgroup {} does not exist", procCgroupPath.toString());
+      return Optional.absent();
     }
   }
 

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
 import com.hubspot.mesos.MesosUtils;
+import com.hubspot.singularity.executor.models.ThreadCheckerType;
 import com.hubspot.singularity.executor.shells.SingularityExecutorShellCommandDescriptor;
 import com.hubspot.singularity.runner.base.configuration.BaseRunnerConfiguration;
 import com.hubspot.singularity.runner.base.configuration.Configuration;
@@ -215,6 +216,9 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
 
   @JsonProperty
   private int dockerClientConnectionPoolSize = 5;
+
+  @JsonProperty
+  private ThreadCheckerType threadCheckerType = ThreadCheckerType.PS;
 
   public SingularityExecutorConfiguration() {
     super(Optional.of("singularity-executor.log"));
@@ -616,6 +620,14 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
     this.dockerClientConnectionPoolSize = dockerClientConnectionPoolSize;
   }
 
+  public ThreadCheckerType getThreadCheckerType() {
+    return threadCheckerType;
+  }
+
+  public void setThreadCheckerType(ThreadCheckerType threadCheckerType) {
+    this.threadCheckerType = threadCheckerType;
+  }
+
   @Override
   public String toString() {
     return "SingularityExecutorConfiguration[" +
@@ -668,6 +680,7 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
             ", shellCommandPrefix='" + shellCommandPrefix + '\'' +
             ", dockerClientTimeLimitMs='" + dockerClientTimeLimitSeconds + '\'' +
             ", dockerClientConnectionPoolSize='" + dockerClientConnectionPoolSize + '\'' +
+            ", threadCheckerType='" + threadCheckerType + '\'' +
             ']';
   }
 }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/models/ThreadCheckerType.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/models/ThreadCheckerType.java
@@ -1,0 +1,5 @@
+package com.hubspot.singularity.executor.models;
+
+public enum ThreadCheckerType {
+  CGROUP, PS, PROC_STATUS
+}


### PR DESCRIPTION
Although cgroup isolation is common, posix is the default. If we are not using cgroup isolation we will not find a cpu cgroup to parse and this will error every time. This PR does a few things:
- Make two types of thread checks, `CGROUP` and `PSTREE`
- Configurably fall back to `PSTREE` when `CGROUP` fails (defaults to false)

/fixes #741