### PR TITLE
Fix filename truncation in sandbox endpoint

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/SandboxResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/SandboxResource.java
@@ -94,6 +94,11 @@ public class SandboxResource extends AbstractHistoryResource {
       @ApiParam("The path to browse from") @QueryParam("path") String path) {
     authorizationHelper.checkForAuthorizationByTaskId(taskId, user, SingularityAuthorizationScope.READ);
 
+    // Remove all trailing slashes from the path
+    if (path != null) {
+      path = path.replaceAll("\\/+$", "");
+    }
+
     final String currentDirectory = getCurrentDirectory(taskId, path);
     final SingularityTaskHistory history = checkHistory(taskId);
 


### PR DESCRIPTION
Filenames would be truncated if there were trailing slashes on the path parameter. Strip these before computing the path length.