### PR TITLE
configurable max metadata message length

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityTaskMetadataConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityTaskMetadataConfiguration.java
@@ -14,6 +14,8 @@ public class SingularityTaskMetadataConfiguration {
 
   private Optional<String> sendTaskCompletedMailOnceMetadataTypeIsAvailable = Optional.absent();
 
+  private long maxMetadataMessageBytes = 10000;
+
   public long getTaskPersistAfterFinishBufferMillis() {
     return taskPersistAfterFinishBufferMillis;
   }
@@ -46,4 +48,11 @@ public class SingularityTaskMetadataConfiguration {
     this.sendTaskCompletedMailOnceMetadataTypeIsAvailable = sendTaskCompletedMailOnceMetadataTypeIsAvailable;
   }
 
+  public long getMaxMetadataMessageBytes() {
+    return maxMetadataMessageBytes;
+  }
+
+  public void setMaxMetadataMessageBytes(long maxMetadataMessageBytes) {
+    this.maxMetadataMessageBytes = maxMetadataMessageBytes;
+  }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityTaskMetadataConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityTaskMetadataConfiguration.java
@@ -16,6 +16,8 @@ public class SingularityTaskMetadataConfiguration {
 
   private long maxMetadataMessageBytes = 10000;
 
+  private long maxMetadataTitleBytes = 2000;
+
   public long getTaskPersistAfterFinishBufferMillis() {
     return taskPersistAfterFinishBufferMillis;
   }
@@ -54,5 +56,13 @@ public class SingularityTaskMetadataConfiguration {
 
   public void setMaxMetadataMessageBytes(long maxMetadataMessageBytes) {
     this.maxMetadataMessageBytes = maxMetadataMessageBytes;
+  }
+
+  public long getMaxMetadataTitleBytes() {
+    return maxMetadataTitleBytes;
+  }
+
+  public void setMaxMetadataTitleBytes(long maxMetadataTitleBytes) {
+    this.maxMetadataTitleBytes = maxMetadataTitleBytes;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityTaskMetadataConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityTaskMetadataConfiguration.java
@@ -14,9 +14,9 @@ public class SingularityTaskMetadataConfiguration {
 
   private Optional<String> sendTaskCompletedMailOnceMetadataTypeIsAvailable = Optional.absent();
 
-  private long maxMetadataMessageBytes = 10000;
+  private long maxMetadataMessageLength = 10000;
 
-  private long maxMetadataTitleBytes = 2000;
+  private long maxMetadataTitleLength = 2000;
 
   public long getTaskPersistAfterFinishBufferMillis() {
     return taskPersistAfterFinishBufferMillis;
@@ -50,19 +50,19 @@ public class SingularityTaskMetadataConfiguration {
     this.sendTaskCompletedMailOnceMetadataTypeIsAvailable = sendTaskCompletedMailOnceMetadataTypeIsAvailable;
   }
 
-  public long getMaxMetadataMessageBytes() {
-    return maxMetadataMessageBytes;
+  public long getMaxMetadataMessageLength() {
+    return maxMetadataMessageLength;
   }
 
-  public void setMaxMetadataMessageBytes(long maxMetadataMessageBytes) {
-    this.maxMetadataMessageBytes = maxMetadataMessageBytes;
+  public void setMaxMetadataMessageLength(long maxMetadataMessageLength) {
+    this.maxMetadataMessageLength = maxMetadataMessageLength;
   }
 
-  public long getMaxMetadataTitleBytes() {
-    return maxMetadataTitleBytes;
+  public long getMaxMetadataTitleLength() {
+    return maxMetadataTitleLength;
   }
 
-  public void setMaxMetadataTitleBytes(long maxMetadataTitleBytes) {
-    this.maxMetadataTitleBytes = maxMetadataTitleBytes;
+  public void setMaxMetadataTitleLength(long maxMetadataTitleLength) {
+    this.maxMetadataTitleLength = maxMetadataTitleLength;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
@@ -340,11 +340,12 @@ public class TaskResource {
 
     authorizationHelper.checkForAuthorizationByTaskId(taskId, user, SingularityAuthorizationScope.WRITE);
 
-    WebExceptions.checkBadRequest(taskMetadataRequest.getTitle().getBytes().length < taskMetadataConfiguration.getMaxMetadataTitleBytes(),
-      "Task metadata title too long, must be less than %s bytes", taskMetadataConfiguration.getMaxMetadataTitleBytes());
+    WebExceptions.checkBadRequest(taskMetadataRequest.getTitle().length() < taskMetadataConfiguration.getMaxMetadataTitleLength(),
+      "Task metadata title too long, must be less than %s bytes", taskMetadataConfiguration.getMaxMetadataTitleLength());
 
-    WebExceptions.checkBadRequest(!taskMetadataRequest.getMessage().isPresent() || taskMetadataRequest.getMessage().get().getBytes().length < taskMetadataConfiguration.getMaxMetadataMessageBytes(),
-      "Task metadata message too long, must be less than %s bytes", taskMetadataConfiguration.getMaxMetadataMessageBytes());
+    int messageLength = taskMetadataRequest.getMessage().isPresent() ? taskMetadataRequest.getMessage().get().length() : 0;
+    WebExceptions.checkBadRequest(!taskMetadataRequest.getMessage().isPresent() || messageLength < taskMetadataConfiguration.getMaxMetadataMessageLength(),
+      "Task metadata message too long, must be less than %s bytes", taskMetadataConfiguration.getMaxMetadataMessageLength());
 
     if (taskMetadataConfiguration.getAllowedMetadataTypes().isPresent()) {
       WebExceptions.checkBadRequest(taskMetadataConfiguration.getAllowedMetadataTypes().get().contains(taskMetadataRequest.getType()), "%s is not one of the allowed metadata types %s",

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
@@ -340,6 +340,9 @@ public class TaskResource {
 
     authorizationHelper.checkForAuthorizationByTaskId(taskId, user, SingularityAuthorizationScope.WRITE);
 
+    WebExceptions.checkBadRequest(!taskMetadataRequest.getMessage().isPresent() || taskMetadataRequest.getMessage().get().getBytes().length < taskMetadataConfiguration.getMaxMetadataMessageBytes(),
+      "Task metadata message too long, must be less than %s bytes", taskMetadataConfiguration.getMaxMetadataMessageBytes());
+
     if (taskMetadataConfiguration.getAllowedMetadataTypes().isPresent()) {
       WebExceptions.checkBadRequest(taskMetadataConfiguration.getAllowedMetadataTypes().get().contains(taskMetadataRequest.getType()), "%s is not one of the allowed metadata types %s",
           taskMetadataRequest.getType(), taskMetadataConfiguration.getAllowedMetadataTypes().get());

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
@@ -340,6 +340,9 @@ public class TaskResource {
 
     authorizationHelper.checkForAuthorizationByTaskId(taskId, user, SingularityAuthorizationScope.WRITE);
 
+    WebExceptions.checkBadRequest(taskMetadataRequest.getTitle().getBytes().length < taskMetadataConfiguration.getMaxMetadataTitleBytes(),
+      "Task metadata title too long, must be less than %s bytes", taskMetadataConfiguration.getMaxMetadataTitleBytes());
+
     WebExceptions.checkBadRequest(!taskMetadataRequest.getMessage().isPresent() || taskMetadataRequest.getMessage().get().getBytes().length < taskMetadataConfiguration.getMaxMetadataMessageBytes(),
       "Task metadata message too long, must be less than %s bytes", taskMetadataConfiguration.getMaxMetadataMessageBytes());
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -645,7 +645,7 @@ public class SingularityScheduler {
     final List<SingularityPendingTask> newTasks = Lists.newArrayListWithCapacity(numMissingInstances);
 
     int nextInstanceNumber = 1;
-t
+
     for (int i = 0; i < numMissingInstances; i++) {
       while (inuseInstanceNumbers.contains(nextInstanceNumber)) {
         nextInstanceNumber++;

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -645,7 +645,7 @@ public class SingularityScheduler {
     final List<SingularityPendingTask> newTasks = Lists.newArrayListWithCapacity(numMissingInstances);
 
     int nextInstanceNumber = 1;
-
+t
     for (int i = 0; i < numMissingInstances; i++) {
       while (inuseInstanceNumbers.contains(nextInstanceNumber)) {
         nextInstanceNumber++;


### PR DESCRIPTION
Since this is stored in zk, would be wise to limit the length of the message and title so we aren't storing huge objects. Limits are pretty high by default here, open to suggestion for better ones