### PR TITLE
Changes to user requested task kills in custom executor

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityFrameworkMessage.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityFrameworkMessage.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonTypeInfo(use = Id.MINIMAL_CLASS, include = As.PROPERTY, property = "@class")
+@JsonTypeInfo(use = Id.MINIMAL_CLASS, include = As.PROPERTY, property = "@class", defaultImpl = SingularityTaskShellCommandRequest.class)
 @JsonSubTypes({
   @Type(value = SingularityTaskShellCommandRequest.class, name = "SHELL_COMMAND"),
   @Type(value = SingularityTaskDestroyFrameworkMessage.class, name = "TASK_KILL")

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityFrameworkMessage.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityFrameworkMessage.java
@@ -1,0 +1,18 @@
+package com.hubspot.singularity;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeInfo(use = Id.MINIMAL_CLASS, include = As.PROPERTY, property = "@class")
+@JsonSubTypes({
+  @Type(value = SingularityTaskShellCommandRequest.class, name = "SHELL_COMMAND"),
+  @Type(value = SingularityTaskDestroyFrameworkMessage.class, name = "TASK_KILL")
+})
+public abstract class SingularityFrameworkMessage {
+  public abstract SingularityTaskId getTaskId();
+}

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskDestroyFrameworkMessage.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskDestroyFrameworkMessage.java
@@ -1,0 +1,51 @@
+package com.hubspot.singularity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+import com.google.common.base.Optional;
+
+public class SingularityTaskDestroyFrameworkMessage extends SingularityFrameworkMessage {
+  private final SingularityTaskId taskId;
+  private final Optional<String> user;
+
+  @JsonCreator
+  public SingularityTaskDestroyFrameworkMessage(@JsonProperty("taskId") SingularityTaskId taskId, @JsonProperty("user") Optional<String> user) {
+    this.taskId = taskId;
+    this.user = user;
+  }
+
+  public SingularityTaskId getTaskId() {
+    return taskId;
+  }
+
+  public Optional<String> getUser() {
+    return user;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SingularityTaskDestroyFrameworkMessage that = (SingularityTaskDestroyFrameworkMessage) o;
+    return Objects.equal(taskId, that.taskId) &&
+      Objects.equal(user, that.user);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(taskId, user);
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+      .add("taskId", taskId)
+      .add("user", user)
+      .toString();
+  }
+}

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskShellCommandRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskShellCommandRequest.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
 import com.google.common.primitives.Longs;
 
-public class SingularityTaskShellCommandRequest implements Comparable<SingularityTaskShellCommandRequest> {
+public class SingularityTaskShellCommandRequest extends SingularityFrameworkMessage implements Comparable<SingularityTaskShellCommandRequest> {
 
   private final SingularityTaskId taskId;
   private final Optional<String> user;

--- a/SingularityBase/src/main/java/com/hubspot/singularity/TaskCleanupType.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/TaskCleanupType.java
@@ -3,7 +3,8 @@ package com.hubspot.singularity;
 public enum TaskCleanupType {
 
   USER_REQUESTED(true, true), USER_REQUESTED_TASK_BOUNCE(false, false), DECOMISSIONING(false, false), SCALING_DOWN(true, false), BOUNCING(false, false), INCREMENTAL_BOUNCE(false, false),
-  DEPLOY_FAILED(false, true), NEW_DEPLOY_SUCCEEDED(true, false), DEPLOY_STEP_FINISHED(true, false), DEPLOY_CANCELED(false, true), UNHEALTHY_NEW_TASK(true, true), OVERDUE_NEW_TASK(true, true);
+  DEPLOY_FAILED(false, true), NEW_DEPLOY_SUCCEEDED(true, false), DEPLOY_STEP_FINISHED(true, false), DEPLOY_CANCELED(false, true), UNHEALTHY_NEW_TASK(true, true),
+  OVERDUE_NEW_TASK(true, true), USER_REQUESTED_DESTROY(true, true);
 
   private final boolean killLongRunningTaskInstantly;
   private final boolean killNonLongRunningTaskInstantly;
@@ -20,5 +21,4 @@ public enum TaskCleanupType {
       return killNonLongRunningTaskInstantly;
     }
   }
-
 }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorProcessKiller.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorProcessKiller.java
@@ -14,6 +14,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.hubspot.mesos.JavaUtils;
+import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.executor.config.SingularityExecutorConfiguration;
 import com.hubspot.singularity.executor.task.SingularityExecutorTaskProcessCallable;
 
@@ -49,6 +50,10 @@ public class SingularityExecutorProcessKiller {
     LOG.info("Signaling -15 to process {} ({})", processCallable.getTask().getTaskId(), processCallable.getCurrentPid());
     processCallable.markKilled();  // makes it so that the task can not start
     processCallable.signalTermToProcessIfActive();
+  }
+
+  public boolean isKillInProgress(String taskId) {
+    return destroyFutures.get(taskId) != null;
   }
 
   public void cancelDestroyFuture(String taskId) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/transcoders/SingularityTranscoderModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/transcoders/SingularityTranscoderModule.java
@@ -34,6 +34,7 @@ import com.hubspot.singularity.SingularityTaskHealthcheckResult;
 import com.hubspot.singularity.SingularityTaskHistory;
 import com.hubspot.singularity.SingularityTaskHistoryUpdate;
 import com.hubspot.singularity.SingularityTaskId;
+import com.hubspot.singularity.SingularityTaskDestroyFrameworkMessage;
 import com.hubspot.singularity.SingularityTaskMetadata;
 import com.hubspot.singularity.SingularityTaskShellCommandRequest;
 import com.hubspot.singularity.SingularityTaskShellCommandUpdate;
@@ -80,6 +81,7 @@ public class SingularityTranscoderModule implements Module {
     bindTranscoder(binder).asJson(SingularityExpiringPause.class);
     bindTranscoder(binder).asJson(SingularityExpiringScale.class);
     bindTranscoder(binder).asJson(SingularityExpiringSkipHealthchecks.class);
+    bindTranscoder(binder).asJson(SingularityTaskDestroyFrameworkMessage.class);
 
     bindTranscoder(binder).asCompressedJson(SingularityDeployHistory.class);
     bindTranscoder(binder).asCompressedJson(SingularityDeploy.class);

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityDriver.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityDriver.java
@@ -8,9 +8,11 @@ import javax.inject.Singleton;
 import org.apache.mesos.MesosSchedulerDriver;
 import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.Credential;
+import org.apache.mesos.Protos.ExecutorID;
 import org.apache.mesos.Protos.FrameworkID;
 import org.apache.mesos.Protos.FrameworkInfo;
 import org.apache.mesos.Protos.MasterInfo;
+import org.apache.mesos.Protos.SlaveID;
 import org.apache.mesos.Protos.TaskID;
 import org.apache.mesos.Scheduler;
 import org.apache.mesos.SchedulerDriver;
@@ -22,6 +24,7 @@ import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.google.protobuf.ByteString;
+import com.hubspot.singularity.SingularityFrameworkMessage;
 import com.hubspot.singularity.SingularityMainModule;
 import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.config.MesosConfiguration;
@@ -104,6 +107,12 @@ public class SingularityDriver {
 
     LOG.info("Killed task {} with driver status: {}", taskId, status);
 
+    return status;
+  }
+
+  public Protos.Status sendFrameworkMessage(SingularityTaskId taskId, ExecutorID executorID, SlaveID slaveID, byte [] bytes) {
+    Protos.Status status = driver.sendFrameworkMessage(executorID, slaveID, bytes);
+    LOG.info("Sent framework message for task {} with driver status: {}", taskId, status);
     return status;
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
@@ -292,12 +292,16 @@ public class TaskResource {
 
     final long now = System.currentTimeMillis();
 
-    final SingularityTaskCleanup taskCleanup = new SingularityTaskCleanup(JavaUtils.getUserEmail(user), cleanupType, now,
-        task.getTaskId(), message, actionId);
+    final SingularityTaskCleanup taskCleanup;
 
     if (override.isPresent() && override.get().booleanValue()) {
+      cleanupType = TaskCleanupType.USER_REQUESTED_DESTROY;
+      taskCleanup = new SingularityTaskCleanup(JavaUtils.getUserEmail(user), cleanupType, now,
+        task.getTaskId(), message, actionId);
       taskManager.saveTaskCleanup(taskCleanup);
     } else {
+      taskCleanup = new SingularityTaskCleanup(JavaUtils.getUserEmail(user), cleanupType, now,
+        task.getTaskId(), message, actionId);
       SingularityCreateResult result = taskManager.createTaskCleanup(taskCleanup);
 
       while (result == SingularityCreateResult.EXISTED) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
@@ -318,7 +318,7 @@ public class SingularityCleaner {
       if (killActiveTasks) {
         for (SingularityTaskId matchingTaskId : matchingActiveTaskIds) {
           LOG.debug("Killing task {} due to {}", matchingTaskId, requestCleanup);
-          driverManager.killAndRecord(matchingTaskId, requestCleanup.getCleanupType());
+          driverManager.killAndRecord(matchingTaskId, requestCleanup.getCleanupType(), Optional.<String>absent());
           numTasksKilled++;
         }
       } else {
@@ -425,7 +425,7 @@ public class SingularityCleaner {
             killedTaskIdRecord, JavaUtils.durationFromMillis(duration), JavaUtils.durationFromMillis(configuration.getAskDriverToKillTasksAgainAfterMillis()));
 
         driverManager.killAndRecord(killedTaskIdRecord.getTaskId(), killedTaskIdRecord.getRequestCleanupType(),
-            killedTaskIdRecord.getTaskCleanupType(), Optional.of(killedTaskIdRecord.getOriginalTimestamp()), Optional.of(killedTaskIdRecord.getRetries()));
+            killedTaskIdRecord.getTaskCleanupType(), Optional.of(killedTaskIdRecord.getOriginalTimestamp()), Optional.of(killedTaskIdRecord.getRetries()), Optional.<String>absent());
 
         rekilled++;
       } else {
@@ -474,7 +474,7 @@ public class SingularityCleaner {
         LOG.info("Couldn't find a matching active task for cleanup task {}, deleting..", cleanupTask);
         taskManager.deleteCleanupTask(cleanupTask.getTaskId().getId());
       } else if (shouldKillTask(cleanupTask, activeTaskIds, cleaningTasks, incrementalBounceCleaningTasks) && checkLBStateAndShouldKillTask(cleanupTask)) {
-        driverManager.killAndRecord(cleanupTask.getTaskId(), cleanupTask.getCleanupType());
+        driverManager.killAndRecord(cleanupTask.getTaskId(), cleanupTask.getCleanupType(), cleanupTask.getUser());
 
         taskManager.deleteCleanupTask(cleanupTask.getTaskId().getId());
 


### PR DESCRIPTION
Two main changes in this:

- For any user-requested kill (direct task kill, task destroy, also includes bounce at the moment), send a framework message to the executor to trigger the kill (if using a custom executor)
- In the SingularityExecutor, don't skip to destroy if we receive a kill (framework message or normal) and there is already a kill process running

In the case when sending the framework message, I am still sending the normal kill as well (now that the executor handles it properly). This is so any other executors (default mesos or another custom) will still receive the kills they expect. I couldn't think of a better way around this since we do not have an easy way to determine that the executor is custom AND is a singularity custom executor, suggestions welcome for easier compatibility with other executors.

@wsorenson @tpetr