### PR TITLE
(logfetch) correct the file extension when auto-decompressing

### DIFF
--- a/scripts/logfetch/callbacks.py
+++ b/scripts/logfetch/callbacks.py
@@ -26,11 +26,12 @@ def update_progress_bar(silent, progress):
 
 
 def generate_callback(request, destination, filename, chunk_size, verbose, silent):
-    path = CALLBACK_FORMAT.format(destination, filename) if destination else filename
-
     def callback(response, **kwargs):
         global progress
         global goal
+        path = CALLBACK_FORMAT.format(destination, filename) if destination else filename
+        if 'content-encoding' in response.headers and response.headers['content-encoding'] == 'gzip' and path.endswith('.gz'):
+            path = path[:-3]
         with open(path, 'wb') as f:
             for chunk in response.iter_content(chunk_size):
                 f.write(chunk)

--- a/scripts/logfetch/s3_logs.py
+++ b/scripts/logfetch/s3_logs.py
@@ -42,10 +42,18 @@ def download_s3_logs(args):
         logfetch_base.log(colored('Starting {0} S3 Downloads with {1} parallel fetches\n'.format(len(async_requests), args.num_parallel_fetches), 'cyan'), args, False)
         callbacks.goal = len(async_requests)
         grequests.map(async_requests, stream=True, size=args.num_parallel_fetches)
+        all_logs = modify_download_list(all_logs)
     else:
         logfetch_base.log(colored('No S3 logs to download\n', 'cyan'), args, False)
     logfetch_base.log(colored('All S3 logs up to date\n', 'cyan'), args, False)
     return all_logs
+
+def modify_download_list(all_logs):
+    for index, log in enumerate(all_logs):
+        if log.endswith('.gz') and not os.path.isfile(log) and os.path.isfile(log[:-3]):
+            all_logs[index] = log[:-3]
+    return all_logs
+
 
 def already_downloaded(dest, filename):
     return (os.path.isfile('{0}/{1}'.format(dest, filename.replace('.gz', '.log'))) or os.path.isfile('{0}/{1}'.format(dest, filename)))

--- a/scripts/logfetch/s3_logs.py
+++ b/scripts/logfetch/s3_logs.py
@@ -56,7 +56,7 @@ def modify_download_list(all_logs):
 
 
 def already_downloaded(dest, filename):
-    return (os.path.isfile('{0}/{1}'.format(dest, filename.replace('.gz', '.log'))) or os.path.isfile('{0}/{1}'.format(dest, filename)))
+    return (os.path.isfile('{0}/{1}'.format(dest, filename.replace('.gz', '.log'))) or os.path.isfile('{0}/{1}'.format(dest, filename[:-3])) or os.path.isfile('{0}/{1}'.format(dest, filename)))
 
 def logs_for_all_requests(args):
     s3_params = {'start': int(time.mktime(args.start.timetuple()) * 1000), 'end': int(time.mktime(args.end.timetuple()) * 1000)}


### PR DESCRIPTION
Now that we have the `Content-Type` and `Content-Encoding` headers set on the s3 uploads, we need to handle them on downloads too! Keeping the auto-decompress since it will make the search faster in the end, this just adds in some checks to correct the file extension if we decompressed it already