### PR TITLE
support overriding the log level in tests

### DIFF
--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityTestModule.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityTestModule.java
@@ -88,10 +88,10 @@ public class SingularityTestModule implements Module {
 
     LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
     Logger rootLogger = context.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
-    rootLogger.setLevel(Level.ERROR);
+    rootLogger.setLevel(Level.toLevel(System.getProperty("singularity.test.log.level", "ERROR")));
 
     Logger hsLogger = context.getLogger("com.hubspot");
-    hsLogger.setLevel(Level.ERROR);
+    hsLogger.setLevel(Level.toLevel(System.getProperty("singularity.test.log.level.for.com.hubspot", "ERROR")));
 
     this.ts = new TestingServer();
   }


### PR DESCRIPTION
Haven't 100% tested this yet, but this PR should make it much easier to bump up log verbosity when diagnosing things.

/cc @ssalinas @jhaber 