### PR TITLE
Reorganize task label colors

### DIFF
--- a/SingularityUI/app/components/tasks/Columns.jsx
+++ b/SingularityUI/app/components/tasks/Columns.jsx
@@ -205,11 +205,11 @@ export const NextRun = (
       (rowData) => rowData.pendingTask.pendingTaskId.nextRunAt
     }
     cellRender={(cellData) => {
-      let label = <span className="label label-default">SCHEDULED</span>;
+      let label = <span className={`label label-${Utils.getLabelClassFromTaskState('TASK_SCHEDULED')}`}>SCHEDULED</span>;
       if (Utils.timestampWithinSeconds(cellData, config.pendingWithinSeconds)) {
-        label = <span className="label label-info">PENDING</span>;
+        label = <span className={`label label-${Utils.getLabelClassFromTaskState('TASK_PENDING')}`}>PENDING</span>;
       } else if (cellData < Date.now() - config.pendingWithinSeconds * 1000) {
-        label = <span className="label label-danger">OVERDUE</span>;
+        label = <span className={`label label-${Utils.getLabelClassFromTaskState('TASK_OVERDUE')}`}>OVERDUE</span>;
       }
       return (
         <div>

--- a/SingularityUI/app/utils.es6
+++ b/SingularityUI/app/utils.es6
@@ -66,24 +66,27 @@ const Utils = {
 
   getLabelClassFromTaskState(state) {
     switch (state) {
-      case 'TASK_STARTING':
-      case 'TASK_CLEANING':
-        return 'warning';
       case 'TASK_STAGING':
+      case 'TASK_STARTING':
+      case 'TASK_SCHEDULED':
+        return 'info'; // Not serving requests but no action necessary
+      case 'TASK_PENDING':
       case 'TASK_LAUNCHED':
-      case 'TASK_RUNNING':
-        return 'info';
       case 'TASK_FINISHED':
-        return 'success';
+        return 'primary'; // Not serving requests but no action necessary; Distinguishes similar states
+      case 'TASK_RUNNING':
+      case 'TASK_CLEANING':
+        return 'success'; // Currently serving requests
       case 'TASK_LOST':
       case 'TASK_FAILED':
       case 'TASK_LOST_WHILE_DOWN':
       case 'TASK_ERROR':
-        return 'danger';
+      case 'TASK_OVERDUE':
+        return 'danger'; // Big problems
       case 'TASK_KILLED':
-        return 'default';
+        return 'warning'; // Small or no problems but not a task initiated completion
       default:
-        return 'default';
+        return 'default'; // Unknown state
     }
   },
 


### PR DESCRIPTION
Reorganizes task label colors such that:
- Task States that don't require action, but aren't serving requests are `info` or `primary` (different shades of blue that distinguish similar but different states)
- Task States that are currently serving requests are `success` (green)
- Task States that indicate a failure and may require attention are `danger` (red)
- Task States that indicate either a small problem or no problem, but aren't a task-initiated completion, are `warning` (orange)
- Task States that are unknown to the UI are `default` (black)

cc @ssalinas @tpetr @markhazlewood @wolfd @kwm4385 
This PR should not be merged until all of those people have a chance to look at it and share their opinions because it is a fairly large change in the look of tasks (even if the code is small).
The original motivation was to distinguish tasks that are currently serving requests from ones that aren't, but then grew to group similar states as a whole.

Screenshots:
![screenshot 2016-07-20 10 42 06](https://cloud.githubusercontent.com/assets/3210505/16997770/d71e2f34-4e84-11e6-98c1-11fc8e01836d.png)
<img width="1175" alt="screenshot 2016-07-20 11 08 45" src="https://cloud.githubusercontent.com/assets/3210505/16997731/af9cc394-4e84-11e6-9589-9b3f0ca0a923.png">
![screenshot 2016-07-20 14 20 20](https://cloud.githubusercontent.com/assets/3210505/16997835/1f2da408-4e85-11e6-8c76-78b8a06f86fe.png)
![screenshot 2016-07-20 14 20 58](https://cloud.githubusercontent.com/assets/3210505/16997857/320d92f4-4e85-11e6-9d6e-306bf4b796d3.png)

