### PR TITLE
Add case-sensitive paths plugin

### DIFF
--- a/SingularityUI/package.json
+++ b/SingularityUI/package.json
@@ -68,6 +68,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.8.0",
     "babel-plugin-transform-react-jsx": "^6.8.0",
     "babel-preset-es2015": "^6.9.0",
+    "case-sensitive-paths-webpack-plugin": "^1.1.3",
     "del": "^2.2.0",
     "eslint": "^2.11.1",
     "eslint-config-hubspot": "^6.2.0",

--- a/SingularityUI/webpack.config.js
+++ b/SingularityUI/webpack.config.js
@@ -1,4 +1,5 @@
 var webpack = require('webpack');
+var CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 var path = require('path');
 
 var dest = path.resolve(__dirname, 'dist');
@@ -52,6 +53,7 @@ module.exports = {
       jQuery: 'jquery',
       'window.jQuery': 'jquery'
     }),
-    new webpack.optimize.CommonsChunkPlugin('vendor', 'vendor.bundle.js')
+    new webpack.optimize.CommonsChunkPlugin('vendor', 'vendor.bundle.js'),
+    new CaseSensitivePathsPlugin()
   ]
 };


### PR DESCRIPTION
This adds the [case-sensitive paths plugin](https://www.npmjs.com/package/case-sensitive-paths-webpack-plugin) Singularity UI - thus preventing the issue where builds succeed locally but not in Jenkins because the OSX filesystem is case-insensitive.
Now it'll fail locally with this error:
```
ERROR in ./app/components/tasks/TasksPage.jsx
Module not found: Error: [CaseSensitivePathsPlugin] `/Users/cpomerantz/repos/Singularity/SingularityUI/app/rootcomponent.jsx` does not match the corresponding path on disk `rootComponent.jsx`.
 @ ./app/components/tasks/TasksPage.jsx 17:21-51
```

cc @tpetr @wolfd @kwm4385 

