### PR TITLE
Remove extraneous console.log in utils fuzzy search function

### DIFF
--- a/SingularityUI/app/utils.coffee
+++ b/SingularityUI/app/utils.coffee
@@ -234,7 +234,6 @@ class Utils
         return false
 
     @fuzzyAdjustScore: (filter, fuzzyObject) ->
-        console.log(fuzzyObject)
         if fuzzyObject.original.id.toLowerCase().startsWith(filter.toLowerCase())
             fuzzyObject.score * 10
         else if fuzzyObject.original.id.toLowerCase().indexOf(filter.toLowerCase()) > -1


### PR DESCRIPTION
Removes a console.log that leads to an absurd amount of logging when searching.