### PR TITLE
Fix broken shell log link

### DIFF
--- a/SingularityUI/app/templates/taskDetail/taskShellCommands.hbs
+++ b/SingularityUI/app/templates/taskDetail/taskShellCommands.hbs
@@ -88,7 +88,7 @@
                                 <ul>{{#each shellUpdates}}<li>{{timestampFormatted timestamp}}: {{ message }}</li>{{/each}}</ul>
                               </td>
                               <td>
-                                {{#ifShellRequestHasOutputFilename shellUpdates}}<a href="{{ appRoot }}/task/{{ ../shellRequest.taskId.id }}/tail/{{ ../shellRequest.taskId.id }}/{{shellRequestOutputFilename shellUpdates}}">View</a>{{/ifShellRequestHasOutputFilename}}
+                                {{#ifShellRequestHasOutputFilename shellUpdates}}<a href="{{ appRoot }}/task/{{ shellRequest.taskId.id }}/tail/{{ shellRequest.taskId.id }}/{{shellRequestOutputFilename shellUpdates}}">View</a>{{/ifShellRequestHasOutputFilename}}
                               </td>
                             </tr>
                           {{/each}}


### PR DESCRIPTION
At one point we updated handlebars which changed the way scopes works in the template. This must have been missed in the conversion.