### PR TITLE
Expiring pause deletion responsibility shift

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -43,7 +43,6 @@ import com.hubspot.singularity.SingularityRequestHistory.RequestHistoryType;
 import com.hubspot.singularity.SingularityRequestParent;
 import com.hubspot.singularity.SingularityRequestWithState;
 import com.hubspot.singularity.SingularityService;
-import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.SingularityTransformHelpers;
 import com.hubspot.singularity.SingularityUser;
@@ -359,6 +358,8 @@ public class RequestResource extends AbstractRequestResource {
       message = unpauseRequest.get().getMessage();
       skipHealthchecks = unpauseRequest.get().getSkipHealthchecks();
     }
+
+    requestManager.deleteExpiringObject(SingularityExpiringPause.class, requestId);
 
     final long now = requestHelper.unpause(requestWithState.getRequest(), JavaUtils.getUserEmail(user), message, skipHealthchecks);
 

--- a/SingularityUI/app/views/request.coffee
+++ b/SingularityUI/app/views/request.coffee
@@ -35,7 +35,6 @@ class RequestView extends View
             'click [data-action="makeSkipHealthchecksPermanent"]': 'makeSkipHealthchecksPermanent'
             'click [data-action="cancelBounce"]': 'cancelBounce'
 
-            'click [data-action="revertPause"]': 'revertPause'
             'click [data-action="revertScale"]': 'revertScale'
             'click [data-action="revertSkipHealthchecks"]': 'revertSkipHealthchecks'
 
@@ -137,10 +136,6 @@ class RequestView extends View
     cancelBounce: (e) =>
         @model.cancelBounce =>
             @trigger 'refreshrequest'
-
-    revertPause: (e) =>
-        @model.promptUnpause =>
-            @makePausePermanent()
 
     revertScale: (e) =>
         @model.scale

--- a/SingularityUI/app/views/requestActionExpirations.coffee
+++ b/SingularityUI/app/views/requestActionExpirations.coffee
@@ -55,7 +55,7 @@ class requestActionExpirations extends View
                 cancelText: 'Make Permanent'
                 cancelAction: 'makePausePermanent'
                 revertText: "Unpause"
-                revertAction: 'unpauseRequest'
+                revertAction: 'unpause'
                 message: request.expiringPause.expiringAPIRequestObject.message
 
         if request.expiringSkipHealthchecks and (request.expiringSkipHealthchecks.startMillis + request.expiringSkipHealthchecks.expiringAPIRequestObject.durationMillis) > new Date().getTime()

--- a/SingularityUI/app/views/requestActionExpirations.coffee
+++ b/SingularityUI/app/views/requestActionExpirations.coffee
@@ -55,7 +55,7 @@ class requestActionExpirations extends View
                 cancelText: 'Make Permanent'
                 cancelAction: 'makePausePermanent'
                 revertText: "Unpause"
-                revertAction: 'revertPause'
+                revertAction: 'unpauseRequest'
                 message: request.expiringPause.expiringAPIRequestObject.message
 
         if request.expiringSkipHealthchecks and (request.expiringSkipHealthchecks.startMillis + request.expiringSkipHealthchecks.expiringAPIRequestObject.durationMillis) > new Date().getTime()


### PR DESCRIPTION
This PR changes the Singularity backend to properly delete any existing SingularityExpiringPause on unpause.  It likewise changes the frontend to no longer take on that responsibility.

/cc @ssalinas @Calvinp @wolfd @tpetr 