### PR TITLE
Aggregate Tailer fix

### DIFF
--- a/SingularityUI/app/actions/log.es6
+++ b/SingularityUI/app/actions/log.es6
@@ -242,11 +242,11 @@ export const taskGroupFetchPrevious = taskGroupId =>
   function(dispatch, getState) {
     let {tasks, taskGroups, logRequestLength, maxLines} = getState();
 
-    let taskGroup = taskGroups[taskGroupId];
+    const taskGroup = taskGroups[taskGroupId];
     tasks = getTasks(taskGroup, tasks);
 
     // bail early if all tasks are at the top
-    if (_.all(tasks.map(({minOffset}) => minOffset === 0))) {
+    if (_.all(tasks.map((task) => task.minOffset === 0))) {
       return Promise.resolve();
     }
 
@@ -256,6 +256,7 @@ export const taskGroupFetchPrevious = taskGroupId =>
     }
 
     dispatch({taskGroupId, type: 'LOG_REQUEST_START'});
+    tasks = _.without(tasks, undefined);
     let promises = tasks.map(function({taskId, exists, minOffset, path, initialDataLoaded}) {
       if (minOffset > 0 && initialDataLoaded && exists !== false) {
         let xhr = fetchData(taskId, path, Math.max(minOffset - logRequestLength, 0), Math.min(logRequestLength, minOffset));

--- a/SingularityUI/app/components/logs/Header.jsx
+++ b/SingularityUI/app/components/logs/Header.jsx
@@ -22,8 +22,8 @@ class Header extends React.Component {
   renderViewButtons() {
     if (this.props.multipleTasks) {
       return (<div className="btn-group" role="group" title="Select View Type">
-        <button type="button" className={classNames({btn: true, 'btn-sm': true, 'btn-default': true, 'no-margin': true, active: this.props.viewMode === 'unified'})} onClick={function () { this.props.switchViewMode('unified'); }}>Unified</button>
-        <button type="button" className={classNames({btn: true, 'btn-sm': true, 'btn-default': true, 'no-margin': true, active: this.props.viewMode === 'split'})} onClick={function () { this.props.switchViewMode('split'); }}>Split</button>
+        <button type="button" className={classNames({btn: true, 'btn-sm': true, 'btn-default': true, 'no-margin': true, active: this.props.viewMode === 'unified'})} onClick={() => { this.props.switchViewMode('unified'); }}>Unified</button>
+        <button type="button" className={classNames({btn: true, 'btn-sm': true, 'btn-default': true, 'no-margin': true, active: this.props.viewMode === 'split'})} onClick={() => { this.props.switchViewMode('split'); }}>Split</button>
       </div>);
     }
   }

--- a/SingularityUI/app/components/logs/Header.jsx
+++ b/SingularityUI/app/components/logs/Header.jsx
@@ -74,7 +74,7 @@ class Header extends React.Component {
 }
 
 Header.propTypes = {
-  requestId: React.PropTypes.string.isRequired,
+  requestId: React.PropTypes.string,
   path: React.PropTypes.string.isRequired,
   multipleTasks: React.PropTypes.bool.isRequired,
   viewMode: React.PropTypes.string.isRequired,

--- a/SingularityUI/app/components/logs/LogLines.jsx
+++ b/SingularityUI/app/components/logs/LogLines.jsx
@@ -8,7 +8,7 @@ import { taskGroupTop, taskGroupBottom } from '../../actions/log';
 
 function sum (numbers) {
   let total = 0;
-  for (let i=0; i<numbers.length; i++) {
+  for (let i = 0; i < numbers.length; i++) {
     total += numbers[i];
   }
   return total;
@@ -58,13 +58,14 @@ class LogLines extends React.Component {
         taskId={taskId}
         timestamp={timestamp}
         isHighlighted={offset === initialOffset}
-        color={colorMap[taskId]} />;
+        color={colorMap[taskId]}
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       />;
     });
   }
 
   renderLoadingMore() {
     if (this.props.terminated) {
-      return null
+      return null;
     } else if (this.props.initialDataLoaded) {
       if (this.props.reachedEndOfFile) {
         if (this.props.search) {
@@ -84,7 +85,7 @@ class LogLines extends React.Component {
 
 
   handleScroll() {
-    const {scrollTop, scrollHeight, clientHeight} = this.refs.tailContents
+    const {scrollTop, scrollHeight, clientHeight} = this.refs.tailContents;
 
     if (scrollTop < clientHeight) {
       this.props.taskGroupTop(this.props.taskGroupId, true);
@@ -100,14 +101,14 @@ class LogLines extends React.Component {
   }
 
   render() {
-    return <div className="contents-container">
+    return (<div className="contents-container">
       <div className={classNames(['tail-contents', this.props.activeColor])} ref="tailContents" onScroll={(event) => { this.handleScroll(event); }}>
         {this.renderLoadingPrevious()}
         {this.renderLogLines()}
         {this.renderLoadingMore()}
         {this.props.fileNotFound}
       </div>
-    </div>;
+    </div>);
   }
 }
 
@@ -129,15 +130,15 @@ LogLines.propTypes = {
 };
 
 function mapStateToProps(state, ownProps) {
-  const taskGroup = state.taskGroups[ownProps.taskGroupId]
+  const taskGroup = state.taskGroups[ownProps.taskGroupId];
   const tasks = taskGroup.taskIds.map(function (taskId) { return state.tasks[taskId]; });
 
-  const colorMap = {}
+  const colorMap = {};
   if (taskGroup.taskIds.length > 1) {
-    let i = 0
-    for (taskId of taskGroup.taskIds) {
+    let i = 0;
+    for (const taskId of taskGroup.taskIds) {
       colorMap[taskId] = `hsla(${(360 / taskGroup.taskIds.length) * i}, 100%, 50%, 0.1)`;
-      i++
+      i++;
     }
   }
 
@@ -152,13 +153,13 @@ function mapStateToProps(state, ownProps) {
     bottom: taskGroup.bottom,
     initialDataLoaded: _.all(_.pluck(tasks, 'initialDataLoaded')),
     terminated: _.all(_.pluck(tasks, 'terminated')),
-    reachedStartOfFile: _.all(tasks.map( function ({minOffset}) { return minOffset === 0; })),
-    reachedEndOfFile: _.all(tasks.map( function ({maxOffset, filesize}) { return maxOffset >= filesize; })),
+    reachedStartOfFile: _.all(tasks.map(function ({minOffset}) { return minOffset === 0; })),
+    reachedEndOfFile: _.all(tasks.map(function ({maxOffset, filesize}) { return maxOffset >= filesize; })),
     bytesRemainingBefore: sum(_.pluck(tasks, 'minOffset')),
-    bytesRemainingAfter: sum(tasks.map( function ({filesize, maxOffset}) { return Math.max(filesize - maxOffset, 0); })),
-    colorMap: colorMap,
+    bytesRemainingAfter: sum(tasks.map(function ({filesize, maxOffset}) { return Math.max(filesize - maxOffset, 0); })),
+    colorMap,
     search: state.search,
-  }
+  };
 }
 
 const mapDispatchToProps = { taskGroupTop, taskGroupBottom };

--- a/SingularityUI/app/components/logs/LogLines.jsx
+++ b/SingularityUI/app/components/logs/LogLines.jsx
@@ -51,15 +51,17 @@ class LogLines extends React.Component {
     const initialOffset = this.props.initialOffset;
     const colorMap = this.props.colorMap;
     return this.props.logLines.map(function ({data, offset, taskId, timestamp}) {
-      return <LogLine
-        content={data}
-        key={taskId + '_' + offset}
-        offset={offset}
-        taskId={taskId}
-        timestamp={timestamp}
-        isHighlighted={offset === initialOffset}
-        color={colorMap[taskId]}
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       />;
+      return (
+        <LogLine
+          content={data}
+          key={taskId + '_' + offset}
+          offset={offset}
+          taskId={taskId}
+          timestamp={timestamp}
+          isHighlighted={offset === initialOffset}
+          color={colorMap[taskId]}
+        />
+      );
     });
   }
 

--- a/SingularityUI/app/components/logs/Tail.jsx
+++ b/SingularityUI/app/components/logs/Tail.jsx
@@ -37,7 +37,14 @@ export const Tail = connect(null, mapDispatchToProps)(rootComponent(TailPage, ge
 function refreshAggregateTail(props) {
   const viewMode = props.location.query.viewMode || 'split';
   const search = props.location.query.search || '';
-  const initPromise = props.initializeUsingActiveTasks(props.params.requestId, props.params.splat, search, viewMode);
+  const taskIds = props.location.query.taskIds;
+
+  let initPromise;
+  if (taskIds) {
+    initPromise = props.initialize(props.params.requestId, props.params.splat, search, taskIds.split(','), viewMode);
+  } else {
+    initPromise = props.initializeUsingActiveTasks(props.params.requestId, props.params.splat, search, viewMode);
+  }
   initPromise.then(() => {
     props.updateActiveTasks(props.params.requestId);
   });

--- a/SingularityUI/app/components/logs/TaskGroupContainer.jsx
+++ b/SingularityUI/app/components/logs/TaskGroupContainer.jsx
@@ -51,7 +51,7 @@ class TaskGroupContainer extends React.Component {
 TaskGroupContainer.propTypes = {
   taskGroupId: React.PropTypes.number.isRequired,
   taskGroupContainerCount: React.PropTypes.number.isRequired,
-  path: React.PropTypes.string.isRequired,
+  path: React.PropTypes.string,
   logDataLoaded: React.PropTypes.bool,
 
   initialDataLoaded: React.PropTypes.bool.isRequired,
@@ -88,4 +88,3 @@ const mapStateToProps = (state, ownProps) => {
 const mapDispatchToProps = { doesFinishedLogExist };
 
 export default connect(mapStateToProps, mapDispatchToProps)(TaskGroupContainer);
-

--- a/SingularityUI/app/components/logs/TaskGroupHeader.jsx
+++ b/SingularityUI/app/components/logs/TaskGroupHeader.jsx
@@ -19,10 +19,13 @@ class TaskGroupHeader extends React.Component {
   }
 
   renderInstanceInfo() {
+    const instances = _.without(this.props.tasks, undefined).map((task) => {
+      return Utils.getTaskDataFromTaskId(task.taskId).instanceNo;
+    }).join(', ');
     if (this.props.tasks.length > 1) {
-      return <span className="instance-link">Viewing Instances {this.props.tasks.map(({ taskId }) => Utils.getTaskDataFromTaskId(taskId).instanceNo).join(', ')}</span>;
+      return <span className="instance-link">Viewing Instances {instances}</span>;
     } else if (this.props.tasks.length > 0) {
-      let taskData = Utils.getTaskDataFromTaskId(this.props.tasks[0].taskId);
+      const taskData = Utils.getTaskDataFromTaskId(this.props.tasks[0].taskId);
       return <span><div className="width-constrained"><OverlayTrigger placement="bottom" overlay={this.getInstanceNoToolTip(taskData)}><Link className="instance-link" to={`task/${ this.props.tasks[0].taskId }`}>Instance {taskData.instanceNo}</Link></OverlayTrigger></div><TaskStatusIndicator status={this.props.tasks[0].lastTaskStatus} /></span>;
     } else {
       return <div className="width-constrained" />;

--- a/SingularityUI/app/reducers/taskGroups.es6
+++ b/SingularityUI/app/reducers/taskGroups.es6
@@ -69,7 +69,7 @@ const ACTIONS = {
 
   // Remove a task from the logger
   LOG_REMOVE_TASK(state, {taskId}) {
-    let newState = [];
+    const newState = [];
     for (let i = 0; i < state.length; i++) {
       let taskGroup = state[i];
       if (__in__(taskId, taskGroup.taskIds)) {
@@ -79,12 +79,12 @@ const ACTIONS = {
         }
 
         // remove task
-        let newTaskIds = _.without(taskGroup.taskIds, taskId);
+        const newTaskIds = _.without(taskGroup.taskIds, taskId);
 
         // remove task loglines
-        let newLogLines = taskGroup.logLines.filter(logLine => logLine.taskId !== taskId);
+        const newLogLines = taskGroup.logLines.filter(logLine => logLine.taskId !== taskId);
 
-        newState.push(Object.assign({}, taskGroup, {tasksIds: newTasksIds, logLines: newLogLines}));
+        newState.push(Object.assign({}, taskGroup, {tasksIds: newTaskIds, logLines: newLogLines}));
       } else {
         newState.push(taskGroup);
       }

--- a/SingularityUI/app/styles/tailer.styl
+++ b/SingularityUI/app/styles/tailer.styl
@@ -198,10 +198,13 @@
         font-family Consolas, "Liberation Mono", Courier, monospace
         min-height 1.6em // Show empty lines too
         line-height 1.6em
-        padding 0 2em
         white-space pre
         font-size 12px
         height 20px
+        display table-row
+
+        &>span
+          padding 0 2em
 
         &:hover
             .pre-line


### PR DESCRIPTION
Fixes the case where the tailer wouldn't respect the taskIds query param when viewing a log via the `/request/*/tail` path. (Example: https://private.hubteamqa.com/singularity-test/request/ORION_TestService_TrafficSplitting-userweb/tail/ORION_TestService_TrafficSplitting-userweb-152_15_19-1470241646336-3-flaky_lion.iad03.hubspot_networks.net-us_east_1e/tail_of_finished_service.log?taskIds=ORION_TestService_TrafficSplitting-userweb-152_15_19-1470241646336-3-flaky_lion.iad03.hubspot_networks.net-us_east_1e)

@tpetr @Calvinp @wolfd 