### PR TITLE
Fix hopefully the last bug in the deploy detail page on decaf

### DIFF
--- a/SingularityUI/app/components/deployDetail/DeployDetail.jsx
+++ b/SingularityUI/app/components/deployDetail/DeployDetail.jsx
@@ -353,17 +353,9 @@ function mapStateToProps(state) {
   };
 }
 
-let firstLoad = true;
-
-function refresh(props) {
-  const promises = [];
+function refresh(props, promises = []) {
   promises.push(props.fetchDeployForRequest(props.params.requestId, props.params.deployId));
   promises.push(props.fetchActiveTasksForDeploy(props.params.requestId, props.params.deployId));
-  if (firstLoad) {
-    firstLoad = false;
-    promises.push(props.clearTaskHistoryForDeploy());
-    promises.push(props.fetchTaskHistoryForDeploy(props.params.requestId, props.params.deployId, 5, 1));
-  }
 
   const allPromises = Promise.all(promises);
   allPromises.then(() => {
@@ -374,4 +366,11 @@ function refresh(props) {
   return allPromises;
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(rootComponent(DeployDetail, (props) => `Deploy ${props.params.deployId}`, refresh));
+function initialize(props) {
+  const promises = [];
+  promises.push(props.clearTaskHistoryForDeploy());
+  promises.push(props.fetchTaskHistoryForDeploy(props.params.requestId, props.params.deployId, 5, 1));
+  return refresh(props, promises);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(rootComponent(DeployDetail, (props) => `Deploy ${props.params.deployId}`, refresh, true, true, initialize));

--- a/SingularityUI/app/rootComponent.jsx
+++ b/SingularityUI/app/rootComponent.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 
-const rootComponent = (Wrapped, title, refresh = _.noop, refreshInterval = true, pageMargin = true) => class extends React.Component {
+const rootComponent = (Wrapped, title, refresh = _.noop, refreshInterval = true, pageMargin = true, initialize) => class extends React.Component {
 
   constructor(props) {
     super(props);
@@ -20,7 +20,7 @@ const rootComponent = (Wrapped, title, refresh = _.noop, refreshInterval = true,
     const titleString = typeof title === 'function' ? title(this.props) : title;
     document.title = `${titleString} - ${config.title}`;
 
-    const promise = refresh(this.props);
+    const promise = initialize ? initialize(this.props) : refresh(this.props);
     if (promise) {
       promise.then(() => {
         if (!this.unmounted) {


### PR DESCRIPTION
Fixes a bug in the deploy detail page that caused the TaskHistory table to show tasks from the last deploy viewed.

Implementation justification:
The problem was that `firstLoad` wasn't an instance variable, and so was only set when the app was first loaded.
One simple solution would be to put this functionality into `componentWillMount()`, but that was what caused the infinite API requests bug.
Another simple solution would be to set `refreshInterval` to be false, but the component does need a refresh interval for other pieces.
So instead I added an `initialize` parameter to the `rootComponent`. If it's set, it will be called instead of `refresh` on the first load. In this case, `initialize` also calls `refresh` to avoid code duplication.

cc @tpetr @kwm4385 @wolfd 