### PR TITLE
UTF-8 support in chunked logs

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosBinaryChunkObject.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosBinaryChunkObject.java
@@ -1,24 +1,29 @@
 package com.hubspot.mesos.json;
 
-import java.util.Objects;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Optional;
 
-public class MesosFileChunkObject {
-  private final String data;
+import java.util.Objects;
+
+public class MesosBinaryChunkObject {
+  @JsonDeserialize(using = UTF8StringDeserializer.class)
+  @JsonSerialize(using = UTF8StringSerializer.class)
+  private final UTF8String data;
+
   private final long offset;
   private final Optional<Long> nextOffset;
 
   @JsonCreator
-  public MesosFileChunkObject(@JsonProperty("data") String data, @JsonProperty("offset") long offset, @JsonProperty("nextOffset") Optional<Long> nextOffset) {
+  public MesosBinaryChunkObject(@JsonProperty("data") UTF8String data, @JsonProperty("offset") long offset, @JsonProperty("nextOffset") Optional<Long> nextOffset) {
     this.data = data;
     this.offset = offset;
     this.nextOffset = nextOffset;
   }
 
-  public String getData() {
+  public UTF8String getData() {
     return data;
   }
 
@@ -32,11 +37,11 @@ public class MesosFileChunkObject {
 
   @Override
   public String toString() {
-    return "MesosFileChunkObject[" +
-            "data='" + data + '\'' +
-            ", offset=" + offset +
-            ", nextOffset=" + nextOffset +
-            ']';
+    return "MesosBinaryChunkObject[" +
+        "data='" + data + "'" +
+        ", offset=" + offset +
+        ", nextOffset=" + nextOffset +
+        ']';
   }
 
   @Override
@@ -47,10 +52,10 @@ public class MesosFileChunkObject {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    MesosFileChunkObject that = (MesosFileChunkObject) o;
+    MesosBinaryChunkObject that = (MesosBinaryChunkObject) o;
     return Objects.equals(offset, that.offset) &&
-            Objects.equals(data, that.data) &&
-            Objects.equals(nextOffset, that.nextOffset);
+        Objects.equals(data, that.data) &&
+        Objects.equals(nextOffset, that.nextOffset);
   }
 
   @Override

--- a/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosFileChunkObject.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosFileChunkObject.java
@@ -1,5 +1,6 @@
 package com.hubspot.mesos.json;
 
+import java.nio.ByteBuffer;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -7,18 +8,18 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
 
 public class MesosFileChunkObject {
-  private final String data;
+  private final ByteBuffer data;
   private final long offset;
   private final Optional<Long> nextOffset;
 
   @JsonCreator
-  public MesosFileChunkObject(@JsonProperty("data") String data, @JsonProperty("offset") long offset, @JsonProperty("nextOffset") Optional<Long> nextOffset) {
+  public MesosFileChunkObject(@JsonProperty("data") ByteBuffer data, @JsonProperty("offset") long offset, @JsonProperty("nextOffset") Optional<Long> nextOffset) {
     this.data = data;
     this.offset = offset;
     this.nextOffset = nextOffset;
   }
 
-  public String getData() {
+  public ByteBuffer getData() {
     return data;
   }
 
@@ -32,6 +33,7 @@ public class MesosFileChunkObject {
 
   @Override
   public String toString() {
+    //TODO: data toString isn't correct
     return "MesosFileChunkObject[" +
             "data='" + data + '\'' +
             ", offset=" + offset +

--- a/SingularityBase/src/main/java/com/hubspot/mesos/json/UTF8String.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/json/UTF8String.java
@@ -1,0 +1,69 @@
+package com.hubspot.mesos.json;
+
+import com.google.common.base.Charsets;
+
+import java.util.Arrays;
+
+public class UTF8String {
+  private final byte[] data;
+
+  private final int offset;
+  private final int length;
+
+  public UTF8String(byte[] data) {
+    this(data, 0, data.length);
+  }
+
+  public UTF8String(byte[] data, int offset, int length) {
+    this.data = data;
+    this.offset = offset;
+    this.length = length;
+  }
+
+  public byte[] getData() {
+    return data;
+  }
+
+  public int getOffset() {
+    return offset;
+  }
+
+  public int getLength() {
+    return length;
+  }
+
+  public byte get(int index) {
+    return data[index + offset];
+  }
+
+  @Override public String toString() {
+    return new String(data, offset, length, Charsets.UTF_8);
+  }
+
+  @Override public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    UTF8String that = (UTF8String) o;
+
+    if (offset != that.offset) {
+      return false;
+    }
+    if (length != that.length) {
+      return false;
+    }
+    return Arrays.equals(data, that.data);
+
+  }
+
+  @Override public int hashCode() {
+    int result = Arrays.hashCode(data);
+    result = 31 * result + offset;
+    result = 31 * result + length;
+    return result;
+  }
+}

--- a/SingularityBase/src/main/java/com/hubspot/mesos/json/UTF8StringDeserializer.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/json/UTF8StringDeserializer.java
@@ -1,0 +1,18 @@
+package com.hubspot.mesos.json;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.google.common.base.Charsets;
+
+import java.io.IOException;
+
+public class UTF8StringDeserializer extends JsonDeserializer<UTF8String>{
+  @Override
+  public UTF8String deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+    p.getTextCharacters()
+    byte[] utf8Bytes = p.getText().getBytes(Charsets.UTF_8);
+    return new UTF8String(utf8Bytes);
+  }
+}

--- a/SingularityBase/src/main/java/com/hubspot/mesos/json/UTF8StringSerializer.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/json/UTF8StringSerializer.java
@@ -1,0 +1,15 @@
+package com.hubspot.mesos.json;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+
+public class UTF8StringSerializer extends JsonSerializer<UTF8String> {
+  @Override
+  public void serialize(UTF8String value, JsonGenerator gen, SerializerProvider serializers) throws IOException, JsonProcessingException {
+    gen.writeUTF8String(value.getData(), value.getOffset(), value.getLength());
+  }
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SandboxManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SandboxManager.java
@@ -68,11 +68,11 @@ public class SandboxManager {
   }
 
 
-  private boolean isContinuationChar(byte b) {
+  private static boolean isContinuationChar(byte b) {
     return b >= (byte)0b1000_0000 && b <= (byte)0b1011_1111;
   }
 
-  private int numberOfFollowingBytes(byte b) {
+  private static int numberOfFollowingBytes(byte b) {
     if (b >= (byte)0b1100_0000 && b <= (byte)0b1101_1111) {
       return 1;
     } else if (b >= (byte)0b1110_0000 && b <= (byte)0b1110_1111) {
@@ -85,7 +85,7 @@ public class SandboxManager {
     }
   }
 
-  Optional<MesosFileChunkObject> stripInvalidUTF8(Optional<MesosFileChunkObject> inChunk) {
+  static Optional<MesosFileChunkObject> stripInvalidUTF8(Optional<MesosFileChunkObject> inChunk) {
     if (!inChunk.isPresent()) {
       return inChunk;
     }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SandboxManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SandboxManager.java
@@ -68,16 +68,23 @@ public class SandboxManager {
   }
 
 
-  private static boolean isContinuationChar(byte b) {
-    return b >= (byte)0b1000_0000 && b <= (byte)0b1011_1111;
+  // Bit-pattern check for UTF-8 continuation byte:
+  // 0b10xxxxxx -> true
+  private static boolean isContinuationByte(byte b) {
+    return b >= (byte)0b10_000000 && b <= (byte)0b10_111111;
   }
 
+  // Bit-pattern check for UTF-8 character extra-byte length:
+  // 0b110_xxxxx -> 1
+  // 0b1110_xxxx -> 2
+  // 0b11110_xxx -> 3
+  // else        -> 0
   private static int numberOfFollowingBytes(byte b) {
-    if (b >= (byte)0b1100_0000 && b <= (byte)0b1101_1111) {
+    if (b >= (byte)0b110_00000 && b <= (byte)0b110_11111) {
       return 1;
     } else if (b >= (byte)0b1110_0000 && b <= (byte)0b1110_1111) {
       return 2;
-    } else if (b >= (byte)0b1111_0000 && b <= (byte)0b1111_0111) {
+    } else if (b >= (byte)0b11110_000 && b <= (byte)0b11110_111) {
       return 3;
     } else {
       // this could be an ASCII char or a continuation byte
@@ -113,7 +120,7 @@ public class SandboxManager {
     // sequence and drop them.
     for (int i = 0; i < 3 && i < data.length; i++) {
       // remove every byte from the sequence that starts like 0b10...
-      if (isContinuationChar(data[i])) {
+      if (isContinuationByte(data[i])) {
         firstIndex += 1;
       } else {
         break;

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SandboxManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SandboxManager.java
@@ -1,6 +1,7 @@
 package com.hubspot.singularity.data;
 
 import java.net.ConnectException;
+import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -66,6 +67,94 @@ public class SandboxManager {
     }
   }
 
+
+  private boolean isContinuationChar(byte b) {
+    return b >= (byte)0b1000_0000 && b <= (byte)0b1011_1111;
+  }
+
+  private int numberOfFollowingBytes(byte b) {
+    if (b >= (byte)0b1100_0000 && b <= (byte)0b1101_1111) {
+      return 1;
+    } else if (b >= (byte)0b1110_0000 && b <= (byte)0b1110_1111) {
+      return 2;
+    } else if (b >= (byte)0b1111_0000 && b <= (byte)0b1111_0111) {
+      return 3;
+    } else {
+      // this could be an ASCII char or a continuation byte
+      return 0;
+    }
+  }
+
+  Optional<MesosFileChunkObject> stripInvalidUTF8(Optional<MesosFileChunkObject> inChunk) {
+    if (!inChunk.isPresent()) {
+      return inChunk;
+    }
+
+    ByteBuffer byteBuffer = inChunk.get().getData();
+
+    // I'm assuming that the position and limit are the same size as this is...
+    // this is a fair assumption iff inChunk is generated directly before this
+    // once run through this function, the file chunk object can no longer
+    // be assumed to be directly mapped to the array within the ByteBuffer
+    // If this cannot be assumed, refer to: http://stackoverflow.com/a/33899475
+    // """
+    // final byte[] b = new byte[myByteBuffer.remaining()];
+    // myByteBuffer.duplicate().get(b);
+    // """
+    byte[] data = byteBuffer.array();
+
+    int firstIndex = 0;
+    int limit = data.length;
+
+
+    // Check to see if there's invalid UTF-8 at the beginning of the chunk
+    // a continuation byte (0b10xxxxxx) can never be at the start of a
+    // character find every continuation byte in a row at the beginning of the
+    // sequence and drop them.
+    for (int i = 0; i < 3 && i < data.length; i++) {
+      // remove every byte from the sequence that starts like 0b10...
+      if (isContinuationChar(data[i])) {
+        firstIndex += 1;
+      } else {
+        break;
+      }
+    }
+
+    // Check to see if there's invalid UTF-8 at the end of the chunk
+    for (int i = data.length - 3; i < data.length; i++) {
+      if (i < 0) {
+        // We don't want to prematurely end loop if data.length < 3
+        // and i < 0 in this loop (but later i >= 0)
+        continue;
+      }
+      // Find number of continuation chars, if it extends the length of the
+      // array, move end offset back to before this byte and stop
+
+      int following = numberOfFollowingBytes(data[i]);
+      if (i + following >= data.length) {
+        limit = i;
+        break;
+      }
+    }
+
+    // byte offset in chunked file
+    long fileOffset = inChunk.get().getOffset();
+
+    // byte length of the data in the truncated buffer
+    // I hope we never need > 2GB buffers
+    int length = limit - firstIndex;
+
+    long newOffset = fileOffset + firstIndex;
+
+    long nextOffset = newOffset + length;
+
+    return Optional.of(new MesosFileChunkObject(
+        ByteBuffer.wrap(data, firstIndex, length),
+        newOffset,
+        Optional.of(nextOffset)
+    ));
+  }
+
   @SuppressWarnings("deprecation")
   public Optional<MesosFileChunkObject> read(String slaveHostname, String fullPath, Optional<Long> offset, Optional<Long> length) throws SlaveNotFoundException {
     try {
@@ -94,6 +183,7 @@ public class SandboxManager {
         throw new RuntimeException(String.format("Got HTTP %s from Mesos slave", response.getStatusCode()));
       }
 
+      // TODO: make sure objectMapper actually converts the string into the ByteBuffer correctly
       return Optional.of(objectMapper.readValue(response.getResponseBodyAsStream(), MesosFileChunkObject.class));
     } catch (ConnectException ce) {
       throw new SlaveNotFoundException(ce);

--- a/SingularityService/src/main/java/com/hubspot/singularity/smtp/MailTemplateHelpers.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/smtp/MailTemplateHelpers.java
@@ -196,7 +196,8 @@ public class MailTemplateHelpers {
     }
 
     if (logChunkObject.isPresent()) {
-      return Optional.of(logChunkObject.get().getData());
+      //NONONONONONONO
+      return Optional.of(logChunkObject.get().getData().toString());
     } else {
       LOG.error("Failed to get {} log for {}", filename, taskId.getId());
       return Optional.absent();
@@ -229,12 +230,14 @@ public class MailTemplateHelpers {
       if (logChunkObject.isPresent()) {
         if (logChunkObject.get().getData().equals("")) { // Passed end of file
           if (previous.isPresent()) { // If there was any log, get the bottom bytes of it
-            long end = previous.get().getOffset() + previous.get().getData().length();
+            //TODO: make this work
+            long end = previous.get().getOffset() + previous.get().getData().limit();
             return Optional.of(end - logLength);
           }
           return Optional.absent();
         }
-        Matcher matcher = pattern.matcher(logChunkObject.get().getData());
+        //TODO: make this work (toString is completely invalid)
+        Matcher matcher = pattern.matcher(logChunkObject.get().getData().toString());
         if (matcher.find()) {
           return Optional.of(offset + matcher.start());
         } else {

--- a/SingularityService/src/main/java/com/hubspot/singularity/smtp/MailTemplateHelpers.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/smtp/MailTemplateHelpers.java
@@ -8,6 +8,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+import com.hubspot.mesos.json.MesosBinaryChunkObject;
 import org.apache.commons.lang3.text.WordUtils;
 import org.apache.commons.lang3.time.DateFormatUtils;
 import org.slf4j.Logger;
@@ -179,7 +180,7 @@ public class MailTemplateHelpers {
 
     final Long logLength = (long) smtpConfiguration.get().getTaskLogLength();
 
-    final Optional<MesosFileChunkObject> logChunkObject;
+    final Optional<MesosBinaryChunkObject> logChunkObject;
 
     LOG.trace("Getting offset (maybe) for task {} file {}", taskId.getId(), fullPath);
     Optional<Long> maybeOffset = getMaybeTaskLogReadOffset(slaveHostname, fullPath, logLength, task);
@@ -189,7 +190,7 @@ public class MailTemplateHelpers {
       return Optional.absent();
     }
     try {
-      logChunkObject = sandboxManager.read(slaveHostname, fullPath, maybeOffset, Optional.of(logLength));
+      logChunkObject = sandboxManager.read(slaveHostname, fullPath, maybeOffset, Optional.of(logLength), Optional.of(true));
     } catch (RuntimeException e) {
       LOG.error("Sandboxmanager failed to read {}/{} on slave {}", directory.get(), filename, slaveHostname, e);
       return Optional.absent();
@@ -217,12 +218,12 @@ public class MailTemplateHelpers {
       return getMaybeTaskLogEndOfFileOffset(slaveHostname, fullPath, logLength);
     }
     long length = logLength + pattern.toString().length(); // Get extra so that we can be sure to find the error
-    Optional<MesosFileChunkObject> logChunkObject;
-    Optional<MesosFileChunkObject> previous = Optional.absent();
+    Optional<MesosBinaryChunkObject> logChunkObject;
+    Optional<MesosBinaryChunkObject> previous = Optional.absent();
 
     while (offset <= maxOffset) {
       try {
-        logChunkObject = sandboxManager.read(slaveHostname, fullPath, Optional.of(offset), Optional.of(length));
+        logChunkObject = sandboxManager.read(slaveHostname, fullPath, Optional.of(offset), Optional.of(length), Optional.of(true));
       } catch (RuntimeException e) {
         LOG.error("Sandboxmanager failed to read {} on slave {}", fullPath, slaveHostname, e);
         return Optional.absent();
@@ -231,7 +232,7 @@ public class MailTemplateHelpers {
         if (logChunkObject.get().getData().equals("")) { // Passed end of file
           if (previous.isPresent()) { // If there was any log, get the bottom bytes of it
             //TODO: make this work
-            long end = previous.get().getOffset() + previous.get().getData().limit();
+            long end = previous.get().getOffset() + previous.get().getData().getLength();
             return Optional.of(end - logLength);
           }
           return Optional.absent();
@@ -254,9 +255,9 @@ public class MailTemplateHelpers {
   }
 
   private Optional<Long> getMaybeTaskLogEndOfFileOffset(final String slaveHostname, final String fullPath, final long logLength) {
-    Optional<MesosFileChunkObject> logChunkObject;
+    Optional<MesosBinaryChunkObject> logChunkObject;
     try {
-      logChunkObject = sandboxManager.read(slaveHostname, fullPath, Optional.<Long>absent(), Optional.<Long>absent());
+      logChunkObject = sandboxManager.read(slaveHostname, fullPath, Optional.<Long>absent(), Optional.<Long>absent(), Optional.of(true));
     } catch (RuntimeException e) {
       LOG.error("Sandboxmanager failed to read {} on slave {}", fullPath, slaveHostname, e);
       return Optional.absent();

--- a/SingularityService/src/test/java/com/hubspot/singularity/data/SandboxManagerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/data/SandboxManagerTest.java
@@ -1,0 +1,263 @@
+package com.hubspot.singularity.data;
+
+import com.google.common.base.Optional;
+import com.google.inject.Inject;
+import com.hubspot.mesos.json.MesosFileChunkObject;
+import com.hubspot.singularity.SingularityTestBaseNoDb;
+import org.apache.commons.lang3.ArrayUtils;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.*;
+
+public class SandboxManagerTest extends SingularityTestBaseNoDb {
+
+  @Inject
+  private SandboxManager sm;
+
+  // valid ASCII "Hi I'm valid ASCII"
+  private byte[] validString = {(byte)0b01001000, (byte)0b01101001, (byte)0b00100000,
+      (byte)0b01001001, (byte)0b00100111, (byte)0b01101101, (byte)0b00100000,
+      (byte)0b01110110, (byte)0b01100001, (byte)0b01101100, (byte)0b01101001,
+      (byte)0b01100100, (byte)0b00100000, (byte)0b01000001, (byte)0b01010011,
+      (byte)0b01000011, (byte)0b01001001, (byte)0b01001001};
+
+  // valid UTF-8 "✓Hi I'm ✓valid✓ UTF-8 ✓"
+  private byte[] validUTF8 = {(byte)0b11100010, (byte)0b10011100, (byte)0b10010011,
+      (byte)0b01001000, (byte)0b01101001, (byte)0b00100000, (byte)0b01001001,
+      (byte)0b00100111, (byte)0b01101101, (byte)0b00100000, (byte)0b11100010,
+      (byte)0b10011100, (byte)0b10010011, (byte)0b01110110, (byte)0b01100001,
+      (byte)0b01101100, (byte)0b01101001, (byte)0b01100100, (byte)0b11100010,
+      (byte)0b10011100, (byte)0b10010011, (byte)0b00100000, (byte)0b01010101,
+      (byte)0b01010100, (byte)0b01000110, (byte)0b00101101, (byte)0b00111000,
+      (byte)0b00100000, (byte)0b11100010, (byte)0b10011100, (byte)0b10010011};
+
+  // invalid cent [2-byte] character - 1 byte(s) cut from beginning
+  private byte[] invalidBeginningCent = {(byte)0b10100010};
+  // invalid check [3-byte] character - 1 byte(s) cut from beginning
+  private byte[] invalidBeginningCheck = {(byte)0b10011100, (byte)0b10010011};
+  // invalid pillow [4-byte] character - 1 byte(s) cut from beginning
+  private byte[] invalidBeginningPillow = {(byte)0b10100000, (byte)0b10110001, (byte)0b10111000};
+  // invalid cent [2-byte] character - 1 byte(s) cut from end
+  private byte[] invalidEndCent1 = {(byte)0b11000010};
+  // invalid check [3-byte] character - 1 byte(s) cut from end
+  private byte[] invalidEndCheck1 = {(byte)0b11100010, (byte)0b10011100};
+  // invalid pillow [4-byte] character - 1 byte(s) cut from end
+  private byte[] invalidEndPillow1 = {(byte)0b11110000, (byte)0b10100000, (byte)0b10110001};
+  // invalid check [3-byte] character - 2 byte(s) cut from end
+  private byte[] invalidEndCheck2 = {(byte)0b11100010};
+  // invalid pillow [4-byte] character - 2 byte(s) cut from end
+  private byte[] invalidEndPillow2 = {(byte)0b11110000, (byte)0b10100000};
+  // invalid pillow [4-byte] character - 3 byte(s) cut from end
+  private byte[] invalidEndPillow3 = {(byte)0b11110000};
+
+  private byte[] validCent = {(byte)0b11000010, (byte)0b10100010};
+  private byte[] validCheck = {(byte)0b11100010, (byte)0b10011100, (byte)0b10010011};
+  private byte[] validPillow = {(byte)0b11110000, (byte)0b10100000, (byte)0b10110001, (byte)0b10111000};
+
+  private Optional<MesosFileChunkObject> makeMFCO(byte[] firstArray, byte[] secondArray) {
+    final byte[] data = ArrayUtils.addAll(firstArray, secondArray);
+
+    return Optional.of(new MesosFileChunkObject(
+        ByteBuffer.wrap(data, 0, data.length),
+        0,
+        Optional.of((long)data.length)
+    ));
+  }
+
+  private byte[] getBytesFromMFCO(Optional<MesosFileChunkObject> mfco) {
+    byte[] resultBytes = new byte[mfco.get().getData().remaining()];
+    mfco.get().getData().duplicate().get(resultBytes);
+
+    return resultBytes;
+  }
+
+  @Test
+  public void stripInvalidBeginningBytes() {
+    assertArrayEquals(
+        getBytesFromMFCO(sm.stripInvalidUTF8(makeMFCO(invalidBeginningCent, validString))),
+        validString
+    );
+    assertArrayEquals(
+        getBytesFromMFCO(sm.stripInvalidUTF8(makeMFCO(invalidBeginningCheck, validString))),
+        validString
+    );
+    assertArrayEquals(
+        getBytesFromMFCO(sm.stripInvalidUTF8(makeMFCO(invalidBeginningPillow, validString))),
+        validString
+    );
+  }
+
+
+  @Test
+  public void stripInvalidEndBytes() {
+    assertArrayEquals(
+        getBytesFromMFCO(sm.stripInvalidUTF8(makeMFCO(validString, invalidEndCent1))),
+        validString
+    );
+    assertArrayEquals(
+        getBytesFromMFCO(sm.stripInvalidUTF8(makeMFCO(validString, invalidEndCheck1))),
+        validString
+    );
+    assertArrayEquals(
+        getBytesFromMFCO(sm.stripInvalidUTF8(makeMFCO(validString, invalidEndPillow1))),
+        validString
+    );
+    assertArrayEquals(
+        getBytesFromMFCO(sm.stripInvalidUTF8(makeMFCO(validString, invalidEndCheck2))),
+        validString
+    );
+    assertArrayEquals(
+        getBytesFromMFCO(sm.stripInvalidUTF8(makeMFCO(validString, invalidEndPillow2))),
+        validString
+    );
+    assertArrayEquals(
+        getBytesFromMFCO(sm.stripInvalidUTF8(makeMFCO(validString, invalidEndPillow3))),
+        validString
+    );
+  }
+
+  @Test
+  public void keepValidStrings() {
+    assertArrayEquals(
+        getBytesFromMFCO(sm.stripInvalidUTF8(makeMFCO(validString, new byte[0]))),
+        validString
+    );
+    assertArrayEquals(
+        getBytesFromMFCO(sm.stripInvalidUTF8(makeMFCO(validUTF8, new byte[0]))),
+        validUTF8
+    );
+    assertArrayEquals(
+        getBytesFromMFCO(sm.stripInvalidUTF8(makeMFCO(validUTF8, validString))),
+        ArrayUtils.addAll(validUTF8, validString)
+    );
+    assertArrayEquals(
+        getBytesFromMFCO(sm.stripInvalidUTF8(makeMFCO(validString, validUTF8))),
+        ArrayUtils.addAll(validString, validUTF8)
+    );
+  }
+
+  @Test
+  public void stripTinyBufferUTF8BeginningBytes() {
+    assertArrayEquals(
+        getBytesFromMFCO(sm.stripInvalidUTF8(makeMFCO(invalidBeginningCent, new byte[0]))),
+        new byte[0]
+    );
+    assertArrayEquals(
+        getBytesFromMFCO(sm.stripInvalidUTF8(makeMFCO(invalidBeginningCheck, new byte[0]))),
+        new byte[0]
+    );
+    assertArrayEquals(
+        getBytesFromMFCO(sm.stripInvalidUTF8(makeMFCO(invalidBeginningPillow, new byte[0]))),
+        new byte[0]
+    );
+  }
+
+  @Test
+  public void stripTinyBufferUTF8EndBytes() {
+    assertArrayEquals(
+        getBytesFromMFCO(sm.stripInvalidUTF8(makeMFCO(new byte[0], invalidEndCent1))),
+        new byte[0]
+    );
+    assertArrayEquals(
+        getBytesFromMFCO(sm.stripInvalidUTF8(makeMFCO(new byte[0], invalidEndCheck1))),
+        new byte[0]
+    );
+    assertArrayEquals(
+        getBytesFromMFCO(sm.stripInvalidUTF8(makeMFCO(new byte[0], invalidEndPillow1))),
+        new byte[0]
+    );
+    assertArrayEquals(
+        getBytesFromMFCO(sm.stripInvalidUTF8(makeMFCO(new byte[0], invalidEndCheck2))),
+        new byte[0]
+    );
+    assertArrayEquals(
+        getBytesFromMFCO(sm.stripInvalidUTF8(makeMFCO(new byte[0], invalidEndPillow2))),
+        new byte[0]
+    );
+    assertArrayEquals(
+        getBytesFromMFCO(sm.stripInvalidUTF8(makeMFCO(new byte[0], invalidEndPillow3))),
+        new byte[0]
+    );
+  }
+
+  @Test
+  public void keepValidUTF8BeginningBytes() {
+    assertArrayEquals(
+        getBytesFromMFCO(sm.stripInvalidUTF8(makeMFCO(validCent, validString))),
+        ArrayUtils.addAll(validCent, validString)
+    );
+    assertArrayEquals(
+        getBytesFromMFCO(sm.stripInvalidUTF8(makeMFCO(validCheck, validString))),
+        ArrayUtils.addAll(validCheck, validString)
+    );
+    assertArrayEquals(
+        getBytesFromMFCO(sm.stripInvalidUTF8(makeMFCO(validPillow, validString))),
+        ArrayUtils.addAll(validPillow, validString)
+    );
+  }
+
+  @Test
+  public void keepValidUTF8EndBytes() {
+    assertArrayEquals(
+        getBytesFromMFCO(sm.stripInvalidUTF8(makeMFCO(validString, validCent))),
+        ArrayUtils.addAll(validString, validCent)
+    );
+    assertArrayEquals(
+        getBytesFromMFCO(sm.stripInvalidUTF8(makeMFCO(validString, validCheck))),
+        ArrayUtils.addAll(validString, validCheck)
+    );
+    assertArrayEquals(
+        getBytesFromMFCO(sm.stripInvalidUTF8(makeMFCO(validString, validPillow))),
+        ArrayUtils.addAll(validString, validPillow)
+    );
+  }
+
+  @Test
+  public void validBeginningOffsetChange() {
+    assertEquals(
+        sm.stripInvalidUTF8(makeMFCO(invalidBeginningCent, validString)).get().getOffset(),
+        makeMFCO(invalidBeginningCent, validString).get().getOffset() + 1
+    );
+    assertEquals(
+        sm.stripInvalidUTF8(makeMFCO(invalidBeginningCheck, validString)).get().getOffset(),
+        makeMFCO(invalidBeginningCheck, validString).get().getOffset() + 2
+    );
+    assertEquals(
+        sm.stripInvalidUTF8(makeMFCO(invalidBeginningPillow, validString)).get().getOffset(),
+        makeMFCO(invalidBeginningPillow, validString).get().getOffset() + 3
+    );
+  }
+
+  @Test
+  public void validEndNextOffsetChange() {
+    assertEquals(
+        (long) sm.stripInvalidUTF8(makeMFCO(validString, invalidEndCent1)).get().getNextOffset().get(),
+        makeMFCO(validString, invalidEndCent1).get().getNextOffset().get() - 1
+    );
+    assertEquals(
+        (long) sm.stripInvalidUTF8(makeMFCO(validString, invalidEndCheck1)).get().getNextOffset().get(),
+        makeMFCO(validString, invalidEndCheck1).get().getNextOffset().get() - 2
+    );
+    assertEquals(
+        (long) sm.stripInvalidUTF8(makeMFCO(validString, invalidEndPillow1)).get().getNextOffset().get(),
+        makeMFCO(validString, invalidEndPillow1).get().getNextOffset().get() - 3
+    );
+
+    assertEquals(
+        (long) sm.stripInvalidUTF8(makeMFCO(validString, invalidEndCheck2)).get().getNextOffset().get(),
+        makeMFCO(validString, invalidEndCheck2).get().getNextOffset().get() - 1
+    );
+    assertEquals(
+        (long) sm.stripInvalidUTF8(makeMFCO(validString, invalidEndPillow2)).get().getNextOffset().get(),
+        makeMFCO(validString, invalidEndPillow2).get().getNextOffset().get() - 2
+    );
+
+    assertEquals(
+        (long) sm.stripInvalidUTF8(makeMFCO(validString, invalidEndPillow3)).get().getNextOffset().get(),
+        makeMFCO(validString, invalidEndPillow3).get().getNextOffset().get() - 1
+    );
+  }
+
+}

--- a/SingularityServiceIntegrationTests/pom.xml
+++ b/SingularityServiceIntegrationTests/pom.xml
@@ -162,6 +162,7 @@
                       <MESOS_HOSTNAME>${mesos.slave1.hostname}</MESOS_HOSTNAME>
                       <MESOS_PORT>5051</MESOS_PORT>
                       <MESOS_ATTRIBUTES>rackid:a</MESOS_ATTRIBUTES>
+                      <MESOS_LAUNCHER>posix</MESOS_LAUNCHER>
                     </env>
                     <volumes>
                       <bind>
@@ -194,6 +195,7 @@
                       <MESOS_HOSTNAME>${mesos.slave2.hostname}</MESOS_HOSTNAME>
                       <MESOS_PORT>5051</MESOS_PORT>
                       <MESOS_ATTRIBUTES>rackid:b</MESOS_ATTRIBUTES>
+                      <MESOS_LAUNCHER>posix</MESOS_LAUNCHER>
                     </env>
                     <volumes>
                       <bind>
@@ -226,6 +228,7 @@
                       <MESOS_HOSTNAME>${mesos.slave3.hostname}</MESOS_HOSTNAME>
                       <MESOS_PORT>5051</MESOS_PORT>
                       <MESOS_ATTRIBUTES>rackid:c</MESOS_ATTRIBUTES>
+                      <MESOS_LAUNCHER>posix</MESOS_LAUNCHER>
                     </env>
                     <volumes>
                       <bind>


### PR DESCRIPTION
On hold: Waiting on upstream Mesos patch to their log tailing endpoint. Probably Mesos 1.0 will fix this by using base64 encoded data.
-------------
* Add support for dropping invalid UTF-8 bytes at the beginning and end of log chunks