### PR TITLE
Better Request and Deploy ID Validation

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
@@ -6,12 +6,14 @@ import static com.hubspot.singularity.WebExceptions.checkBadRequest;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
 import javax.inject.Singleton;
 
+import org.apache.commons.lang.StringUtils;
 
 import org.quartz.CronExpression;
 
@@ -40,6 +42,8 @@ import com.hubspot.singularity.data.history.DeployHistoryHelper;
 @Singleton
 public class SingularityValidator {
   private static final Joiner JOINER = Joiner.on(" ");
+  private static final List<Character> DEPLOY_ID_ILLEGAL_CHARACTERS = Arrays.asList('@', '-', '\\', '/', '*', '?', '%', ' ', '[', ']', '#', '$'); // Characters that make Mesos or URL bars sad
+  private static final List<Character> REQUEST_ID_ILLEGAL_CHARACTERS = Arrays.asList('@', '\\', '/', '*', '?', '%', ' ', '[', ']', '#', '$'); // Characters that make Mesos or URL bars sad
 
   private final int maxDeployIdSize;
   private final int maxRequestIdSize;
@@ -103,7 +107,7 @@ public class SingularityValidator {
   public SingularityRequest checkSingularityRequest(SingularityRequest request, Optional<SingularityRequest> existingRequest, Optional<SingularityDeploy> activeDeploy,
       Optional<SingularityDeploy> pendingDeploy) {
 
-    checkBadRequest(request.getId() != null && !request.getId().contains("/"), "Id can not be null or contain / characters");
+    checkBadRequest(request.getId() != null && !StringUtils.containsAny(request.getId(), JOINER.join(REQUEST_ID_ILLEGAL_CHARACTERS)), "Id can not be null or contain any of the following characters: %s", REQUEST_ID_ILLEGAL_CHARACTERS);
     checkBadRequest(request.getRequestType() != null, "RequestType cannot be null or missing");
 
     if (!allowRequestsWithoutOwners) {
@@ -197,7 +201,7 @@ public class SingularityValidator {
       deployId = deploy.getId();
     }
 
-    checkBadRequest(!deployId.contains("/") && !deployId.contains("-"), "Id must not be null and can not contain / or - characters");
+    checkBadRequest(deployId != null && !StringUtils.containsAny(deployId, JOINER.join(DEPLOY_ID_ILLEGAL_CHARACTERS)), "Id must not be null and can not contain any of the following characters: %s", DEPLOY_ID_ILLEGAL_CHARACTERS);
     checkBadRequest(deployId.length() < maxDeployIdSize, "Deploy id must be less than %s characters, it is %s (%s)", maxDeployIdSize, deployId.length(), deployId);
     checkBadRequest(deploy.getRequestId() != null && deploy.getRequestId().equals(request.getId()), "Deploy id must match request id");
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
@@ -13,7 +13,7 @@ import java.util.regex.Pattern;
 
 import javax.inject.Singleton;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.quartz.CronExpression;
 

--- a/SingularityUI/app/views/requestFormEdit.coffee
+++ b/SingularityUI/app/views/requestFormEdit.coffee
@@ -74,8 +74,7 @@ class RequestFormEdit extends RequestFormBaseView
             @postSave()
 
             app.caughtError()
-            @alert "There was a problem saving your request. The server response has been logged to your JS console.", false
-            console.error response
+            @alert "There was a problem saving your request: #{ response.responseText }", false
 
 
 module.exports = RequestFormEdit

--- a/SingularityUI/app/views/requestFormNew.coffee
+++ b/SingularityUI/app/views/requestFormNew.coffee
@@ -20,8 +20,7 @@ class RequestFormNew extends RequestFormBaseView
             @postSave()
 
             app.caughtError()
-            @alert "There was a problem saving your request. The server response has been logged to your JS console.", false
-            console.error response
+            @alert "There was a problem saving your request: #{ response.responseText }", false
 
 
 module.exports = RequestFormNew


### PR DESCRIPTION
Reject more characters from request IDs and deploy IDs to prevent tasks from being created that can either never be run in Mesos or would have URLs that can't be visited.