### PR TITLE
Scroll to bottom of run now dialog

### DIFF
--- a/SingularityUI/app/models/Request.coffee
+++ b/SingularityUI/app/models/Request.coffee
@@ -520,7 +520,7 @@ class Request extends Model
                         @run( @data.commandLineInput, message, @data.runId ).done doneFn
                         return true
 
-                afterOpen: =>
+                afterOpen: (vexContent) =>
                     taskRunAfterStart = localStorage.getItem('taskRunAfterStart')
                     $('#filename').val localStorage.getItem('taskRunRedirectFilename') or Utils.fileName(config.runningTaskLogPath)
                     $('#autoTail').prop 'checked', (taskRunAfterStart is 'autoTail')
@@ -532,9 +532,10 @@ class Request extends Model
                     $('#browse-to-sandbox').on('click', () => $('#filename').prop('disabled', true))
                     $('#autoTail').on('click', () => $('#filename').prop('disabled', false))
                     $('#filename').prop 'disabled', false if taskRunAfterStart is 'autoTail'
-                    focusFn = () => $('.vex-dialog-button, .vex-primary, .vex-first').focus()
-                    focusFn()
-                    setTimeout focusFn, 500 # For Firefox...
+                    vexContent.bind('vexOpen', () =>
+                      vexElement = document.getElementsByClassName('vex')[0]
+                      vexElement.scrollTop = vexElement.scrollHeight
+                    )
 
                 callback: (data) =>
                     if data.commandLineInput

--- a/SingularityUI/app/models/Request.coffee
+++ b/SingularityUI/app/models/Request.coffee
@@ -532,6 +532,7 @@ class Request extends Model
                     $('#browse-to-sandbox').on('click', () => $('#filename').prop('disabled', true))
                     $('#autoTail').on('click', () => $('#filename').prop('disabled', false))
                     $('#filename').prop 'disabled', false if taskRunAfterStart is 'autoTail'
+                    $('.vex-dialog-button, .vex-primary, .vex-first').focus()
 
                 callback: (data) =>
                     if data.commandLineInput

--- a/SingularityUI/app/models/Request.coffee
+++ b/SingularityUI/app/models/Request.coffee
@@ -532,7 +532,9 @@ class Request extends Model
                     $('#browse-to-sandbox').on('click', () => $('#filename').prop('disabled', true))
                     $('#autoTail').on('click', () => $('#filename').prop('disabled', false))
                     $('#filename').prop 'disabled', false if taskRunAfterStart is 'autoTail'
-                    $('.vex-dialog-button, .vex-primary, .vex-first').focus()
+                    focusFn = () => $('.vex-dialog-button, .vex-primary, .vex-first').focus()
+                    focusFn()
+                    setTimeout focusFn, 500 # For Firefox...
 
                 callback: (data) =>
                     if data.commandLineInput


### PR DESCRIPTION
If the screen is too small, the 'Run now' button in the dialog will be off the screen, defeating the efforts to make this dialog one-click whenever possible.

With this change, the button will gain focus when the dialog is opened, causing the browser to automatically scroll to the button.

The timeout causes the button to focus again in half a second, which is necessary because Firefox ignores the first focus call (it's too close to trying to focus on the Vex dialog). There are two downsides to this:
- In Firefox, the UI jumps half a second after the dialog opens, which is kind of awkward. I tested this and the button won't properly be in the viewscreen if the timeout is less than half a second. The only other option is to leave firefox out completely, and let firefox users scroll on their own (which is a valid choice if the jump is too awkward).
- In other browsers the UI will also jump half a second after the dialog opens. However, it is very difficult to scroll within half a second of opening the dialog, so this seems irrelevant to me. It can be fixed by detecting if the user agent is firefox, but that may lead to other browsers with the same limitation as firefox not scrolling (Looking at you, Internet Explorer - I don't have a machine capable of running IE, so I can't test what it'll do).