### PR TITLE
only suggest even accross racks for SERVICE type

### DIFF
--- a/SingularityUI/app/models/Request.coffee
+++ b/SingularityUI/app/models/Request.coffee
@@ -351,7 +351,7 @@ class Request extends Model
                 message = $('.vex #scale-message').val()
                 duration = $('.vex #scale-expiration').val()
                 if !duration or (duration and @_validateDuration(duration, @promptScale, callback))
-                    if @attributes.request.rackSensitive and not @attributes.request.hideEvenNumberAcrossRacksHint
+                    if @attributes.request.requestType is 'SERVICE' and @attributes.request.rackSensitive and not @attributes.request.hideEvenNumberAcrossRacksHint
                         if @racks
                             @checkScaleEvenNumberRacks data, bounce, incremental, message, duration, callback
                         else


### PR DESCRIPTION
Generally, having an even number across racks is more important for a service that will be serving web traffic. Workers more often need to be scaled one at a time or to a more specific amount regardless of rack distribution. This makes it so we only prompt for SERVICE type requests