### PR TITLE
Show only name of log file in aggregate tail title

### DIFF
--- a/SingularityUI/app/controllers/LogViewer.cjsx
+++ b/SingularityUI/app/controllers/LogViewer.cjsx
@@ -13,7 +13,7 @@ ActiveTasks = require '../actions/activeTasks'
 
 class LogViewer extends Controller
   initialize: ({@requestId, @path, @initialOffset, taskIds, viewMode, search}) ->
-    @title 'Tail of ' + @path
+    @title "Tail of #{_.last @path.split('/')}"
 
     initialState = {
         viewMode,


### PR DESCRIPTION
The title of the aggregate log page was showing `$TASK_ID` when the task id was in the path to a log file.
This fixes that, and improves the title to only show the name of the file. The fully qualified path, which was displayed before, is usually not as useful as the name when looking at a tab preview, and it was pushing out the name itself since the space is so tiny.