### PR TITLE
Don't trigger cooldown if task lost reason is invalid offers

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
@@ -392,7 +392,7 @@ public class SingularityMesosScheduler implements Scheduler {
 
       slaveAndRackManager.checkStateAfterFinishedTask(taskIdObj, status.getSlaveId().getValue(), stateCache);
 
-      scheduler.handleCompletedTask(task, taskIdObj, isActiveTask, timestamp, taskState, taskHistoryUpdateCreateResult, stateCache);
+      scheduler.handleCompletedTask(task, taskIdObj, isActiveTask, timestamp, taskState, taskHistoryUpdateCreateResult, stateCache, status);
     }
 
     saveNewTaskStatusHolder(taskIdObj, newTaskStatusHolder, taskState);

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -12,6 +12,8 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Singleton;
 
+import org.apache.mesos.Protos;
+import org.apache.mesos.Protos.TaskStatus.Reason;
 import org.quartz.CronExpression;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -432,7 +434,7 @@ public class SingularityScheduler {
   }
 
   private Optional<PendingType> handleCompletedTaskWithStatistics(Optional<SingularityTask> task, SingularityTaskId taskId, long timestamp, ExtendedTaskState state,
-    SingularityDeployStatistics deployStatistics, SingularityCreateResult taskHistoryUpdateCreateResult, SingularitySchedulerStateCache stateCache) {
+    SingularityDeployStatistics deployStatistics, SingularityCreateResult taskHistoryUpdateCreateResult, SingularitySchedulerStateCache stateCache, Protos.TaskStatus status) {
     final Optional<SingularityRequestWithState> maybeRequestWithState = requestManager.getRequest(taskId.getRequestId());
     final Optional<SingularityPendingDeploy> maybePendingDeploy = deployManager.getPendingDeploy(taskId.getRequestId());
 
@@ -459,11 +461,15 @@ public class SingularityScheduler {
       LOG.debug("Not sending a task completed email for task {} because Singularity already processed this update", taskId);
     }
 
-    if (!state.isSuccess() && taskHistoryUpdateCreateResult == SingularityCreateResult.CREATED && cooldown.shouldEnterCooldown(request, taskId, requestState, deployStatistics, timestamp)) {
-      LOG.info("Request {} is entering cooldown due to task {}", request.getId(), taskId);
-      requestState = RequestState.SYSTEM_COOLDOWN;
-      requestManager.cooldown(request, System.currentTimeMillis());
-      mailer.sendRequestInCooldownMail(request);
+    if (!status.hasReason() || !status.getReason().equals(Reason.REASON_INVALID_OFFERS)) {
+      if (!state.isSuccess() && taskHistoryUpdateCreateResult == SingularityCreateResult.CREATED && cooldown.shouldEnterCooldown(request, taskId, requestState, deployStatistics, timestamp)) {
+        LOG.info("Request {} is entering cooldown due to task {}", request.getId(), taskId);
+        requestState = RequestState.SYSTEM_COOLDOWN;
+        requestManager.cooldown(request, System.currentTimeMillis());
+        mailer.sendRequestInCooldownMail(request);
+      }
+    } else {
+      LOG.debug("Not triggering cooldown due to TASK_LOST from invalid offers for request {}", request.getId());
     }
 
     PendingType pendingType = PendingType.TASK_DONE;
@@ -502,7 +508,7 @@ public class SingularityScheduler {
 
   @Timed
   public void handleCompletedTask(Optional<SingularityTask> task, SingularityTaskId taskId, boolean wasActive, long timestamp, ExtendedTaskState state,
-    SingularityCreateResult taskHistoryUpdateCreateResult, SingularitySchedulerStateCache stateCache) {
+    SingularityCreateResult taskHistoryUpdateCreateResult, SingularitySchedulerStateCache stateCache, Protos.TaskStatus status) {
     final SingularityDeployStatistics deployStatistics = getDeployStatistics(taskId.getRequestId(), taskId.getDeployId());
 
     if (wasActive) {
@@ -514,7 +520,7 @@ public class SingularityScheduler {
       taskManager.createLBCleanupTask(taskId);
     }
 
-    final Optional<PendingType> scheduleResult = handleCompletedTaskWithStatistics(task, taskId, timestamp, state, deployStatistics, taskHistoryUpdateCreateResult, stateCache);
+    final Optional<PendingType> scheduleResult = handleCompletedTaskWithStatistics(task, taskId, timestamp, state, deployStatistics, taskHistoryUpdateCreateResult, stateCache, status);
 
     if (taskHistoryUpdateCreateResult == SingularityCreateResult.EXISTED) {
       return;


### PR DESCRIPTION
Related to rescinded offers. If we end up using a bunch of rescinded offers, these will result in a task lost with a reason of invalid offer. This should not trigger a cooldown and we should keep trying to schedule new tasks