### PR TITLE
Request -- Null Owner fix

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
@@ -115,7 +115,7 @@ public class SingularityValidator {
     checkBadRequest(request.getRequestType() != null, "RequestType cannot be null or missing");
 
     if (request.getOwners().isPresent()) {
-      checkBadRequest(!request.getOwners().get().contains(null), "Request owner(s) must not be null");
+      checkBadRequest(!request.getOwners().get().contains(null), "Request owners cannot contain null values");
     }
 
     if (!allowRequestsWithoutOwners) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
@@ -114,6 +114,10 @@ public class SingularityValidator {
     checkBadRequest(request.getId() != null && !StringUtils.containsAny(request.getId(), JOINER.join(REQUEST_ID_ILLEGAL_CHARACTERS)), "Id can not be null or contain any of the following characters: %s", REQUEST_ID_ILLEGAL_CHARACTERS);
     checkBadRequest(request.getRequestType() != null, "RequestType cannot be null or missing");
 
+    if (request.getOwners().isPresent()) {
+      checkBadRequest(!request.getOwners().get().contains(null), "Request owner(s) must not be null");
+    }
+
     if (!allowRequestsWithoutOwners) {
       checkBadRequest(request.getOwners().isPresent() && !request.getOwners().get().isEmpty(), "Request must have owners defined (this can be turned off in Singularity configuration)");
     }


### PR DESCRIPTION
This PR prevents new requests from being created which have one or more null owners, which have been causing errors elsewhere in Singularity.

(Dupe of #1160 for master at ssalinas' request)

/cc @ssalinas @Calvinp @tpetr