### PR TITLE
Better failure message when creating a scheduled reqeust with no schedule

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
@@ -126,9 +126,9 @@ public class SingularityValidator {
     String quartzSchedule = null;
 
     if (request.isScheduled()) {
-      final String originalSchedule = request.getQuartzScheduleSafe();
-
       checkBadRequest(request.getQuartzSchedule().isPresent() || request.getSchedule().isPresent(), "Specify at least one of schedule or quartzSchedule");
+
+      final String originalSchedule = request.getQuartzScheduleSafe();
 
       if (request.getQuartzSchedule().isPresent() && !request.getSchedule().isPresent()) {
         checkBadRequest(request.getScheduleType().or(ScheduleType.QUARTZ) == ScheduleType.QUARTZ, "If using quartzSchedule specify scheduleType QUARTZ or leave it blank");


### PR DESCRIPTION
When creating a request, the API calls the method `request.getQuartzScheduleSafe()`. As it turns out, this method is not safe and throws an error when the schedule and quartzSchedule are not present. Now we check if those are present before calling `getQuartzScheduleSafe()`.

I also intend to change `getQuartzScheduleSafe()` to either actually be safe, or at least not be misleading. Still working on exactly how to do that.