### PR TITLE
Task badge color for TASK_KILLED is now default (grey)

### DIFF
--- a/SingularityUI/app/components/common/atomicDisplayItems/TaskStateLabel.cjsx
+++ b/SingularityUI/app/components/common/atomicDisplayItems/TaskStateLabel.cjsx
@@ -5,17 +5,7 @@ Utils = require '../../../utils'
 TaskStateLabel = React.createClass
 
     getLabelClass: ->
-        switch @props.prop.taskState
-            when 'TASK_STARTING', 'TASK_CLEANING'
-                'warning'
-            when 'TASK_STAGING', 'TASK_LAUNCHED', 'TASK_RUNNING'
-                'info'
-            when 'TASK_FINISHED'
-                'success'
-            when 'TASK_KILLED', 'TASK_LOST', 'TASK_FAILED', 'TASK_LOST_WHILE_DOWN'
-                'danger'
-            else
-                'default'
+        Utils.getLabelClassFromTaskState @props.prop.taskState
 
     getClass: ->
         return classNames 'label', "label-#{@getLabelClass()}", @props.prop.className

--- a/SingularityUI/app/handlebarsHelpers.coffee
+++ b/SingularityUI/app/handlebarsHelpers.coffee
@@ -1,5 +1,6 @@
 Handlebars = require 'handlebars'
 moment = require 'moment'
+Utils = require './utils'
 
 Handlebars.registerHelper 'appRoot', ->
     config.appRoot
@@ -145,17 +146,7 @@ Handlebars.registerHelper 'filename', (value) ->
     value.substring(value.lastIndexOf('/') + 1)
 
 Handlebars.registerHelper 'getLabelClass', (state) ->
-    switch state
-        when 'TASK_STARTING', 'TASK_CLEANING'
-            'warning'
-        when 'TASK_STAGING', 'TASK_LAUNCHED', 'TASK_RUNNING'
-            'info'
-        when 'TASK_FINISHED'
-            'success'
-        when 'TASK_KILLED', 'TASK_LOST', 'TASK_FAILED', 'TASK_LOST_WHILE_DOWN'
-            'danger'
-        else
-            'default'
+    Utils.getLabelClassFromTaskState state
 
 Handlebars.registerHelper 'trimS3File', (filename, taskId) ->
     unless config.taskS3LogOmitPrefix

--- a/SingularityUI/app/utils.coffee
+++ b/SingularityUI/app/utils.coffee
@@ -197,6 +197,21 @@ class Utils
         text = text[0].toUpperCase() + text.substr 1
         return text
 
+    @getLabelClassFromTaskState: (state) ->
+        switch state
+            when 'TASK_STARTING', 'TASK_CLEANING'
+                'warning'
+            when 'TASK_STAGING', 'TASK_LAUNCHED', 'TASK_RUNNING'
+                'info'
+            when 'TASK_FINISHED'
+                'success'
+            when 'TASK_LOST', 'TASK_FAILED', 'TASK_LOST_WHILE_DOWN'
+                'danger'
+            when 'TASK_KILLED'
+                'default'
+            else
+                'default'
+
     @fuzzyAdjustScore: (filter, fuzzyObject) ->
         if fuzzyObject.original.id.toLowerCase().startsWith(filter.toLowerCase())
             fuzzyObject.score * 10


### PR DESCRIPTION
The color for TASK_KILLED badges is now grey, the bootstrap default color, to distinguish it from TASK_FAILED.

The two getLabelClass functions were combined into one helper function in utils to avert confusion when changing these colors in the future.