### PR TITLE
Show TASK_ERROR state as danger in the UI

### DIFF
--- a/SingularityUI/app/components/taskSearch/Enums.cjsx
+++ b/SingularityUI/app/components/taskSearch/Enums.cjsx
@@ -5,6 +5,7 @@ class Enums
                         {user: 'Descending', value: 'DESC'}]
 
     @extendedTaskState:  -> return [
+                        {user: 'Error', value: 'TASK_ERROR'},
                         {user: 'Failed', value: 'TASK_FAILED'},
                         {user: 'Finished', value: 'TASK_FINISHED'},
                         {user: 'Killed', value: 'TASK_KILLED'},

--- a/SingularityUI/app/components/taskSearch/TaskSearchForm.cjsx
+++ b/SingularityUI/app/components/taskSearch/TaskSearchForm.cjsx
@@ -5,6 +5,9 @@ FormField = require '../common/formItems/FormField'
 DropDown = require '../common/formItems/DropDown'
 DateEntry = require '../common/formItems/DateEntry'
 LinkedFormItem = require '../common/formItems/LinkedFormItem'
+Glyphicon = require '../common/atomicDisplayItems/Glyphicon'
+OverlayTrigger = require 'react-bootstrap/lib/OverlayTrigger'
+ToolTip = require 'react-bootstrap/lib/Tooltip'
 Enums = require './Enums'
 
 TaskSearchForm = React.createClass
@@ -39,10 +42,21 @@ TaskSearchForm = React.createClass
         </div>
 
     getLastTaskStatusTitle: ->
-        <div>
+        lastTaskStatusTitle = <div className={if @props.lastTaskStatus is 'TASK_ERROR' then 'color-error' else ''}>
+            {if @props.lastTaskStatus is 'TASK_ERROR'
+                <span><Glyphicon iconClass='info-sign' /> </span>}
             Last Task Status
             {<span className='badge current-query-param'>{@props.lastTaskStatusCurrentSearch}</span> if @props.lastTaskStatusCurrentSearch}
         </div>
+        if @props.lastTaskStatus is 'TASK_ERROR'
+            <OverlayTrigger
+                placement = 'top'
+                overlay = {<ToolTip id='lastTaskStatusTitleTip'>Error is an extremely rare task state. You may have meant to search for 'Failed'</ToolTip>}
+            >
+                {lastTaskStatusTitle}
+            </OverlayTrigger>
+        else
+            lastTaskStatusTitle
 
     render: ->
         render: ->

--- a/SingularityUI/app/components/taskSearch/TaskSearchForm.cjsx
+++ b/SingularityUI/app/components/taskSearch/TaskSearchForm.cjsx
@@ -5,9 +5,6 @@ FormField = require '../common/formItems/FormField'
 DropDown = require '../common/formItems/DropDown'
 DateEntry = require '../common/formItems/DateEntry'
 LinkedFormItem = require '../common/formItems/LinkedFormItem'
-Glyphicon = require '../common/atomicDisplayItems/Glyphicon'
-OverlayTrigger = require 'react-bootstrap/lib/OverlayTrigger'
-ToolTip = require 'react-bootstrap/lib/Tooltip'
 Enums = require './Enums'
 
 TaskSearchForm = React.createClass
@@ -42,21 +39,10 @@ TaskSearchForm = React.createClass
         </div>
 
     getLastTaskStatusTitle: ->
-        lastTaskStatusTitle = <div className={if @props.lastTaskStatus is 'TASK_ERROR' then 'color-error' else ''}>
-            {if @props.lastTaskStatus is 'TASK_ERROR'
-                <span><Glyphicon iconClass='info-sign' /> </span>}
+        <div>
             Last Task Status
             {<span className='badge current-query-param'>{@props.lastTaskStatusCurrentSearch}</span> if @props.lastTaskStatusCurrentSearch}
         </div>
-        if @props.lastTaskStatus is 'TASK_ERROR'
-            <OverlayTrigger
-                placement = 'top'
-                overlay = {<ToolTip id='lastTaskStatusTitleTip'>Error is an extremely rare task state. You may have meant to search for 'Failed'</ToolTip>}
-            >
-                {lastTaskStatusTitle}
-            </OverlayTrigger>
-        else
-            lastTaskStatusTitle
 
     render: ->
         render: ->

--- a/SingularityUI/app/utils.coffee
+++ b/SingularityUI/app/utils.coffee
@@ -4,7 +4,7 @@ vex = require 'vex.dialog'
 class Utils
 
     # Constants
-    @TERMINAL_TASK_STATES: ['TASK_KILLED', 'TASK_LOST', 'TASK_FAILED', 'TASK_FINISHED']
+    @TERMINAL_TASK_STATES: ['TASK_KILLED', 'TASK_LOST', 'TASK_FAILED', 'TASK_FINISHED', 'TASK_ERROR']
     @DECOMMISION_STATES: ['DECOMMISSIONING', 'DECOMMISSIONED', 'STARTING_DECOMMISSION', 'DECOMISSIONING', 'DECOMISSIONED', 'STARTING_DECOMISSION']
 
     @viewJSON: (model, callback) ->
@@ -205,7 +205,7 @@ class Utils
                 'info'
             when 'TASK_FINISHED'
                 'success'
-            when 'TASK_LOST', 'TASK_FAILED', 'TASK_LOST_WHILE_DOWN'
+            when 'TASK_LOST', 'TASK_FAILED', 'TASK_LOST_WHILE_DOWN', 'TASK_ERROR'
                 'danger'
             when 'TASK_KILLED'
                 'default'


### PR DESCRIPTION
This is a task state that should usually not happen, but as I've found out it's actually possible in certain rare cases.

This makes the UI aware of this state and shows it as a danger state like TASK_FAILED.