### PR TITLE
Build the UI as its own module

### DIFF
--- a/SingularityService/pom.xml
+++ b/SingularityService/pom.xml
@@ -417,44 +417,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <artifactId>maven-resources-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>copy-index.html-template</id>
-            <phase>generate-resources</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${basedir}/target/generated-resources/com/hubspot/singularity/views</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>../SingularityUI/app/assets/</directory>
-                  <includes>
-                    <include>index.mustache</include>
-                  </includes>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-          <execution>
-            <id>copy-ui</id>
-            <phase>generate-resources</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${basedir}/target/generated-resources/assets</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>../SingularityUI/dist</directory>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
 
     <pluginManagement>
@@ -549,6 +511,44 @@
       </activation>
       <build>
         <plugins>
+          <plugin>
+            <artifactId>maven-resources-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>copy-index.html-template</id>
+                <phase>generate-resources</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${basedir}/target/generated-resources/com/hubspot/singularity/views</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>../SingularityUI/app/assets/</directory>
+                      <includes>
+                        <include>index.mustache</include>
+                      </includes>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+              <execution>
+                <id>copy-ui</id>
+                <phase>generate-resources</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${basedir}/target/generated-resources/assets</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>../SingularityUI/dist</directory>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>build-helper-maven-plugin</artifactId>

--- a/SingularityService/pom.xml
+++ b/SingularityService/pom.xml
@@ -23,6 +23,7 @@
     <dependency>
       <groupId>com.hubspot</groupId>
       <artifactId>SingularityUI</artifactId>
+      <type>pom</type>
     </dependency>
 
     <dependency>
@@ -436,6 +437,24 @@
               </resources>
             </configuration>
           </execution>
+          <execution>
+            <id>copy-ui</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${basedir}/target/generated-resources/static</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>../SingularityUI/app/dist/</directory>
+                  <includes>
+                    <include>*</include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
     </plugins>
@@ -462,7 +481,7 @@
                         </pluginExecutionFilter>
                       <action>
                       <ignore />
-                    </action>		
+                    </action>
                  </pluginExecution>
                </pluginExecutions>
              </lifecycleMappingMetadata>

--- a/SingularityService/pom.xml
+++ b/SingularityService/pom.xml
@@ -22,6 +22,11 @@
 
     <dependency>
       <groupId>com.hubspot</groupId>
+      <artifactId>SingularityUI</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.hubspot</groupId>
       <artifactId>SingularityMesosClient</artifactId>
     </dependency>
 
@@ -357,7 +362,7 @@
       <artifactId>curator-test</artifactId>
       <scope>test</scope>
     </dependency>
-    
+
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
@@ -437,46 +442,8 @@
 
     <pluginManagement>
       <plugins>
-        <!--This plugin's configuration is used to store Eclipse m2e settings 
+        <!--This plugin's configuration is used to store Eclipse m2e settings
           only. It has no influence on the Maven build itself. -->
-        <plugin>
-          <groupId>org.eclipse.m2e</groupId>
-          <artifactId>lifecycle-mapping</artifactId>
-          <version>1.0.0</version>
-          <configuration>
-            <lifecycleMappingMetadata>
-              <pluginExecutions>
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>com.github.eirslett</groupId>
-                    <artifactId>frontend-maven-plugin</artifactId>
-                    <versionRange>[0,)</versionRange>
-                    <goals>
-                      <goal>install-node-and-npm</goal>
-                      <goal>npm</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <ignore />
-                  </action>
-                </pluginExecution>
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>com.github.kongchen</groupId>
-                    <artifactId>swagger-maven-plugin</artifactId>
-                    <versionRange>[0,)</versionRange>
-                    <goals>
-                      <goal>generate</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <ignore />
-                  </action>
-                </pluginExecution>
-              </pluginExecutions>
-            </lifecycleMappingMetadata>
-          </configuration>
-        </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
@@ -542,37 +509,6 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>com.github.eirslett</groupId>
-            <artifactId>frontend-maven-plugin</artifactId>
-            <configuration>
-              <workingDirectory>../SingularityUI</workingDirectory>
-            </configuration>
-            <executions>
-              <execution>
-                <id>install node and npm</id>
-                <goals>
-                  <goal>install-node-and-npm</goal>
-                </goals>
-                <configuration>
-                  <nodeVersion>v4.1.2</nodeVersion>
-                  <npmVersion>2.14.16</npmVersion>
-                </configuration>
-              </execution>
-              <execution>
-                <id>npm install</id>
-                <goals>
-                  <goal>npm</goal>
-                </goals>
-              </execution>
-              <execution>
-                <id>gulp build</id>
-                <goals>
-                  <goal>gulp</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>build-helper-maven-plugin</artifactId>
             <executions>
@@ -585,7 +521,7 @@
                 <configuration>
                   <resources>
                     <resource>
-                      <directory>${project.build.directory}/generated-resources</directory>
+                      <directory>../SingularityUI/dist</directory>
                     </resource>
                   </resources>
                 </configuration>

--- a/SingularityService/pom.xml
+++ b/SingularityService/pom.xml
@@ -444,6 +444,30 @@
       <plugins>
         <!--This plugin's configuration is used to store Eclipse m2e settings
           only. It has no influence on the Maven build itself. -->
+          <plugin>
+            <groupId>org.eclipse.m2e</groupId>
+            <artifactId>lifecycle-mapping</artifactId>
+            <version>1.0.0</version>
+            <configuration>
+              <lifecycleMappingMetadata>
+                <pluginExecutions>
+                  <pluginExecution>
+                    <pluginExecutionFilter>
+                      <groupId>com.github.kongchen</groupId>
+                      <artifactId>swagger-maven-plugin</artifactId>
+                      <versionRange>[0,)</versionRange>
+                      <goals>
+                        <goal>generate</goal>
+                       </goals>
+                        </pluginExecutionFilter>
+                      <action>
+                      <ignore />
+                    </action>		
+                 </pluginExecution>
+               </pluginExecutions>
+             </lifecycleMappingMetadata>
+          </configuration>
+        </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>

--- a/SingularityService/pom.xml
+++ b/SingularityService/pom.xml
@@ -447,10 +447,7 @@
               <outputDirectory>${basedir}/target/generated-resources/static</outputDirectory>
               <resources>
                 <resource>
-                  <directory>../SingularityUI/app/dist/</directory>
-                  <includes>
-                    <include>*</include>
-                  </includes>
+                  <directory>../SingularityUI/dist</directory>
                 </resource>
               </resources>
             </configuration>

--- a/SingularityService/pom.xml
+++ b/SingularityService/pom.xml
@@ -24,6 +24,7 @@
       <groupId>com.hubspot</groupId>
       <artifactId>SingularityUI</artifactId>
       <type>pom</type>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>

--- a/SingularityService/pom.xml
+++ b/SingularityService/pom.xml
@@ -444,7 +444,7 @@
               <goal>copy-resources</goal>
             </goals>
             <configuration>
-              <outputDirectory>${basedir}/target/generated-resources/static</outputDirectory>
+              <outputDirectory>${basedir}/target/generated-resources/assets</outputDirectory>
               <resources>
                 <resource>
                   <directory>../SingularityUI/dist</directory>
@@ -561,7 +561,7 @@
                 <configuration>
                   <resources>
                     <resource>
-                      <directory>../SingularityUI/dist</directory>
+                      <directory>${project.build.directory}/generated-resources</directory>
                     </resource>
                   </resources>
                 </configuration>

--- a/SingularityUI/.gitignore
+++ b/SingularityUI/.gitignore
@@ -1,2 +1,3 @@
 node
 /dist
+/target

--- a/SingularityUI/.gitignore
+++ b/SingularityUI/.gitignore
@@ -1,1 +1,2 @@
 node
+/dist

--- a/SingularityUI/gulpfile.js
+++ b/SingularityUI/gulpfile.js
@@ -41,7 +41,7 @@ var templateData = {
   redirectOnUnauthorizedUrl: process.env.SINGULARITY_REDIRECT_ON_UNAUTHORIZED_URL || ''
 }
 
-var dest = path.resolve(__dirname, '../SingularityService/target/generated-resources/assets');
+var dest = path.resolve(__dirname, 'dist');
 
 var webpack = require('webpack-stream');
 var webpackConfig = require('./webpack.config');
@@ -50,7 +50,8 @@ var WebpackDevServer = require('webpack-dev-server');
 gulp.task("clean", function() {
   return del([
     path.resolve(dest, 'static/**'),
-    path.resolve(dest, 'index.html')], {force: true});
+    path.resolve(dest, 'index.html'),
+    dest], {force: true});
 });
 
 gulp.task('fonts', function() {

--- a/SingularityUI/gulpfile.js
+++ b/SingularityUI/gulpfile.js
@@ -48,10 +48,7 @@ var webpackConfig = require('./webpack.config');
 var WebpackDevServer = require('webpack-dev-server');
 
 gulp.task("clean", function() {
-  return del([
-    path.resolve(dest, 'static/**'),
-    path.resolve(dest, 'index.html'),
-    dest], {force: true});
+  return del(dest);
 });
 
 gulp.task('fonts', function() {

--- a/SingularityUI/pom.xml
+++ b/SingularityUI/pom.xml
@@ -11,46 +11,56 @@
     <artifactId>SingularityUI</artifactId>
     <packaging>pom</packaging>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>com.github.eirslett</groupId>
-                <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.0</version>
+    <profiles>
+        <profile>
+            <id>build-webui</id>
+            <activation>
+                <property>
+                    <name>!skipSingularityWebUI</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.eirslett</groupId>
+                        <artifactId>frontend-maven-plugin</artifactId>
+                        <version>1.0</version>
 
-                <executions>
-                    <execution>
-                        <id>install node and npm</id>
-                        <goals>
-                            <goal>install-node-and-npm</goal>
-                        </goals>
-                        <configuration>
-                            <nodeVersion>v5.3.0</nodeVersion>
-                            <npmVersion>3.3.12</npmVersion>
-                        </configuration>
-                    </execution>
+                        <executions>
+                            <execution>
+                                <id>install node and npm</id>
+                                <goals>
+                                    <goal>install-node-and-npm</goal>
+                                </goals>
+                                <configuration>
+                                    <nodeVersion>v5.3.0</nodeVersion>
+                                    <npmVersion>3.3.12</npmVersion>
+                                </configuration>
+                            </execution>
 
-                    <execution>
-                        <id>npm install</id>
-                        <goals>
-                            <goal>npm</goal>
-                        </goals>
-                        <configuration>
-                            <arguments>install</arguments>
-                        </configuration>
-                    </execution>
+                            <execution>
+                                <id>npm install</id>
+                                <goals>
+                                    <goal>npm</goal>
+                                </goals>
+                                <configuration>
+                                    <arguments>install</arguments>
+                                </configuration>
+                            </execution>
 
-                    <execution>
-                        <id>gulp build</id>
-                        <goals>
-                            <goal>gulp</goal>
-                        </goals>
-                        <configuration>
-                            <arguments>build</arguments>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+                            <execution>
+                                <id>gulp build</id>
+                                <goals>
+                                    <goal>gulp</goal>
+                                </goals>
+                                <configuration>
+                                    <arguments>build</arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/SingularityUI/pom.xml
+++ b/SingularityUI/pom.xml
@@ -10,17 +10,13 @@
 
     <artifactId>SingularityUI</artifactId>
     <packaging>pom</packaging>
-    
+
     <build>
         <plugins>
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
                 <version>1.0</version>
-
-                <!-- <configuration>
-                    <workingDirectory>SingularityUI/</workingDirectory>
-                </configuration> -->
 
                 <executions>
                     <execution>

--- a/SingularityUI/pom.xml
+++ b/SingularityUI/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <packaging>pom</packaging>
 
     <parent>
         <groupId>com.hubspot</groupId>
@@ -10,7 +9,8 @@
     </parent>
 
     <artifactId>SingularityUI</artifactId>
-
+    <packaging>pom</packaging>
+    
     <build>
         <plugins>
             <plugin>

--- a/SingularityUI/pom.xml
+++ b/SingularityUI/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>pom</packaging>
+
+    <parent>
+        <groupId>com.hubspot</groupId>
+        <artifactId>Singularity</artifactId>
+        <version>0.8.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>SingularityUI</artifactId>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
+                <version>1.0</version>
+
+                <!-- <configuration>
+                    <workingDirectory>SingularityUI/</workingDirectory>
+                </configuration> -->
+
+                <executions>
+                    <execution>
+                        <id>install node and npm</id>
+                        <goals>
+                            <goal>install-node-and-npm</goal>
+                        </goals>
+                        <configuration>
+                            <nodeVersion>v5.3.0</nodeVersion>
+                            <npmVersion>3.3.12</npmVersion>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>npm install</id>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>install</arguments>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>gulp build</id>
+                        <goals>
+                            <goal>gulp</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>build</arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/SingularityUI/webpack.config.js
+++ b/SingularityUI/webpack.config.js
@@ -1,7 +1,7 @@
 var webpack = require('webpack');
 var path = require('path');
 
-dest = path.resolve(__dirname, '../SingularityService/target/generated-resources/assets');
+dest = path.resolve(__dirname, 'dist');
 
 module.exports = {
   entry: {

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
     <module>SingularitySwagger</module>
     <module>EmbedSingularityExample</module>
     <module>SingularityServiceIntegrationTests</module>
+    <module>SingularityUI</module>
   </modules>
 
   <dependencyManagement>
@@ -92,6 +93,12 @@
       <dependency>
         <groupId>com.hubspot</groupId>
         <artifactId>SingularityClient</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.hubspot</groupId>
+        <artifactId>SingularityUI</artifactId>
         <version>${project.version}</version>
       </dependency>
 
@@ -136,7 +143,7 @@
         <artifactId>jackson-jaxrs-propertyfiltering</artifactId>
         <version>0.7.0</version>
       </dependency>
-    
+
       <dependency>
         <groupId>com.h2database</groupId>
         <artifactId>h2</artifactId>
@@ -148,13 +155,13 @@
         <artifactId>liquibase-core</artifactId>
         <version>3.1.1</version>
       </dependency>
-    
+
       <dependency>
         <groupId>org.yaml</groupId>
         <artifactId>snakeyaml</artifactId>
         <version>1.13</version>
       </dependency>
-        
+
       <dependency>
         <groupId>com.hubspot</groupId>
         <artifactId>BaragonCore</artifactId>
@@ -266,7 +273,7 @@
         <plugin>
           <groupId>com.github.eirslett</groupId>
           <artifactId>frontend-maven-plugin</artifactId>
-          <version>0.0.23</version>
+          <version>1.0</version>
         </plugin>
         <plugin>
           <groupId>com.github.kongchen</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
         <groupId>com.hubspot</groupId>
         <artifactId>SingularityUI</artifactId>
         <version>${project.version}</version>
+        <type>pom</type>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
We want Singularity to build independently of SingularityService. This creates a new pom for the UI and moves the build into that. SingularityService then depends on that and copies the files from `dist/` to its own resources.

@tpetr 