### PR TITLE
Move back to react-typeahead mainline version instead of HubSpot fork.

### DIFF
--- a/SingularityUI/package.json
+++ b/SingularityUI/package.json
@@ -43,7 +43,7 @@
     "react-interval": "^1.2.1",
     "react-list": "~0.7.3",
     "react-redux": "^4.4.1",
-    "react-typeahead": "git://github.com/HubSpot/react-typeahead.git#hubspot-3",
+    "react-typeahead": "2.0.0-alpha.4",
     "redux": "^3.3.1",
     "redux-logger": "^2.6.1",
     "redux-thunk": "^2.0.1",


### PR DESCRIPTION
Very, very, simple.