### PR TITLE
Change API path "/skipHealthchecks" to "/skip-healthchecks"

### DIFF
--- a/Docs/features/expiring-actions.md
+++ b/Docs/features/expiring-actions.md
@@ -116,7 +116,7 @@ This URL accepts a JSON object with this format:
 **NOTE:** The `user` field has been removed from this object.
 
 #### Disabling request healthchecks
-- `/requests/request/{requestId}/skipHealthchecks`
+- `/requests/request/{requestId}/skip-healthchecks`
 
 This URL accepts a JSON object with this format:
 
@@ -130,6 +130,6 @@ This URL accepts a JSON object with this format:
 ### New endpoints for cancelling actions
 These endpoints were added in order to support cancelling certain actions:
 - `DELETE /requests/request/{requestId}/scale` -- Cancel an expiring scale
-- `DELETE /requests/request/{requestId}/skipHealthchecks` -- Cancel an expiring skip healthchecks override
+- `DELETE /requests/request/{requestId}/skip-healthchecks` -- Cancel an expiring skip healthchecks override
 - `DELETE /request/{requestId}/pause` -- Cancel (unpause) an expiring pause
 - `DELETE /request/{requestId}/bounce` -- Cancel a bounce

--- a/Docs/reference/api.md
+++ b/Docs/reference/api.md
@@ -825,7 +825,7 @@ Unpause a Singularity Request, scheduling new tasks immediately
 
 
 - - -
-#### **PUT** `/api/requests/request/{requestId}/skipHealthchecks`
+#### **PUT** `/api/requests/request/{requestId}/skip-healthchecks`
 
 Update the skipHealthchecks field for the request, possibly temporarily
 
@@ -853,7 +853,7 @@ Update the skipHealthchecks field for the request, possibly temporarily
 
 
 - - -
-#### **DELETE** `/api/requests/request/{requestId}/skipHealthchecks`
+#### **DELETE** `/api/requests/request/{requestId}/skip-healthchecks`
 
 Delete/cancel the expiring skipHealthchecks. This makes the skipHealthchecks request permanent.
 

--- a/Docs/reference/apidocs/api-requests.md
+++ b/Docs/reference/apidocs/api-requests.md
@@ -29,7 +29,7 @@ Unpause a Singularity Request, scheduling new tasks immediately
 
 
 - - -
-#### **PUT** `/api/requests/request/{requestId}/skipHealthchecks`
+#### **PUT** `/api/requests/request/{requestId}/skip-healthchecks`
 
 Update the skipHealthchecks field for the request, possibly temporarily
 
@@ -57,7 +57,7 @@ Update the skipHealthchecks field for the request, possibly temporarily
 
 
 - - -
-#### **DELETE** `/api/requests/request/{requestId}/skipHealthchecks`
+#### **DELETE** `/api/requests/request/{requestId}/skip-healthchecks`
 
 Delete/cancel the expiring skipHealthchecks. This makes the skipHealthchecks request permanent.
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -43,7 +43,6 @@ import com.hubspot.singularity.SingularityRequestHistory.RequestHistoryType;
 import com.hubspot.singularity.SingularityRequestParent;
 import com.hubspot.singularity.SingularityRequestWithState;
 import com.hubspot.singularity.SingularityService;
-import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.SingularityTransformHelpers;
 import com.hubspot.singularity.SingularityUser;
@@ -585,8 +584,19 @@ public class RequestResource extends AbstractRequestResource {
     return deleteExpiringObject(SingularityExpiringScale.class, requestId);
   }
 
+  @Deprecated
   @DELETE
   @Path("/request/{requestId}/skipHealthchecks")
+  @ApiOperation(value="Delete/cancel the expiring skipHealthchecks. This makes the skipHealthchecks request permanent.", response=SingularityRequestParent.class)
+  @ApiResponses({
+      @ApiResponse(code=404, message="No Request or expiring skipHealthchecks request for that ID"),
+  })
+  public SingularityRequestParent deleteExpiringSkipHealthchecksDeprecated(@ApiParam("The Request ID") @PathParam("requestId") String requestId) {
+    return deleteExpiringSkipHealthchecks(requestId);
+  }
+
+  @DELETE
+  @Path("/request/{requestId}/skip-healthchecks")
   @ApiOperation(value="Delete/cancel the expiring skipHealthchecks. This makes the skipHealthchecks request permanent.", response=SingularityRequestParent.class)
   @ApiResponses({
     @ApiResponse(code=404, message="No Request or expiring skipHealthchecks request for that ID"),
@@ -615,8 +625,21 @@ public class RequestResource extends AbstractRequestResource {
     return deleteExpiringObject(SingularityExpiringBounce.class, requestId);
   }
 
+  @Deprecated
   @PUT
   @Path("/request/{requestId}/skipHealthchecks")
+  @Consumes({ MediaType.APPLICATION_JSON })
+  @ApiOperation(value="Update the skipHealthchecks field for the request, possibly temporarily", response=SingularityRequestParent.class)
+  @ApiResponses({
+      @ApiResponse(code=404, message="No Request with that ID"),
+  })
+  public SingularityRequestParent skipHealthchecksDeprecated(@ApiParam("The Request ID to scale") @PathParam("requestId") String requestId,
+                                                   @ApiParam("SkipHealtchecks options") SingularitySkipHealthchecksRequest skipHealthchecksRequest) {
+    return skipHealthchecks(requestId, skipHealthchecksRequest);
+  }
+
+  @PUT
+  @Path("/request/{requestId}/skip-healthchecks")
   @Consumes({ MediaType.APPLICATION_JSON })
   @ApiOperation(value="Update the skipHealthchecks field for the request, possibly temporarily", response=SingularityRequestParent.class)
   @ApiResponses({

--- a/SingularityUI/app/models/Request.coffee
+++ b/SingularityUI/app/models/Request.coffee
@@ -145,7 +145,7 @@ class Request extends Model
 
     makeSkipHealthchecksPermanent: (callback) =>
         $.ajax(
-          url: "#{ @url() }/skipHealthchecks"
+          url: "#{ @url() }/skip-healthchecks"
           type: "DELETE"
         ).then () =>
           @unset('expiringSkipHealthchecks')
@@ -189,7 +189,7 @@ class Request extends Model
             data.durationMillis = duration
         $.ajax
             type: "PUT"
-            url:  "#{ @url() }/skipHealthchecks"
+            url:  "#{ @url() }/skip-healthchecks"
             contentType: 'application/json'
             data: JSON.stringify data
 
@@ -203,7 +203,7 @@ class Request extends Model
             data.durationMillis = duration
         $.ajax
             type: "PUT"
-            url:  "#{ @url() }/skipHealthchecks"
+            url:  "#{ @url() }/skip-healthchecks"
             contentType: 'application/json'
             data: JSON.stringify data
 


### PR DESCRIPTION
This PR changes the "/skipHealthchecks" API path to "/skip-healthchecks" to maintain the dominant style, but preserves the old API paths (marked deprecated) for backwards compatibility.  Frontend code, backend code, and READMEs have been modified accordingly.

After a thorough search, I couldn't turn up any other @Paths that violated convention.

/cc @ssalinas @Calvinp @wolfd @tpetr 