### PR TITLE
handle new lines better in docker.env using bashEscaped helper

### DIFF
--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/models/EnvironmentContext.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/models/EnvironmentContext.java
@@ -30,6 +30,10 @@ public class EnvironmentContext {
     return taskInfo.getContainer().getVolumesList();
   }
 
+  public boolean isDocker() {
+    return taskInfo.hasContainer() && taskInfo.getContainer().hasDocker();
+  }
+
   @Override
   public String toString() {
     return "EnvironmentContext [taskInfo=" + taskInfo + "]";

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskProcessBuilder.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskProcessBuilder.java
@@ -125,6 +125,7 @@ public class SingularityExecutorTaskProcessBuilder implements Callable<ProcessBu
 
     if (taskInfo.hasContainer() && taskInfo.getContainer().hasDocker()) {
       task.getLog().info("Writing a runner script to execute {} in docker container", cmd);
+      templateManager.writeEnvironmentScript(getPath("docker.env"), environmentContext);
       templateManager.writeDockerScript(getPath("runner.sh"), new DockerContext(environmentContext, runnerContext, configuration.getDockerPrefix(), configuration.getDockerStopTimeout(), taskInfo.getContainer().getDocker().getPrivileged()));
     } else {
       templateManager.writeEnvironmentScript(getPath("deploy.env"), environmentContext);

--- a/SingularityExecutor/src/main/resources/deploy.env.hbs
+++ b/SingularityExecutor/src/main/resources/deploy.env.hbs
@@ -1,7 +1,13 @@
 # mesos task env
+{{#if docker}}
+{{#each env}}
+{{{name}}}={{{bashEscaped value}}}
+{{/each}}
+{{else}}
 {{#each env}}
 export {{{name}}}={{{bashEscaped value}}}
 {{/each}}
+{{/if}}
 
 # HubSpot-Specific-TODO
 export RODAN_HOSTNAME="$TASK_REQUEST_ID-$INSTANCE_NO"

--- a/SingularityExecutor/src/main/resources/deploy.env.hbs
+++ b/SingularityExecutor/src/main/resources/deploy.env.hbs
@@ -7,7 +7,6 @@
 {{#each env}}
 export {{{name}}}={{{bashEscaped value}}}
 {{/each}}
-{{/if}}
-
 # HubSpot-Specific-TODO
 export RODAN_HOSTNAME="$TASK_REQUEST_ID-$INSTANCE_NO"
+{{/if}}

--- a/SingularityExecutor/src/main/resources/docker.sh.hbs
+++ b/SingularityExecutor/src/main/resources/docker.sh.hbs
@@ -59,11 +59,7 @@ function enable_cgroup_hierarchy {
 DOCKER_IMAGE={{{ envContext.dockerInfo.image }}}
 
 # load env vars
-touch docker.env
-{{#each envContext.env}}
-{{{name}}}={{{bashEscaped value}}}
-echo "{{{name}}}={{{value}}}" >> docker.env
-{{/each}}
+source docker.env
 
 # Create log directory for logrotate runs
 if [[ ! -d {{{ runContext.logDir }}} ]]; then


### PR DESCRIPTION
still sourcing docker.env in the runner script as well so that any vars set can be used in docker arguments

/cc @jonathanwgoodwin 