### PR TITLE
Dashboard page improvements

### DIFF
--- a/SingularityUI/app/templates/dashboard.hbs
+++ b/SingularityUI/app/templates/dashboard.hbs
@@ -1,6 +1,6 @@
 <header>
     {{#if deployUser}}
-        <h1>{{ deployUser }} <small><a data-action="change-user">change</a></small></h1>
+        <h1>{{ deployUser }}</h1>
     {{else}}
         <h1>Singularity</h1>
     {{/if}}

--- a/SingularityUI/app/templates/dashboardTable/dashboardStarred.hbs
+++ b/SingularityUI/app/templates/dashboardTable/dashboardStarred.hbs
@@ -4,6 +4,7 @@
             <tr>
                 <th>{{! Star column }}</th>
                 <th>Request</th>
+                <th>Type</th>
                 <th class="hidden-xs">Time of Last Deploy</th>
                 <th>Status</th>
                 <th class="visible-lg visible-md">Deploy user</th>
@@ -23,6 +24,9 @@
                 <a href="{{appRoot}}/request/{{ request.id }}">
                     {{ request.id }}
                 </a>
+            </td>
+            <td>
+                {{humanizeText request.requestType}}
             </td>
             <td class="hidden-xs" data-value="{{ requestDeployState.activeDeploy.timestamp }}">
                 <span title="{{ requestDeployState.activeDeploy.timestamp }}">

--- a/SingularityUI/app/templates/dashboardTable/dashboardStarred.hbs
+++ b/SingularityUI/app/templates/dashboardTable/dashboardStarred.hbs
@@ -4,7 +4,7 @@
             <tr>
                 <th>{{! Star column }}</th>
                 <th>Request</th>
-                <th class="hidden-xs">Requested</th>
+                <th class="hidden-xs">Time of Last Deploy</th>
                 <th>Status</th>
                 <th class="visible-lg visible-md">Deploy user</th>
                 <th class="visible-lg visible-md">Instances</th>

--- a/SingularityUI/app/templates/requestsTable/requestsPausedBody.hbs
+++ b/SingularityUI/app/templates/requestsTable/requestsPausedBody.hbs
@@ -12,9 +12,11 @@
                     <th class="hidden-xs" data-sort-attribute="requestDeployState.activeDeploy.timestamp">
                         Time of Last Deploy
                     </th>
-                    <th class="hidden-sm hidden-xs" data-sort-attribute="requestDeployState.activeDeploy.user">
-                        Deploy user
-                    </th>
+                    {{#unless onDashboardPage}}
+                        <th class="hidden-sm hidden-xs" data-sort-attribute="requestDeployState.activeDeploy.user">
+                            Deploy user
+                        </th>
+                    {{/unless}}
 
                     {{#ifInSubFilter 'SCHEDULED' requestsSubFilter}}
                         <th class="visible-lg visible-xl schedule-header" data-sort-attribute="request.schedule">
@@ -45,9 +47,11 @@
                         <td class="hidden-xs" data-value="{{requestDeployState.activeDeploy.timestamp}}">
                             {{timestampFromNow requestDeployState.activeDeploy.timestamp}}
                         </td>
-                        <td class="hidden-sm hidden-xs">
-                            {{usernameFromEmail requestDeployState.activeDeploy.user}}
-                        </td>
+                        {{#unless ../onDashboardPage}}
+                            <td class="hidden-sm hidden-xs">
+                                {{usernameFromEmail requestDeployState.activeDeploy.user}}
+                            </td>
+                        {{/unless}}
 
                         {{#ifInSubFilter 'SCHEDULED' ../requestsSubFilter}}
                             <td class="visible-lg visible-xl">

--- a/SingularityUI/app/templates/requestsTable/requestsPausedBody.hbs
+++ b/SingularityUI/app/templates/requestsTable/requestsPausedBody.hbs
@@ -10,7 +10,7 @@
                         Type
                     </th>
                     <th class="hidden-xs" data-sort-attribute="requestDeployState.activeDeploy.timestamp">
-                        Requested
+                        Time of Last Deploy
                     </th>
                     <th class="hidden-sm hidden-xs" data-sort-attribute="requestDeployState.activeDeploy.user">
                         Deploy user

--- a/SingularityUI/app/views/dashboard.coffee
+++ b/SingularityUI/app/views/dashboard.coffee
@@ -9,7 +9,6 @@ class DashboardView extends View
     events: ->
         _.extend super,
             'click [data-action="unstar"]': 'unstar'
-            'click [data-action="change-user"]': 'changeUser'
             'click th[data-sort-attribute]': 'sortTable'
             'click [data-action="viewJSON"]': 'viewJson'
             'click [data-action="remove"]': 'removeRequest'
@@ -118,9 +117,6 @@ class DashboardView extends View
 
         if @$('tbody tr').length is 0
             @render()
-
-    changeUser: =>
-        app.deployUserPrompt()
 
     getRequest: (id) =>
         maybeRequest = @collection.models.filter (model) ->

--- a/SingularityUI/app/views/dashboard.coffee
+++ b/SingularityUI/app/views/dashboard.coffee
@@ -40,6 +40,7 @@ class DashboardView extends View
                 requests: pausedRequests
                 haveRequests: pausedRequests.length > 0
                 requestsSubFilter: ''
+                onDashboardPage: true
                 collectionSynced: @collection.synced
 
         @$el.html @templateBase context, partials


### PR DESCRIPTION
This implements the following changes to the dashboard page:
- Don't show the `change` link next to the username (it tried to call a nonexistent function, so we know it was useless anyway)
- Change the name of the `Requested` column in paused requests and starred requests to `Time of Last Deploy`. This also changes the name of the same column in the paused requests table on the Requests page
- Don't show `Deploy User` on the paused requests table on the dashboard (still will show it on the paused requests table on the Requests page)
- Add a `Request type` column on the starred requests table