### PR TITLE
Do not remove from LB if not yet added

### DIFF
--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
@@ -1549,6 +1550,33 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     Assert.assertTrue(lbUpdate.isPresent());
     Assert.assertTrue(lbUpdate.get().getLoadBalancerState() == BaragonRequestState.SUCCESS);
     Assert.assertTrue(lbUpdate.get().getLoadBalancerRequestId().getAttemptNumber() == 2);
+  }
+
+  @Test
+  public void testLbCleanupDoesNotRemoveBeforeAdd() {
+    initLoadBalancedRequest();
+    initFirstDeploy();
+    SingularityTask taskOne = launchTask(request, firstDeploy, 1, TaskState.TASK_RUNNING);
+
+    initSecondDeploy();
+    SingularityTask taskTwo = launchTask(request, secondDeploy, 1, TaskState.TASK_RUNNING);
+    testingLbClient.setNextBaragonRequestState(BaragonRequestState.WAITING);
+    deployChecker.checkDeploys();
+
+    // First task from old deploy is still starting, never got added to LB so it should not have a removal request
+    Assert.assertFalse(taskManager.getLoadBalancerState(taskOne.getTaskId(), LoadBalancerRequestType.ADD).isPresent());
+    Assert.assertFalse(taskManager.getLoadBalancerState(taskOne.getTaskId(), LoadBalancerRequestType.REMOVE).isPresent());
+
+    // Second task should have an add request
+    Assert.assertTrue(taskManager.getLoadBalancerState(taskTwo.getTaskId(), LoadBalancerRequestType.ADD).isPresent());
+
+    testingLbClient.setNextBaragonRequestState(BaragonRequestState.SUCCESS);
+    deployChecker.checkDeploys();
+
+    // First task from old deploy should still have no LB updates, but should have a cleanup
+    Assert.assertFalse(taskManager.getLoadBalancerState(taskOne.getTaskId(), LoadBalancerRequestType.ADD).isPresent());
+    Assert.assertFalse(taskManager.getLoadBalancerState(taskOne.getTaskId(), LoadBalancerRequestType.REMOVE).isPresent());
+    Assert.assertTrue(taskManager.getCleanupTaskIds().contains(taskOne.getTaskId()));
   }
 
   @Test


### PR DESCRIPTION
In this order of events, we were submitting a LB `ADD` request _after_ the `REMOVE` request, with the result that the presence of the REMOVE caused us to never properly remove the task from the LB:

- deploy `1` running
- deploy `2` starts
- replacement task for deploy `1` enters `TASK_RUNNING`
- deploy `2` tasks are healthy and LB `ADD`/`REMOVE` is triggered (but contains the replacement task above)
- replacement task from deploy `1` becomes healthy and LB `ADD` is sent

This fixes the deploy logic to only issue the `REMOVE` as part of the deploy if the `ADD` is already present and successful. If the `ADD` completes after/during the deploy lb actions, the task will still be properly removed from the LB during cleanup since the LB `REMOVE` will not be present.