### PR TITLE
Transition Resource Usage Badge & Bar Back to Normal When CPU Safe

### DIFF
--- a/SingularityUI/app/models/TaskResourceUsage.coffee
+++ b/SingularityUI/app/models/TaskResourceUsage.coffee
@@ -15,9 +15,12 @@ class TaskResourceUsage extends Model
         cpus_used = (currentTime - previousTime) / timestampDiff
         cpuUsageExceeding = (cpus_used / @get('cpusLimit')) > 1.10
         
+        @set 'cpuUsageExceeding', cpuUsageExceeding
         if cpuUsageExceeding
-            @set 'cpuUsageExceeding', cpuUsageExceeding
             @set 'cpuUsageClassStatus', 'danger'
+        else
+            @set 'cpuUsageClassStatus', 'success'
+
         @set 'cpuUsage', cpus_used
 
 module.exports = TaskResourceUsage


### PR DESCRIPTION
When the CPU usage was more than 1.1x the allowed amount, but fell below 1.1x the allowed amount the UI wouldn't transition back to showing that the CPU usage is safe. Now it will.