### PR TITLE
Fix and Rename getQuartzScheduleSafe() Method

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
@@ -191,12 +191,12 @@ public class SingularityRequest {
   }
 
   @JsonIgnore
-  public String getQuartzScheduleSafe() {
+  public Optional<String> getQuartzScheduleOrSchedule() {
     if (quartzSchedule.isPresent()) {
-      return quartzSchedule.get();
+      return quartzSchedule;
+    } else {
+      return schedule;
     }
-
-    return schedule.get();
   }
 
   @JsonIgnore

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
@@ -126,7 +126,11 @@ public class SingularityValidator {
     String quartzSchedule = null;
 
     if (request.isScheduled()) {
-      final String originalSchedule = request.getQuartzScheduleSafe();
+      final Optional<String> maybeOriginalSchedule = request.getQuartzScheduleOrSchedule();
+
+      checkBadRequest(maybeOriginalSchedule.isPresent(), "Specify at least one of schedule or quartzSchedule");
+
+      final String originalSchedule = maybeOriginalSchedule.get();
 
       checkBadRequest(request.getQuartzSchedule().isPresent() || request.getSchedule().isPresent(), "Specify at least one of schedule or quartzSchedule");
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/helpers/RequestHelper.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/helpers/RequestHelper.java
@@ -71,7 +71,7 @@ public class RequestHelper {
       return true;
     }
     if (newRequest.isScheduled() && oldRequest.isScheduled()) {
-      if (!newRequest.getQuartzScheduleSafe().equals(oldRequest.getQuartzScheduleSafe())) {
+      if (!newRequest.getQuartzScheduleOrSchedule().equals(oldRequest.getQuartzScheduleOrSchedule())) {
         return true;
       }
     }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -662,7 +662,12 @@ public class SingularityScheduler {
         LOG.info("Scheduling requested immediate run of {}", request.getId());
       } else {
         try {
-          final CronExpression cronExpression = new CronExpression(request.getQuartzScheduleSafe());
+          Optional<String> maybeSchedule = request.getQuartzScheduleOrSchedule();
+          if (!maybeSchedule.isPresent()) {
+            LOG.warn("Scheduled Reqeust {} doesn't have a schedule.", request.getId());
+            return Optional.absent();
+          }
+          final CronExpression cronExpression = new CronExpression(maybeSchedule.get());
 
           final Date scheduleFrom = new Date(now);
           final Date nextRunAtDate = cronExpression.getNextValidTimeAfter(scheduleFrom);


### PR DESCRIPTION
This refactors `getQuartzScheduleSafe()`. It is now named `getQuartzScheduleOrSchedule()`, and returns an optional instead of a string.
Uses of this method are updated to be able to handle an optional instead of a string.

If there are any potential side effects of doing this that I didn't think of, discuss here.