### PR TITLE
Add ability to show task disk resource if configured to do so

### DIFF
--- a/SingularityUI/app/assets/index.mustache
+++ b/SingularityUI/app/assets/index.mustache
@@ -32,6 +32,7 @@
             runningTaskLogPath: "{{{ runningTaskLogPath }}}",
             finishedTaskLogPath: "{{{ finishedTaskLogPath }}}",
             commonHostnameSuffixToOmit: "{{{ commonHostnameSuffixToOmit }}}",
+            showTaskDiskResource: {{{showTaskDiskResource}}},
             taskS3LogOmitPrefix: "{{{ taskS3LogOmitPrefix }}}",
             slaveHttpPort: {{{slaveHttpPort}}},
             warnIfScheduledJobIsRunningPastNextRunPct: {{{warnIfScheduledJobIsRunningPastNextRunPct}}},

--- a/SingularityUI/app/components/newDeployForm/NewDeployForm.jsx
+++ b/SingularityUI/app/components/newDeployForm/NewDeployForm.jsx
@@ -86,6 +86,7 @@ class NewDeployForm extends Component {
       cpus: PropTypes.string,
       memoryMb: PropTypes.string,
       numPorts: PropTypes.string,
+      diskMb: PropTypes.string,
       env: PropTypes.arrayOf(PropTypes.string),
       healthcheckUri: PropTypes.string,
       healthcheckIntervalSeconds: PropTypes.string,
@@ -1105,6 +1106,15 @@ class NewDeployForm extends Component {
         feedback={this.formFieldFeedback(INDEXED_FIELDS.numPorts, this.props.form.numPorts)}
       />
     );
+    const diskMb = (
+      <TextFormGroup
+        id="disk-mb"
+        onChange={event => this.updateField('diskMb', event.target.value)}
+        value={this.props.form.diskMb}
+        label="Disk (MB)"
+        feedback={this.formFieldFeedback(INDEXED_FIELDS.diskMb, this.props.form.diskMb)}
+      />
+    );
     const env = (
       <MultiInputFormGroup
         id="env-vars"
@@ -1303,6 +1313,13 @@ class NewDeployForm extends Component {
             <div className="col-sm-4">
               {numPorts}
             </div>
+          </div>
+          <div className="row">
+            {config.showTaskDiskResource &&
+              <div className="col-sm-4">
+                {diskMb}
+              </div>
+            }
           </div>
         </fieldset>
       </div>

--- a/SingularityUI/app/components/newDeployForm/fields.es6
+++ b/SingularityUI/app/components/newDeployForm/fields.es6
@@ -14,7 +14,8 @@ export const FIELDS = {
       values: [
         {id: 'cpus', type: 'number', default: 1},
         {id: 'memoryMb', type: 'number', default: 128},
-        {id: 'numPorts', type: 'number', default: 0}
+        {id: 'numPorts', type: 'number', default: 0},
+        {id: 'diskMb', type: 'number'}
       ]
     }
   ],

--- a/SingularityUI/app/components/tasks/Columns.jsx
+++ b/SingularityUI/app/components/tasks/Columns.jsx
@@ -179,6 +179,29 @@ export const Memory = (
   />
 );
 
+export const Disk = (
+  <Column
+    label="Disk"
+    id="disk"
+    key="disk"
+    cellData={
+      (rowData) => {
+        const disk = _.find(rowData.mesosTask.resources, (resource) => resource.name === 'disk');
+        if (disk) {
+          return disk.scalar.value;
+        }
+        return null;
+      }
+    }
+    cellRender={
+      (cellData) => (cellData &&
+        <span>{cellData} MB</span>
+      )
+    }
+    sortable={true}
+  />
+);
+
 export const ActiveActions = (
   <Column
     label=""

--- a/SingularityUI/app/components/tasks/TasksPage.jsx
+++ b/SingularityUI/app/components/tasks/TasksPage.jsx
@@ -24,6 +24,7 @@ import {
   Rack,
   CPUs,
   Memory,
+  Disk,
   ActiveActions,
   NextRun,
   PendingType,
@@ -81,9 +82,15 @@ class TasksPage extends React.Component {
 
 
   getColumns() {
+    let columns;
     switch (this.props.filter.taskStatus) {
       case 'active':
-        return [TaskIdShortened, StartedAt, Host, Rack, CPUs, Memory, ActiveActions];
+        columns = [TaskIdShortened, StartedAt, Host, Rack, CPUs, Memory];
+        if (config.showTaskDiskResource) {
+          columns.push(Disk);
+        }
+        columns.push(ActiveActions);
+        return columns;
       case 'scheduled':
         return [ScheduledTaskId, NextRun, PendingType, PendingDeployId, ScheduledActions];
       case 'cleaning':
@@ -91,7 +98,12 @@ class TasksPage extends React.Component {
       case 'lbcleanup':
         return [TaskIdShortened, StartedAt, Host, Rack, InstanceNumber, JSONAction];
       case 'decommissioning':
-        return [TaskIdShortened, StartedAt, Host, Rack, CPUs, Memory, ActiveActions];
+        columns = [TaskIdShortened, StartedAt, Host, Rack, CPUs, Memory, ActiveActions];
+        if (config.showTaskDiskResource) {
+          columns.push(Disk);
+        }
+        columns.push(ActiveActions);
+        return columns;
       default:
         return [TaskIdShortened, JSONAction];
     }

--- a/SingularityUI/gulpfile.js
+++ b/SingularityUI/gulpfile.js
@@ -32,6 +32,7 @@ var templateData = {
   defaultHealthcheckTimeoutSeconds: process.env.SINGULARITY_HEALTHCHECK_TIMEOUT_SECONDS || 5,
   defaultDeployHealthTimeoutSeconds: process.env.SINGULARITY_DEPLOY_HEALTH_TIMEOUT_SECONDS || 120,
   defaultHealthcheckMaxRetries: process.env.SINGULARITY_HEALTHCHECK_MAX_RETRIES || 0,
+  showTaskDiskResource: process.env.SINGULARITY_SHOW_TASK_DISK_RESOURCE || "false",
   hideNewDeployButton: process.env.SINGULARITY_HIDE_NEW_DEPLOY_BUTTON || 'false',
   hideNewRequestButton: process.env.SINGULARITY_HIDE_NEW_REQUEST_BUTTON || 'false',
   loadBalancingEnabled: process.env.SINGULARITY_LOAD_BALANCING_ENABLED || 'false',


### PR DESCRIPTION
Exactly what it says on the tin.

If `config.showTaskDiskResource` is true, the disk resource will be shown on the tasks table and as an option on the New Deploy form.

cc @tpetr @kwm4385 @wolfd 