### PR TITLE
support for task id var substitution in env

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilder.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilder.java
@@ -169,12 +169,12 @@ class SingularityMesosTaskBuilder {
     setEnv(envBldr, "ESTIMATED_INSTANCE_COUNT", task.getRequest().getInstancesSafe());
 
     for (Entry<String, String> envEntry : task.getDeploy().getEnv().or(Collections.<String, String>emptyMap()).entrySet()) {
-      setEnv(envBldr, envEntry.getKey(), envEntry.getValue());
+      setEnv(envBldr, envEntry.getKey(), fillInTaskIdValues(envEntry.getValue(), offer, taskId));
     }
 
     if (task.getDeploy().getTaskEnv().isPresent() && task.getDeploy().getTaskEnv().get().containsKey(taskId.getInstanceNo()) && !task.getDeploy().getTaskEnv().get().get(taskId.getInstanceNo()).isEmpty()) {
       for (Entry<String, String> envEntry : task.getDeploy().getTaskEnv().get().get(taskId.getInstanceNo()).entrySet()) {
-        setEnv(envBldr, envEntry.getKey(), envEntry.getValue());
+        setEnv(envBldr, envEntry.getKey(), fillInTaskIdValues(envEntry.getValue(), offer, taskId));
       }
     }
 


### PR DESCRIPTION
In response to question on the mailing list. We do this already for docker volumes, makes sense to do it for user-provided environment variables too

Will support 
- `${TASK_REQUEST_ID}`
- `${TASK_DEPLOY_ID}`
- `${TASK_STARTED_AT}`
- `${TASK_INSTANCE_NO}`
- `${TASK_HOST}`
- `${TASK_RACK_ID}`
- `${TASK_ID}`