### PR TITLE
don't set shell if arguments list is empty, ability to override shell

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeploy.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeploy.java
@@ -69,6 +69,7 @@ public class SingularityDeploy {
   private final Optional<Integer> deployStepWaitTimeMs;
   private final Optional<Boolean> autoAdvanceDeploySteps;
   private final Optional<Integer> maxTaskRetries;
+  private final Optional<Boolean> shell;
 
   public static SingularityDeployBuilder newBuilder(String requestId, String id) {
     return new SingularityDeployBuilder(requestId, id);
@@ -113,7 +114,8 @@ public class SingularityDeploy {
       @JsonProperty("deployInstanceCountPerStep") Optional<Integer> deployInstanceCountPerStep,
       @JsonProperty("deployStepWaitTimeMs") Optional<Integer> deployStepWaitTimeMs,
       @JsonProperty("autoAdvanceDeploySteps") Optional<Boolean> autoAdvanceDeploySteps,
-      @JsonProperty("maxTaskRetries") Optional<Integer> maxTaskRetries) {
+      @JsonProperty("maxTaskRetries") Optional<Integer> maxTaskRetries,
+      @JsonProperty("shell") Optional<Boolean> shell) {
     this.requestId = requestId;
 
     this.command = command;
@@ -163,6 +165,7 @@ public class SingularityDeploy {
     this.deployStepWaitTimeMs = deployStepWaitTimeMs;
     this.autoAdvanceDeploySteps = autoAdvanceDeploySteps;
     this.maxTaskRetries = maxTaskRetries;
+    this.shell = shell;
   }
 
   public SingularityDeployBuilder toBuilder() {
@@ -203,7 +206,8 @@ public class SingularityDeploy {
     .setDeployInstanceCountPerStep(deployInstanceCountPerStep)
     .setDeployStepWaitTimeMs(deployStepWaitTimeMs)
     .setAutoAdvanceDeploySteps(autoAdvanceDeploySteps)
-    .setMaxTaskRetries(maxTaskRetries);
+    .setMaxTaskRetries(maxTaskRetries)
+    .setShell(shell);
   }
 
   @ApiModelProperty(required=false, value="Number of seconds that Singularity waits for this service to become healthy (for it to download artifacts, start running, and optionally pass healthchecks.)")
@@ -398,6 +402,11 @@ public class SingularityDeploy {
   @ApiModelProperty(required=false, value="allowed at most this many failed tasks to be retried before failing the deploy")
   public Optional<Integer> getMaxTaskRetries() {
     return maxTaskRetries;
+  }
+
+  @ApiModelProperty(required=false, value="Override the shell property on the mesos task")
+  public Optional<Boolean> getShell() {
+    return shell;
   }
 
   @Override

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeployBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeployBuilder.java
@@ -62,6 +62,7 @@ public class SingularityDeployBuilder {
   private Optional<Integer> deployStepWaitTimeMs;
   private Optional<Boolean> autoAdvanceDeploySteps;
   private Optional<Integer> maxTaskRetries;
+  private Optional<Boolean> shell;
 
   public SingularityDeployBuilder(String requestId, String id) {
     this.requestId = requestId;
@@ -103,13 +104,14 @@ public class SingularityDeployBuilder {
     this.deployStepWaitTimeMs = Optional.absent();
     this.autoAdvanceDeploySteps = Optional.absent();
     this.maxTaskRetries = Optional.absent();
+    this.shell = Optional.absent();
   }
 
   public SingularityDeploy build() {
     return new SingularityDeploy(requestId, id, command, arguments, containerInfo, customExecutorCmd, customExecutorId, customExecutorSource, customExecutorResources, customExecutorUser, resources,
       env, uris, metadata, executorData, version, timestamp, labels, deployHealthTimeoutSeconds, healthcheckUri, healthcheckIntervalSeconds, healthcheckTimeoutSeconds, healthcheckPortIndex, healthcheckMaxRetries,
       healthcheckMaxTotalTimeoutSeconds, serviceBasePath, loadBalancerGroups, loadBalancerPortIndex, considerHealthyAfterRunningForSeconds, loadBalancerOptions, loadBalancerDomains, loadBalancerAdditionalRoutes,
-      loadBalancerTemplate, skipHealthchecksOnDeploy, healthcheckProtocol, deployInstanceCountPerStep, deployStepWaitTimeMs, autoAdvanceDeploySteps, maxTaskRetries);
+      loadBalancerTemplate, skipHealthchecksOnDeploy, healthcheckProtocol, deployInstanceCountPerStep, deployStepWaitTimeMs, autoAdvanceDeploySteps, maxTaskRetries, shell);
   }
 
   public String getRequestId() {
@@ -455,6 +457,15 @@ public class SingularityDeployBuilder {
 
   public SingularityDeployBuilder setMaxTaskRetries(Optional<Integer> maxTaskRetries) {
     this.maxTaskRetries = maxTaskRetries;
+    return this;
+  }
+
+  public Optional<Boolean> getShell() {
+    return shell;
+  }
+
+  public SingularityDeployBuilder setShell(Optional<Boolean> shell) {
+    this.shell = shell;
     return this;
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilder.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilder.java
@@ -369,11 +369,13 @@ class SingularityMesosTaskBuilder {
       commandBldr.addAllArguments(task.getPendingTask().getCmdLineArgsList().get());
     }
 
-    if (task.getDeploy().getArguments().isPresent() ||
+    if (task.getDeploy().getShell().isPresent()){
+      commandBldr.setShell(task.getDeploy().getShell().get());
+    } else if ((task.getDeploy().getArguments().isPresent() && !task.getDeploy().getArguments().get().isEmpty()) ||
         // Hopefully temporary workaround for
         // http://www.mail-archive.com/user@mesos.apache.org/msg01449.html
         task.getDeploy().getContainerInfo().isPresent() ||
-        task.getPendingTask().getCmdLineArgsList().isPresent()) {
+        (task.getPendingTask().getCmdLineArgsList().isPresent() && !task.getPendingTask().getCmdLineArgsList().get().isEmpty())) {
       commandBldr.setShell(false);
     }
 


### PR DESCRIPTION
With the new changes to the `ON_DEMAND` ui we made, we are defaulting the arguments list to set, but empty. Because it was now present, this triggered the `shell: false` being set on the mesos task, so commands set as long strings were coming back with `Failed to exec: No such file or directory` errors. This fixes that bug, and also allows us to override the shell setting in case we need to.

/fixes #1047 