### PR TITLE
Optional disk resource column tasks page

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/config/UIConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/UIConfiguration.java
@@ -61,7 +61,7 @@ public class UIConfiguration {
 
   @JsonProperty
   @NotNull
-  private Boolean showTaskDiskSpace = false;
+  private boolean showTaskDiskResource = false;
 
   private boolean hideNewDeployButton = false;
   private boolean hideNewRequestButton = false;
@@ -163,9 +163,9 @@ public class UIConfiguration {
     this.shellCommands = shellCommands;
   }
 
-  public Boolean isShowTaskDiskSpace() { return showTaskDiskSpace; }
+  public boolean isShowTaskDiskResource() { return showTaskDiskResource; }
 
-  public void setShowTaskDiskSpace(Boolean showTaskDiskSpace) { this.showTaskDiskSpace = showTaskDiskSpace; }
+  public void setShowTaskDiskResource(boolean showTaskDiskResource) { this.showTaskDiskResource = showTaskDiskResource; }
 
   public String getRunningTaskLogPath() {
     return runningTaskLogPath;

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/UIConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/UIConfiguration.java
@@ -59,6 +59,10 @@ public class UIConfiguration {
   @NotNull
   private List<ShellCommandDescriptor> shellCommands = Collections.emptyList();
 
+  @JsonProperty
+  @NotNull
+  private Boolean showTaskDiskSpace = false;
+
   private boolean hideNewDeployButton = false;
   private boolean hideNewRequestButton = false;
 
@@ -158,6 +162,10 @@ public class UIConfiguration {
   public void setShellCommands(List<ShellCommandDescriptor> shellCommands) {
     this.shellCommands = shellCommands;
   }
+
+  public Boolean isShowTaskDiskSpace() { return showTaskDiskSpace; }
+
+  public void setShowTaskDiskSpace(Boolean showTaskDiskSpace) { this.showTaskDiskSpace = showTaskDiskSpace; }
 
   public String getRunningTaskLogPath() {
     return runningTaskLogPath;

--- a/SingularityService/src/main/java/com/hubspot/singularity/views/IndexView.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/views/IndexView.java
@@ -56,7 +56,7 @@ public class IndexView extends View {
 
   private final String redirectOnUnauthorizedUrl;
 
-  private final Boolean showTaskDiskSpace;
+  private final boolean showTaskDiskResource;
 
   public IndexView(String singularityUriBase, String appRoot, SingularityConfiguration configuration, ObjectMapper mapper) {
     super("index.mustache");
@@ -93,7 +93,7 @@ public class IndexView extends View {
     this.runningTaskLogPath = configuration.getUiConfiguration().getRunningTaskLogPath();
     this.finishedTaskLogPath = configuration.getUiConfiguration().getFinishedTaskLogPath();
 
-    this.showTaskDiskSpace = configuration.getUiConfiguration().isShowTaskDiskSpace();
+    this.showTaskDiskResource = configuration.getUiConfiguration().isShowTaskDiskResource();
 
     this.commonHostnameSuffixToOmit = configuration.getCommonHostnameSuffixToOmit().or("");
 
@@ -215,7 +215,7 @@ public class IndexView extends View {
     return timestampFormat;
   }
 
-  public Boolean isShowTaskDiskSpace() { return showTaskDiskSpace; }
+  public Boolean isShowTaskDiskResource() { return showTaskDiskResource; }
 
   public String getTimestampWithSecondsFormat() {
     return timestampWithSecondsFormat;
@@ -249,7 +249,7 @@ public class IndexView extends View {
             ", shellCommands='" + shellCommands + '\'' +
             ", timestampFormat='" + timestampFormat + '\'' +
             ", timestampWithSecondsFormat='" + timestampWithSecondsFormat + '\'' +
-            ", showTaskDiskSpace=" + showTaskDiskSpace +
+            ", showTaskDiskResource=" + showTaskDiskResource +
             ", redirectOnUnauthorizedUrl='" + redirectOnUnauthorizedUrl + '\'' +
             ']';
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/views/IndexView.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/views/IndexView.java
@@ -56,6 +56,8 @@ public class IndexView extends View {
 
   private final String redirectOnUnauthorizedUrl;
 
+  private final Boolean showTaskDiskSpace;
+
   public IndexView(String singularityUriBase, String appRoot, SingularityConfiguration configuration, ObjectMapper mapper) {
     super("index.mustache");
 
@@ -90,6 +92,8 @@ public class IndexView extends View {
 
     this.runningTaskLogPath = configuration.getUiConfiguration().getRunningTaskLogPath();
     this.finishedTaskLogPath = configuration.getUiConfiguration().getFinishedTaskLogPath();
+
+    this.showTaskDiskSpace = configuration.getUiConfiguration().isShowTaskDiskSpace();
 
     this.commonHostnameSuffixToOmit = configuration.getCommonHostnameSuffixToOmit().or("");
 
@@ -211,6 +215,8 @@ public class IndexView extends View {
     return timestampFormat;
   }
 
+  public Boolean isShowTaskDiskSpace() { return showTaskDiskSpace; }
+
   public String getTimestampWithSecondsFormat() {
     return timestampWithSecondsFormat;
   }
@@ -243,6 +249,7 @@ public class IndexView extends View {
             ", shellCommands='" + shellCommands + '\'' +
             ", timestampFormat='" + timestampFormat + '\'' +
             ", timestampWithSecondsFormat='" + timestampWithSecondsFormat + '\'' +
+            ", showTaskDiskSpace=" + showTaskDiskSpace +
             ", redirectOnUnauthorizedUrl='" + redirectOnUnauthorizedUrl + '\'' +
             ']';
   }

--- a/SingularityUI/app/assets/index.mustache
+++ b/SingularityUI/app/assets/index.mustache
@@ -32,7 +32,7 @@
             runningTaskLogPath: "{{{ runningTaskLogPath }}}",
             finishedTaskLogPath: "{{{ finishedTaskLogPath }}}",
             commonHostnameSuffixToOmit: "{{{ commonHostnameSuffixToOmit }}}",
-            showTaskDiskSpace: {{{showTaskDiskSpace}}},
+            showTaskDiskResource: {{{showTaskDiskResource}}},
             taskS3LogOmitPrefix: "{{{ taskS3LogOmitPrefix }}}",
             slaveHttpPort: {{{slaveHttpPort}}},
             warnIfScheduledJobIsRunningPastNextRunPct: {{{warnIfScheduledJobIsRunningPastNextRunPct}}},

--- a/SingularityUI/app/assets/index.mustache
+++ b/SingularityUI/app/assets/index.mustache
@@ -32,6 +32,7 @@
             runningTaskLogPath: "{{{ runningTaskLogPath }}}",
             finishedTaskLogPath: "{{{ finishedTaskLogPath }}}",
             commonHostnameSuffixToOmit: "{{{ commonHostnameSuffixToOmit }}}",
+            showTaskDiskSpace: {{{showTaskDiskSpace}}},
             taskS3LogOmitPrefix: "{{{ taskS3LogOmitPrefix }}}",
             slaveHttpPort: {{{slaveHttpPort}}},
             warnIfScheduledJobIsRunningPastNextRunPct: {{{warnIfScheduledJobIsRunningPastNextRunPct}}},

--- a/SingularityUI/app/models/Task.coffee
+++ b/SingularityUI/app/models/Task.coffee
@@ -26,6 +26,7 @@ class Task extends Model
         if task.mesosTask?
             task.cpus     = _.find(task.mesosTask.resources, (resource) -> resource.name is 'cpus')?.scalar?.value ? ''
             task.memoryMb = _.find(task.mesosTask.resources, (resource) -> resource.name is 'mem')?.scalar?.value ? ''
+            task.diskMb   = _.find(task.mesosTask.resources, (resource) -> resource.name is 'disk')?.scalar?.value ? ''
 
         if task.taskId?
             task.id = task.taskId.id

--- a/SingularityUI/app/templates/tasksTable/tasksActiveBody.hbs
+++ b/SingularityUI/app/templates/tasksTable/tasksActiveBody.hbs
@@ -21,6 +21,11 @@
                     <th class="visible-lg" data-sort-attribute="memoryMb">
                         Memory
                     </th>
+                    {{#if showDiskSpace}}
+                        <th class="visible-lg" data-sort-attribute="memoryMb">
+                            Disk Space
+                        </th>
+                    {{/if}}
                     <th class="hidden-xs">
                         {{! Actions column }}
                     </th>
@@ -58,6 +63,11 @@
                     <td class="visible-lg" data-value="{{ memoryMb }}">
                         {{ memoryMb }} MB
                     </td>
+                    {{#if ../showDiskSpace}}
+                        <td class="visible-lg" data-value="{{ diskMb }}">
+                            {{#if diskMb}} {{ diskMb }} MB {{/if}}
+                        </td>
+                    {{/if}}
                     <td>
                         {{#if pendingTask.pendingTaskId}}
                             {{#ifTimestampInPast pendingTask.pendingTaskId.nextRunAt}}

--- a/SingularityUI/app/templates/tasksTable/tasksActiveBody.hbs
+++ b/SingularityUI/app/templates/tasksTable/tasksActiveBody.hbs
@@ -22,8 +22,8 @@
                         Memory
                     </th>
                     {{#if showDiskSpace}}
-                        <th class="visible-lg" data-sort-attribute="memoryMb">
-                            Disk Space
+                        <th class="visible-lg" data-sort-attribute="diskMb">
+                            Disk
                         </th>
                     {{/if}}
                     <th class="hidden-xs">

--- a/SingularityUI/app/templates/tasksTable/tasksDecommissioningBody.hbs
+++ b/SingularityUI/app/templates/tasksTable/tasksDecommissioningBody.hbs
@@ -21,6 +21,11 @@
                     <th class="visible-lg" data-sort-attribute="memoryMb">
                         Memory
                     </th>
+                    {{#if showDiskSpace}}
+                        <th class="visible-lg" data-sort-attribute="memoryMb">
+                            Disk Space
+                        </th>
+                    {{/if}}
                     <th class="hidden-xs">
                         {{! Actions column }}
                     </th>
@@ -57,6 +62,11 @@
                         <td class="hidden-xs">
                             {{ memoryMb }} MB
                         </td>
+                        {{#if showDiskSpace}}
+                            <td class="visible-lg" data-value="{{ diskMb }}">
+                                {{#if diskMb}} {{ diskMb }} MB {{/if}}
+                            </td>
+                        {{/if}}
                         <td class="actions-column hidden-xs">
                             <a data-task-id="{{ taskId.id }}" data-action="remove" title="Kill task">
                                 <span class="glyphicon glyphicon-remove"></span>

--- a/SingularityUI/app/templates/tasksTable/tasksDecommissioningBody.hbs
+++ b/SingularityUI/app/templates/tasksTable/tasksDecommissioningBody.hbs
@@ -23,8 +23,8 @@
                             Memory
                         </th>
                         {{#if showDiskSpace}}
-                            <th class="visible-lg" data-sort-attribute="memoryMb">
-                                Disk Space
+                            <th class="visible-lg" data-sort-attribute="diskMb">
+                                Disk
                             </th>
                         {{/if}}
                         <th class="hidden-xs">

--- a/SingularityUI/app/views/tasks.coffee
+++ b/SingularityUI/app/views/tasks.coffee
@@ -54,7 +54,7 @@ class TasksView extends View
         @listenTo @taskKillRecords, 'change', @render
 
         @fuzzySearch = _.memoize(@fuzzySearch)
-        @showDiskSpace = true
+        @showDiskSpace = window.config.showTaskDiskSpace
 
     fuzzySearch: (filter, tasks) =>
         host =

--- a/SingularityUI/app/views/tasks.coffee
+++ b/SingularityUI/app/views/tasks.coffee
@@ -54,6 +54,7 @@ class TasksView extends View
         @listenTo @taskKillRecords, 'change', @render
 
         @fuzzySearch = _.memoize(@fuzzySearch)
+        @showDiskSpace = true
 
     fuzzySearch: (filter, tasks) =>
         host =
@@ -129,6 +130,7 @@ class TasksView extends View
             collectionSynced: @collection.synced
             requestsSubFilter: @requestsSubFilter
             haveTasks: @collection.length and @collection.synced
+            showDiskSpace: @showDiskSpace
 
         partials =
             partials:
@@ -183,6 +185,8 @@ class TasksView extends View
             rowsOnly: true
             decomissioning_tasks: decomTasks
             config: config
+            showDiskSpace: @showDiskSpace
+
 
         $table = @$ ".table-staged table"
         $tableBody = $table.find "tbody"


### PR DESCRIPTION
This adds an optional 'disk resource' column to the tasks page. It will be configurable in singularity.yml under `ui`.
This is separate from #1017 because unlike the rest of the improvements to the tasks page, this depends on #993.