### PR TITLE
Request groups page

### DIFF
--- a/SingularityUI/app/actions/api/requestGroups.es6
+++ b/SingularityUI/app/actions/api/requestGroups.es6
@@ -1,6 +1,6 @@
 import { buildApiAction } from './base';
 
 export const FetchGroups = buildApiAction(
-  'FETCH_GROUPS',
+  'FETCH_REQUEST_GROUPS',
   {url: '/groups'}
 );

--- a/SingularityUI/app/actions/api/requestGroups.es6
+++ b/SingularityUI/app/actions/api/requestGroups.es6
@@ -1,0 +1,6 @@
+import { buildApiAction } from './base';
+
+export const FetchGroups = buildApiAction(
+  'FETCH_GROUPS',
+  {url: '/groups'}
+);

--- a/SingularityUI/app/components/common/MetadataButton.jsx
+++ b/SingularityUI/app/components/common/MetadataButton.jsx
@@ -1,0 +1,74 @@
+import React, { Component, PropTypes } from 'react';
+import { Modal, Button } from 'react-bootstrap';
+import Clipboard from 'clipboard';
+import Utils from '../../utils';
+
+import { InfoBox } from '../common/statelessComponents';
+
+export default class MetadataButton extends Component {
+  static propTypes = {
+    children: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.node),
+      PropTypes.node
+    ]).isRequired,
+    metadata: PropTypes.object.isRequired,
+    className: PropTypes.string,
+    title: PropTypes.string
+  };
+
+  constructor() {
+    super();
+    this.state = {
+      modalOpen: false
+    };
+    _.bindAll(this, 'hide', 'show');
+  }
+
+  componentDidMount() {
+    this.clipboard = new Clipboard('.copy-btn');
+  }
+
+  show() {
+    this.setState({
+      modalOpen: true
+    });
+  }
+
+  hide() {
+    this.setState({
+      modalOpen: false
+    });
+  }
+
+  render() {
+    const items = [];
+    for (const key of _.keys(this.props.metadata)) {
+      items.push(
+        <InfoBox copyableClassName="info-copyable" key={key} name={Utils.humanizeCamelcase(key)} value={this.props.metadata[key]} />
+      );
+    }
+
+    return (
+      <span className={this.props.className}>
+        <Button onClick={this.show} alt="Show Metadata">{this.props.children}</Button>
+        <Modal show={this.state.modalOpen} onHide={this.hide} bsSize="large">
+          <Modal.Header>
+            <Modal.Title>{this.props.title}</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <div className="constrained-modal">
+              <div className="row">
+                <ul className="list-unstyled horizontal-description-list">
+                  {items}
+                </ul>
+              </div>
+            </div>
+          </Modal.Body>
+          <Modal.Footer>
+            <Button bsStyle="info" onClick={this.hide}>Close</Button>
+          </Modal.Footer>
+        </Modal>
+      </span>
+    );
+  }
+}

--- a/SingularityUI/app/components/deployDetail/DeployDetail.jsx
+++ b/SingularityUI/app/components/deployDetail/DeployDetail.jsx
@@ -362,7 +362,7 @@ function mapStateToProps(state, ownProps) {
     deploy: state.api.deploy.data,
     taskHistory: state.api.taskHistoryForDeploy.data,
     isTaskHistoryFetching: state.api.taskHistoryForDeploy.isFetching,
-    group: state.api.deploy.data.deploy && _.first(_.filter(state.api.requestGroups.data, (g) => _.contains(g.requestIds, state.api.deploy.data.deploy.requestId))),
+    group: state.api.deploy.data.deploy && _.first(_.filter(state.api.requestGroups.data, (filterGroup) => _.contains(filterGroup.requestIds, state.api.deploy.data.deploy.requestId))),
     latestHealthchecks
   };
 }

--- a/SingularityUI/app/components/deployDetail/DeployDetail.jsx
+++ b/SingularityUI/app/components/deployDetail/DeployDetail.jsx
@@ -37,7 +37,8 @@ class DeployDetail extends React.Component {
     fetchTaskHistoryForDeploy: PropTypes.func,
     params: PropTypes.object,
     isTaskHistoryFetching: PropTypes.bool,
-    notFound: PropTypes.bool
+    notFound: PropTypes.bool,
+    group: PropTypes.object
   }
 
   componentDidMount() {
@@ -91,22 +92,30 @@ class DeployDetail extends React.Component {
         Click to copy
       </Popover>
     );
+    const breadcrumbs = [
+      {
+        label: 'Request',
+        text: deploy.deploy.requestId,
+        link: `request/${deploy.deploy.requestId}`
+      },
+      {
+        label: 'Deploy',
+        text: deploy.deploy.id
+      }
+    ];
+    if (this.props.group) {
+      breadcrumbs.unshift({
+        label: 'Group',
+        text: this.props.group.id,
+        link: `group/${this.props.group.id}`
+      });
+    }
     return (
       <header className="detail-header">
         <div className="row">
           <div className="col-md-12">
             <Breadcrumbs
-              items={[
-                {
-                  label: 'Request',
-                  text: deploy.deploy.requestId,
-                  link: `request/${deploy.deploy.requestId}`
-                },
-                {
-                  label: 'Deploy',
-                  text: deploy.deploy.id
-                }
-              ]}
+              items={breadcrumbs}
             />
           </div>
         </div>
@@ -353,6 +362,7 @@ function mapStateToProps(state, ownProps) {
     deploy: state.api.deploy.data,
     taskHistory: state.api.taskHistoryForDeploy.data,
     isTaskHistoryFetching: state.api.taskHistoryForDeploy.isFetching,
+    group: state.api.deploy.data.deploy && _.first(_.filter(state.api.requestGroups.data, (g) => _.contains(g.requestIds, state.api.deploy.data.deploy.requestId))),
     latestHealthchecks
   };
 }

--- a/SingularityUI/app/components/groupDetail/GroupDetail.jsx
+++ b/SingularityUI/app/components/groupDetail/GroupDetail.jsx
@@ -1,0 +1,25 @@
+import React, {PropTypes} from 'react';
+import { connect } from 'react-redux';
+import rootComponent from '../../rootComponent';
+
+class GroupDetail extends React.Component {
+
+  static propTypes = {
+    group: PropTypes.object
+  }
+
+  render() {
+    if (!this.props.group) return <div className="loader loader-fixed"></div>;
+    return (
+      <h2>{this.props.group.id}</h2>
+    );
+  }
+}
+
+function mapStateToProps(state, ownProps) {
+  return ({
+    group: _.find(state.api.requestGroups.data, (group) => group.id === ownProps.params.groupId)
+  });
+}
+
+export default connect(mapStateToProps)(rootComponent(GroupDetail, (props) => `Group ${props.params.groupId}`));

--- a/SingularityUI/app/components/groupDetail/GroupDetail.jsx
+++ b/SingularityUI/app/components/groupDetail/GroupDetail.jsx
@@ -45,7 +45,7 @@ GroupDetail.propTypes = {
 };
 
 function mapStateToProps(state, ownProps) {
-  const group = _.find(state.api.requestGroups.data, (g) => g.id === ownProps.params.groupId);
+  const group = _.find(state.api.requestGroups.data, (filterGroup) => filterGroup.id === ownProps.params.groupId);
   return ({
     notFound: !state.api.requestGroups.isFetching && !group,
     pathname: ownProps.location.pathname,

--- a/SingularityUI/app/components/groupDetail/GroupDetail.jsx
+++ b/SingularityUI/app/components/groupDetail/GroupDetail.jsx
@@ -17,8 +17,11 @@ class GroupDetail extends React.Component {
 }
 
 function mapStateToProps(state, ownProps) {
+  const group = _.find(state.api.requestGroups.data, (g) => g.id === ownProps.params.groupId);
   return ({
-    group: _.find(state.api.requestGroups.data, (group) => group.id === ownProps.params.groupId)
+    notFound: !state.api.requestGroups.isFetching && !group,
+    pathname: ownProps.location.pathname,
+    group
   });
 }
 

--- a/SingularityUI/app/components/groupDetail/GroupDetail.jsx
+++ b/SingularityUI/app/components/groupDetail/GroupDetail.jsx
@@ -4,8 +4,9 @@ import rootComponent from '../../rootComponent';
 
 import { FetchGroups } from '../../actions/api/requestGroups';
 
-import { Tabs, Tab } from 'react-bootstrap';
+import { Row, Col, Tabs, Tab } from 'react-bootstrap';
 import RequestDetailPage from '../requestDetail/RequestDetailPage';
+import MetadataButton from '../common/MetadataButton';
 
 const GroupDetail = ({group, location}) => {
   const tabs = group.requestIds.map((requestId, index) => {
@@ -17,10 +18,20 @@ const GroupDetail = ({group, location}) => {
       </Tab>
     );
   });
+  const metadata = !_.isEmpty(group.metadata) && (
+    <MetadataButton title={group.id} metadata={group.metadata}>View Metadata</MetadataButton>
+  );
 
   return (
     <div>
-      <h1>{group.id}</h1>
+      <Row className="detail-header">
+        <Col md={7} lg={6}>
+          <h1>{group.id}</h1>
+        </Col>
+        <Col md={5} lg={6} className="button-container">
+          {metadata}
+        </Col>
+      </Row>
       <Tabs id="request-ids">
         {tabs}
       </Tabs>

--- a/SingularityUI/app/components/groupDetail/GroupDetail.jsx
+++ b/SingularityUI/app/components/groupDetail/GroupDetail.jsx
@@ -2,19 +2,12 @@ import React, {PropTypes} from 'react';
 import { connect } from 'react-redux';
 import rootComponent from '../../rootComponent';
 
-class GroupDetail extends React.Component {
-
-  static propTypes = {
-    group: PropTypes.object
-  }
-
-  render() {
-    if (!this.props.group) return <div className="loader loader-fixed"></div>;
-    return (
-      <h2>{this.props.group.id}</h2>
-    );
-  }
-}
+const GroupDetail = ({group}) => {
+  if (!group) return <div className="loader loader-fixed"></div>;
+  return (
+    <h2>{group.id}</h2>
+  );
+};
 
 function mapStateToProps(state, ownProps) {
   const group = _.find(state.api.requestGroups.data, (g) => g.id === ownProps.params.groupId);
@@ -24,5 +17,9 @@ function mapStateToProps(state, ownProps) {
     group
   });
 }
+
+GroupDetail.propTypes = {
+  group: PropTypes.object
+};
 
 export default connect(mapStateToProps)(rootComponent(GroupDetail, (props) => `Group ${props.params.groupId}`));

--- a/SingularityUI/app/components/groupDetail/GroupDetail.jsx
+++ b/SingularityUI/app/components/groupDetail/GroupDetail.jsx
@@ -2,11 +2,35 @@ import React, {PropTypes} from 'react';
 import { connect } from 'react-redux';
 import rootComponent from '../../rootComponent';
 
-const GroupDetail = ({group}) => {
-  if (!group) return <div className="loader loader-fixed"></div>;
+import { FetchGroups } from '../../actions/api/requestGroups';
+
+import { Tabs, Tab } from 'react-bootstrap';
+import RequestDetailPage from '../requestDetail/RequestDetailPage';
+
+const GroupDetail = ({group, location}) => {
+  const tabs = group.requestIds.map((requestId, index) => {
+    return (
+      <Tab key={index} eventKey={index} title={requestId}>
+        <div className="tab-container">
+          <RequestDetailPage index={index} params={{requestId}} location={location} showBreadcrumbs={false} />
+        </div>
+      </Tab>
+    );
+  });
+
   return (
-    <h2>{group.id}</h2>
+    <div>
+      <h1>{group.id}</h1>
+      <Tabs id="request-ids">
+        {tabs}
+      </Tabs>
+    </div>
   );
+};
+
+GroupDetail.propTypes = {
+  group: PropTypes.object,
+  location: PropTypes.object
 };
 
 function mapStateToProps(state, ownProps) {
@@ -18,8 +42,14 @@ function mapStateToProps(state, ownProps) {
   });
 }
 
-GroupDetail.propTypes = {
-  group: PropTypes.object
+const mapDispatchToProps = (dispatch) => {
+  return {
+    fetchGroups: () => dispatch(FetchGroups.trigger())
+  };
 };
 
-export default connect(mapStateToProps)(rootComponent(GroupDetail, (props) => `Group ${props.params.groupId}`));
+function refresh(props) {
+  return props.fetchGroups();
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(rootComponent(GroupDetail, (props) => `Group ${props.params.groupId}`, refresh, false));

--- a/SingularityUI/app/components/requestDetail/RequestDetailPage.jsx
+++ b/SingularityUI/app/components/requestDetail/RequestDetailPage.jsx
@@ -15,6 +15,7 @@ import {
   FetchScheduledTasksForRequest,
   FetchTaskCleanups
 } from '../../actions/api/tasks';
+import { FetchGroups } from '../../actions/api/requestGroups';
 
 import RequestHeader from './RequestHeader';
 import RequestExpiringActions from './RequestExpiringActions';
@@ -34,6 +35,7 @@ function refresh(props) {
   props.fetchDeploysForRequest(props.params.requestId, 5, 1);
   props.fetchRequestHistory(props.params.requestId, 5, 1);
   props.fetchScheduledTasksForRequest(props.params.requestId);
+  props.fetchGroups();
 }
 
 class RequestDetailPage extends Component {
@@ -89,11 +91,13 @@ const mapDispatchToProps = (dispatch, ownProps) => {
     FetchTaskCleanups.trigger()
   ];
   return {
-    refresh: () => dispatch(RefreshActions.BeginAutoRefresh(
-      'RequestDetailPage',
-      refreshActions,
-      5000
-    )),
+    refresh: () => {
+      dispatch(RefreshActions.BeginAutoRefresh(
+        'RequestDetailPage',
+        refreshActions,
+        5000
+      ));
+    },
     cancelRefresh: () => dispatch(
       RefreshActions.CancelAutoRefresh('RequestDetailPage')
     ),
@@ -104,6 +108,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
     fetchTaskHistoryForRequest: (requestId, count, page) => dispatch(FetchTaskHistoryForRequest.trigger(requestId, count, page)),
     fetchDeploysForRequest: (requestId, count, page) => dispatch(FetchDeploysForRequest.trigger(requestId, count, page)),
     fetchRequestHistory: (requestId, count, page) => dispatch(FetchRequestHistory.trigger(requestId, count, page)),
+    fetchGroups: () => dispatch(FetchGroups.trigger())
   };
 };
 

--- a/SingularityUI/app/components/requestDetail/RequestDetailPage.jsx
+++ b/SingularityUI/app/components/requestDetail/RequestDetailPage.jsx
@@ -55,7 +55,7 @@ class RequestDetailPage extends Component {
     const { requestId } = this.props.params;
     return (
       <div>
-        <RequestHeader requestId={requestId} />
+        <RequestHeader requestId={requestId} showBreadcrumbs={this.props.showBreadcrumbs} />
         <RequestExpiringActions requestId={requestId} />
         <ActiveTasksTable requestId={requestId} />
         <PendingTasksTable requestId={requestId} />
@@ -70,7 +70,8 @@ class RequestDetailPage extends Component {
 RequestDetailPage.propTypes = {
   params: PropTypes.object.isRequired,
   refresh: PropTypes.func.isRequired,
-  cancelRefresh: PropTypes.func.isRequired
+  cancelRefresh: PropTypes.func.isRequired,
+  showBreadcrumbs: PropTypes.bool
 };
 
 const mapStateToProps = (state, ownProps) => {
@@ -91,13 +92,13 @@ const mapDispatchToProps = (dispatch, ownProps) => {
   return {
     refresh: () => {
       dispatch(RefreshActions.BeginAutoRefresh(
-        'RequestDetailPage',
+        `RequestDetailPage-${ownProps.index}`,
         refreshActions,
         5000
       ));
     },
     cancelRefresh: () => dispatch(
-      RefreshActions.CancelAutoRefresh('RequestDetailPage')
+      RefreshActions.CancelAutoRefresh(`RequestDetailPage-${ownProps.index}`)
     ),
     fetchRequest: (requestId) => dispatch(FetchRequest.trigger(requestId, true)),
     fetchActiveTasksForRequest: (requestId) => dispatch(FetchActiveTasksForRequest.trigger(requestId)),

--- a/SingularityUI/app/components/requestDetail/RequestDetailPage.jsx
+++ b/SingularityUI/app/components/requestDetail/RequestDetailPage.jsx
@@ -15,7 +15,6 @@ import {
   FetchScheduledTasksForRequest,
   FetchTaskCleanups
 } from '../../actions/api/tasks';
-import { FetchGroups } from '../../actions/api/requestGroups';
 
 import RequestHeader from './RequestHeader';
 import RequestExpiringActions from './RequestExpiringActions';
@@ -35,7 +34,6 @@ function refresh(props) {
   props.fetchDeploysForRequest(props.params.requestId, 5, 1);
   props.fetchRequestHistory(props.params.requestId, 5, 1);
   props.fetchScheduledTasksForRequest(props.params.requestId);
-  props.fetchGroups();
 }
 
 class RequestDetailPage extends Component {
@@ -107,8 +105,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
     fetchTaskCleanups: () => dispatch(FetchTaskCleanups.trigger()),
     fetchTaskHistoryForRequest: (requestId, count, page) => dispatch(FetchTaskHistoryForRequest.trigger(requestId, count, page)),
     fetchDeploysForRequest: (requestId, count, page) => dispatch(FetchDeploysForRequest.trigger(requestId, count, page)),
-    fetchRequestHistory: (requestId, count, page) => dispatch(FetchRequestHistory.trigger(requestId, count, page)),
-    fetchGroups: () => dispatch(FetchGroups.trigger())
+    fetchRequestHistory: (requestId, count, page) => dispatch(FetchRequestHistory.trigger(requestId, count, page))
   };
 };
 

--- a/SingularityUI/app/components/requestDetail/RequestHeader.jsx
+++ b/SingularityUI/app/components/requestDetail/RequestHeader.jsx
@@ -8,8 +8,8 @@ import RequestActionButtons from './header/RequestActionButtons';
 import RequestAlerts from './header/RequestAlerts';
 import Breadcrumbs from '../common/Breadcrumbs';
 
-const RequestHeader = ({requestId, group}) => {
-  const breadcrumbs = group && (
+const RequestHeader = ({requestId, group, showBreadcrumbs = true}) => {
+  const breadcrumbs = showBreadcrumbs && group && (
     <Row>
       <Col md={12}>
         <Breadcrumbs items={[{
@@ -43,7 +43,8 @@ const RequestHeader = ({requestId, group}) => {
 
 RequestHeader.propTypes = {
   requestId: PropTypes.string.isRequired,
-  group: PropTypes.object
+  group: PropTypes.object,
+  showBreadcrumbs: PropTypes.bool
 };
 
 function mapStateToProps(state, ownProps) {

--- a/SingularityUI/app/components/requestDetail/RequestHeader.jsx
+++ b/SingularityUI/app/components/requestDetail/RequestHeader.jsx
@@ -49,7 +49,7 @@ RequestHeader.propTypes = {
 
 function mapStateToProps(state, ownProps) {
   return {
-    group: _.first(_.filter(state.api.requestGroups.data, (g) => _.contains(g.requestIds, ownProps.requestId)))
+    group: _.first(_.filter(state.api.requestGroups.data, (filterGroup) => _.contains(filterGroup.requestIds, ownProps.requestId)))
   };
 }
 

--- a/SingularityUI/app/components/requestDetail/RequestHeader.jsx
+++ b/SingularityUI/app/components/requestDetail/RequestHeader.jsx
@@ -1,31 +1,55 @@
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
 
 import { Row, Col } from 'react-bootstrap';
 
 import RequestTitle from './header/RequestTitle';
 import RequestActionButtons from './header/RequestActionButtons';
 import RequestAlerts from './header/RequestAlerts';
+import Breadcrumbs from '../common/Breadcrumbs';
 
-const RequestHeader = ({requestId}) => (
-  <header className="detail-header">
-    <Row>
-      <Col md={7} lg={6}>
-        <RequestTitle requestId={requestId} />
-      </Col>
-      <Col md={5} lg={6} className="button-container">
-        <RequestActionButtons requestId={requestId} />
-      </Col>
-    </Row>
+const RequestHeader = ({requestId, group}) => {
+  const breadcrumbs = group && (
     <Row>
       <Col md={12}>
-        <RequestAlerts requestId={requestId} />
+        <Breadcrumbs items={[{
+          label: 'Group',
+          text: group.id,
+          link: `group/${group.id}`
+        }]}
+        />
       </Col>
     </Row>
-  </header>
-);
-
-RequestHeader.propTypes = {
-  requestId: PropTypes.string.isRequired
+  );
+  return (
+    <header className="detail-header">
+      {breadcrumbs}
+      <Row>
+        <Col md={7} lg={6}>
+          <RequestTitle requestId={requestId} />
+        </Col>
+        <Col md={5} lg={6} className="button-container">
+          <RequestActionButtons requestId={requestId} />
+        </Col>
+      </Row>
+      <Row>
+        <Col md={12}>
+          <RequestAlerts requestId={requestId} />
+        </Col>
+      </Row>
+    </header>
+  );
 };
 
-export default RequestHeader;
+RequestHeader.propTypes = {
+  requestId: PropTypes.string.isRequired,
+  group: PropTypes.object
+};
+
+function mapStateToProps(state, ownProps) {
+  return {
+    group: _.first(_.filter(state.api.requestGroups.data, (g) => _.contains(g.requestIds, ownProps.requestId)))
+  };
+}
+
+export default connect(mapStateToProps)(RequestHeader);

--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -481,7 +481,7 @@ function mapStateToProps(state, ownProps) {
     deploy: state.api.deploy.data,
     pendingDeploys: state.api.deploys.data,
     shellCommandResponse: state.api.taskShellCommandResponse.data,
-    group: task.task && _.first(_.filter(state.api.requestGroups.data, (g) => _.contains(g.requestIds, task.task.taskId.requestId)))
+    group: task.task && _.first(_.filter(state.api.requestGroups.data, (filterGroup) => _.contains(filterGroup.requestIds, task.task.taskId.requestId)))
   };
 }
 

--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -110,7 +110,8 @@ class TaskDetail extends Component {
     fetchTaskStatistics: PropTypes.func.isRequired,
     fetchTaskFiles: PropTypes.func.isRequired,
     killTask: PropTypes.func.isRequired,
-    runCommandOnTask: PropTypes.func.isRequired
+    runCommandOnTask: PropTypes.func.isRequired,
+    group: PropTypes.object
   };
 
   constructor(props) {
@@ -262,28 +263,36 @@ class TaskDetail extends Component {
           <strong>Task is terminating:</strong> To issue a non-graceful termination (kill -term), click Destroy Task.
       </Alert>
     );
+    const breadcrumbs = [
+      {
+        label: 'Request',
+        text: this.props.task.task.taskId.requestId,
+        link: `request/${this.props.task.task.taskId.requestId}`
+      },
+      {
+        label: 'Deploy',
+        text: this.props.task.task.taskId.deployId,
+        link: `request/${this.props.task.task.taskId.requestId}/deploy/${this.props.task.task.taskId.deployId}`
+      },
+      {
+        label: 'Instance',
+        text: this.props.task.task.taskId.instanceNo,
+      }
+    ];
+    if (this.props.group) {
+      breadcrumbs.unshift({
+        label: 'Group',
+        text: this.props.group.id,
+        link: `group/${this.props.group.id}`
+      });
+    }
 
     return (
       <header className="detail-header">
         <div className="row">
           <div className="col-md-12">
             <Breadcrumbs
-              items={[
-                {
-                  label: 'Request',
-                  text: this.props.task.task.taskId.requestId,
-                  link: `request/${this.props.task.task.taskId.requestId}`
-                },
-                {
-                  label: 'Deploy',
-                  text: this.props.task.task.taskId.deployId,
-                  link: `request/${this.props.task.task.taskId.requestId}/deploy/${this.props.task.task.taskId.deployId}`
-                },
-                {
-                  label: 'Instance',
-                  text: this.props.task.task.taskId.instanceNo,
-                }
-              ]}
+              items={breadcrumbs}
               right={<span><strong>Hostname: </strong>{this.props.task.task.offer.hostname}</span>}
             />
           </div>
@@ -471,7 +480,8 @@ function mapStateToProps(state, ownProps) {
     s3Logs: state.api.taskS3Logs.data,
     deploy: state.api.deploy.data,
     pendingDeploys: state.api.deploys.data,
-    shellCommandResponse: state.api.taskShellCommandResponse.data
+    shellCommandResponse: state.api.taskShellCommandResponse.data,
+    group: task.task && _.first(_.filter(state.api.requestGroups.data, (g) => _.contains(g.requestIds, task.task.taskId.requestId)))
   };
 }
 

--- a/SingularityUI/app/initialize.jsx
+++ b/SingularityUI/app/initialize.jsx
@@ -4,6 +4,7 @@ import FormModal from './components/common/modal/FormModal';
 import AppRouter from './router';
 import configureStore from 'store';
 import { FetchUser } from 'actions/api/auth';
+import { FetchGroups } from 'actions/api/requestGroups';
 
 // Set up third party configurations
 import 'thirdPartyConfigurations';
@@ -22,6 +23,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // set up user
     store.dispatch(FetchUser.trigger());
+
+    // set up request groups
+    store.dispatch(FetchGroups.trigger());
 
     // Render the page content
     return ReactDOM.render(<AppRouter store={store} />, document.getElementById('root'), () => {

--- a/SingularityUI/app/reducers/api/index.es6
+++ b/SingularityUI/app/reducers/api/index.es6
@@ -67,6 +67,8 @@ import {
 
 import { FetchWebhooks } from '../../actions/api/webhooks';
 
+import { FetchGroups } from '../../actions/api/requestGroups';
+
 const user = buildApiActionReducer(FetchUser);
 const webhooks = buildApiActionReducer(FetchWebhooks, []);
 const slaves = buildApiActionReducer(FetchSlaves, []);
@@ -108,6 +110,7 @@ const taskKill = buildApiActionReducer(KillTask);
 const task = buildKeyedApiActionReducer(FetchTaskHistory);
 const taskHistory = buildApiActionReducer(FetchTaskSearchParams, []);
 const tasks = buildApiActionReducer(FetchTasksInState, []);
+const requestGroups = buildApiActionReducer(FetchGroups, []);
 
 export default combineReducers({
   user,
@@ -150,5 +153,6 @@ export default combineReducers({
   taskShellCommandResponse,
   runningTask,
   taskKill,
-  taskHistory
+  taskHistory,
+  requestGroups
 });

--- a/SingularityUI/app/router.jsx
+++ b/SingularityUI/app/router.jsx
@@ -37,7 +37,7 @@ const AppRouter = (props) => {
           <Route path="requests/new" component={RequestForm} />
           <Route path="requests/edit/:requestId" component={RequestForm} />
           <Route path="requests(/:state)(/:subFilter)(/:searchFilter)" component={RequestsPage} />
-          <Route path="group/:groupId" component={Group} />
+          <Route path="group/:groupId" component={Group} store={props.store} />
           <Route path="request">
             <Route path=":requestId" component={RequestDetailPage} />
             <Route path=":requestId/task-search" component={TaskSearch} />

--- a/SingularityUI/app/router.jsx
+++ b/SingularityUI/app/router.jsx
@@ -37,7 +37,7 @@ const AppRouter = (props) => {
           <Route path="requests/new" component={RequestForm} />
           <Route path="requests/edit/:requestId" component={RequestForm} />
           <Route path="requests(/:state)(/:subFilter)(/:searchFilter)" component={RequestsPage} />
-          <Route path="group/:groupId" component={Group} store={props.store} />
+          <Route path="group/:groupId" component={Group} />
           <Route path="request">
             <Route path=":requestId" component={RequestDetailPage} />
             <Route path=":requestId/task-search" component={TaskSearch} />

--- a/SingularityUI/app/router.jsx
+++ b/SingularityUI/app/router.jsx
@@ -20,6 +20,7 @@ import RequestForm from './components/requestForm/RequestForm';
 import NewDeployForm from './components/newDeployForm/NewDeployForm';
 import { Tail, AggregateTail } from './components/logs/Tail';
 import RequestDetailPage from './components/requestDetail/RequestDetailPage';
+import Group from './components/groupDetail/GroupDetail.jsx';
 
 const AppRouter = (props) => {
   let history = useRouterHistory(createHistory)({
@@ -36,6 +37,7 @@ const AppRouter = (props) => {
           <Route path="requests/new" component={RequestForm} />
           <Route path="requests/edit/:requestId" component={RequestForm} />
           <Route path="requests(/:state)(/:subFilter)(/:searchFilter)" component={RequestsPage} />
+          <Route path="group/:groupId" component={Group} />
           <Route path="request">
             <Route path=":requestId" component={RequestDetailPage} />
             <Route path=":requestId/task-search" component={TaskSearch} />

--- a/SingularityUI/app/styles/detailHeader.styl
+++ b/SingularityUI/app/styles/detailHeader.styl
@@ -8,6 +8,7 @@
         overflow hidden
         text-overflow ellipsis
         position relative
+        line-height: normal
 
         .btn.offset-link
             background #fff

--- a/SingularityUI/app/styles/layout.styl
+++ b/SingularityUI/app/styles/layout.styl
@@ -17,6 +17,8 @@
     max-width: 1500px;
 }
 
-.tab-container {
-  padding-top: 30px;
-}
+.tab-container
+  padding-top: 25px;
+
+  .page
+    padding: 0

--- a/SingularityUI/app/styles/layout.styl
+++ b/SingularityUI/app/styles/layout.styl
@@ -16,3 +16,7 @@
 .page, .navbar .container-fluid {
     max-width: 1500px;
 }
+
+.tab-container {
+  padding-top: 30px;
+}


### PR DESCRIPTION
Creates a new Group page (`/group/:groupId`) which shows details for all requests contained in it.
Also adds a breadcrumb item for requests, deploys, and tasks which are part of a group. 
The metadata button displays a modal with copyable infoboxes. (button only is only shown if the group has metadata)

![image](https://cloud.githubusercontent.com/assets/3221272/17523353/4525b33c-5e28-11e6-9c07-fab2e2ee76a5.png)

![screen shot 2016-08-09 at 11 51 18 am](https://cloud.githubusercontent.com/assets/3221272/17523347/3e34c086-5e28-11e6-86e3-5feb99ebd69e.png)

@tpetr @wolfd @Calvinp 
