### PR TITLE
Don't count non-active requests towards total number of requests on the dashboard page

### DIFF
--- a/SingularityUI/app/collections/Requests.coffee
+++ b/SingularityUI/app/collections/Requests.coffee
@@ -77,7 +77,7 @@ class Requests extends Collection
         userRequests = @getUserRequests user
 
         userRequestTotals =
-            all: userRequests.length
+            all: 0
             onDemand: 0
             worker: 0
             scheduled: 0
@@ -89,6 +89,8 @@ class Requests extends Collection
             type = request.get 'type'
 
             continue if request.get('state') isnt 'ACTIVE'
+
+            userRequestTotals.all += 1
 
             if type is 'ON_DEMAND'  then userRequestTotals.onDemand  += 1
             if type is 'SCHEDULED'  then userRequestTotals.scheduled += 1

--- a/SingularityUI/app/templates/dashboard.hbs
+++ b/SingularityUI/app/templates/dashboard.hbs
@@ -11,7 +11,7 @@
         <div class="row">
             <div class="col-md-12">
                 <div class="page-header">
-                    <h2>My requests</h2>
+                    <h2>My active requests</h2>
                 </div>
                 <div class="row">
                     <div class="col-md-2">


### PR DESCRIPTION
Fixes the bug where the total number of requests are not equal to the sum of the number of each type of request by not counting non-active requests towards the individual number of requests of each type.