### PR TITLE
Count non-active requests towards request totals on dashboard page

### DIFF
--- a/SingularityUI/app/collections/Requests.coffee
+++ b/SingularityUI/app/collections/Requests.coffee
@@ -88,8 +88,6 @@ class Requests extends Collection
 
             type = request.get 'type'
 
-            continue if request.get('state') isnt 'ACTIVE'
-
             if type is 'ON_DEMAND'  then userRequestTotals.onDemand  += 1
             if type is 'SCHEDULED'  then userRequestTotals.scheduled += 1
             if type is 'WORKER'     then userRequestTotals.worker    += 1


### PR DESCRIPTION
Fixes the bug where the total number of requests are not equal to the sum of the number of each type of request by counting non-active requests towards the total number of requests.