### PR TITLE
Fix user requested destroy when cleaning

### DIFF
--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorMonitor.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorMonitor.java
@@ -413,6 +413,11 @@ public class SingularityExecutorMonitor {
 
     final SingularityExecutorTask task = maybeTask.get();
 
+    if (!destroy && task.wasForceDestroyed()) {
+      task.getLog().debug("Already force destroyed, will not issue additional kill");
+      return KillState.DESTROYING_PROCESS;
+    }
+
     task.getLog().info("Executor asked to kill {}", taskId);
 
     ListenableFuture<ProcessBuilder> processBuilderFuture = null;

--- a/SingularityUI/app/views/taskOverviewSubview.coffee
+++ b/SingularityUI/app/views/taskOverviewSubview.coffee
@@ -87,7 +87,7 @@ class taskOverviewSubview extends View
 
 
     killTask: (data) =>
-        @taskModel.kill(data.message, @model.has('cleanup') or @model.get('isCleaning'), data.waitForReplacementTask)
+        @taskModel.kill(data.message, (@model.has('cleanup') or @model.get('isCleaning')) and @model.get('cleanup').isImmediate, data.waitForReplacementTask)
             .done (data) =>
                 @collection.add [data], parse: true  # automatically response  object to the cleanup collection
             .error (response) =>


### PR DESCRIPTION
@tpetr fixes the odd out of order signals we saw earlier, as well as making sure to not jump right to -9 for something that's cleaning but not actually sent a kill yet