### PR TITLE
Better Slave Decommissioned / Offline Communication

### DIFF
--- a/SingularityUI/app/controllers/TaskDetail.coffee
+++ b/SingularityUI/app/controllers/TaskDetail.coffee
@@ -91,6 +91,7 @@ class TaskDetailController extends Controller
             model:           @models.task
             # If we've been given a path we want the files, so scroll directly to it
             scrollWhenReady: @filePath isnt null
+            slaveOffline: false
 
         @subviews.s3Logs = new ExpandableTableSubview
             collection: @collections.s3Logs
@@ -181,9 +182,8 @@ class TaskDetailController extends Controller
                 return u.taskState == 'TASK_KILLED'
             if decomMessage.length > 0 and killedMessage.length > 0
                 alerts.push
-                  title: 'Alert:',
-                  message: 'This task was killed due to a slave decommissioning.',
-                  level: 'danger'
+                  message: 'This task was replaced then killed by Singularity due to a slave decommissioning.',
+                  level: 'warning'
 
         if deployPromise
             deployPromise.done =>
@@ -206,7 +206,10 @@ class TaskDetailController extends Controller
                 logPath = logPath.replace('$TASK_ID', @taskId)
                 logPath = _.initial(logPath.split('/')).join('/')
                 @collections.logDirectory.path = logPath
-                @collections.logDirectory.fetch().error @ignore400
+                @collections.logDirectory.fetch().error (response) =>
+                    @ignore400 response
+                    @ignore404 response
+                    @subviews.fileBrowser.slaveOffline = true and @subviews.fileBrowser.render() if response.status is 404
             .success =>
                 @getAlerts()
             .error =>

--- a/SingularityUI/app/views/fileBrowserSubview.coffee
+++ b/SingularityUI/app/views/fileBrowserSubview.coffee
@@ -9,7 +9,7 @@ class FileBrowserSubview extends View
     events: ->
         'click [data-directory-path]':  'navigate'
 
-    initialize: ({ @scrollWhenReady }) ->
+    initialize: ({ @scrollWhenReady, @slaveOffline }) ->
         @listenTo @collection, 'sync',  @render
         @listenTo @collection, 'error', @catchAjaxError
         @listenTo @model, 'sync', @render
@@ -29,6 +29,8 @@ class FileBrowserSubview extends View
             switch _.last(@task.get('taskUpdates')).taskState
                 when 'TASK_LAUNCHED', 'TASK_STAGING', 'TASK_STARTING' then emptySandboxMessage = 'Could not browse files. The task is still starting up.'
                 when 'TASK_KILLED', 'TASK_FAILED', 'TASK_LOST', 'TASK_FINISHED' then emptySandboxMessage = 'No files exist in task directory. It may have been cleaned up.'
+
+        emptySandboxMessage = "Task files are not availible because #{@task.attributes.task.taskId.sanitizedHost} is offline." if @slaveOffline
 
         @$el.html @template
             synced:                 @collection.synced and @task.synced


### PR DESCRIPTION
- The alert for a slave decommissioning is now at warn level, not danger level
- The wording of the alert now suggests that this is a normal Singularity action, nothing is on fire, your task has been replaced, and you can continue about your day without (much) worry
- If a slave is offline, the scary ajax error stating so is now caught if it appears when trying to fetch files
- Instead of the scary ajax error, the files table now says that the slave is offline so we don't have files.