### PR TITLE
Run now fixes

### DIFF
--- a/SingularityUI/app/components/common/TaskLauncher.jsx
+++ b/SingularityUI/app/components/common/TaskLauncher.jsx
@@ -42,7 +42,7 @@ class TaskLauncher extends Component {
       promises.push(this.props.fetchRequestRun(requestId, runId, [404]));
       promises.push(this.props.fetchRequestRunHistory(requestId, runId, [404]));
       Promise.all(promises).then((responses) => {
-        const responseList = _.filter(_.pluck(responses, 'data'), (r) => !!r);
+        const responseList = _.filter(_.pluck(responses, 'data'), (response) => !!response);
         if (responseList.length) {
           this.clearIntervals();
           this.setState({
@@ -67,7 +67,7 @@ class TaskLauncher extends Component {
       this.props.fetchTaskFiles(taskId, `${taskId}${directory}`, [400]).then((response) => {
         const files = response.data && response.data.files;
         if (files) {
-          const file = _.find(files, (f) => f.name === _.last(filename.split('/')));
+          const file = _.find(files, (fileToCheck) => fileToCheck.name === _.last(filename.split('/')));
           if (file) {
             this.setState({
               fileExists: true

--- a/SingularityUI/app/components/common/modal/FormModal.jsx
+++ b/SingularityUI/app/components/common/modal/FormModal.jsx
@@ -8,17 +8,28 @@ import Select from 'react-select';
 
 const TAGS_CHARACTER_LIMIT = 75;
 
+function getDefaultFormState(props) {
+  const formState = {};
+  props.formElements.forEach((formElement) => {
+    const { defaultValue } = formElement;
+    if (defaultValue) {
+      if (Array.isArray(defaultValue)) {
+        formState[formElement.name] = defaultValue;
+      } else {
+        formState[formElement.name] = formElement.defaultValue.toString();
+      }
+    }
+  });
+  return formState;
+}
+
 export default class FormModal extends React.Component {
   constructor(props) {
     super(props);
-    const formState = {};
-    props.formElements.forEach((formElement) => {
-      formState[formElement.name] = formElement.defaultValue && formElement.defaultValue.toString();
-    });
 
     this.state = {
       visible: false,
-      formState,
+      formState: getDefaultFormState(props),
       errors: {}
     };
 
@@ -54,13 +65,14 @@ export default class FormModal extends React.Component {
 
   show() {
     this.setState({
-      visible: true
+      visible: true,
+      formState: getDefaultFormState(this.props)
     });
   }
 
   handleFormChange(name, value) {
     const formState = this.state.formState;
-    formState[name] = value;
+    formState[name] = value; // Mutates pre-existing state, probably bad
     this.setState({ formState });
   }
 
@@ -375,7 +387,7 @@ FormModal.propTypes = {
     label: React.PropTypes.string,
     isRequired: React.PropTypes.bool,
     values: React.PropTypes.array,
-    defaultValue: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.bool, React.PropTypes.number]),
+    defaultValue: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.bool, React.PropTypes.number, React.PropTypes.array]),
     validateField: React.PropTypes.func, // String -> String, return field validation error or falsey value if valid
     dependsOn: React.PropTypes.string // Only show this item if the other item (referenced by name) has a truthy value
   })).isRequired

--- a/SingularityUI/app/components/common/modal/FormModal.jsx
+++ b/SingularityUI/app/components/common/modal/FormModal.jsx
@@ -5,6 +5,7 @@ import { Modal, Button, Popover, OverlayTrigger } from 'react-bootstrap';
 import TagsInput from 'react-tagsinput';
 import Duration from '../formItems/Duration';
 import Select from 'react-select';
+import Utils from '../../../utils';
 
 const TAGS_CHARACTER_LIMIT = 75;
 
@@ -36,6 +37,12 @@ export default class FormModal extends React.Component {
     _.bindAll(this, 'hide', 'show', 'confirm');
   }
 
+  componentWillReceiveProps(newProps) {
+    if (_.isEqual(this.state.formState, getDefaultFormState(this.props))) {
+      this.setState({formState: getDefaultFormState(newProps)});
+    }
+  }
+
   static FormItem = (props) => {
     if ((props.element.dependsOn && props.formState[props.element.dependsOn]) || !props.element.dependsOn) {
       return (
@@ -65,14 +72,13 @@ export default class FormModal extends React.Component {
 
   show() {
     this.setState({
-      visible: true,
-      formState: getDefaultFormState(this.props)
+      visible: true
     });
   }
 
   handleFormChange(name, value) {
-    const formState = this.state.formState;
-    formState[name] = value; // Mutates pre-existing state, probably bad
+    const formState = Utils.deepClone(this.state.formState);
+    formState[name] = value;
     this.setState({ formState });
   }
 

--- a/SingularityUI/app/components/common/modal/ModalWrapper.es6
+++ b/SingularityUI/app/components/common/modal/ModalWrapper.es6
@@ -1,14 +1,10 @@
 import React from 'react';
 
-export const getClickComponent = (component, doFirst) => (
+export const getClickComponent = (component, doFirst = (() => Promise.resolve())) => (
   React.Children.map(component.props.children, child => (
     React.cloneElement(child, {
       onClick: () => {
-        if (doFirst) {
-          doFirst().then(() => component.refs.modal.getWrappedInstance().show());
-        } else {
-          component.refs.modal.getWrappedInstance().show();
-        }
+        doFirst().then(() => component.refs.modal.getWrappedInstance().show());
       }
     })
   ))

--- a/SingularityUI/app/components/common/modal/ModalWrapper.es6
+++ b/SingularityUI/app/components/common/modal/ModalWrapper.es6
@@ -3,9 +3,7 @@ import React from 'react';
 export const getClickComponent = (component, doFirst = (() => Promise.resolve())) => (
   React.Children.map(component.props.children, child => (
     React.cloneElement(child, {
-      onClick: () => {
-        doFirst().then(() => component.refs.modal.getWrappedInstance().show());
-      }
+      onClick: () => doFirst().then(() => component.refs.modal.getWrappedInstance().show())
     })
   ))
 );

--- a/SingularityUI/app/components/common/modal/ModalWrapper.es6
+++ b/SingularityUI/app/components/common/modal/ModalWrapper.es6
@@ -1,9 +1,14 @@
 import React from 'react';
 
-export const getClickComponent = (component) => (
+export const getClickComponent = (component, doFirst) => (
   React.Children.map(component.props.children, child => (
     React.cloneElement(child, {
-      onClick: () => component.refs.modal.getWrappedInstance().show()
+      onClick: () => {
+        if (doFirst) {
+          return doFirst().then(() => component.refs.modal.getWrappedInstance().show());
+        }
+        return component.refs.modal.getWrappedInstance().show();
+      }
     })
   ))
 );

--- a/SingularityUI/app/components/common/modal/ModalWrapper.es6
+++ b/SingularityUI/app/components/common/modal/ModalWrapper.es6
@@ -5,9 +5,10 @@ export const getClickComponent = (component, doFirst) => (
     React.cloneElement(child, {
       onClick: () => {
         if (doFirst) {
-          return doFirst().then(() => component.refs.modal.getWrappedInstance().show());
+          doFirst().then(() => component.refs.modal.getWrappedInstance().show());
+        } else {
+          component.refs.modal.getWrappedInstance().show();
         }
-        return component.refs.modal.getWrappedInstance().show();
       }
     })
   ))

--- a/SingularityUI/app/components/requestDetail/TaskHistoryTable.jsx
+++ b/SingularityUI/app/components/requestDetail/TaskHistoryTable.jsx
@@ -9,14 +9,14 @@ import { Link } from 'react-router';
 import Utils from '../../utils';
 
 import { FetchTaskHistoryForRequest } from '../../actions/api/history';
-
+import RunNowButton from '../requests/RunNowButton';
 import Section from '../common/Section';
 
 import UITable from '../common/table/UITable';
 import Column from '../common/table/Column';
 import JSONButton from '../common/JSONButton';
 
-const TaskHistoryTable = ({requestId, tasksAPI, fetchTaskHistoryForRequest}) => {
+const TaskHistoryTable = ({requestId, requestParent, tasksAPI, fetchTaskHistoryForRequest}) => {
   const tasks = tasksAPI ? tasksAPI.data : [];
   const isFetching = tasksAPI ? tasksAPI.isFetching : false;
   const emptyTableMessage = (Utils.api.isFirstLoad(tasksAPI)
@@ -45,6 +45,12 @@ const TaskHistoryTable = ({requestId, tasksAPI, fetchTaskHistoryForRequest}) => 
   const logTooltip = (
     <ToolTip id="log">
       Logs
+    </ToolTip>
+  );
+
+  const runNowTooltip = (
+    <ToolTip id="run-now">
+      Rerun This Task
     </ToolTip>
   );
 
@@ -112,6 +118,15 @@ const TaskHistoryTable = ({requestId, tasksAPI, fetchTaskHistoryForRequest}) => 
                   <Glyphicon glyph="file" />
                 </Link>
               </OverlayTrigger>
+              {Utils.request.canBeRunNow(requestParent) && (
+                <RunNowButton requestId={requestId} taskId={task.taskId.id}>
+                  <OverlayTrigger placement="top" id="view-run-now-overlay" overlay={runNowTooltip}>
+                    <a title="Rerun This Task">
+                      <Glyphicon glyph="repeat" />
+                    </a>
+                  </OverlayTrigger>
+                </RunNowButton>
+              )}
               <JSONButton object={task}>
                 {'{ }'}
               </JSONButton>
@@ -125,6 +140,7 @@ const TaskHistoryTable = ({requestId, tasksAPI, fetchTaskHistoryForRequest}) => 
 
 TaskHistoryTable.propTypes = {
   requestId: PropTypes.string.isRequired,
+  requestParent: PropTypes.object,
   tasksAPI: PropTypes.object.isRequired,
   fetchTaskHistoryForRequest: PropTypes.func.isRequired
 };
@@ -134,6 +150,7 @@ const mapDispatchToProps = (dispatch) => ({
 });
 
 const mapStateToProps = (state, ownProps) => ({
+  requestParent: Utils.maybe(state.api.request, [ownProps.requestId, 'data']),
   tasksAPI: Utils.maybe(
     state.api.taskHistoryForRequest,
     [ownProps.requestId]

--- a/SingularityUI/app/components/requests/RunNowButton.jsx
+++ b/SingularityUI/app/components/requests/RunNowButton.jsx
@@ -1,11 +1,14 @@
 import React, { Component, PropTypes } from 'react';
 import { withRouter } from 'react-router';
+import { connect } from 'react-redux';
+import { FetchTaskHistory } from '../../actions/api/history';
 
 import { Glyphicon } from 'react-bootstrap';
 import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
 import ToolTip from 'react-bootstrap/lib/Tooltip';
 import RunNowModal from './RunNowModal';
 import { getClickComponent } from '../common/modal/ModalWrapper';
+import Utils from '../../utils';
 
 const runNowTooltip = (
   <ToolTip id="run-now">
@@ -17,8 +20,11 @@ class RunNowButton extends Component {
 
   static propTypes = {
     requestId: PropTypes.string.isRequired,
+    fetchTaskHistory: PropTypes.func.isRequired,
     children: PropTypes.node,
-    router: PropTypes.object
+    router: PropTypes.object,
+    taskId: PropTypes.string,
+    task: PropTypes.object
   };
 
   static defaultProps = {
@@ -34,11 +40,19 @@ class RunNowButton extends Component {
   render() {
     return (
       <span>
-        <span>{getClickComponent(this)}</span>
-        <RunNowModal ref="modal" requestId={this.props.requestId} router={this.props.router} />
+        <span>{getClickComponent(this, this.props.taskId && (() => this.props.fetchTaskHistory(this.props.taskId)))}</span>
+        <RunNowModal ref="modal" requestId={this.props.requestId} task={this.props.task} router={this.props.router} />
       </span>
     );
   }
 }
 
-export default withRouter(RunNowButton);
+const mapStateToProps = (state, ownProps) => ({
+  task: ownProps.taskId && Utils.maybe(state.api.task[ownProps.taskId], ['data', 'task'])
+});
+
+const mapDispatchToProps = (dispatch) => ({
+  fetchTaskHistory: (taskId) => dispatch(FetchTaskHistory.trigger(taskId))
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(withRouter(RunNowButton));

--- a/SingularityUI/app/components/requests/RunNowButton.jsx
+++ b/SingularityUI/app/components/requests/RunNowButton.jsx
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import { withRouter } from 'react-router';
 import { connect } from 'react-redux';
-import { FetchTaskHistory } from '../../actions/api/history';
+import { FetchTaskHistory, FetchTaskHistoryForRequest } from '../../actions/api/history';
 
 import { Glyphicon } from 'react-bootstrap';
 import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
@@ -21,11 +21,22 @@ class RunNowButton extends Component {
   static propTypes = {
     requestId: PropTypes.string.isRequired,
     fetchTaskHistory: PropTypes.func.isRequired,
+    fetchLastRunTask: PropTypes.func.isRequired,
+    taskHistory: PropTypes.arrayOf(PropTypes.shape({
+      taskId: PropTypes.shape({
+        id: PropTypes.string.isRequired
+      }).isRequired
+    })),
     children: PropTypes.node,
     router: PropTypes.object,
     taskId: PropTypes.string,
     task: PropTypes.object
   };
+
+  constructor(props) {
+    super(props);
+    _.bindAll(this, 'doBeforeOpeningModal');
+  }
 
   static defaultProps = {
     children: (
@@ -37,21 +48,43 @@ class RunNowButton extends Component {
     )
   };
 
+  doBeforeOpeningModal() {
+    if (this.props.taskId) {
+      return this.props.fetchTaskHistory(this.props.taskId);
+    }
+    if (!_.isEmpty(this.props.taskHistory)) {
+      return this.props.fetchTaskHistory(this.props.taskHistory[0].taskId.id);
+    }
+    return this.props.fetchLastRunTask(this.props.requestId).then((response) => {
+      const taskId = Utils.maybe(response, ['data', '0', 'taskId', 'id']);
+      if (taskId) {
+        return this.props.fetchTaskHistory(taskId);
+      }
+      return Promise.resolve();
+    });
+  }
+
   render() {
     return (
       <span>
-        <span>{getClickComponent(this, this.props.taskId && (() => this.props.fetchTaskHistory(this.props.taskId)))}</span>
-        <RunNowModal ref="modal" requestId={this.props.requestId} task={this.props.task} router={this.props.router} />
+        <span>{getClickComponent(this, this.doBeforeOpeningModal)}</span>
+        <RunNowModal ref="modal" requestId={this.props.requestId} task={this.props.task} rerun={!!this.props.taskId} router={this.props.router} />
       </span>
     );
   }
 }
 
-const mapStateToProps = (state, ownProps) => ({
-  task: ownProps.taskId && Utils.maybe(state.api.task[ownProps.taskId], ['data', 'task'])
-});
+const mapStateToProps = (state, ownProps) => {
+  const taskHistory = Utils.maybe(state.api.taskHistoryForRequest, [ownProps.requestId, 'data'], []);
+  const taskId = ownProps.taskId || taskHistory[0] && taskHistory[0].taskId.id;
+  return {
+    taskHistory,
+    task: Utils.maybe(state.api.task[taskId], ['data', 'task'])
+  };
+};
 
 const mapDispatchToProps = (dispatch) => ({
+  fetchLastRunTask: (requestId) => dispatch(FetchTaskHistoryForRequest.trigger(requestId, 1, 1)),
   fetchTaskHistory: (taskId) => dispatch(FetchTaskHistory.trigger(taskId))
 });
 

--- a/SingularityUI/app/components/requests/RunNowModal.jsx
+++ b/SingularityUI/app/components/requests/RunNowModal.jsx
@@ -80,7 +80,7 @@ class RunNowModal extends Component {
             {
               name: 'fileToTail',
               type: FormModal.INPUT_TYPES.STRING,
-              defaultValue: _.rest(config.runningTaskLogPath.split('/'), '1').join('/')
+              defaultValue: config.runningTaskLogPath.indexOf('/') === -1 ? config.runningTaskLogPath : _.rest(config.runningTaskLogPath.split('/'), '1').join('/')
             }
           ]}>
           <span>

--- a/SingularityUI/app/components/requests/RunNowModal.jsx
+++ b/SingularityUI/app/components/requests/RunNowModal.jsx
@@ -59,6 +59,7 @@ class RunNowModal extends Component {
           router={this.props.router}
         />
         <FormModal
+          name={this.props.rerun ? 'Rerun this task now' : 'Run a task for this request now'}
           ref="runNowModal"
           action={<span><Glyphicon glyph="flash" /> {this.props.rerun ? 'Rerun' : 'Run'} Task</span>}
           onConfirm={(data) => this.handleRunNow(data)}

--- a/SingularityUI/app/components/requests/RunNowModal.jsx
+++ b/SingularityUI/app/components/requests/RunNowModal.jsx
@@ -15,6 +15,7 @@ class RunNowModal extends Component {
     requestId: PropTypes.string.isRequired,
     runNow: PropTypes.func.isRequired,
     router: PropTypes.object.isRequired,
+    rerun: PropTypes.bool,
     task: PropTypes.object
   };
 
@@ -23,6 +24,10 @@ class RunNowModal extends Component {
     SANDBOX: {label: 'Wait for task to start, then browse its sandbox', value: 'SANDBOX'},
     TAIL: {label: 'Wait for task to start, then start tailing:', value: 'TAIL'}
   };
+
+  defaultCommandLineArgs() {
+    return Utils.maybe(this.props.task, ['taskRequest', 'pendingTask', 'cmdLineArgsList']);
+  }
 
   show() {
     this.refs.runNowModal.show();
@@ -55,7 +60,7 @@ class RunNowModal extends Component {
         />
         <FormModal
           ref="runNowModal"
-          action={<span><Glyphicon glyph="flash" /> {this.props.task ? 'Rerun' : 'Run'} Task</span>}
+          action={<span><Glyphicon glyph="flash" /> {this.props.rerun ? 'Rerun' : 'Run'} Task</span>}
           onConfirm={(data) => this.handleRunNow(data)}
           buttonStyle="primary"
           formElements={[
@@ -63,7 +68,7 @@ class RunNowModal extends Component {
               name: 'commandLineArgs',
               type: FormModal.INPUT_TYPES.TAGS,
               label: 'Additional command line input: (optional)',
-              defaultValue: Utils.maybe(this.props.task, ['taskRequest', 'pendingTask', 'cmdLineArgsList'])
+              defaultValue: this.defaultCommandLineArgs()
             },
             {
               name: 'message',
@@ -84,8 +89,8 @@ class RunNowModal extends Component {
             }
           ]}>
           <span>
-            <p>Are you sure you want to immediately {this.props.task ? 'rerun this task' : 'launch a task for this request'}?</p>
-            <pre>{maybeTaskId || this.props.requestId}</pre>
+            <p>Are you sure you want to immediately {this.props.rerun ? 'rerun this task' : 'launch a task for this request'}?</p>
+            <pre>{this.props.rerun && maybeTaskId || this.props.requestId}</pre>
           </span>
         </FormModal>
       </span>

--- a/SingularityUI/app/components/requests/RunNowModal.jsx
+++ b/SingularityUI/app/components/requests/RunNowModal.jsx
@@ -8,12 +8,14 @@ import TaskLauncher from '../common/TaskLauncher';
 import FormModal from '../common/modal/FormModal';
 
 import Messenger from 'messenger';
+import Utils from '../../utils';
 
 class RunNowModal extends Component {
   static propTypes = {
     requestId: PropTypes.string.isRequired,
     runNow: PropTypes.func.isRequired,
-    router: PropTypes.object.isRequired
+    router: PropTypes.object.isRequired,
+    task: PropTypes.object
   };
 
   static AFTER_TRIGGER = {
@@ -44,6 +46,7 @@ class RunNowModal extends Component {
   }
 
   render() {
+    const maybeTaskId = Utils.maybe(this.props.task, ['taskId', 'id']);
     return (
       <span>
         <TaskLauncher
@@ -52,14 +55,15 @@ class RunNowModal extends Component {
         />
         <FormModal
           ref="runNowModal"
-          action={<span><Glyphicon glyph="flash" /> Run Task</span>}
+          action={<span><Glyphicon glyph="flash" /> {this.props.task ? 'Rerun' : 'Run'} Task</span>}
           onConfirm={(data) => this.handleRunNow(data)}
           buttonStyle="primary"
           formElements={[
             {
               name: 'commandLineArgs',
               type: FormModal.INPUT_TYPES.TAGS,
-              label: 'Additional command line input: (optional)'
+              label: 'Additional command line input: (optional)',
+              defaultValue: Utils.maybe(this.props.task, ['taskRequest', 'pendingTask', 'cmdLineArgsList'])
             },
             {
               name: 'message',
@@ -80,8 +84,8 @@ class RunNowModal extends Component {
             }
           ]}>
           <span>
-            <p>Are you sure you want to immediately launch a task for this request?</p>
-            <pre>{this.props.requestId}</pre>
+            <p>Are you sure you want to immediately {this.props.task ? 'rerun this task' : 'launch a task for this request'}?</p>
+            <pre>{maybeTaskId || this.props.requestId}</pre>
           </span>
         </FormModal>
       </span>

--- a/SingularityUI/app/utils.es6
+++ b/SingularityUI/app/utils.es6
@@ -206,6 +206,9 @@ const Utils = {
     if (!path.length) {
       return object;
     }
+    if (!object) {
+      return defaultValue;
+    }
     if (object.hasOwnProperty(path[0])) {
       return Utils.maybe(
         object[path[0]],

--- a/SingularityUI/package.json
+++ b/SingularityUI/package.json
@@ -46,7 +46,7 @@
     "react-router": "^2.5.2",
     "react-router-redux": "^4.0.5",
     "react-select": "1.0.0-beta14",
-    "react-tagsinput": "^3.9.0",
+    "react-tagsinput": "^3.13.0",
     "react-typeahead": "git://github.com/HubSpot/react-typeahead.git#hubspot-3",
     "react-waypoint": "^2.0.3",
     "redux": "^3.5.2",


### PR DESCRIPTION
Implements the following changes:
- A rerun button now appears on the task history table for requests whose tasks can be rerun.
- The run now dialog imports default command line arguments from the previously run task - unless it's a rerun in which case it imports from the task to be rerun.
- The run now dialog guesses that you want to tail the running log path.
- Code cleanliness, including not mutating state.