### PR TITLE
include offer ID in resourceOffers() logging statement

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
@@ -128,8 +128,8 @@ public class SingularityMesosScheduler implements Scheduler {
     LOG.info("Received {} offer(s)", offers.size());
 
     for (Offer offer : offers) {
-      LOG.debug("Received offer from {} ({}) for {} cpu(s), {} memory, {} ports, and {} disk", offer.getHostname(), offer.getSlaveId().getValue(), MesosUtils.getNumCpus(offer), MesosUtils.getMemory(offer),
-          MesosUtils.getNumPorts(offer));
+      LOG.debug("Received offer ID {} from {} ({}) for {} cpu(s), {} memory, {} ports, and {} disk", offer.getId().getValue(), offer.getHostname(), offer.getSlaveId().getValue(), MesosUtils.getNumCpus(offer), MesosUtils.getMemory(offer),
+          MesosUtils.getNumPorts(offer), MesosUtils.getDisk(offer));
     }
 
     final long start = System.currentTimeMillis();


### PR DESCRIPTION
- Update logging to include offer IDs in `resourceOffers()`
- Fix bug where disk resource amount wasn't being displayed