### PR TITLE
deployProgress was undefined yet we tried to get attributes out of it

### DIFF
--- a/SingularityUI/app/views/requestHeader.coffee
+++ b/SingularityUI/app/views/requestHeader.coffee
@@ -26,7 +26,7 @@ class requestHeaderSubview extends View
 
         if !!@model.get('pendingDeploy')
             deployingInstanceCount = @activeTasks.where({deployId: @model.get('pendingDeploy').id, lastTaskState: 'TASK_RUNNING'}).length
-        if !!@model.get('pendingDeployState')
+        if !!@model.get('pendingDeployState') and @model.get('pendingDeployState').deployProgress
             nextDeployStepTimestamp = @model.get('pendingDeployState').deployProgress.timestamp + (@model.get('pendingDeployState').deployProgress.deployStepWaitTimeMs)
 
         isBouncing: bounces?.length > 0 and @taskCleanups.synced and @activeTasks.synced


### PR DESCRIPTION
This fixes a small bug that was triggered when looking at a request page within a few seconds of adding a new deploy to that request.
The deployProgress attribute of that deploy is not yet defined, yet Singularity tried to get timestamp and deployStepWaitTimeMs out of it, causing an error to be logged to the console.