### PR TITLE
Concurrent run once tasks

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityDeployChecker.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityDeployChecker.java
@@ -27,6 +27,7 @@ import com.hubspot.singularity.DeployState;
 import com.hubspot.singularity.LoadBalancerRequestType;
 import com.hubspot.singularity.LoadBalancerRequestType.LoadBalancerRequestId;
 import com.hubspot.singularity.RequestState;
+import com.hubspot.singularity.RequestType;
 import com.hubspot.singularity.SingularityDeleteResult;
 import com.hubspot.singularity.SingularityDeploy;
 import com.hubspot.singularity.SingularityDeployFailure;
@@ -153,7 +154,9 @@ public class SingularityDeployChecker {
 
     if (deployResult.getDeployState() == DeployState.SUCCEEDED) {
       if (saveNewDeployState(pendingDeployMarker, Optional.of(pendingDeployMarker))) {
-        deleteObsoletePendingTasks(pendingDeploy);
+        if (!(request.getRequestType() == RequestType.RUN_ONCE)) {
+          deleteObsoletePendingTasks(pendingDeploy);
+        }
         finishDeploy(requestWithState, deploy, pendingDeploy, allOtherMatchingTasks, deployResult);
         return;
       } else {
@@ -230,7 +233,7 @@ public class SingularityDeployChecker {
     SingularityDeployResult deployResult) {
     SingularityRequest request = requestWithState.getRequest();
 
-    if (!request.isOneOff()) {
+    if (!request.isOneOff() && !(request.getRequestType() == RequestType.RUN_ONCE)) {
       cleanupTasks(pendingDeploy.getDeployMarker(), deployResult, tasksToKill);
     }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -609,7 +609,7 @@ public class SingularityScheduler {
       } else {
         return 0;
       }
-    } else if (request.getRequestType() == RequestType.RUN_ONCE) {
+    } else if (request.getRequestType() == RequestType.RUN_ONCE && pendingRequest.getPendingType() == PendingType.NEW_DEPLOY) {
       return 1;
     }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -279,6 +279,9 @@ public class SingularityScheduler {
     if (request.isDeployable() && pendingRequest.getPendingType() == PendingType.NEW_DEPLOY && !maybePendingDeploy.isPresent()) {
       return false;
     }
+    if (request.getRequestType() == RequestType.RUN_ONCE && pendingRequest.getPendingType() == PendingType.NEW_DEPLOY) {
+      return true;
+    }
 
     return isDeployInUse(maybeRequestDeployState, pendingRequest.getDeployId(), false);
   }
@@ -325,7 +328,7 @@ public class SingularityScheduler {
     for (SingularityTaskRequest taskRequest : taskRequests) {
       SingularityRequestDeployState requestDeployState = deployStates.get(taskRequest.getRequest().getId());
 
-      if (!matchesDeploy(requestDeployState, taskRequest)) {
+      if (!matchesDeploy(requestDeployState, taskRequest) && !(taskRequest.getRequest().getRequestType() == RequestType.RUN_ONCE)) {
         LOG.info("Removing stale pending task {} because the deployId did not match active/pending deploys {}", taskRequest.getPendingTask().getPendingTaskId(), requestDeployState);
         taskManager.deletePendingTask(taskRequest.getPendingTask().getPendingTaskId());
       } else {
@@ -606,6 +609,8 @@ public class SingularityScheduler {
       } else {
         return 0;
       }
+    } else if (request.getRequestType() == RequestType.RUN_ONCE) {
+      return 1;
     }
 
     return numInstancesExpected(request, pendingRequest, maybePendingDeploy) - matchingTaskIds.size();

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -1100,6 +1100,26 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
   }
 
   @Test
+  public void testMultipleRunOnceTasks() {
+    SingularityRequestBuilder bldr = new SingularityRequestBuilder(requestId, RequestType.RUN_ONCE);
+    request = bldr.build();
+    saveRequest(request);
+
+    deployResource.deploy(new SingularityDeployRequest(new SingularityDeployBuilder(requestId, "d1").setCommand(Optional.of("cmd")).build(), Optional.<Boolean> absent(), Optional.<String> absent()));
+    deployChecker.checkDeploys();
+    Assert.assertEquals(1, requestManager.getSizeOfPendingQueue());
+
+    deployResource.deploy(new SingularityDeployRequest(new SingularityDeployBuilder(requestId, "d2").setCommand(Optional.of("cmd")).build(), Optional.<Boolean> absent(), Optional.<String> absent()));
+    deployChecker.checkDeploys();
+    Assert.assertEquals(2, requestManager.getSizeOfPendingQueue());
+
+    scheduler.drainPendingQueue(stateCacheProvider.get());
+
+    resourceOffers();
+    Assert.assertEquals(2, taskManager.getActiveTaskIds().size());
+  }
+
+  @Test
   public void testRunOnceDontMoveDuringDecomission() {
     SingularityRequestBuilder bldr = new SingularityRequestBuilder(requestId, RequestType.RUN_ONCE);
     request = bldr.build();


### PR DESCRIPTION
Right now, if a run once task is already running, we cannot enqueue another until it is finished. These changes allow multiple run once tasks (from different deploys) to run at the same time. There will still be a conflict if the previous deploy is still in progress (i.e. poller hasn't finished it yet), but that's a separate problem to tackle if it happens to slow us down too much

@gchomatas 

edit: previously if deploys came too close together, we would actually miss one of them and never run a task for it, that is fixed in this as well