### PR TITLE
If there are exactly four tasks, show their logs in a square

### DIFF
--- a/SingularityUI/app/components/logs/LogContainer.cjsx
+++ b/SingularityUI/app/components/logs/LogContainer.cjsx
@@ -18,16 +18,18 @@ class LogContainer extends React.Component
   renderTaskGroups: ->
     rows = []
 
+    tasksPerRow = if @props.taskGroupsCount is 4 then 2 else 3
+
     row = []
-    for i in [1..Math.min(@props.taskGroupsCount, 3)]
-      row.push <TaskGroupContainer key={i - 1} taskGroupId={i - 1} taskGroupContainerCount={Math.min(@props.taskGroupsCount, 3)} />
+    for i in [1..Math.min(@props.taskGroupsCount, tasksPerRow)]
+      row.push <TaskGroupContainer key={i - 1} taskGroupId={i - 1} taskGroupContainerCount={Math.min(@props.taskGroupsCount, tasksPerRow)} />
 
     rows.push row
 
-    if @props.taskGroupsCount > 3
+    if @props.taskGroupsCount > tasksPerRow
       row = []
-      for i in [4..Math.min(@props.taskGroupsCount, 6)]
-        row.push <TaskGroupContainer key={i - 1} taskGroupId={i - 1} taskGroupContainerCount={Math.min(@props.taskGroupsCount, 6) - 3} />
+      for i in [tasksPerRow+1..Math.min(@props.taskGroupsCount, 6)]
+        row.push <TaskGroupContainer key={i - 1} taskGroupId={i - 1} taskGroupContainerCount={Math.min(@props.taskGroupsCount, 6) - tasksPerRow} />
       rows.push row
 
     rowClassName = 'row tail-row'


### PR DESCRIPTION
The tailer used to show the logs in one row of three tiny log windows, and one huge log window across the bottom.
This changes it to show them in a 2x2 square.