### PR TITLE
warning if singularity has no leader or leader has no mesos connection

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityHostState.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityHostState.java
@@ -17,6 +17,7 @@ public class SingularityHostState {
   private final String hostname;
 
   private final String mesosMaster;
+  private final boolean mesosConnected;
 
   @JsonCreator
   public SingularityHostState(@JsonProperty("master") boolean master,
@@ -25,7 +26,8 @@ public class SingularityHostState {
       @JsonProperty("millisSinceLastOffer") Optional<Long> millisSinceLastOffer,
       @JsonProperty("hostAddress") String hostAddress,
       @JsonProperty("hostname") String hostname,
-      @JsonProperty("mesosMaster") String mesosMaster) {
+      @JsonProperty("mesosMaster") String mesosMaster,
+      @JsonProperty("mesosConnected") boolean mesosConnected) {
     this.master = master;
     this.uptime = uptime;
     this.driverStatus = driverStatus;
@@ -33,6 +35,7 @@ public class SingularityHostState {
     this.hostAddress = hostAddress;
     this.hostname = hostname;
     this.mesosMaster = mesosMaster;
+    this.mesosConnected = mesosConnected;
   }
 
   public String getHostAddress() {
@@ -63,10 +66,14 @@ public class SingularityHostState {
     return mesosMaster;
   }
 
+  public boolean isMesosConnected() {
+    return mesosConnected;
+  }
+
   @Override
   public String toString() {
     return "SingularityHostState [master=" + master + ", uptime=" + uptime + ", driverStatus=" + driverStatus + ", millisSinceLastOffer=" + millisSinceLastOffer + ", hostAddress=" + hostAddress + ", hostname=" + hostname + ", mesosMaster="
-        + mesosMaster + "]";
+        + mesosMaster + ", mesosConnected=" + mesosConnected + "]";
   }
 
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
@@ -428,4 +428,8 @@ public class SingularityMesosScheduler implements Scheduler {
     LOG.warn("Error from mesos: {}", message);
   }
 
+  public boolean isConnected() {
+    return schedulerDriverSupplier.get().isPresent();
+  }
+
 }

--- a/SingularityUI/app/styles/color-helpers.styl
+++ b/SingularityUI/app/styles/color-helpers.styl
@@ -5,3 +5,6 @@
 
 .color-success
 	color: $green
+
+.color-error
+    color: $red

--- a/SingularityUI/app/templates/status.hbs
+++ b/SingularityUI/app/templates/status.hbs
@@ -1,5 +1,17 @@
 {{#if synced}}
 <div class="row page-width-normal">
+    {{#unless hasLeader}}
+        <div class="alert alert-danger" role="alert">
+            <b>No Leading Scheduler Instance</b>
+            <p>There is currently no leading scheduler instance! Ensure that all scheduler instances are running connected to zookeeper.</p>
+        </div>
+    {{/unless}}
+    {{#unless isLeaderConnected}}
+        <div class="alert alert-danger" role="alert">
+            <b>No Connection To Mesos Master</b>
+            <p>The leading scheduler instance currently has no connection to the mesos master. Ensure that the scheduler can reach the mesos master and check the mesos master logs for possible framework registration errors.</p>
+        </div>
+    {{/unless}}
     <div class="col-md-6 col-sm-6">
         <div>
             <a class='headline-link' href="{{appRoot}}/requests"><h2>Requests</h2></a>
@@ -182,6 +194,7 @@
                 <tr>
                     <th>Hostname</th>
                     <th>Driver status</th>
+                    <th>Connected</th>
                     <th class="hidden-xs">Uptime</th>
                     <th class="hidden-xs">Time since last offer</th>
                 </tr>
@@ -191,6 +204,15 @@
                 <tr>
                     <td>{{ hostname }}</td>
                     <td class='{{#ifEqual driverStatus 'DRIVER_NOT_STARTED'}}text-muted{{/ifEqual}}{{#ifEqual driverStatus 'DRIVER_RUNNING'}}color-success{{/ifEqual}}'>{{humanizeText driverStatus }}
+                    </td>
+                    <td>
+                        {{#ifEqual driverStatus 'DRIVER_RUNNING'}}
+                           {{#if mesosConnected }}
+                                <span class="glyphicon glyphicon-ok color-success"/>
+                           {{else}}
+                                <span class="glyphicon glyphicon-remove color-error"/>
+                           {{/if}}
+                        {{/ifEqual}}
                     </td>
                     <td data-value="{{ uptime }}" class="hidden-xs">
                         {{timestampDuration uptime}}

--- a/SingularityUI/app/views/status.coffee
+++ b/SingularityUI/app/views/status.coffee
@@ -11,6 +11,13 @@ class StatusView extends View
         @lastState = _.clone @model.toJSON()
 
     render: =>
+        isLeaderConnected = false
+        hasLeader = false
+        for host in @model.attributes.hostStates
+           if host.driverStatus is 'DRIVER_RUNNING'
+               hasLeader = true
+               if host.mesosConnected
+                   isLeaderConnected = true
         @$el.html @template
             state:  @model.toJSON()
             synced: @model.synced
@@ -18,6 +25,8 @@ class StatusView extends View
             requests: @model.requestDetail().requests
             totalRequests: @model.requestDetail().total
             totalTasks: @model.taskDetail().total
+            hasLeader: hasLeader
+            isLeaderConnected: isLeaderConnected
 
         if @lastState?
             changedNumbers = {}


### PR DESCRIPTION
An alert message will show at the top of the status page, a `Connected` column also appears in the table of scheduler hosts. Let me know if you have any inputs on the warning message itself.
/fixes #776 

![screen shot 2016-03-18 at 3 23 55 pm](https://cloud.githubusercontent.com/assets/6034439/13889564/a34e542c-ed1d-11e5-8738-11dce93cd29e.png)