### PR TITLE
add downloadUrl field, for explicitly downloading from S3

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityS3Log.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityS3Log.java
@@ -2,7 +2,6 @@ package com.hubspot.singularity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Optional;
 import com.wordnik.swagger.annotations.ApiModel;
 import com.wordnik.swagger.annotations.ApiModelProperty;
 
@@ -13,10 +12,10 @@ public class SingularityS3Log {
   private final String key;
   private final long lastModified;
   private final long size;
-  private final Optional<String> downloadUrl;
+  private final String downloadUrl;
 
   @JsonCreator
-  public SingularityS3Log(@JsonProperty("getUrl") String getUrl, @JsonProperty("key") String key, @JsonProperty("lastModified") long lastModified, @JsonProperty("size") long size, @JsonProperty("downloadUrl") Optional<String> downloadUrl) {
+  public SingularityS3Log(@JsonProperty("getUrl") String getUrl, @JsonProperty("key") String key, @JsonProperty("lastModified") long lastModified, @JsonProperty("size") long size, @JsonProperty("downloadUrl") String downloadUrl) {
     this.getUrl = getUrl;
     this.key = key;
     this.lastModified = lastModified;
@@ -44,8 +43,8 @@ public class SingularityS3Log {
     return size;
   }
 
-  @ApiModelProperty("URL to file in S3 to explicitly download")
-  public Optional<String> getDownloadUrl() {
+  @ApiModelProperty("URL to file in S3 containing headers that will force file to be downloaded instead of viewed")
+  public String getDownloadUrl() {
     return downloadUrl;
   }
 

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityS3Log.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityS3Log.java
@@ -2,6 +2,7 @@ package com.hubspot.singularity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Optional;
 import com.wordnik.swagger.annotations.ApiModel;
 import com.wordnik.swagger.annotations.ApiModelProperty;
 
@@ -12,13 +13,15 @@ public class SingularityS3Log {
   private final String key;
   private final long lastModified;
   private final long size;
+  private final Optional<String> downloadUrl;
 
   @JsonCreator
-  public SingularityS3Log(@JsonProperty("getUrl") String getUrl, @JsonProperty("key") String key, @JsonProperty("lastModified") long lastModified, @JsonProperty("size") long size) {
+  public SingularityS3Log(@JsonProperty("getUrl") String getUrl, @JsonProperty("key") String key, @JsonProperty("lastModified") long lastModified, @JsonProperty("size") long size, @JsonProperty("downloadUrl") Optional<String> downloadUrl) {
     this.getUrl = getUrl;
     this.key = key;
     this.lastModified = lastModified;
     this.size = size;
+    this.downloadUrl = downloadUrl;
   }
 
   @ApiModelProperty("URL to file in S3")
@@ -41,8 +44,13 @@ public class SingularityS3Log {
     return size;
   }
 
+  @ApiModelProperty("URL to file in S3 to explicitly download")
+  public Optional<String> getDownloadUrl() {
+    return downloadUrl;
+  }
+
   @Override
   public String toString() {
-    return "SingularityS3Log [getUrl=" + getUrl + ", key=" + key + ", lastModified=" + lastModified + ", size=" + size + "]";
+    return "SingularityS3Log [getUrl=" + getUrl + ", key=" + key + ", lastModified=" + lastModified + ", size=" + size + ", downloadUrl=" + downloadUrl + "]";
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/S3LogResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/S3LogResource.java
@@ -240,7 +240,7 @@ public class S3LogResource extends AbstractHistoryResource {
           String getUrl = s3Service.createSignedGetUrl(s3Bucket, s3Object.getKey(), expireAt);
           String downloadUrl = s3Service.createSignedUrl("GET", s3Bucket, s3Object.getKey(), FORCE_DOWNLOAD_S3_PARAMS, null, expireAt.getTime() / 1000, false);
 
-          return new SingularityS3Log(getUrl, s3Object.getKey(), s3Object.getLastModifiedDate().getTime(), s3Object.getContentLength(), Optional.of(downloadUrl));
+          return new SingularityS3Log(getUrl, s3Object.getKey(), s3Object.getLastModifiedDate().getTime(), s3Object.getContentLength(), downloadUrl);
         }
 
       }));

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/S3LogResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/S3LogResource.java
@@ -71,6 +71,8 @@ public class S3LogResource extends AbstractHistoryResource {
 
   private static final Logger LOG = LoggerFactory.getLogger(S3LogResource.class);
 
+  private static final String FORCE_DOWNLOAD_S3_PARAMS = "response-content-disposition=attachment&response-content-encoding=identity";
+
   private final Optional<S3Service> s3ServiceDefault;
   private final Map<String, S3Service> s3GroupOverride;
   private final Optional<S3Configuration> configuration;
@@ -236,8 +238,9 @@ public class S3LogResource extends AbstractHistoryResource {
         @Override
         public SingularityS3Log call() throws Exception {
           String getUrl = s3Service.createSignedGetUrl(s3Bucket, s3Object.getKey(), expireAt);
+          String downloadUrl = s3Service.createSignedUrl("GET", s3Bucket, s3Object.getKey(), FORCE_DOWNLOAD_S3_PARAMS, null, expireAt.getTime() / 1000, false);
 
-          return new SingularityS3Log(getUrl, s3Object.getKey(), s3Object.getLastModifiedDate().getTime(), s3Object.getContentLength());
+          return new SingularityS3Log(getUrl, s3Object.getKey(), s3Object.getLastModifiedDate().getTime(), s3Object.getContentLength(), Optional.of(downloadUrl));
         }
 
       }));

--- a/SingularityUI/app/templates/taskDetail/taskS3Logs.hbs
+++ b/SingularityUI/app/templates/taskDetail/taskS3Logs.hbs
@@ -28,7 +28,7 @@
                                 {{timestampFormatted lastModified}}
                             </td>
                             <td class="actions-column">
-                                <a href="{{ getUrl }}" target="_blank" title="Download">
+                                <a href="{{ downloadUrl }}" target="_blank" title="Download">
                                     <span class="glyphicon glyphicon-download-alt"></span>
                                 </a>
                             </td>


### PR DESCRIPTION
- Adds an optional `downloadUrl` field to `SingularityS3Log`, which contains a signed S3 link that explicitly downloads the file (as opposed to possibly opening the file inside the browser)
- Updates the UI such that the Download icon for an S3 file uses the `downloadUrl`