### PR TITLE
fix docker compose yaml to get hostname properly

### DIFF
--- a/SingularityService/src/main/docker/start.sh
+++ b/SingularityService/src/main/docker/start.sh
@@ -4,10 +4,10 @@ PATH=/usr/local/singularity/bin:/usr/local/sbin:/usr/sbin:/sbin:/usr/lib64/qt-3.
 
 if [ ${DOCKER_HOST} ]; then
 	HOST_AND_PORT=`echo $DOCKER_HOST | awk -F/ '{print $3}'`
-	HOST_IP="${HOST_AND_PORT%:*}"
+	SINGULARITY_HOSTNAME="${SINGULARITY_HOSTNAME:=HOST_AND_PORT%:*}"
 fi
 
-DEFAULT_URI_BASE="http://${HOST_IP:=localhost}:${SINGULARITY_PORT:=7099}${SINGULARITY_UI_BASE:=/singularity}"
+DEFAULT_URI_BASE="http://${SINGULARITY_HOSTNAME:=localhost}:${SINGULARITY_PORT:=7099}${SINGULARITY_UI_BASE:=/singularity}"
 
 
 [[ ! ${SINGULARITY_PORT:-} ]] || args+=( -Ddw.server.connector.port="$SINGULARITY_PORT" )
@@ -23,6 +23,7 @@ args+=( -Ddw.ui.baseUrl="${SINGULARITY_URI_BASE:=$DEFAULT_URI_BASE}" )
 [[ ! ${SINGULARITY_DB_USER:-} ]] || args+=( -Ddw.database.user="${SINGULARITY_DB_USER}" )
 [[ ! ${SINGULARITY_DB_PASSWORD:-} ]] || args+=( -Ddw.database.password="${SINGULARITY_DB_PASSWORD}" )
 [[ ! ${SINGULARITY_DB_URL:-} ]] || args+=( -Ddw.database.url="${SINGULARITY_DB_URL}" -Ddw.database.driverClass="${SINGULARITY_DB_DRIVER_CLASS:-com.mysql.jdbc.Driver}" )
+[[ ! ${SINGULARITY_HOSTNAME:-} ]] || args+= ( -Ddw.hostname="${SINGULARITY_HOSTNAME}" )
 
 # SMTP
 [[ ! ${SINGULARITY_SMTP_USERNAME:-} ]] || args+=( -Ddw.smtp.username="${SINGULARITY_SMTP_USERNAME}" )


### PR DESCRIPTION
As mentioned in HubSpot/Singularity#1107 , for newer docker versions grabbing the hostname via InetAddress does not work when running the container in host mode. This adds a way to set the hostname via an environment variable, and will automatically find it for you when using docker-compose (i.e. DOCKER_HOST var is passed in)