### PR TITLE
sort task history updates by ExtendedTaskState enum ordinal, not timestamp

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskIdHistory.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskIdHistory.java
@@ -17,19 +17,12 @@ public class SingularityTaskIdHistory implements Comparable<SingularityTaskIdHis
   private final Optional<ExtendedTaskState> lastTaskState;
   private final Optional<String> runId;
 
-  private static final Comparator<SingularityTaskHistoryUpdate> comparator = new Comparator<SingularityTaskHistoryUpdate>() {
-    @Override
-    public int compare(SingularityTaskHistoryUpdate o1, SingularityTaskHistoryUpdate o2) {
-      return o1.getTaskState().compareTo(o2.getTaskState());
-    }
-  };
-
   public static SingularityTaskIdHistory fromTaskIdAndTaskAndUpdates(SingularityTaskId taskId, SingularityTask task, List<SingularityTaskHistoryUpdate> updates) {
     ExtendedTaskState lastTaskState = null;
     long updatedAt = taskId.getStartedAt();
 
     if (updates != null && !updates.isEmpty()) {
-      SingularityTaskHistoryUpdate lastUpdate = Collections.max(updates, comparator);
+      SingularityTaskHistoryUpdate lastUpdate = Collections.max(updates);
       lastTaskState = lastUpdate.getTaskState();
       updatedAt = lastUpdate.getTimestamp();
     }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskIdHistory.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskIdHistory.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.collect.ComparisonChain;
-import com.google.common.collect.Iterables;
 
 public class SingularityTaskIdHistory implements Comparable<SingularityTaskIdHistory> {
 
@@ -30,8 +29,7 @@ public class SingularityTaskIdHistory implements Comparable<SingularityTaskIdHis
     long updatedAt = taskId.getStartedAt();
 
     if (updates != null && !updates.isEmpty()) {
-      Collections.sort(updates, comparator);
-      SingularityTaskHistoryUpdate lastUpdate = Iterables.getLast(updates);
+      SingularityTaskHistoryUpdate lastUpdate = Collections.max(updates, comparator);
       lastTaskState = lastUpdate.getTaskState();
       updatedAt = lastUpdate.getTimestamp();
     }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskIdHistory.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskIdHistory.java
@@ -1,5 +1,7 @@
 package com.hubspot.singularity;
 
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -7,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.Iterables;
 
 public class SingularityTaskIdHistory implements Comparable<SingularityTaskIdHistory> {
 
@@ -15,17 +18,20 @@ public class SingularityTaskIdHistory implements Comparable<SingularityTaskIdHis
   private final Optional<ExtendedTaskState> lastTaskState;
   private final Optional<String> runId;
 
+  private static final Comparator<SingularityTaskHistoryUpdate> comparator = new Comparator<SingularityTaskHistoryUpdate>() {
+    @Override
+    public int compare(SingularityTaskHistoryUpdate o1, SingularityTaskHistoryUpdate o2) {
+      return o1.getTaskState().compareTo(o2.getTaskState());
+    }
+  };
+
   public static SingularityTaskIdHistory fromTaskIdAndTaskAndUpdates(SingularityTaskId taskId, SingularityTask task, List<SingularityTaskHistoryUpdate> updates) {
     ExtendedTaskState lastTaskState = null;
     long updatedAt = taskId.getStartedAt();
 
     if (updates != null && !updates.isEmpty()) {
-      SingularityTaskHistoryUpdate lastUpdate = updates.get(0);
-      for (SingularityTaskHistoryUpdate update : updates.subList(1, updates.size())) {
-        if (update.getTimestamp() > lastUpdate.getTimestamp()) {
-          lastUpdate = update;
-        }
-      }
+      Collections.sort(updates, comparator);
+      SingularityTaskHistoryUpdate lastUpdate = Iterables.getLast(updates);
       lastTaskState = lastUpdate.getTaskState();
       updatedAt = lastUpdate.getTimestamp();
     }


### PR DESCRIPTION
I found a few cases where it could happen that what we would consider the 'current state' of the task, is not the update that has the latest timestamp:
- Rapid updates in succession, causing the history updates to have identical or out-of-order timestamps
- cleaning triggered early in task lifecycle, followed quickly by a starting/running update will indefinitely leave the task in that state (not allowing it to clean/shut down properly)

This PR updates the sort called when fetching task histories to sort by the `ExtendedTaskSTate` ordinal instead of relying only on timestamp. This should give us the correct 'current' state in all cases since the enum is defined in the order we expect statuses to progress during the task lifecycle.

/cc @tpetr @stevenschlansker @subratbasnet #1187 