### PR TITLE
Upgrade Mesos Version

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/ExtendedTaskState.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/ExtendedTaskState.java
@@ -12,7 +12,7 @@ public enum ExtendedTaskState {
 
   TASK_LAUNCHED("launched", false, Optional.<TaskState> absent()), TASK_STAGING("staging", false, Optional.of(TaskState.TASK_STAGING)),
   TASK_STARTING("starting", false, Optional.of(TaskState.TASK_STARTING)), TASK_RUNNING("running", false, Optional.of(TaskState.TASK_RUNNING)),
-  TASK_CLEANING("cleaning", false, Optional.<TaskState> absent()), TASK_FINISHED("finished", true, Optional.of(TaskState.TASK_FINISHED)),
+  TASK_CLEANING("cleaning", false, Optional.<TaskState> absent()), TASK_KILLING("killing", false, Optional.of(TaskState.TASK_KILLING)), TASK_FINISHED("finished", true, Optional.of(TaskState.TASK_FINISHED)),
   TASK_FAILED("failed", true, Optional.of(TaskState.TASK_FAILED)), TASK_KILLED("killed", true, Optional.of(TaskState.TASK_KILLED)),
   TASK_LOST("lost", true, Optional.of(TaskState.TASK_LOST)), TASK_LOST_WHILE_DOWN("lost", true, Optional.<TaskState> absent()), TASK_ERROR("error", true, Optional.of(TaskState.TASK_ERROR));
 

--- a/SingularityExecutor/Dockerfile
+++ b/SingularityExecutor/Dockerfile
@@ -1,25 +1,29 @@
-FROM mesosphere/mesos:0.23.0-1.0.ubuntu1404
+FROM mesosphere/mesos:0.27.2-2.0.15.ubuntu1404
 ## mesos + java used to build hubspot/singularitybase
 
 MAINTAINER platform-infrastructure-groups@hubspot.com
 
 # Java Version
 ENV JAVA_VERSION_MAJOR 8
-ENV JAVA_VERSION_MINOR 45
-ENV JAVA_VERSION_BUILD 14
+ENV JAVA_VERSION_MINOR 77
+ENV JAVA_VERSION_BUILD 03
 ENV JAVA_PACKAGE       server-jre
 
 RUN apt-get update && \
-    apt-get upgrade -y && \
     apt-get install -y curl tar logrotate ca-certificates apt-transport-https lxc iptables && \
+    apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
+    echo "deb https://apt.dockerproject.org/repo ubuntu-trusty main"  > /etc/apt/sources.list.d/docker.list && \
+    apt-get update && \
+    apt-get -y install docker-engine && \
     curl -kLOH "Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie" \
-    http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/${JAVA_PACKAGE}-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz &&\
-    gunzip ${JAVA_PACKAGE}-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz &&\
-    tar -xf ${JAVA_PACKAGE}-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar -C /opt &&\
-    rm ${JAVA_PACKAGE}-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar &&\
-    ln -s /opt/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} /opt/jdk
-
-RUN curl -sSL https://get.docker.com/ubuntu/ | sh
+      http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/${JAVA_PACKAGE}-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz && \
+    gunzip ${JAVA_PACKAGE}-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz && \
+    tar -xf ${JAVA_PACKAGE}-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar -C /opt && \
+    rm ${JAVA_PACKAGE}-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar && \
+    ln -s /opt/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} /opt/jdk && \
+    apt-get clean autoclean && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/{apt,dpkg,cache,log}/
 
 RUN mkdir -p /usr/share/mesos/logwatcher && \
     mkdir -p /usr/share/mesos/s3 && \

--- a/SingularityExecutor/Dockerfile
+++ b/SingularityExecutor/Dockerfile
@@ -1,4 +1,4 @@
-FROM mesosphere/mesos:0.27.2-2.0.15.ubuntu1404
+FROM mesosphere/mesos:0.28.1-2.0.20.ubuntu1404
 ## mesos + java used to build hubspot/singularitybase
 
 MAINTAINER platform-infrastructure-groups@hubspot.com

--- a/SingularityMesosClient/src/main/java/com/hubspot/mesos/client/MesosClient.java
+++ b/SingularityMesosClient/src/main/java/com/hubspot/mesos/client/MesosClient.java
@@ -24,9 +24,9 @@ public class MesosClient {
 
   private static final Logger LOG = LoggerFactory.getLogger(MesosClient.class);
 
-  private static final String MASTER_STATE_FORMAT = "http://%s/master/state.json";
-  private static final String MESOS_SLAVE_JSON_URL = "http://%s:5051/slave(1)/state.json";
-  private static final String MESOS_SLAVE_STATISTICS_URL = "http://%s:5051/monitor/statistics.json";
+  private static final String MASTER_STATE_FORMAT = "http://%s/master/state";
+  private static final String MESOS_SLAVE_JSON_URL = "http://%s:5051/slave(1)/state";
+  private static final String MESOS_SLAVE_STATISTICS_URL = "http://%s:5051/monitor/statistics";
 
   private static final TypeReference<List<MesosTaskMonitorObject>> TASK_MONITOR_TYPE_REFERENCE = new TypeReference<List<MesosTaskMonitorObject>>() {};
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SandboxManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SandboxManager.java
@@ -42,7 +42,7 @@ public class SandboxManager {
 
   public Collection<MesosFileObject> browse(String slaveHostname, String fullPath) throws SlaveNotFoundException {
     try {
-      Response response = asyncHttpClient.prepareGet(String.format("http://%s:5051/files/browse.json", slaveHostname))
+      Response response = asyncHttpClient.prepareGet(String.format("http://%s:5051/files/browse", slaveHostname))
           .addQueryParameter("path", fullPath)
           .execute().get();
 
@@ -69,7 +69,7 @@ public class SandboxManager {
   @SuppressWarnings("deprecation")
   public Optional<MesosFileChunkObject> read(String slaveHostname, String fullPath, Optional<Long> offset, Optional<Long> length) throws SlaveNotFoundException {
     try {
-      final AsyncHttpClient.BoundRequestBuilder builder = asyncHttpClient.prepareGet(String.format("http://%s:5051/files/read.json", slaveHostname))
+      final AsyncHttpClient.BoundRequestBuilder builder = asyncHttpClient.prepareGet(String.format("http://%s:5051/files/read", slaveHostname))
           .addQueryParameter("path", fullPath);
 
       PerRequestConfig timeoutConfig = new PerRequestConfig();

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityDriver.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityDriver.java
@@ -68,7 +68,7 @@ public class SingularityDriver {
     if (configuration.getCredentialPrincipal().isPresent() && configuration.getCredentialSecret().isPresent()) {
       Credential credential = Credential.newBuilder()
         .setPrincipal(configuration.getCredentialPrincipal().get())
-        .setSecret(ByteString.copyFrom(configuration.getCredentialSecret().get().getBytes(StandardCharsets.UTF_8)))
+        .setSecret(configuration.getCredentialSecret().get())
         .build();
       this.driver = new MesosSchedulerDriver(scheduler, frameworkInfo, configuration.getMaster(), credential);
     } else {

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
@@ -10,6 +10,7 @@ import javax.inject.Singleton;
 
 import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.Protos.TaskStatus.Reason;
 import org.apache.mesos.Scheduler;
 import org.apache.mesos.SchedulerDriver;
 import org.slf4j.Logger;
@@ -305,7 +306,7 @@ public class SingularityMesosScheduler implements Scheduler {
   private Optional<String> getStatusMessage(Protos.TaskStatus status, Optional<SingularityTask> task) {
     if (status.hasMessage() && !Strings.isNullOrEmpty(status.getMessage())) {
       return Optional.of(status.getMessage());
-    } else if (status.hasReason() && status.getReason() == Protos.TaskStatus.Reason.REASON_MEMORY_LIMIT) {
+    } else if (status.hasReason() && status.getReason() == Reason.REASON_CONTAINER_LIMITATION_MEMORY) {
       if (task.isPresent() && task.get().getTaskRequest().getDeploy().getResources().isPresent()) {
           return Optional.of(String.format("Task exceeded memory limit of %s MB", task.get().getTaskRequest().getDeploy().getResources().get().getMemoryMb()));
       }

--- a/compose-dev.yml
+++ b/compose-dev.yml
@@ -6,7 +6,7 @@ zk:
     ZK_ID: 1
 
 master:
-  image: mesosphere/mesos-master:0.23.0-1.0.ubuntu1404
+  image: mesosphere/mesos-master:0.27.2-2.0.15.ubuntu1404
   net: host
   environment:
     MESOS_ZK: zk://localhost:2181/mesos

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
     <dropwizard.guicier.version>0.7.1.2</dropwizard.guicier.version>
     <baragon.version>0.2.0</baragon.version>
     <horizon.version>0.0.24</horizon.version>
-    <mesos.docker.tag>0.23.0-1.0.ubuntu1404</mesos.docker.tag>
-    <mesos.version>0.23.0</mesos.version>
+    <mesos.docker.tag>0.27.2-2.0.15.ubuntu1404</mesos.docker.tag>
+    <mesos.version>0.27.2</mesos.version>
     <singularitybase.image.revision>1</singularitybase.image.revision>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
     <dropwizard.guicier.version>0.7.1.2</dropwizard.guicier.version>
     <baragon.version>0.2.0</baragon.version>
     <horizon.version>0.0.24</horizon.version>
-    <mesos.docker.tag>0.27.2-2.0.15.ubuntu1404</mesos.docker.tag>
-    <mesos.version>0.27.2</mesos.version>
+    <mesos.docker.tag>0.28.1-2.0.20.ubuntu1404</mesos.docker.tag>
+    <mesos.version>0.28.1</mesos.version>
     <singularitybase.image.revision>1</singularitybase.image.revision>
   </properties>
 

--- a/scripts/logfetch/live_logs.py
+++ b/scripts/logfetch/live_logs.py
@@ -5,7 +5,7 @@ import callbacks
 import logfetch_base
 from termcolor import colored
 
-DOWNLOAD_FILE_FORMAT = 'http://{0}:5051/files/download.json'
+DOWNLOAD_FILE_FORMAT = 'http://{0}:5051/files/download'
 BROWSE_FOLDER_FORMAT = '{0}/sandbox/{1}/browse'
 TASK_HISTORY_FORMAT = '{0}/history/task/{1}'
 


### PR DESCRIPTION
Currently built against `0.27.2`, will bump to `0.28.1` if it is ready before we are ready to release.

Major changes:
- `.json` endpoints no longer have the `.json`, however the deprecated versions of the endpoints are still in place, so no worries around the upgrade process
- `TaskStatus.Reason` enum updated for memory limit
- Bumped java version in docker image
- Installing docker in slave image via apt
- credential secret is now a String not a byte array