### PR TITLE
Avoid race condition in deploy to unpause

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/DeployResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/DeployResource.java
@@ -129,11 +129,11 @@ public class DeployResource extends AbstractRequestResource {
     checkConflict(deployManager.createPendingDeploy(pendingDeployObj) != SingularityCreateResult.EXISTED,
         "Pending deploy already in progress for %s - cancel it or wait for it to complete (%s)", requestId, deployManager.getPendingDeploy(requestId).orNull());
 
-    deployManager.saveDeploy(request, deployMarker, deploy);
-
     if (requestWithState.getState() == RequestState.PAUSED) {
       requestManager.deployToUnpause(request, now, deployUser, deployRequest.getMessage());
     }
+
+    deployManager.saveDeploy(request, deployMarker, deploy);
 
     if (request.isDeployable()) {
       requestManager.addToPendingQueue(new SingularityPendingRequest(requestId, deployMarker.getDeployId(), now, deployUser, PendingType.NEW_DEPLOY,

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityDeployChecker.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityDeployChecker.java
@@ -126,7 +126,7 @@ public class SingularityDeployChecker {
         cancelLoadBalancer(pendingDeploy, SingularityDeployFailure.deployRemoved());
       }
 
-      removePendingDeploy(pendingDeploy);
+      failPendingDeployDueToState(pendingDeploy, maybeRequestWithState.get(), deploy);
       return;
     }
 
@@ -275,6 +275,12 @@ public class SingularityDeployChecker {
 
   private void removePendingDeploy(SingularityPendingDeploy pendingDeploy) {
     deployManager.deletePendingDeploy(pendingDeploy.getDeployMarker().getRequestId());
+  }
+
+  private void failPendingDeployDueToState(SingularityPendingDeploy pendingDeploy, SingularityRequestWithState requestWithState, Optional<SingularityDeploy> deploy) {
+    SingularityDeployResult deployResult = new SingularityDeployResult(DeployState.FAILED, Optional.of(String.format("Request in state %s is not deployable", requestWithState.getState())), Optional.<SingularityLoadBalancerUpdate>absent());
+    saveNewDeployState(pendingDeploy.getDeployMarker(), Optional.<SingularityDeployMarker> absent());
+    finishDeploy(requestWithState, deploy, pendingDeploy, Collections.<SingularityTaskId>emptyList(), deployResult);
   }
 
   private long getAllowedMillis(SingularityDeploy deploy) {

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -506,6 +506,21 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
   }
 
   @Test
+  public void testDeployFailsForInvalidRequestState() {
+    initRequest();
+
+    SingularityRequest request = requestResource.getRequest(requestId).getRequest();
+
+    initFirstDeploy();
+
+    deploy(secondDeployId, Optional.<Boolean>absent(), Optional.of(1), Optional.of(false), false);
+    requestManager.pause(request, System.currentTimeMillis(), Optional.<String>absent(), Optional.<String>absent());
+    deployChecker.checkDeploys();
+
+    Assert.assertEquals(DeployState.FAILED, deployManager.getDeployResult(requestId, secondDeployId).get().getDeployState());
+  }
+
+  @Test
   public void testDeployFailsAfterMaxTaskRetries() {
     initRequest();
 


### PR DESCRIPTION
If the request status is not updated to `DEPLOY_TO_UNPAUSE` _before_ the deploy is saved. It is possible that the deploy checker can run the first check of the deploy while the request is still in the paused state. This code path also left the deploy in a waiting state with no message.

Changes here move the request state update before the deploy save, and will also be sure to complete the deploy with a failure when hitting the code path where request state is not valid to proceed with the deploy