### PR TITLE
Replace dashes with underscores when searching for matching hosts

### DIFF
--- a/SingularityUI/app/selectors/tasks.es6
+++ b/SingularityUI/app/selectors/tasks.es6
@@ -68,7 +68,7 @@ export const getFilteredTasks = createSelector(
         _.each(tasks, (t) => {
           t.id = id.extract(t);
         });
-        const hostMatch = fuzzy.filter(filter.filterText, tasks, host);
+        const hostMatch = fuzzy.filter(filter.filterText.split('-').join('_'), tasks, host);
         const idMatch = fuzzy.filter(filter.filterText, tasks, id);
         const rackMatch = fuzzy.filter(filter.filterText, tasks, rack);
         tasks = _.uniq(

--- a/SingularityUI/app/selectors/tasks.es6
+++ b/SingularityUI/app/selectors/tasks.es6
@@ -68,7 +68,7 @@ export const getFilteredTasks = createSelector(
         _.each(tasks, (t) => {
           t.id = id.extract(t);
         });
-        const hostMatch = fuzzy.filter(filter.filterText.split('-').join('_'), tasks, host);
+        const hostMatch = fuzzy.filter(filter.filterText.replace(/-/g, '_'), tasks, host);
         const idMatch = fuzzy.filter(filter.filterText, tasks, id);
         const rackMatch = fuzzy.filter(filter.filterText, tasks, rack);
         tasks = _.uniq(


### PR DESCRIPTION
Sometimes hostnames are presented with dashes, sometimes with underscores.  On the tasks page they are presented with underscores. Because of this, when linked from a page where they're presented with dashes, no match would be found. This fixes that.