### PR TITLE
Consistent terminology and more ovbious deploy failure on task page

### DIFF
--- a/SingularityUI/app/controllers/DeployDetail.coffee
+++ b/SingularityUI/app/controllers/DeployDetail.coffee
@@ -2,7 +2,7 @@ Controller = require './Controller'
 
 DeployDetails           = require '../models/DeployDetails'
 DeployHistoricalTasks   = require '../collections/DeployHistoricalTasks'
-DeployActiveTasks       = require '../collections/DeployActiveTasks'
+DeployActiveTasks   = require '../collections/DeployActiveTasks'
 HealthCheckResult       = require '../models/HealthCheckResult'
 DeployTasksHealthChecks = require '../collections/DeployTasksHealthChecks'
 

--- a/SingularityUI/app/controllers/DeployDetail.coffee
+++ b/SingularityUI/app/controllers/DeployDetail.coffee
@@ -2,7 +2,7 @@ Controller = require './Controller'
 
 DeployDetails           = require '../models/DeployDetails'
 DeployHistoricalTasks   = require '../collections/DeployHistoricalTasks'
-DeployActiveTasks   = require '../collections/DeployActiveTasks'
+DeployActiveTasks       = require '../collections/DeployActiveTasks'
 HealthCheckResult       = require '../models/HealthCheckResult'
 DeployTasksHealthChecks = require '../collections/DeployTasksHealthChecks'
 

--- a/SingularityUI/app/controllers/TaskDetail.coffee
+++ b/SingularityUI/app/controllers/TaskDetail.coffee
@@ -134,6 +134,7 @@ class TaskDetailController extends Controller
 
         app.showView @view
 
+
     fetchResourceUsage: ->
         @models.resourceUsage?.fetch()
             .done =>
@@ -191,6 +192,14 @@ class TaskDetailController extends Controller
         else
             @collections.alerts.reset(alerts)
 
+    fetchDeployDetails: ->
+        @models.deploy = new DeployDetails
+            deployId: @models.task.attributes.task.taskId.deployId
+            requestId: @models.task.attributes.task.taskId.requestId
+        @models.deploy.fetch()
+            .error =>
+                app.caughtError()
+
     refresh: ->
         @resourcesFetched = false
 
@@ -209,6 +218,11 @@ class TaskDetailController extends Controller
                 @collections.logDirectory.fetch().error @ignore400
             .success =>
                 @getAlerts()
+                if @deployFailureKilledTask()
+                    @models.task.doNotDisplayHealthcheckNotification = true
+                else
+                    @models.task.doNotDisplayHealthcheckNotification = false
+                @fetchDeployDetails()
             .error =>
                 # If this 404s the task doesn't exist
                 app.caughtError()

--- a/SingularityUI/app/controllers/TaskDetail.coffee
+++ b/SingularityUI/app/controllers/TaskDetail.coffee
@@ -208,7 +208,6 @@ class TaskDetailController extends Controller
             requestId: @models.task.attributes.task.taskId.requestId
         @deploy.fetch()
             .success =>
-                console.log "Done"
                 @dontFetchDeployDetails = true
                 @refresh()
             .error =>

--- a/SingularityUI/app/controllers/TaskDetail.coffee
+++ b/SingularityUI/app/controllers/TaskDetail.coffee
@@ -206,6 +206,8 @@ class TaskDetailController extends Controller
         @deploy.fetch()
             .success =>
                 @subviews.deployFailureNotification.render()
+                @subviews.healthcheckNotification.deploy = @deploy
+                @subviews.healthcheckNotification.render()
             .error =>
                 app.caughtError()
 

--- a/SingularityUI/app/controllers/TaskDetail.coffee
+++ b/SingularityUI/app/controllers/TaskDetail.coffee
@@ -200,16 +200,12 @@ class TaskDetailController extends Controller
             @collections.alerts.reset(alerts)
 
     fetchDeployDetails: ->
-        if @dontFetchDeployDetails
-            dontFetchDeployDetails = false
-            return
         @deploy = new DeployDetails
             deployId: @models.task.attributes.task.taskId.deployId
             requestId: @models.task.attributes.task.taskId.requestId
         @deploy.fetch()
             .success =>
-                @dontFetchDeployDetails = true
-                @refresh()
+                @subviews.deployFailureNotification.render()
             .error =>
                 app.caughtError()
 

--- a/SingularityUI/app/templates/deployDetail/deployHeader.hbs
+++ b/SingularityUI/app/templates/deployDetail/deployHeader.hbs
@@ -43,7 +43,7 @@
                     <div class="panel-body">
                         {{#each data.deployResult.deployFailures}}
                             {{#if taskId}}
-                                <a href="{{appRoot}}/task/{{ taskId.id }}" class="list-group-item">{{humanizeText reason }} (Instance {{taskId.instanceNo}}){{#if message}}: {{ message }}{{/if}}</a>
+                                <a href="{{appRoot}}/task/{{ taskId.id }}" class="list-group-item"><b>{{taskId.id}}</b>: {{humanizeText reason }} (Instance {{taskId.instanceNo}}){{#if message}}: {{ message }}{{/if}}</a>
                             {{else}}
                                 <li class="list-group-item">{{humanizeText reason }}{{#if message}}: {{ message }}{{/if}}</li>
                             {{/if}}

--- a/SingularityUI/app/templates/deployDetail/deployHeader.hbs
+++ b/SingularityUI/app/templates/deployDetail/deployHeader.hbs
@@ -39,7 +39,7 @@
         <div class="row">
             <div class="col-md-12">
                 <div class="panel panel-default">
-                    <div class="panel-heading text-muted">{{ data.deployResult.message }}</div>
+                    <div class="panel-heading text-muted">Deploy had {{ data.deployResult.deployFailures.length }} failure{{#ifNotEqual data.deployResult.deployFailures.length 1}}s{{/ifNotEqual}}:</div>
                     <div class="panel-body">
                         {{#each data.deployResult.deployFailures}}
                             {{#if taskId}}

--- a/SingularityUI/app/templates/taskDetail/taskBase.hbs
+++ b/SingularityUI/app/templates/taskDetail/taskBase.hbs
@@ -8,6 +8,10 @@
 
     </div>
 
+    <div id="deploy-failure-notification" class='col-md-12'>
+
+    </div>
+
     <div id="healthcheck-notification" class='col-md-12'>
 
     </div>

--- a/SingularityUI/app/templates/taskDetail/taskDeployFailureNotification.hbs
+++ b/SingularityUI/app/templates/taskDetail/taskDeployFailureNotification.hbs
@@ -1,0 +1,46 @@
+{{#ifEqual deploy.deployResult.deployState "FAILED"}}
+    {{#ifCauseOfFailure data deploy }}
+        <div class="alert alert-danger" role="alert">
+            <p>This task casued <a href='{{appRoot}}/request/{{deploy.requestId}}/deploy/{{deploy.deployId}}'>Deploy {{deploy.deployId}}</a> to fail. Cause: {{causeOfDeployFailure data deploy }}</p>
+            {{#ifGT deploy.deployResult.deployFailures.length 1}}
+                <p>The deploy failure was also caused by:</p>
+                <ul>
+                    {{#each deploy.deployResult.deployFailures}}
+                        {{#if taskId}}
+                            {{#ifNotEqual taskId.id ../data.taskId}}
+                                <li><a href='{{appRoot}}/task/{{taskId.id}}'>{{taskId.id}}</a>: {{humanizeText reason}} {{#if message}}({{ message }}){{/if}}</li>
+                            {{/ifNotEqual}}
+                        {{else}}
+                            <li>{{humanizeText reason}} {{#if message}}({{ message }}){{/if}}</li>
+                        {{/if}}
+                    {{/each}}
+                </ul>
+            {{/ifGT}}
+        </div>
+    {{else}}
+        <div class="alert alert-warning" role="alert">
+            <p>
+                <a href='{{appRoot}}/request/{{deploy.requestId}}/deploy/{{deploy.deployId}}'>Deploy {{deploy.deployId}}</a> failed.
+                {{#ifDeployFailureCausedTaskToBeKilled data}}
+                    This task was killed as a result of the failing deploy.
+                {{/ifDeployFailureCausedTaskToBeKilled}}
+                {{#if deploy.deployResult.deployFailures.length}}
+                    The deploy failure was caused by:
+                {{else}}
+                    The reason for the deploy failure is unknown.
+                {{/if}}
+            </p>
+            {{#if deploy.deployResult.deployFailures.length}}
+                <ul>
+                    {{#each deploy.deployResult.deployFailures}}
+                        {{#if taskId}}
+                            <li><a href='{{appRoot}}/task/{{taskId.id}}'>{{taskId.id}}</a>: {{humanizeText reason}} {{#if message}}({{ message }}){{/if}}</li>
+                        {{else}}
+                            <li>{{humanizeText reason}} {{#if message}}({{ message }}){{/if}}</li>
+                        {{/if}}
+                    {{/each}}
+                </ul>
+            {{/if}}
+        </div>
+    {{/ifCauseOfFailure}}
+{{/ifEqual}}

--- a/SingularityUI/app/templates/taskDetail/taskDeployFailureNotification.hbs
+++ b/SingularityUI/app/templates/taskDetail/taskDeployFailureNotification.hbs
@@ -26,8 +26,6 @@
                 {{/ifDeployFailureCausedTaskToBeKilled}}
                 {{#if deploy.deployResult.deployFailures.length}}
                     The deploy failure was caused by:
-                {{else}}
-                    The reason for the deploy failure is unknown.
                 {{/if}}
             </p>
             {{#if deploy.deployResult.deployFailures.length}}

--- a/SingularityUI/app/templates/taskDetail/taskDeployFailureNotification.hbs
+++ b/SingularityUI/app/templates/taskDetail/taskDeployFailureNotification.hbs
@@ -1,3 +1,4 @@
+{{#if deploy}}
 {{#ifEqual deploy.deployResult.deployState "FAILED"}}
     {{#ifCauseOfFailure data deploy }}
         <div class="alert alert-danger" role="alert">
@@ -42,3 +43,4 @@
         </div>
     {{/ifCauseOfFailure}}
 {{/ifEqual}}
+{{/if}}

--- a/SingularityUI/app/templates/taskDetail/taskHealthcheckNotification.hbs
+++ b/SingularityUI/app/templates/taskDetail/taskHealthcheckNotification.hbs
@@ -1,3 +1,4 @@
+ {{#unless doNotDisplayHealthcheckNotification}}
     {{#if deployStatus}}
         <div class="alert alert-warning" role="alert">
             {{#if hasSuccessfulHealthcheck}}
@@ -53,8 +54,14 @@
     {{#if lastHealthcheckFailed}}
         {{#with data.healthcheckResults.[0]}}
         <div class="alert alert-warning" role="alert">
-            <b>Task failed due to no passing healthchecks after {{#if ../tooManyRetries}}{{../numberFailed}} tries{{else}}{{../secondsElapsed}} seconds{{/if}}:</b> Last healthcheck {{#if statusCode}}responded with <span class="label label-danger">HTTP {{statusCode}}</span>{{else}}did not respond{{/if}}{{#if durationMillis}} in {{durationMillis}}ms{{/if}} at {{timestampFormattedWithSeconds timestamp}}. <a href="#health-checks" data-action="viewHealthchecks">View all healthchecks.</a> <a href="{{ appRoot }}/task/{{ ../data.taskId }}/tail/{{ substituteTaskId ../config.finishedTaskLogPath ../data.taskId }}">View service logs.</a>
+            <b>Task killed due to no passing healthchecks after {{#if ../tooManyRetries}}{{../numberFailed}} tries{{else}}{{../secondsElapsed}} seconds{{/if}}:</b> Last healthcheck {{#if statusCode}}responded with <span class="label label-danger">HTTP {{statusCode}}</span>{{else}}did not respond{{/if}}{{#if durationMillis}} in {{durationMillis}}ms{{/if}} at {{timestampFormattedWithSeconds timestamp}}. <a href="#health-checks" data-action="viewHealthchecks">View all healthchecks.</a> <a href="{{ appRoot }}/task/{{ ../data.taskId }}/tail/{{ substituteTaskId ../config.finishedTaskLogPath ../data.taskId }}">View service logs.</a>
+            {{#if ../healthcheckFailureReasonMessage}}
+                <p>
+                    The healthcheck failed because {{ ../healthcheckFailureReasonMessage}}
+                </p>
+            {{/if}}
         </div>
         {{/with}}
     {{/if}}
     {{/if}}
+{{/unless}}

--- a/SingularityUI/app/views/task.coffee
+++ b/SingularityUI/app/views/task.coffee
@@ -27,19 +27,20 @@ class TaskView extends View
         @$el.html @baseTemplate
 
         # Plop subview contents in there. It'll take care of everything itself
-        @$('#overview').html                    @subviews.overview.$el
-        @$('#alerts').html                      @subviews.alerts.$el
-        @$('#healthcheck-notification').html    @subviews.healthcheckNotification.$el
-        @$('#history').html                     @subviews.history.$el
-        @$('#latest-log').html                  @subviews.latestLog.$el
-        @$('#file-browser').html                @subviews.fileBrowser.$el
-        @$('#s3-logs').html                     @subviews.s3Logs.$el
-        @$('#lb-updates').html                  @subviews.lbUpdates.$el
-        @$('#health-checks').html               @subviews.healthChecks.$el
-        @$('#info').html                        @subviews.info.$el
-        @$('#resources').html                   @subviews.resourceUsage.$el
-        @$('#environment').html                 @subviews.environment.$el
-        @$('#shell-commands').html              @subviews.shellCommands.$el
+        @$('#overview').html                       @subviews.overview.$el
+        @$('#alerts').html                         @subviews.alerts.$el
+        @$('#deploy-failure-notification').html    @subviews.deployFailureNotification.$el
+        @$('#healthcheck-notification').html       @subviews.healthcheckNotification.$el
+        @$('#history').html                        @subviews.history.$el
+        @$('#latest-log').html                     @subviews.latestLog.$el
+        @$('#file-browser').html                   @subviews.fileBrowser.$el
+        @$('#s3-logs').html                        @subviews.s3Logs.$el
+        @$('#lb-updates').html                     @subviews.lbUpdates.$el
+        @$('#health-checks').html                  @subviews.healthChecks.$el
+        @$('#info').html                           @subviews.info.$el
+        @$('#resources').html                      @subviews.resourceUsage.$el
+        @$('#environment').html                    @subviews.environment.$el
+        @$('#shell-commands').html                 @subviews.shellCommands.$el
 
         super.afterRender()
 

--- a/SingularityUI/app/views/taskHealthcheckNotificationSubview.coffee
+++ b/SingularityUI/app/views/taskHealthcheckNotificationSubview.coffee
@@ -61,11 +61,13 @@ class taskHealthcheckNotificationSubview extends View
         secondsElapsed: healthTimeoutSeconds
         doNotDisplayHealthcheckNotification: @deployFailureKilledTask()
 
-    healthcheckFailureReasonMessage: () ->
+    healthcheckFailureReasonMessage: () -> # For now this only looks for connection refused, but feel free to improve the logic to detect more reasons.
         healthcheckResults = @model.get('healthcheckResults')
         if healthcheckResults.length > 0
             if healthcheckResults[0].errorMessage.toLowerCase().indexOf('connection refused') isnt -1
-                return 'a connection was refused. This is probably the connection to the host your app is running on.'
+                portIndex = @model.attributes.task.taskRequest.deploy.healthcheckPortIndex or 0
+                port = if @model.attributes.ports.length > portIndex then @model.attributes.ports[portIndex] else false
+                return "a refused connection. It is possible your app did not start properly or was not listening on the anticipated port (#{port}). Please check the logs for more details."
 
     triggerToggleHealthchecks: ->
         @trigger 'toggleHealthchecks'

--- a/SingularityUI/app/views/taskHealthcheckNotificationSubview.coffee
+++ b/SingularityUI/app/views/taskHealthcheckNotificationSubview.coffee
@@ -63,8 +63,8 @@ class taskHealthcheckNotificationSubview extends View
 
     healthcheckFailureReasonMessage: () -> # For now this only looks for connection refused, but feel free to improve the logic to detect more reasons.
         healthcheckResults = @model.get('healthcheckResults')
-        if healthcheckResults.length > 0
-            if healthcheckResults[0].errorMessage.toLowerCase().indexOf('connection refused') isnt -1
+        if healthcheckResults and healthcheckResults.length > 0
+            if healthcheckResults[0].errorMessage and healthcheckResults[0].errorMessage.toLowerCase().indexOf('connection refused') isnt -1
                 portIndex = @model.attributes.task.taskRequest.deploy.healthcheckPortIndex or 0
                 port = if @model.attributes.ports.length > portIndex then @model.attributes.ports[portIndex] else false
                 return "a refused connection. It is possible your app did not start properly or was not listening on the anticipated port (#{port}). Please check the logs for more details."

--- a/SingularityUI/app/views/taskHealthcheckNotificationSubview.coffee
+++ b/SingularityUI/app/views/taskHealthcheckNotificationSubview.coffee
@@ -28,14 +28,10 @@ class taskHealthcheckNotificationSubview extends View
     render: =>
         return if not @model.synced
         return if @model.attributes.lastKnownState in @noHealthcheckMessageStates
-        @$el.html @template @renderData
+        @$el.html @template @renderData()
 
     renderData: =>
         updates = @model.get('taskUpdates')
-        deployFailureKilledTask = false
-        if updates
-            for update in updates
-                deployFailureKilledTask = true if update.statusMessage and update.statusMessage.indexOf('DEPLOY_FAILED') isnt -1
         requestId = @model.get('task').taskId.requestId
         deployId = @model.get('task').taskId.deployId
         deployStatus = @pendingDeploys.find (item) -> item.get('deployMarker') and item.get('deployMarker').requestId is requestId and item.get('deployMarker').deployId is deployId and item.get('currentDeployState') is 'WAITING'
@@ -63,7 +59,7 @@ class taskHealthcheckNotificationSubview extends View
         tooManyRetries: @model.get('healthcheckResults').length > maxRetries and maxRetries != 0
         numberFailed: @model.get('healthcheckResults').length
         secondsElapsed: healthTimeoutSeconds
-        doNotDisplayHealthcheckNotification: deployFailureKilledTask
+        doNotDisplayHealthcheckNotification: @deployFailureKilledTask()
 
     healthcheckFailureReasonMessage: () ->
         healthcheckResults = @model.get('healthcheckResults')


### PR DESCRIPTION
This includes several UI improvements around task and deploy failures:

On the task page:
- Healthcheck failed notification now states that the task was killed, rather than task failed
- If the healthcheck failed because a connection was refused, the healthcheck failed notification will state that it was probably a problem with the app, not the cluster
- The healthcheck notification will not display if the deploy failed and killed the task after one healthcheck ran and failed (but not enough to kill the task) 
- If this task caused the deploy to fail, it will have a danger notification saying this (and linking to other causes)
- If this task's deploy failed, but this task was not a cause of that failure, then it will have a warn notification. This notification will state if the task was killed because the deploy failed, and it will link to failure causes.

On the deploy page:
- Rather than say (n) tasks failed, now the message states how many causes of deploy failure there were. Those two numbers don't always match and caused some confusion.
- The links to the tasks that failed will now have the taskIds bolded to make it more clear that they are links to the task pages.