### PR TITLE
sentry support

### DIFF
--- a/SingularityUI/app/assets/index.mustache
+++ b/SingularityUI/app/assets/index.mustache
@@ -47,10 +47,10 @@
         };
     </script>
     <script src="{{{staticRoot}}}/js/vendor.bundle.js"></script>
-    <script src="{{{staticRoot}}}/js/app.js"></script>
     {{#extraScript}}
     {{{extraScript}}}
     {{/extraScript}}
+    <script src="{{{staticRoot}}}/js/app.js"></script>
 </head>
 {{#navColor}}
 <body class="env-color-{{{.}}}">

--- a/SingularityUI/app/rootComponent.jsx
+++ b/SingularityUI/app/rootComponent.jsx
@@ -34,6 +34,11 @@ const rootComponent = (Wrapped, title, refresh = _.noop, refreshInterval = true,
             loading: false
           });
         }
+      }).catch((reason) => {
+        // Boot React errors out of the promise so they can be picked up by Sentry
+        setTimeout(() => {
+          throw new Error(reason);
+        });
       });
     } else {
       this.setState({
@@ -62,12 +67,12 @@ const rootComponent = (Wrapped, title, refresh = _.noop, refreshInterval = true,
   }
 
   handleFocus() {
-    refresh(this.props);
+    refresh(this.props).catch((reason) => setTimeout(() => { throw new Error(reason); }));
     this.startRefreshInterval();
   }
 
   startRefreshInterval() {
-    this.refreshInterval = setInterval(() => refresh(this.props), config.globalRefreshInterval);
+    this.refreshInterval = setInterval(() => refresh(this.props).catch((reason) => setTimeout(() => { throw new Error(reason); })), config.globalRefreshInterval);
   }
 
   stopRefreshInterval() {


### PR DESCRIPTION
This PR allows sentry to support the UI by surfacing errors out of the main rendering promise in `rootComponent`. Sentry can't detect errors inside promises because they aren't bubbled up to window.onerror. (Actual sentry tracking code is injected normally through `SINGULARITY_EXTRA_SCRIPTS`.

@tpetr @Calvinp @wolfd 