### PR TITLE
Tasks page improvements

### DIFF
--- a/SingularityUI/app/handlebarsHelpers.coffee
+++ b/SingularityUI/app/handlebarsHelpers.coffee
@@ -40,7 +40,6 @@ Handlebars.registerHelper 'ifTaskInList', (list, task, options) ->
     return options.inverse @
 
 Handlebars.registerHelper 'ifInSubFilter', (needle, haystack, options) ->
-    #return options.inverse @ unless haystack
     return options.fn @ if haystack is 'all'
     if haystack.indexOf(needle) isnt -1
         options.fn @

--- a/SingularityUI/app/handlebarsHelpers.coffee
+++ b/SingularityUI/app/handlebarsHelpers.coffee
@@ -40,6 +40,7 @@ Handlebars.registerHelper 'ifTaskInList', (list, task, options) ->
     return options.inverse @
 
 Handlebars.registerHelper 'ifInSubFilter', (needle, haystack, options) ->
+    #return options.inverse @ unless haystack
     return options.fn @ if haystack is 'all'
     if haystack.indexOf(needle) isnt -1
         options.fn @

--- a/SingularityUI/app/templates/requestTypeFilter.hbs
+++ b/SingularityUI/app/templates/requestTypeFilter.hbs
@@ -1,30 +1,30 @@
 <ul class="nav nav-pills nav-pills-multi-select">
     <li {{#unlessInSubFilter 'SERVICE' requestsSubFilter}}class="active"{{/unlessInSubFilter}}>
-        <a data-filter="SERVICE" class='has-tooltip' title="Protip: press cmd to select multiple" data-toggle='tooltip'>
+        <a data-filter="SERVICE">
             <span class="glyphicon glyphicon-ok"></span>
             Service
         </a>
     </li>
     <li {{#unlessInSubFilter 'WORKER' requestsSubFilter}}class="active"{{/unlessInSubFilter}}>
-        <a data-filter="WORKER" class='has-tooltip' title="Protip: press cmd to select multiple" data-toggle='tooltip'>
+        <a data-filter="WORKER">
             <span class="glyphicon glyphicon-ok"></span>
             Worker
         </a>
     </li>
     <li {{#unlessInSubFilter 'SCHEDULED' requestsSubFilter}}class="active"{{/unlessInSubFilter}}>
-        <a data-filter="SCHEDULED" class='has-tooltip' title="Protip: press cmd to select multiple" data-toggle='tooltip'>
+        <a data-filter="SCHEDULED">
             <span class="glyphicon glyphicon-ok"></span>
             Scheduled
         </a>
     </li>
     <li {{#unlessInSubFilter 'ON_DEMAND' requestsSubFilter}}class="active"{{/unlessInSubFilter}}>
-        <a data-filter="ON_DEMAND" class='has-tooltip' title="Protip: press cmd to select multiple" data-toggle='tooltip'>
+        <a data-filter="ON_DEMAND">
             <span class="glyphicon glyphicon-ok"></span>
             On-demand
         </a>
     </li>
     <li {{#unlessInSubFilter 'RUN_ONCE' requestsSubFilter}}class="active"{{/unlessInSubFilter}}>
-        <a data-filter="RUN_ONCE" class='has-tooltip' title="Protip: press cmd to select multiple" data-toggle='tooltip'>
+        <a data-filter="RUN_ONCE">
             <span class="glyphicon glyphicon-ok"></span>
             Run-once
         </a>

--- a/SingularityUI/app/templates/requestTypeFilter.hbs
+++ b/SingularityUI/app/templates/requestTypeFilter.hbs
@@ -1,30 +1,30 @@
-<ul class="nav nav-pills nav-pills-multi-select has-tooltip" title="Protip: press cmd to select multiple" data-toggle='tooltip'>
+<ul class="nav nav-pills nav-pills-multi-select">
     <li {{#unlessInSubFilter 'SERVICE' requestsSubFilter}}class="active"{{/unlessInSubFilter}}>
-        <a data-filter="SERVICE">
+        <a data-filter="SERVICE" class='has-tooltip' title="Protip: press cmd to select multiple" data-toggle='tooltip'>
             <span class="glyphicon glyphicon-ok"></span>
             Service
         </a>
     </li>
     <li {{#unlessInSubFilter 'WORKER' requestsSubFilter}}class="active"{{/unlessInSubFilter}}>
-        <a data-filter="WORKER">
+        <a data-filter="WORKER" class='has-tooltip' title="Protip: press cmd to select multiple" data-toggle='tooltip'>
             <span class="glyphicon glyphicon-ok"></span>
             Worker
         </a>
     </li>
     <li {{#unlessInSubFilter 'SCHEDULED' requestsSubFilter}}class="active"{{/unlessInSubFilter}}>
-        <a data-filter="SCHEDULED">
+        <a data-filter="SCHEDULED" class='has-tooltip' title="Protip: press cmd to select multiple" data-toggle='tooltip'>
             <span class="glyphicon glyphicon-ok"></span>
             Scheduled
         </a>
     </li>
     <li {{#unlessInSubFilter 'ON_DEMAND' requestsSubFilter}}class="active"{{/unlessInSubFilter}}>
-        <a data-filter="ON_DEMAND">
+        <a data-filter="ON_DEMAND" class='has-tooltip' title="Protip: press cmd to select multiple" data-toggle='tooltip'>
             <span class="glyphicon glyphicon-ok"></span>
             On-demand
         </a>
     </li>
     <li {{#unlessInSubFilter 'RUN_ONCE' requestsSubFilter}}class="active"{{/unlessInSubFilter}}>
-        <a data-filter="RUN_ONCE">
+        <a data-filter="RUN_ONCE" class='has-tooltip' title="Protip: press cmd to select multiple" data-toggle='tooltip'>
             <span class="glyphicon glyphicon-ok"></span>
             Run-once
         </a>

--- a/SingularityUI/app/templates/requestTypeFilter.hbs
+++ b/SingularityUI/app/templates/requestTypeFilter.hbs
@@ -1,32 +1,34 @@
-<ul class="nav nav-pills nav-pills-multi-select">
-    <li {{#unlessInSubFilter 'SERVICE' requestsSubFilter}}class="active"{{/unlessInSubFilter}}>
-        <a data-filter="SERVICE">
-            <span class="glyphicon glyphicon-ok"></span>
-            Service
-        </a>
-    </li>
-    <li {{#unlessInSubFilter 'WORKER' requestsSubFilter}}class="active"{{/unlessInSubFilter}}>
-        <a data-filter="WORKER">
-            <span class="glyphicon glyphicon-ok"></span>
-            Worker
-        </a>
-    </li>
-    <li {{#unlessInSubFilter 'SCHEDULED' requestsSubFilter}}class="active"{{/unlessInSubFilter}}>
-        <a data-filter="SCHEDULED">
-            <span class="glyphicon glyphicon-ok"></span>
-            Scheduled
-        </a>
-    </li>
-    <li {{#unlessInSubFilter 'ON_DEMAND' requestsSubFilter}}class="active"{{/unlessInSubFilter}}>
-        <a data-filter="ON_DEMAND">
-            <span class="glyphicon glyphicon-ok"></span>
-            On-demand
-        </a>
-    </li>
-    <li {{#unlessInSubFilter 'RUN_ONCE' requestsSubFilter}}class="active"{{/unlessInSubFilter}}>
-        <a data-filter="RUN_ONCE">
-            <span class="glyphicon glyphicon-ok"></span>
-            Run-once
-        </a>
-    </li>
-</ul>
+{{#unless hideRequestTypeFilter}}
+    <ul class="nav nav-pills nav-pills-multi-select">
+        <li {{#unlessInSubFilter 'SERVICE' requestsSubFilter}}class="active"{{/unlessInSubFilter}}>
+            <a data-filter="SERVICE">
+                <span class="glyphicon glyphicon-ok"></span>
+                Service
+            </a>
+        </li>
+        <li {{#unlessInSubFilter 'WORKER' requestsSubFilter}}class="active"{{/unlessInSubFilter}}>
+            <a data-filter="WORKER">
+                <span class="glyphicon glyphicon-ok"></span>
+                Worker
+            </a>
+        </li>
+        <li {{#unlessInSubFilter 'SCHEDULED' requestsSubFilter}}class="active"{{/unlessInSubFilter}}>
+            <a data-filter="SCHEDULED">
+                <span class="glyphicon glyphicon-ok"></span>
+                Scheduled
+            </a>
+        </li>
+        <li {{#unlessInSubFilter 'ON_DEMAND' requestsSubFilter}}class="active"{{/unlessInSubFilter}}>
+            <a data-filter="ON_DEMAND">
+                <span class="glyphicon glyphicon-ok"></span>
+                On-demand
+            </a>
+        </li>
+        <li {{#unlessInSubFilter 'RUN_ONCE' requestsSubFilter}}class="active"{{/unlessInSubFilter}}>
+            <a data-filter="RUN_ONCE">
+                <span class="glyphicon glyphicon-ok"></span>
+                Run-once
+            </a>
+        </li>
+    </ul>
+{{/unless}}

--- a/SingularityUI/app/templates/requestTypeFilter.hbs
+++ b/SingularityUI/app/templates/requestTypeFilter.hbs
@@ -1,4 +1,4 @@
-<ul class="nav nav-pills nav-pills-multi-select">
+<ul class="nav nav-pills nav-pills-multi-select has-tooltip" title="Protip: press cmd to select multiple" data-toggle='tooltip'>
     <li {{#unlessInSubFilter 'SERVICE' requestsSubFilter}}class="active"{{/unlessInSubFilter}}>
         <a data-filter="SERVICE">
             <span class="glyphicon glyphicon-ok"></span>
@@ -30,7 +30,3 @@
         </a>
     </li>
 </ul>
-
-<span class="text-muted filter-tip hidden-xs">
-    Protip: press <kbd>cmd</kbd> to select multiple
-</span>

--- a/SingularityUI/app/templates/tasksTable/tasksActiveBody.hbs
+++ b/SingularityUI/app/templates/tasksTable/tasksActiveBody.hbs
@@ -12,7 +12,7 @@
                     <th class="hidden-xs" data-sort-attribute="host">
                         Host
                     </th>
-                    <th class="hidden-xs" data-sort-attribute="taskId.rackId">
+                    <th class="visible-lg" data-sort-attribute="taskId.rackId">
                         Rack
                     </th>
                     <th class="visible-lg" data-sort-attribute="cpus">
@@ -53,7 +53,7 @@
                     <td class="visible-lg">
                         {{ cpus }}
                     </td>
-                    <td class="hidden-xs" data-value="{{ memoryMb }}">
+                    <td class="visible-lg" data-value="{{ memoryMb }}">
                         {{ memoryMb }} MB
                     </td>
                     <td>

--- a/SingularityUI/app/templates/tasksTable/tasksActiveBody.hbs
+++ b/SingularityUI/app/templates/tasksTable/tasksActiveBody.hbs
@@ -48,7 +48,9 @@
                         {{/ifTaskInList}}
                     </td>
                     <td class="visible-lg">
-                        {{ rackId }}
+                        <a href='{{appRoot}}/tasks/active/all/{{rackId}}'>
+                            {{ rackId }}
+                        </a>
                     </td>
                     <td class="visible-lg">
                         {{ cpus }}

--- a/SingularityUI/app/templates/tasksTable/tasksActiveBody.hbs
+++ b/SingularityUI/app/templates/tasksTable/tasksActiveBody.hbs
@@ -4,7 +4,7 @@
             <thead>
                 <tr>
                     <th data-sort-attribute="taskId.id">
-                        Name
+                        Task ID
                     </th>
                     <th class="hidden-xs" data-sort-attribute="taskId.startedAt">
                         Started

--- a/SingularityUI/app/templates/tasksTable/tasksActiveBody.hbs
+++ b/SingularityUI/app/templates/tasksTable/tasksActiveBody.hbs
@@ -9,19 +9,19 @@
                     <th class="hidden-xs" data-sort-attribute="taskId.startedAt">
                         Started At
                     </th>
-                    <th class="hidden-xs" data-sort-attribute="host">
+                    <th data-sort-attribute="host">
                         Host
                     </th>
-                    <th class="visible-lg" data-sort-attribute="taskId.rackId">
+                    <th class="hidden-xs" data-sort-attribute="taskId.rackId">
                         Rack
                     </th>
-                    <th class="visible-lg" data-sort-attribute="cpus">
+                    <th data-sort-attribute="cpus">
                         CPUs
                     </th>
-                    <th class="visible-lg" data-sort-attribute="memoryMb">
+                    <th data-sort-attribute="memoryMb">
                         Memory
                     </th>
-                    <th class="hidden-xs">
+                    <th>
                         {{! Actions column }}
                     </th>
                 </tr>
@@ -39,7 +39,7 @@
                     <td class="hidden-xs" data-value="{{taskId.startedAt}}">
                         {{timestampFromNow taskId.startedAt}}
                     </td>
-                    <td class="hidden-xs">
+                    <td>
                         <a href='{{appRoot}}/tasks/active/all/{{host}}'>
                             {{ host }}
                         </a>
@@ -47,15 +47,15 @@
                             <span class='label label-warning'>DECOM</span>
                         {{/ifTaskInList}}
                     </td>
-                    <td class="visible-lg">
+                    <td class="hidden-xs">
                         <a href='{{appRoot}}/tasks/active/all/{{rackId}}'>
                             {{ rackId }}
                         </a>
                     </td>
-                    <td class="visible-lg">
+                    <td>
                         {{ cpus }}
                     </td>
-                    <td class="visible-lg" data-value="{{ memoryMb }}">
+                    <td data-value="{{ memoryMb }}">
                         {{ memoryMb }} MB
                     </td>
                     <td>
@@ -65,7 +65,7 @@
                             {{/ifTimestampInPast}}
                         {{/if}}
                     </td>
-                    <td class="actions-column hidden-xs">
+                    <td class="actions-column">
                         <a data-task-id="{{ taskId.id }}" data-action="remove" title="Kill task">
                             <span class="glyphicon glyphicon-remove"></span>
                         </a>

--- a/SingularityUI/app/templates/tasksTable/tasksActiveBody.hbs
+++ b/SingularityUI/app/templates/tasksTable/tasksActiveBody.hbs
@@ -7,7 +7,7 @@
                         Task ID
                     </th>
                     <th class="hidden-xs" data-sort-attribute="taskId.startedAt">
-                        Started
+                        Started At
                     </th>
                     <th class="hidden-xs" data-sort-attribute="host">
                         Host

--- a/SingularityUI/app/templates/tasksTable/tasksActiveBody.hbs
+++ b/SingularityUI/app/templates/tasksTable/tasksActiveBody.hbs
@@ -40,7 +40,9 @@
                         {{timestampFromNow taskId.startedAt}}
                     </td>
                     <td class="hidden-xs">
-                        {{ host }}
+                        <a href='{{appRoot}}/tasks/active/all/{{host}}'>
+                            {{ host }}
+                        </a>
                         {{#ifTaskInList ../decomissioning_tasks taskId.id}}
                             <span class='label label-warning'>DECOM</span>
                         {{/ifTaskInList}}

--- a/SingularityUI/app/templates/tasksTable/tasksActiveBody.hbs
+++ b/SingularityUI/app/templates/tasksTable/tasksActiveBody.hbs
@@ -58,13 +58,6 @@
                     <td data-value="{{ memoryMb }}">
                         {{ memoryMb }} MB
                     </td>
-                    <td>
-                        {{#if pendingTask.pendingTaskId}}
-                            {{#ifTimestampInPast pendingTask.pendingTaskId.nextRunAt}}
-                                <span class="label label-danger">OVERDUE</span>
-                            {{/ifTimestampInPast}}
-                        {{/if}}
-                    </td>
                     <td class="actions-column">
                         <a data-task-id="{{ taskId.id }}" data-action="remove" title="Kill task">
                             <span class="glyphicon glyphicon-remove"></span>

--- a/SingularityUI/app/templates/tasksTable/tasksBase.hbs
+++ b/SingularityUI/app/templates/tasksTable/tasksBase.hbs
@@ -2,19 +2,19 @@
     <div class="col-md-12">
         <ul class="nav nav-pills">
             <li {{#ifEqual tasksFilter "active"}}class="active"{{/ifEqual}}>
-                <a href="{{appRoot}}/tasks">Active</a>
+                <a href="{{appRoot}}/tasks" class='has-tooltip' title="Currently running tasks" data-toggle='tooltip'>Active</a>
             </li>
             <li {{#ifEqual tasksFilter "scheduled"}}class="active"{{/ifEqual}}>
-                <a href="{{appRoot}}/tasks/scheduled">Scheduled</a>
+                <a href="{{appRoot}}/tasks/scheduled" class='has-tooltip' title="Tasks that will run when the time comes" data-toggle='tooltip'>Scheduled</a>
             </li>
             <li {{#ifEqual tasksFilter "cleaning"}}class="active"{{/ifEqual}}>
-                <a href="{{appRoot}}/tasks/cleaning">Cleaning</a>
+                <a href="{{appRoot}}/tasks/cleaning" class='has-tooltip' title="Tasks that are cleaning" data-toggle='tooltip'>Cleaning</a>
             </li>
             <li {{#ifEqual tasksFilter "lbcleanup"}}class="active"{{/ifEqual}}>
-                <a href="{{appRoot}}/tasks/lbcleanup">LB Cleaning</a>
+                <a href="{{appRoot}}/tasks/lbcleanup" class='has-tooltip' title="Tasks that are load balancer cleaning" data-toggle='tooltip'>LB Cleaning</a>
             </li>
             <li {{#ifEqual tasksFilter "decommissioning"}}class="active"{{/ifEqual}}>
-                <a href="{{appRoot}}/tasks/decommissioning">Decommissioning</a>
+                <a href="{{appRoot}}/tasks/decommissioning" class='has-tooltip' title="Tasks that are being killed due to a decommissioning slave" data-toggle='tooltip'>Decommissioning</a>
             </li>
         </ul>
     </div>

--- a/SingularityUI/app/templates/tasksTable/tasksBase.hbs
+++ b/SingularityUI/app/templates/tasksTable/tasksBase.hbs
@@ -2,19 +2,19 @@
     <div class="col-md-12">
         <ul class="nav nav-pills">
             <li {{#ifEqual tasksFilter "active"}}class="active"{{/ifEqual}}>
-                <a href="{{appRoot}}/tasks" class='has-tooltip' title="Currently running tasks" data-toggle='tooltip'>Active</a>
+                <a href="{{appRoot}}/tasks" class='has-tooltip' title="Currently running" data-toggle='tooltip'>Active</a>
             </li>
             <li {{#ifEqual tasksFilter "scheduled"}}class="active"{{/ifEqual}}>
-                <a href="{{appRoot}}/tasks/scheduled" class='has-tooltip' title="Tasks that will run when the time comes" data-toggle='tooltip'>Scheduled</a>
+                <a href="{{appRoot}}/tasks/scheduled" class='has-tooltip' title="Will run at next scheduled interval" data-toggle='tooltip'>Scheduled</a>
             </li>
             <li {{#ifEqual tasksFilter "cleaning"}}class="active"{{/ifEqual}}>
-                <a href="{{appRoot}}/tasks/cleaning" class='has-tooltip' title="Tasks that are cleaning" data-toggle='tooltip'>Cleaning</a>
+                <a href="{{appRoot}}/tasks/cleaning" class='has-tooltip' title="Have been asked to shut down" data-toggle='tooltip'>Cleaning</a>
             </li>
             <li {{#ifEqual tasksFilter "lbcleanup"}}class="active"{{/ifEqual}}>
-                <a href="{{appRoot}}/tasks/lbcleanup" class='has-tooltip' title="Tasks that are load balancer cleaning" data-toggle='tooltip'>LB Cleaning</a>
+                <a href="{{appRoot}}/tasks/lbcleanup" class='has-tooltip' title="Being removed from the load balancer" data-toggle='tooltip'>LB Cleaning</a>
             </li>
             <li {{#ifEqual tasksFilter "decommissioning"}}class="active"{{/ifEqual}}>
-                <a href="{{appRoot}}/tasks/decommissioning" class='has-tooltip' title="Tasks that are being killed due to a decommissioning slave" data-toggle='tooltip'>Decommissioning</a>
+                <a href="{{appRoot}}/tasks/decommissioning" class='has-tooltip' title="Being killed due to a decommissioning slave" data-toggle='tooltip'>Decommissioning</a>
             </li>
         </ul>
     </div>

--- a/SingularityUI/app/templates/tasksTable/tasksCleaningBody.hbs
+++ b/SingularityUI/app/templates/tasksTable/tasksCleaningBody.hbs
@@ -4,7 +4,7 @@
             <thead>
                 <tr>
                     <th data-sort-attribute="name">
-                        Name
+                        Task ID
                     </th>
                     <th data-sort-attribute="cleanupTypeHuman">
                         Cleanup type

--- a/SingularityUI/app/templates/tasksTable/tasksDecommissioningBody.hbs
+++ b/SingularityUI/app/templates/tasksTable/tasksDecommissioningBody.hbs
@@ -47,7 +47,9 @@
                             <span class='label label-warning'>DECOMMISSIONING</span>
                         </td>
                         <td class="visible-lg">
-                            {{ rackId }}
+                            <a href='{{appRoot}}/tasks/decommissioning/all/{{rackId}}'>
+                                {{ rackId }}
+                            </a>
                         </td>
                         <td class="visible-lg">
                             {{ cpus }}

--- a/SingularityUI/app/templates/tasksTable/tasksDecommissioningBody.hbs
+++ b/SingularityUI/app/templates/tasksTable/tasksDecommissioningBody.hbs
@@ -1,82 +1,86 @@
-{{#unless rowsOnly}}
-    {{#if haveTasks}}
-        <table class="table table-striped">
-            <thead>
-                <tr>
-                    <th data-sort-attribute="taskId.id">
-                        Task ID
-                    </th>
-                    <th class="hidden-xs" data-sort-attribute="taskId.startedAt">
-                        Started At
-                    </th>
-                    <th class="hidden-xs" data-sort-attribute="host">
-                        Host
-                    </th>
-                    <th class="hidden-xs" data-sort-attribute="taskId.rackId">
-                        Rack
-                    </th>
-                    <th class="visible-lg" data-sort-attribute="cpus">
-                        CPUs
-                    </th>
-                    <th class="visible-lg" data-sort-attribute="memoryMb">
-                        Memory
-                    </th>
-                    <th class="hidden-xs">
-                        {{! Actions column }}
-                    </th>
-                </tr>
-            </thead>
-            <tbody>
-    {{/if}}
-{{/unless}}
-            {{#each tasks}}
-                {{#ifInSubFilter host ../decommissioning_hosts}}
-                    <tr data-task-id="{{ taskId.id }}" data-task-host="{{ host }}">
-                        <td class='keep-in-check'>
-                            <a title="{{ taskId.id }}" href="{{appRoot}}/task/{{ taskId.id }}">
-                                {{ taskId.id }}
-                            </a>
-                        </td>
-                        <td class="hidden-xs">
-                            {{timestampFromNow taskId.startedAt}}
-                        </td>
-                        <td class="hidden-xs">
-                            <a href='{{appRoot}}/tasks/decommissioning/all/{{host}}'>
-                                {{ host }}
-                            </a>
-                            <span class='label label-warning'>DECOMMISSIONING</span>
-                        </td>
-                        <td class="visible-lg">
-                            <a href='{{appRoot}}/tasks/decommissioning/all/{{rackId}}'>
-                                {{ rackId }}
-                            </a>
-                        </td>
-                        <td class="visible-lg">
-                            {{ cpus }}
-                        </td>
-                        <td class="hidden-xs">
-                            {{ memoryMb }} MB
-                        </td>
-                        <td class="actions-column hidden-xs">
-                            <a data-task-id="{{ taskId.id }}" data-action="remove" title="Kill task">
-                                <span class="glyphicon glyphicon-remove"></span>
-                            </a>
-                            <a data-task-id="{{ taskId.id }}" data-action="viewJSON" title="JSON">
-                                { }
-                            </a>
-                        </td>
+{{#if decomissioning_tasks}}
+    {{#unless rowsOnly}}
+        {{#if haveTasks}}
+            <table class="table table-striped">
+                <thead>
+                    <tr>
+                        <th data-sort-attribute="taskId.id">
+                            Task ID
+                        </th>
+                        <th class="hidden-xs" data-sort-attribute="taskId.startedAt">
+                            Started At
+                        </th>
+                        <th class="hidden-xs" data-sort-attribute="host">
+                            Host
+                        </th>
+                        <th class="hidden-xs" data-sort-attribute="taskId.rackId">
+                            Rack
+                        </th>
+                        <th class="visible-lg" data-sort-attribute="cpus">
+                            CPUs
+                        </th>
+                        <th class="visible-lg" data-sort-attribute="memoryMb">
+                            Memory
+                        </th>
+                        <th class="hidden-xs">
+                            {{! Actions column }}
+                        </th>
                     </tr>
-                {{/ifInSubFilter}}
-            {{/each}}
-{{#unless rowsOnly}}
-    {{#if haveTasks}}
-            </tbody>
-        </table>
-    {{else}}
-        {{#if collectionSynced}}
-            <div class="empty-table-message"><p>No active tasks</p></div>
-        {{else}}
-            <div class="page-loader centered cushy"></div>
+                </thead>
+                <tbody>
         {{/if}}
-    {{/if}}
-{{/unless}}
+    {{/unless}}
+                {{#each tasks}}
+                    {{#ifInSubFilter taskId.id ../decomissioning_tasks}}
+                        <tr data-task-id="{{ taskId.id }}" data-task-host="{{ host }}">
+                            <td class='keep-in-check'>
+                                <a title="{{ taskId.id }}" href="{{appRoot}}/task/{{ taskId.id }}">
+                                    {{ taskId.id }}
+                                </a>
+                            </td>
+                            <td class="hidden-xs">
+                                {{timestampFromNow taskId.startedAt}}
+                            </td>
+                            <td class="hidden-xs">
+                                <a href='{{appRoot}}/tasks/decommissioning/all/{{host}}'>
+                                    {{ host }}
+                                </a>
+                                <span class='label label-warning'>DECOMMISSIONING</span>
+                            </td>
+                            <td class="visible-lg">
+                                <a href='{{appRoot}}/tasks/decommissioning/all/{{rackId}}'>
+                                    {{ rackId }}
+                                </a>
+                            </td>
+                            <td class="visible-lg">
+                                {{ cpus }}
+                            </td>
+                            <td class="hidden-xs">
+                                {{ memoryMb }} MB
+                            </td>
+                            <td class="actions-column hidden-xs">
+                                <a data-task-id="{{ taskId.id }}" data-action="remove" title="Kill task">
+                                    <span class="glyphicon glyphicon-remove"></span>
+                                </a>
+                                <a data-task-id="{{ taskId.id }}" data-action="viewJSON" title="JSON">
+                                    { }
+                                </a>
+                            </td>
+                        </tr>
+                    {{/ifInSubFilter}}
+                {{/each}}
+    {{#unless rowsOnly}}
+        {{#if haveTasks}}
+                </tbody>
+            </table>
+        {{else}}
+            {{#if collectionSynced}}
+                <div class="empty-table-message"><p>No decommissioning tasks</p></div>
+            {{else}}
+                <div class="page-loader centered cushy"></div>
+            {{/if}}
+        {{/if}}
+    {{/unless}}
+{{else}}
+    <div class="empty-table-message"><p>No decommissioning tasks</p></div>
+{{/if}}

--- a/SingularityUI/app/templates/tasksTable/tasksDecommissioningBody.hbs
+++ b/SingularityUI/app/templates/tasksTable/tasksDecommissioningBody.hbs
@@ -4,7 +4,7 @@
             <thead>
                 <tr>
                     <th data-sort-attribute="taskId.id">
-                        Name
+                        Task ID
                     </th>
                     <th class="hidden-xs" data-sort-attribute="taskId.startedAt">
                         Started

--- a/SingularityUI/app/templates/tasksTable/tasksDecommissioningBody.hbs
+++ b/SingularityUI/app/templates/tasksTable/tasksDecommissioningBody.hbs
@@ -41,7 +41,9 @@
                             {{timestampFromNow taskId.startedAt}}
                         </td>
                         <td class="hidden-xs">
-                            {{ host }}
+                            <a href='{{appRoot}}/tasks/decommissioning/all/{{host}}'>
+                                {{ host }}
+                            </a>
                             <span class='label label-warning'>DECOMMISSIONING</span>
                         </td>
                         <td class="visible-lg">

--- a/SingularityUI/app/templates/tasksTable/tasksDecommissioningBody.hbs
+++ b/SingularityUI/app/templates/tasksTable/tasksDecommissioningBody.hbs
@@ -7,7 +7,7 @@
                         Task ID
                     </th>
                     <th class="hidden-xs" data-sort-attribute="taskId.startedAt">
-                        Started
+                        Started At
                     </th>
                     <th class="hidden-xs" data-sort-attribute="host">
                         Host

--- a/SingularityUI/app/templates/tasksTable/tasksLbCleaningBody.hbs
+++ b/SingularityUI/app/templates/tasksTable/tasksLbCleaningBody.hbs
@@ -7,7 +7,7 @@
                         Task ID
                     </th>
                     <th data-sort-attribute="startedAt">
-                        Started
+                        Started At
                     </th>
                     <th data-sort-attribute="host">
                         Host

--- a/SingularityUI/app/templates/tasksTable/tasksLbCleaningBody.hbs
+++ b/SingularityUI/app/templates/tasksTable/tasksLbCleaningBody.hbs
@@ -4,7 +4,7 @@
             <thead>
                 <tr>
                     <th data-sort-attribute="id">
-                        Name
+                        Task ID
                     </th>
                     <th data-sort-attribute="startedAt">
                         Started

--- a/SingularityUI/app/templates/tasksTable/tasksLbCleaningBody.hbs
+++ b/SingularityUI/app/templates/tasksTable/tasksLbCleaningBody.hbs
@@ -37,7 +37,9 @@
                         {{timestampFromNow startedAt}}
                     </td>
                     <td>
-                        {{host}}
+                        <a href='{{appRoot}}/tasks/lbcleanup/all/{{host}}'>
+                            {{host}}
+                        </a>
                     </td>
                     <td>
                         {{rackId}}

--- a/SingularityUI/app/templates/tasksTable/tasksLbCleaningBody.hbs
+++ b/SingularityUI/app/templates/tasksTable/tasksLbCleaningBody.hbs
@@ -42,7 +42,9 @@
                         </a>
                     </td>
                     <td>
-                        {{rackId}}
+                        <a href='{{appRoot}}/tasks/lbcleanup/all/{{rackId}}'>
+                            {{ rackId }}
+                        </a>
                     </td>
                     <td>
                         {{instanceNo}}

--- a/SingularityUI/app/templates/tasksTable/tasksScheduledBody.hbs
+++ b/SingularityUI/app/templates/tasksTable/tasksScheduledBody.hbs
@@ -4,7 +4,7 @@
             <thead>
                 <tr>
                     <th data-sort-attribute="id">
-                        Name
+                        Task ID
                     </th>
                     <th class="hidden-xs" data-sort-attribute="pendingTask.pendingTaskId.nextRunAt">
                         Next run

--- a/SingularityUI/app/views/requests.coffee
+++ b/SingularityUI/app/views/requests.coffee
@@ -159,6 +159,7 @@ class RequestsView extends View
 
         @renderTable()
         @$('.actions-column a[title]').tooltip()
+        @$('.has-tooltip').tooltip()
         @$('.schedule-header span#schedule').popover({
             animation: false,
             placement : 'auto',

--- a/SingularityUI/app/views/requests.coffee
+++ b/SingularityUI/app/views/requests.coffee
@@ -27,6 +27,8 @@ class RequestsView extends View
     # Which table views have sub-filters (daemon, scheduled, on-demand)
     haveSubfilter: ['all', 'active', 'paused', 'cooldown', 'activeDeploy', 'noDeploy']
 
+    allRequestTypes: ['SERVICE', 'WORKER', 'SCHEDULED', 'ON_DEMAND', 'RUN_ONCE']
+
     # For staged rendering
     renderProgress: 0
     renderAtOnce: 100
@@ -355,22 +357,23 @@ class RequestsView extends View
 
         filter = $(event.currentTarget).data 'filter'
 
-        if not event.metaKey
-            # Select individual filters
+        currentFilter = if @subFilter then @subFilter.split '-' else []
+
+        # Select multiple filters
+        if @subFilter is 'all' or _.difference(@allRequestTypes, currentFilter).length is 0
             @subFilter = filter
         else
-            # Select multiple filters
-            currentFilter = if @subFilter is 'all' then 'SERVICE-WORKER-SCHEDULED-ON_DEMAND-RUN_ONCE' else  @subFilter
+            currentlyInFilter = _.contains currentFilter, filter
 
-            currentFilter = currentFilter.split '-'
-            needToAdd = not _.contains currentFilter, filter
-
-            if needToAdd
-                currentFilter.push filter
-            else
+            if currentlyInFilter
                 currentFilter = _.without currentFilter, filter
+            else
+                currentFilter.push filter
 
-            @subFilter = currentFilter.join '-'
+            if currentFilter.length isnt 0 and _.difference(@allRequestTypes, currentFilter).length isnt 0
+                @subFilter = currentFilter.join '-'
+            else
+                @subFilter = 'all'
 
         @updateUrl()
         @render()

--- a/SingularityUI/app/views/tasks.coffee
+++ b/SingularityUI/app/views/tasks.coffee
@@ -54,6 +54,7 @@ class TasksView extends View
         @listenTo @taskKillRecords, 'change', @render
 
         @fuzzySearch = _.memoize(@fuzzySearch)
+        @showDiskSpace = window.config.showTaskDiskSpace
 
     fuzzySearch: (filter, tasks) =>
         host =
@@ -129,6 +130,7 @@ class TasksView extends View
             collectionSynced: @collection.synced
             requestsSubFilter: @requestsSubFilter
             haveTasks: @collection.length and @collection.synced
+            showDiskSpace: @showDiskSpace
 
         partials =
             partials:
@@ -183,6 +185,8 @@ class TasksView extends View
             rowsOnly: true
             decomissioning_tasks: decomTasks
             config: config
+            showDiskSpace: @showDiskSpace
+
 
         $table = @$ ".table-staged table"
         $tableBody = $table.find "tbody"

--- a/SingularityUI/app/views/tasks.coffee
+++ b/SingularityUI/app/views/tasks.coffee
@@ -82,7 +82,7 @@ class TasksView extends View
             tasks = @fuzzySearch(@searchFilter, tasks)
 
         # Only show tasks of requests that match the clicky filters
-        if @requestsSubFilter isnt 'all'
+        if @requestsSubFilter isnt 'all' and @state is 'active'
             tasks = _.filter tasks, (task) =>
                 filter = false
 
@@ -133,6 +133,7 @@ class TasksView extends View
             requestsSubFilter: @requestsSubFilter
             haveTasks: @collection.length and @collection.synced
             showDiskSpace: @showDiskSpace
+            hideRequestTypeFilter: @state isnt 'active'
 
         partials =
             partials:

--- a/SingularityUI/app/views/tasks.coffee
+++ b/SingularityUI/app/views/tasks.coffee
@@ -32,6 +32,8 @@ class TasksView extends View
     # Cache for the task array we're currently rendering
     currentTasks: []
 
+    allRequestTypes: ['SERVICE', 'WORKER', 'SCHEDULED', 'ON_DEMAND', 'RUN_ONCE']
+
     events: =>
         _.extend super,
             'click [data-action="viewJSON"]': 'viewJson'
@@ -243,7 +245,7 @@ class TasksView extends View
                 @renderTableChunk()
 
     updateUrl: =>
-        app.router.navigate "/tasks/#{ @state }/#{ @requestsSubFilter }/#{ @searchFilter }", { replace: true }
+        app.router.navigate "/tasks/#{ @state }/#{ if @requestsSubFilter then @requestsSubFilter else 'all' }/#{ @searchFilter }", { replace: true }
 
     viewJson: (e) ->
         task =
@@ -315,22 +317,23 @@ class TasksView extends View
 
         filter = $(event.currentTarget).data 'filter'
 
-        if not event.metaKey
-            # Select individual filters
+        currentFilter = if @requestsSubFilter then @requestsSubFilter.split '-' else []
+
+        # Select multiple filters
+        if @requestsSubFilter is 'all' or _.difference(@allRequestTypes, currentFilter).length is 0
             @requestsSubFilter = filter
         else
-            # Select multiple filters
-            currentFilter = if @requestsSubFilter is 'all' then 'SERVICE-WORKER-SCHEDULED-ON_DEMAND-RUN_ONCE' else  @requestsSubFilter
+            currentlyInFilter = _.contains currentFilter, filter
 
-            currentFilter = currentFilter.split '-'
-            needToAdd = not _.contains currentFilter, filter
-
-            if needToAdd
-                currentFilter.push filter
-            else
+            if currentlyInFilter
                 currentFilter = _.without currentFilter, filter
+            else
+                currentFilter.push filter
 
-            @requestsSubFilter = currentFilter.join '-'
+            if currentFilter.length isnt 0 and _.difference(@allRequestTypes, currentFilter).length isnt 0
+                @requestsSubFilter = currentFilter.join '-'
+            else
+                @requestsSubFilter = 'all'
 
         @updateUrl()
         @render()

--- a/SingularityUI/app/views/tasks.coffee
+++ b/SingularityUI/app/views/tasks.coffee
@@ -62,9 +62,13 @@ class TasksView extends View
         id =
             extract: (o) ->
                 "#{o.id}"
+        rack =
+            extract: (o) ->
+                "#{o.rackId}"
         res1 = fuzzy.filter(filter, tasks, host)
         res2 = fuzzy.filter(filter, tasks, id)
-        _.uniq(_.pluck(_.sortBy(_.union(res1, res2), (t) => Utils.fuzzyAdjustScore(filter, t)), 'original').reverse())
+        res3 = fuzzy.filter(filter, tasks, rack)
+        _.uniq(_.pluck(_.sortBy(_.union(res3, _.union(res1, res2)), (t) => Utils.fuzzyAdjustScore(filter, t)), 'original').reverse())
 
     # Returns the array of tasks that need to be rendered
     filterCollection: =>

--- a/SingularityUI/app/views/tasks.coffee
+++ b/SingularityUI/app/views/tasks.coffee
@@ -140,6 +140,7 @@ class TasksView extends View
         # Reset search box caret
         $searchInput = $('.big-search-box')
         $searchInput[0].setSelectionRange(@prevSelectionStart, @prevSelectionEnd)
+        @$('.has-tooltip').tooltip()
 
     # Prepares the staged rendering and triggers the first one
     renderTable: =>


### PR DESCRIPTION
Implements several improvements to the tasks table page:
- `Name` field is changed to `Task ID` and `Started` is changed to `Started At`
- Host and rack fields link to a page of all tasks on said host or rack. It is now possible to filter by rackId.
- On screens that aren't extra small or large, the racks and memory columns now line up properly.
- The protip is now a tooltip on both this page and the requests page
- Tooltips on task state filter links now explain the meaning of those states. **Please review the wording of these tooltips**
- Fix an error in the decommissioning tasks table that caused it to never render.