### PR TITLE
Fix table paging

### DIFF
--- a/SingularityUI/app/views/expandableTableSubview.coffee
+++ b/SingularityUI/app/views/expandableTableSubview.coffee
@@ -41,7 +41,7 @@ class ExpandableTableSubview extends View
     render: ->
         # If we've already rendered stuff and now we're trying to render
         # an empty collection (`next` returned an empty list)
-        if not @collection.length and @collection.currentPage isnt 1
+        if not @collection.length
             # Disable the next button and don't render anything
             $nextButton = @$('[data-action="next-page"]')
             $nextButton.attr 'disabled', true


### PR DESCRIPTION
Not sure why this check was added, but it was the cause of the issue where paging would break when `collection.length == collection.atATime` on the first page. Removing this doesn't seem to produce any side-effects.