### PR TITLE
Reimplementation of RFC5545 Schedule

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/ScheduleType.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/ScheduleType.java
@@ -2,6 +2,6 @@ package com.hubspot.singularity;
 
 public enum ScheduleType {
 
-  CRON, QUARTZ;
+  CRON, QUARTZ, RFC5545;
 
 }

--- a/SingularityService/pom.xml
+++ b/SingularityService/pom.xml
@@ -374,6 +374,21 @@
       <artifactId>api-all</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.dmfs</groupId>
+      <artifactId>lib-recur</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.dmfs</groupId>
+      <artifactId>rfc5545-datetime</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
@@ -1,6 +1,7 @@
 package com.hubspot.singularity.data;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.hubspot.singularity.WebExceptions.badRequest;
 import static com.hubspot.singularity.WebExceptions.checkBadRequest;
 
 import java.net.URI;
@@ -180,15 +181,11 @@ public class SingularityValidator {
   }
 
   private void checkForValidRFC5545Schedule(String schedule) {
-    String message = "";
-    boolean valid = true;
     try {
       new RecurrenceRule(schedule);
     } catch (InvalidRecurrenceRuleException ex) {
-      message = String.format("Schedule %s was not a valid RFC5545 schedule, error was: %s", schedule, ex);
-      valid = false;
+      badRequest("Schedule %s was not a valid RFC5545 schedule, error was: %s", schedule, ex);
     }
-    checkBadRequest(valid, message);
   }
 
   public SingularityWebhook checkSingularityWebhook(SingularityWebhook webhook) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
@@ -155,7 +155,7 @@ public class SingularityValidator {
 
         checkBadRequest(isValidCronSchedule(quartzSchedule), "Schedule %s (from: %s) was not valid", quartzSchedule, originalSchedule);
       } else {
-        isValidRFC5545Schedule(request.getSchedule().get());
+        checkForValidRFC5545Schedule(request.getSchedule().get());
       }
     } else {
       checkBadRequest(!request.getQuartzSchedule().isPresent() && !request.getSchedule().isPresent(), "Non-scheduled requests can not specify a schedule");
@@ -179,7 +179,7 @@ public class SingularityValidator {
     return request.toBuilder().setQuartzSchedule(Optional.fromNullable(quartzSchedule)).build();
   }
 
-  private void isValidRFC5545Schedule(String schedule) {
+  private void checkForValidRFC5545Schedule(String schedule) {
     String message = "";
     boolean valid = true;
     try {

--- a/SingularityService/src/main/java/com/hubspot/singularity/helpers/RFC5545Schedule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/helpers/RFC5545Schedule.java
@@ -29,12 +29,6 @@ public class RFC5545Schedule {
       this.recurrenceRule = new RecurrenceRule(schedule);
       this.dtStart = org.joda.time.DateTime.now().withSecondOfMinute(0);
     }
-
-
-    if (this.recurrenceRule.isInfinite()) {
-      // set limit at 2100-01-01 00:00:00
-      this.recurrenceRule.setUntil(new DateTime(2100, 1, 1, 0, 0, 0));
-    }
   }
 
   public org.joda.time.DateTime getStartDateTime() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/helpers/RFC5545Schedule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/helpers/RFC5545Schedule.java
@@ -1,0 +1,64 @@
+package com.hubspot.singularity.helpers;
+
+import java.util.Date;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.dmfs.rfc5545.recur.InvalidRecurrenceRuleException;
+import org.dmfs.rfc5545.recur.RecurrenceRule;
+import org.dmfs.rfc5545.DateTime;
+import org.dmfs.rfc5545.recur.RecurrenceRuleIterator;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
+public class RFC5545Schedule {
+  public static final int MAX_ITERATIONS = 10000;
+  private final RecurrenceRule recurrenceRule;
+  private final org.joda.time.DateTime dtStart;
+
+  public RFC5545Schedule(String schedule) throws InvalidRecurrenceRuleException {
+    // DTSTART is RFC5545 but NOT in the recur string, but its a nice to have? :)
+    Pattern pattern = Pattern.compile("DTSTART=([0-9]{8}T[0-9]{6})");
+    Matcher matcher = pattern.matcher(schedule);
+
+    if (matcher.find()) {
+      DateTimeFormatter formatter = DateTimeFormat.forPattern("yyyyMMdd'T'HHmmss");
+      this.dtStart = formatter.parseDateTime(matcher.group(1));
+      this.recurrenceRule = new RecurrenceRule(matcher.replaceAll("").replace("RRULE:", ""));
+    } else {
+      this.recurrenceRule = new RecurrenceRule(schedule);
+      this.dtStart = org.joda.time.DateTime.now().withSecondOfMinute(0);
+    }
+
+
+    if (this.recurrenceRule.isInfinite()) {
+      // set limit at 2100-01-01 00:00:00
+      this.recurrenceRule.setUntil(new DateTime(2100, 1, 1, 0, 0, 0));
+    }
+  }
+
+  public org.joda.time.DateTime getStartDateTime() {
+    return dtStart;
+  }
+
+  public Date getNextValidTime() {
+    final long now = System.currentTimeMillis();
+    DateTime startDateTime = new DateTime(dtStart.getYear(), (dtStart.getMonthOfYear() - 1), dtStart.getDayOfMonth(),
+      dtStart.getHourOfDay(), dtStart.getMinuteOfHour(), dtStart.getSecondOfMinute());
+    RecurrenceRuleIterator timeIterator = recurrenceRule.iterator(startDateTime);
+
+    int count = 0;
+    while (timeIterator.hasNext() && count < MAX_ITERATIONS) {
+      count ++;
+      long nextRunAtTimestamp = timeIterator.nextMillis();
+      if (nextRunAtTimestamp >= now) {
+        return new Date(nextRunAtTimestamp);
+      }
+    }
+    return null;
+  }
+
+  public RecurrenceRule getRecurrenceRule() {
+    return recurrenceRule;
+  }
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduledJobPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduledJobPoller.java
@@ -9,6 +9,7 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Singleton;
 
+import org.dmfs.rfc5545.recur.InvalidRecurrenceRuleException;
 import org.quartz.CronExpression;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,6 +19,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
+import com.hubspot.singularity.ScheduleType;
 import com.hubspot.singularity.SingularityDeployStatistics;
 import com.hubspot.singularity.SingularityRequestWithState;
 import com.hubspot.singularity.SingularityTaskId;
@@ -25,6 +27,7 @@ import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.DeployManager;
 import com.hubspot.singularity.data.RequestManager;
 import com.hubspot.singularity.data.TaskManager;
+import com.hubspot.singularity.helpers.RFC5545Schedule;
 import com.hubspot.singularity.sentry.SingularityExceptionNotifier;
 import com.hubspot.singularity.smtp.SingularityMailer;
 
@@ -110,23 +113,30 @@ public class SingularityScheduledJobPoller extends SingularityLeaderOnlyPoller {
         return deployStatistics.get().getAverageRuntimeMillis();
       }
 
-      final CronExpression cronExpression;
+      String scheduleExpression = request.getRequest().getScheduleTypeSafe() == ScheduleType.RFC5545 ? request.getRequest().getSchedule().get() : request.getRequest().getQuartzScheduleSafe();
+      Date nextRunAtDate;
 
       try {
-        cronExpression = new CronExpression(request.getRequest().getQuartzScheduleSafe());
-      } catch (ParseException e) {
-        LOG.warn("Unable to parse cron for {} ({})", taskId, request.getRequest().getQuartzScheduleSafe(), e);
-        exceptionNotifier.notify(e, ImmutableMap.of("taskId", taskId.toString()));
-        return Optional.absent();
-      }
+        if (request.getRequest().getScheduleTypeSafe() == ScheduleType.RFC5545) {
+          final RFC5545Schedule rfc5545Schedule = new RFC5545Schedule(scheduleExpression);
+          nextRunAtDate = rfc5545Schedule.getNextValidTime();
+        } else {
+          final CronExpression cronExpression;
+          cronExpression = new CronExpression(scheduleExpression);
+          final Date startDate = new Date(taskId.getStartedAt());
+          nextRunAtDate = cronExpression.getNextValidTimeAfter(startDate);
+        }
 
-      final Date startDate = new Date(taskId.getStartedAt());
-      final Date nextRunAtDate = cronExpression.getNextValidTimeAfter(startDate);
+        if (nextRunAtDate == null) {
+          String msg = String.format("No next run date found for %s (%s)", taskId, scheduleExpression);
+          LOG.warn(msg);
+          exceptionNotifier.notify(msg, ImmutableMap.of("taskId", taskId.toString()));
+          return Optional.absent();
+        }
 
-      if (nextRunAtDate == null) {
-        String msg = String.format("No next run date found for %s (%s)", taskId, request.getRequest().getQuartzScheduleSafe());
-        LOG.warn(msg);
-        exceptionNotifier.notify(msg, ImmutableMap.of("taskId", taskId.toString()));
+      } catch (ParseException|InvalidRecurrenceRuleException e) {
+        LOG.warn("Unable to parse schedule of type {} for expression {} (taskId: {}, err: {})", request.getRequest().getScheduleTypeSafe(), scheduleExpression, taskId, e);
+        exceptionNotifier.notify(e, ImmutableMap.of("taskId", taskId.toString(), "scheduleExpression", scheduleExpression, "scheduleType", request.getRequest().getScheduleTypeSafe().toString()));
         return Optional.absent();
       }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduledJobPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduledJobPoller.java
@@ -121,8 +121,7 @@ public class SingularityScheduledJobPoller extends SingularityLeaderOnlyPoller {
           final RFC5545Schedule rfc5545Schedule = new RFC5545Schedule(scheduleExpression);
           nextRunAtDate = rfc5545Schedule.getNextValidTime();
         } else {
-          final CronExpression cronExpression;
-          cronExpression = new CronExpression(scheduleExpression);
+          final CronExpression cronExpression = new CronExpression(scheduleExpression);
           final Date startDate = new Date(taskId.getStartedAt());
           nextRunAtDate = cronExpression.getNextValidTimeAfter(startDate);
         }

--- a/SingularityService/src/test/java/com/hubspot/singularity/helpers/RFC5545ScheduleTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/helpers/RFC5545ScheduleTest.java
@@ -17,12 +17,6 @@ public class RFC5545ScheduleTest {
   }
 
   @Test
-  public void testInfiniteScheduleIsLimited() throws Exception {
-    String schedule = "FREQ=DAILY;BYDAY=MO,TU,WE,TH,FR";
-    Assert.assertEquals(new RFC5545Schedule(schedule).getRecurrenceRule().getUntil(), new DateTime(2100, 1, 1, 0, 0, 0));
-  }
-
-  @Test
   public void testMaxIterations() throws Exception {
     String schedule = "DTSTART=19970902T090000\nRRULE:FREQ=HOURLY;COUNT=10001";
     Assert.assertEquals(new RFC5545Schedule(schedule).getStartDateTime(), new org.joda.time.DateTime(1997, 9, 2, 9, 0, 0));

--- a/SingularityService/src/test/java/com/hubspot/singularity/helpers/RFC5545ScheduleTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/helpers/RFC5545ScheduleTest.java
@@ -1,0 +1,37 @@
+package com.hubspot.singularity.helpers;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+import org.dmfs.rfc5545.DateTime;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RFC5545ScheduleTest {
+  @Test
+  public void testEveryWeekdayRFC5545Schdule() throws Exception {
+    String schedule = "FREQ=DAILY;BYDAY=MO,TU,WE,TH,FR";
+    Date nextValidTime = new RFC5545Schedule(schedule).getNextValidTime();
+    Assert.assertTrue(nextValidTime.after(new Date()));
+    Assert.assertTrue(nextValidTime.before(new Date(System.currentTimeMillis() + TimeUnit.DAYS.toMillis(3))));
+  }
+
+  @Test
+  public void testInfiniteScheduleIsLimited() throws Exception {
+    String schedule = "FREQ=DAILY;BYDAY=MO,TU,WE,TH,FR";
+    Assert.assertEquals(new RFC5545Schedule(schedule).getRecurrenceRule().getUntil(), new DateTime(2100, 1, 1, 0, 0, 0));
+  }
+
+  @Test
+  public void testMaxIterations() throws Exception {
+    String schedule = "DTSTART=19970902T090000\nRRULE:FREQ=HOURLY;COUNT=10001";
+    Assert.assertEquals(new RFC5545Schedule(schedule).getStartDateTime(), new org.joda.time.DateTime(1997, 9, 2, 9, 0, 0));
+    Assert.assertEquals(new RFC5545Schedule(schedule).getNextValidTime(), null);
+  }
+
+  @Test
+  public void testRecurInPastDoesNotGiveNext() throws Exception {
+    String schedule = "FREQ=YEARLY;INTERVAL=4;BYMONTH=11;BYDAY=TU;BYMONTHDAY=2,3,4,5,6,7,8;COUNT=1";
+    Assert.assertEquals(new RFC5545Schedule(schedule).getNextValidTime(), null);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -226,6 +226,18 @@
         <artifactId>metrics-graphite</artifactId>
         <version>${dep.metrics.version}</version><!-- TOOD: add this to HubSpot's basepom -->
       </dependency>
+
+      <dependency>
+        <groupId>org.dmfs</groupId>
+        <artifactId>lib-recur</artifactId>
+        <version>0.9.4</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.dmfs</groupId>
+        <artifactId>rfc5545-datetime</artifactId>
+        <version>0.2.2</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Realized the branch that @grepsr started had a lot of odd merge artifacts present and was difficult to get into our staging environment. Reimplemented the functionality here based on that work, with a few tweaks + added basic tests. Usage via the api remains the same

caveats/changes from #931:
- DTSTART functionality as it was implemented in #931 cannot handle a provided timezone correctly, and did not parse out the RRULE string separately. I've updated so a simple DTSTART=xxxxxxx will function, however specification of time zone will still throw an error at the moment
- removed the limiter in year 2100 when the schedule is infinite since it's a bit arbitrary and instead implemented a max iterations (10k) for the finding of next valid time. Unless we are using a very old DTSTART and a very frequent schedule, we should not be hitting this anyways

Thanks @grepsr for starting this. I think it will be easier for us to get into our staging environments and into a release for you from this branch.

/cc @tpetr 