### PR TITLE
Better cleanup of incremental tasks

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/TaskCleanupType.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/TaskCleanupType.java
@@ -3,8 +3,8 @@ package com.hubspot.singularity;
 public enum TaskCleanupType {
 
   USER_REQUESTED(true, true), USER_REQUESTED_TASK_BOUNCE(false, false), DECOMISSIONING(false, false), SCALING_DOWN(true, false), BOUNCING(false, false), INCREMENTAL_BOUNCE(false, false),
-  DEPLOY_FAILED(false, true), NEW_DEPLOY_SUCCEEDED(true, false), DEPLOY_STEP_FINISHED(true, false), DEPLOY_CANCELED(false, true), UNHEALTHY_NEW_TASK(true, true),
-  OVERDUE_NEW_TASK(true, true), USER_REQUESTED_DESTROY(true, true);
+  DEPLOY_FAILED(true, true), NEW_DEPLOY_SUCCEEDED(true, false), DEPLOY_STEP_FINISHED(true, false), DEPLOY_CANCELED(true, true), UNHEALTHY_NEW_TASK(true, true),
+  OVERDUE_NEW_TASK(true, true), USER_REQUESTED_DESTROY(true, true), INCREMENTAL_DEPLOY_FAILED(false, true), INCREMENTAL_DEPLOY_CANCELLED(false, true);
 
   private final boolean killLongRunningTaskInstantly;
   private final boolean killNonLongRunningTaskInstantly;

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityDeployChecker.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityDeployChecker.java
@@ -216,6 +216,7 @@ public class SingularityDeployChecker {
 
   private TaskCleanupType getCleanupType(SingularityPendingDeploy pendingDeploy, SingularityRequest request, SingularityDeployResult deployResult) {
     if (pendingDeploy.getDeployProgress().isPresent() && pendingDeploy.getDeployProgress().get().getDeployInstanceCountPerStep() != request.getInstancesSafe()) {
+      // For incremental deploys, return a special cleanup type
       if (deployResult.getDeployState() == DeployState.FAILED) {
         return TaskCleanupType.INCREMENTAL_DEPLOY_FAILED;
       } else if (deployResult.getDeployState() == DeployState.CANCELED) {

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -19,7 +19,6 @@ import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
@@ -63,6 +64,7 @@ import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.SingularityTaskRequest;
 import com.hubspot.singularity.SingularityUpdatePendingDeployRequest;
 import com.hubspot.singularity.SlavePlacement;
+import com.hubspot.singularity.TaskCleanupType;
 import com.hubspot.singularity.api.SingularityBounceRequest;
 import com.hubspot.singularity.api.SingularityDeleteRequestRequest;
 import com.hubspot.singularity.api.SingularityDeployRequest;
@@ -286,6 +288,46 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
 
     Assert.assertEquals(2, taskManager.getActiveTaskIdsForDeploy(requestId, secondDeployId).size());
     Assert.assertEquals(DeployState.SUCCEEDED, deployManager.getDeployResult(requestId, secondDeployId).get().getDeployState());
+  }
+
+  @Test
+  public void testIncrementalDeployCancel() {
+    initRequest();
+
+    // Set up incremental deploy that is partly finished
+    SingularityRequest request = requestResource.getRequest(requestId).getRequest();
+    requestResource.postRequest(request.toBuilder().setInstances(Optional.of(2)).build());
+    initFirstDeploy();
+
+    SingularityTask firstTask = launchTask(request, firstDeploy, 1, TaskState.TASK_RUNNING);
+    launchTask(request, firstDeploy, 2, TaskState.TASK_RUNNING);
+    deploy(secondDeployId, Optional.<Boolean> absent(), Optional.of(1), Optional.<Boolean> absent(), false);
+    deployChecker.checkDeploys();
+    scheduler.drainPendingQueue(stateCacheProvider.get());
+    resourceOffers();
+    SingularityTaskId firstNewTaskId = taskManager.getActiveTaskIdsForDeploy(requestId, secondDeployId).get(0);
+    statusUpdate(taskManager.getTask(firstNewTaskId).get(), TaskState.TASK_RUNNING);
+    deployChecker.checkDeploys();
+
+    cleaner.drainCleanupQueue();
+    statusUpdate(firstTask, TaskState.TASK_KILLED);
+    deployChecker.checkDeploys();
+    scheduler.drainPendingQueue(stateCacheProvider.get());
+    resourceOffers();
+    // End in-progress incremental deploy setup
+
+    deployResource.cancelDeploy(requestId, secondDeployId);
+    deployChecker.checkDeploys();
+    Assert.assertEquals(taskManager.getCleanupTasks().get(0).getCleanupType(), TaskCleanupType.INCREMENTAL_DEPLOY_CANCELLED);
+
+    // Incremental deploy task should not be shut down while active deploy is below target instances
+    cleaner.drainCleanupQueue();
+    Assert.assertTrue(taskManager.getKilledTaskIdRecords().isEmpty());
+    Assert.assertEquals(taskManager.getCleanupTasks().get(0).getCleanupType(), TaskCleanupType.INCREMENTAL_DEPLOY_CANCELLED);
+
+    launchTask(request, firstDeploy, 1, TaskState.TASK_RUNNING);
+    cleaner.drainCleanupQueue();
+    Assert.assertFalse(taskManager.getKilledTaskIdRecords().isEmpty());
   }
 
   @Test


### PR DESCRIPTION
This PR addresses two bugs:
- When an incremental deploys fails, it will wait for the active deploy to return to normal instance count so there is never reduced capacity in a load balancer. If there are not enough resources to return the active deploy to the original instance count, these can essentially be 'stuck' in  cleaning state waiting for more tasks to start.
- If bounce is initiated during a deploy that will fail and the replacement tasks for the bounce are continually failing healthchecks, the failed deploy tasks will not shut down and will remain in cleaning until the bounce completes (not harmful, but annoying since they should be killed more quickly)

These are both due to the change introduced in d6ba7e3ea431f387b0d06de7795e6d5ab0d60d1b which considered deploy failures and cancellations as non-immediate kills for the sake of incremental deploy rollbacks as mentioned in the first point above.

This PR updates the deploy checker and cleaner to be more aware of incremental vs non-incremental deploy failures so that the cleanup can be done appropriately, as well as cleaning up tasks from failed incremental deploys in a more rolling fashion (similar to incremental bounce)

/cc @tpetr 