### PR TITLE
Add a "defaultPortMapping" option which exposes all Mesos provided ports

### DIFF
--- a/Docs/reference/configuration.md
+++ b/Docs/reference/configuration.md
@@ -232,7 +232,7 @@ These settings live under the "sentry" field in the root config and enable Singu
 
 ## SMTP ##
 
-These settings live under the "smtp" field in teh root config.
+These settings live under the "smtp" field in the root config.
 
 | Parameter | Default | Description | Type |
 |-----------|---------|-------------|------|

--- a/Docs/reference/configuration.md
+++ b/Docs/reference/configuration.md
@@ -21,6 +21,7 @@ Singularity (Service) is configured by DropWizard via a YAML file referenced on 
     - [Resource Limits](#resource-limits)
     - [Racks](#racks)
     - [Slaves](#slaves)
+  - [Network Configuration](#network-configuration)
   - [Database](#database)
     - [History Purging](#history-purging)
   - [S3](#s3)
@@ -191,6 +192,14 @@ These settings should live under the "mesos" field inside the root configuration
 | Parameter | Default | Description | Type |
 |-----------|---------|-------------|------|
 | database | | The database connection for SingularityService follows the [dropwizard DataSourceFactory format](http://www.dropwizard.io/0.7.0/dropwizard-db/apidocs/io/dropwizard/db/DataSourceFactory.html) | [DataSourceFactory](http://www.dropwizard.io/0.7.0/dropwizard-db/apidocs/io/dropwizard/db/DataSourceFactory.html) |
+
+## Network Configuration
+
+These settings should live under the "network" field of the root configuration.
+
+| Parameter | Default | Description | Type |
+|-----------|---------|-------------|------|
+| defaultPortMapping | false | If no port mapping is provided, map all Mesos-provided ports to the host | boolean |
 
 #### History Purging ####
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/NetworkConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/NetworkConfiguration.java
@@ -1,0 +1,18 @@
+package com.hubspot.singularity.config;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties( ignoreUnknown = true )
+public class NetworkConfiguration {
+  private boolean defaultPortMapping;
+
+  public void setDefaultPortMapping(boolean defaultPortMapping)
+  {
+    this.defaultPortMapping = defaultPortMapping;
+  }
+
+  public boolean isDefaultPortMapping()
+  {
+    return defaultPortMapping;
+  }
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -169,6 +169,10 @@ public class SingularityConfiguration extends Configuration {
   @Valid
   private MesosConfiguration mesosConfiguration;
 
+  @JsonProperty("network")
+  @Valid
+  private NetworkConfiguration networkConfiguration = new NetworkConfiguration();
+
   private int newTaskCheckerBaseDelaySeconds = 1;
 
   private long pendingDeployHoldTaskDuringDecommissionMillis = TimeUnit.MINUTES.toMillis(10);
@@ -523,6 +527,10 @@ public class SingularityConfiguration extends Configuration {
     return mesosConfiguration;
   }
 
+  public NetworkConfiguration getNetworkConfiguration() {
+    return networkConfiguration;
+  }
+
   public int getNewTaskCheckerBaseDelaySeconds() {
     return newTaskCheckerBaseDelaySeconds;
   }
@@ -841,6 +849,10 @@ public class SingularityConfiguration extends Configuration {
 
   public void setMesosConfiguration(MesosConfiguration mesosConfiguration) {
     this.mesosConfiguration = mesosConfiguration;
+  }
+
+  public void setNetworkConfiguration(NetworkConfiguration networkConfiguration) {
+    this.networkConfiguration = networkConfiguration;
   }
 
   public void setNewTaskCheckerBaseDelaySeconds(int newTaskCheckerBaseDelaySeconds) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilder.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilder.java
@@ -239,6 +239,14 @@ class SingularityMesosTaskBuilder {
             dockerInfoBuilder.addPortMappings(maybePortMapping.get());
           }
         }
+      } else if (configuration.getNetworkConfiguration().isDefaultPortMapping() && dockerInfo.get().getPortMappings().isEmpty() && ports.isPresent()) {
+        for (long longPort : ports.get()) {
+          int port = Ints.checkedCast(longPort);
+          dockerInfoBuilder.addPortMappings(DockerInfo.PortMapping.newBuilder()
+              .setHostPort(port)
+              .setContainerPort(port)
+              .build());
+        }
       }
 
       if (!dockerInfo.get().getParameters().isEmpty()) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilder.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilder.java
@@ -231,15 +231,16 @@ class SingularityMesosTaskBuilder {
         dockerInfoBuilder.setNetwork(DockerInfo.Network.valueOf(dockerInfo.get().getNetwork().get().toString()));
       }
 
-      if ((dockerInfo.get().hasAllLiteralHostPortMappings() || ports.isPresent()) && !dockerInfo.get().getPortMappings().isEmpty()) {
-        for (SingularityDockerPortMapping singularityDockerPortMapping : dockerInfo.get().getPortMappings()) {
+      List<SingularityDockerPortMapping> portMappings = dockerInfo.get().getPortMappings();
+      if ((dockerInfo.get().hasAllLiteralHostPortMappings() || ports.isPresent()) && !portMappings.isEmpty()) {
+        for (SingularityDockerPortMapping singularityDockerPortMapping : portMappings) {
           final Optional<DockerInfo.PortMapping> maybePortMapping = buildPortMapping(singularityDockerPortMapping, ports);
 
           if (maybePortMapping.isPresent()) {
             dockerInfoBuilder.addPortMappings(maybePortMapping.get());
           }
         }
-      } else if (configuration.getNetworkConfiguration().isDefaultPortMapping() && dockerInfo.get().getPortMappings().isEmpty() && ports.isPresent()) {
+      } else if (configuration.getNetworkConfiguration().isDefaultPortMapping() && portMappings.isEmpty() && ports.isPresent()) {
         for (long longPort : ports.get()) {
           int port = Ints.checkedCast(longPort);
           dockerInfoBuilder.addPortMappings(DockerInfo.PortMapping.newBuilder()

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilderTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilderTest.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.mesos.Protos;
+import org.apache.mesos.Protos.ContainerInfo.DockerInfo.PortMapping;
 import org.apache.mesos.Protos.ContainerInfo.Type;
 import org.apache.mesos.Protos.FrameworkID;
 import org.apache.mesos.Protos.Offer;
@@ -48,10 +49,12 @@ import com.hubspot.singularity.SingularityRequest;
 import com.hubspot.singularity.SingularityRequestBuilder;
 import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.SingularityTaskRequest;
+import com.hubspot.singularity.config.NetworkConfiguration;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.ExecutorIdGenerator;
 
 public class SingularityMesosTaskBuilderTest {
+  private final SingularityConfiguration configuration = new SingularityConfiguration();
   private SingularityMesosTaskBuilder builder;
   private Resources taskResources;
   private Resources executorResources;
@@ -68,7 +71,7 @@ public class SingularityMesosTaskBuilderTest {
 
     when(idGenerator.getNextExecutorId()).then(new CreateFakeId());
 
-    builder = new SingularityMesosTaskBuilder(new ObjectMapper(), slaveAndRackHelper, idGenerator, new SingularityConfiguration());
+    builder = new SingularityMesosTaskBuilder(new ObjectMapper(), slaveAndRackHelper, idGenerator, configuration);
 
     taskResources = new Resources(1, 1, 0);
     executorResources = new Resources(0.1, 1, 0);
@@ -186,7 +189,9 @@ public class SingularityMesosTaskBuilderTest {
         SingularityContainerType.DOCKER,
         Optional.<List<SingularityVolume>>absent(),
         Optional.of(new SingularityDockerInfo("docker-image", true, SingularityDockerNetworkType.NONE,
-            Optional.<List<SingularityDockerPortMapping>>absent())));
+            Optional.<List<SingularityDockerPortMapping>>absent(),
+            Optional.<Boolean>absent(),
+            Optional.<Map<String, String>>absent())));
     final SingularityDeploy deploy = new SingularityDeployBuilder("test", "1")
         .setContainerInfo(Optional.of(containerInfo))
         .build();
@@ -195,6 +200,41 @@ public class SingularityMesosTaskBuilderTest {
 
     assertEquals(Type.DOCKER, task.getMesosTask().getContainer().getType());
     assertEquals(Protos.ContainerInfo.DockerInfo.Network.NONE, task.getMesosTask().getContainer().getDocker().getNetwork());
+  }
+
+  @Test
+  public void testAutomaticPortMapping() {
+    NetworkConfiguration netConf = new NetworkConfiguration();
+    netConf.setDefaultPortMapping(true);
+    configuration.setNetworkConfiguration(netConf);
+
+    taskResources = new Resources(1, 1, 2);
+
+    final SingularityRequest request = new SingularityRequestBuilder("test", RequestType.WORKER).build();
+    final SingularityContainerInfo containerInfo = new SingularityContainerInfo(
+        SingularityContainerType.DOCKER,
+        Optional.<List<SingularityVolume>>absent(),
+        Optional.of(new SingularityDockerInfo("docker-image", false, SingularityDockerNetworkType.BRIDGE,
+            Optional.<List<SingularityDockerPortMapping>>absent(),
+            Optional.<Boolean>absent(),
+            Optional.<Map<String, String>>absent())));
+    final SingularityDeploy deploy = new SingularityDeployBuilder("test", "1")
+        .setContainerInfo(Optional.of(containerInfo))
+        .build();
+    final SingularityTaskRequest taskRequest = new SingularityTaskRequest(request, deploy, pendingTask);
+    final SingularityTask task = builder.buildTask(offer, Collections.singletonList(MesosUtils.getPortRangeResource(31010, 31011)), taskRequest, taskResources, executorResources);
+
+    assertEquals(Type.DOCKER, task.getMesosTask().getContainer().getType());
+    assertEquals(Protos.ContainerInfo.DockerInfo.Network.BRIDGE, task.getMesosTask().getContainer().getDocker().getNetwork());
+
+    List<PortMapping> portMappings = task.getMesosTask().getContainer().getDocker().getPortMappingsList();
+    assertEquals(2, portMappings.size());
+
+    assertEquals(31010, portMappings.get(0).getHostPort());
+    assertEquals(31010, portMappings.get(0).getContainerPort());
+
+    assertEquals(31011, portMappings.get(1).getHostPort());
+    assertEquals(31011, portMappings.get(1).getContainerPort());
   }
 
   private static class CreateFakeId implements Answer<String> {


### PR DESCRIPTION
Our apps generally ask for 1 or 2 ports.  It's a pain to repeatedly write
```
      "portMappings": [
        {"hostPort": 0, "hostPortType": "FROM_OFFER", "containerPort": 0, "containerPortType": "FROM_OFFER"},
        {"hostPort": 1, "hostPortType": "FROM_OFFER", "containerPort": 1, "containerPortType": "FROM_OFFER"}
      ]
```

so why not just let Singularity fill it in for you?