### PR TITLE
use 0.28.2 to fix MESOS-5449

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <baragon.version>0.2.0</baragon.version>
     <horizon.version>0.0.24</horizon.version>
     <mesos.docker.tag>0.28.1-2.0.20.ubuntu1404</mesos.docker.tag>
-    <mesos.version>0.28.1</mesos.version>
+    <mesos.version>0.28.2</mesos.version>
     <singularitybase.image.revision>1</singularitybase.image.revision>
   </properties>
 


### PR DESCRIPTION
Need to wait for the docker images and packages to officially be published, but the release was confirmed today. This will fix the memory leak in `declineOffer`.