### PR TITLE
Refresh the request detail page after performing actions

### DIFF
--- a/SingularityUI/app/components/requestDetail/header/AdvanceDeployButton.jsx
+++ b/SingularityUI/app/components/requestDetail/header/AdvanceDeployButton.jsx
@@ -9,7 +9,8 @@ import AdvanceDeployModal from './AdvanceDeployModal';
 export default class AdvanceDeployButton extends Component {
   static propTypes = {
     requestId: PropTypes.string.isRequired,
-    deployId: PropTypes.string.isRequired
+    deployId: PropTypes.string.isRequired,
+    then: PropTypes.func
   };
 
   static defaultProps = {
@@ -28,6 +29,7 @@ export default class AdvanceDeployButton extends Component {
           ref="modal"
           deployId={this.props.deployId}
           requestId={this.props.requestId}
+          then={this.props.then}
         />
       </span>
     );

--- a/SingularityUI/app/components/requestDetail/header/AdvanceDeployModal.jsx
+++ b/SingularityUI/app/components/requestDetail/header/AdvanceDeployModal.jsx
@@ -12,7 +12,8 @@ class AdvanceDeployModal extends Component {
     deployId: PropTypes.string.isRequired,
     requestId: PropTypes.string.isRequired,
     requestParent: PropTypes.object.isRequired,
-    advanceDeploy: PropTypes.func.isRequired
+    advanceDeploy: PropTypes.func.isRequired,
+    then: PropTypes.func
   };
 
   show() {
@@ -70,7 +71,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
     ownProps.deployId,
     ownProps.requestId,
     targetActiveInstances
-  ))
+  )).then(response => (ownProps.then && ownProps.then(response)))
 });
 
 export default connect(

--- a/SingularityUI/app/components/requestDetail/header/CancelDeployButton.jsx
+++ b/SingularityUI/app/components/requestDetail/header/CancelDeployButton.jsx
@@ -9,7 +9,8 @@ import CancelDeployModal from './CancelDeployModal';
 export default class CancelDeployButton extends Component {
   static propTypes = {
     requestId: PropTypes.string.isRequired,
-    deployId: PropTypes.string.isRequired
+    deployId: PropTypes.string.isRequired,
+    then: PropTypes.func
   };
 
   static defaultProps = {
@@ -28,6 +29,7 @@ export default class CancelDeployButton extends Component {
           ref="modal"
           deployId={this.props.deployId}
           requestId={this.props.requestId}
+          then={this.props.then}
         />
       </span>
     );

--- a/SingularityUI/app/components/requestDetail/header/CancelDeployModal.jsx
+++ b/SingularityUI/app/components/requestDetail/header/CancelDeployModal.jsx
@@ -9,7 +9,8 @@ class CancelDeployModal extends Component {
   static propTypes = {
     deployId: PropTypes.string.isRequired,
     requestId: PropTypes.string.isRequired,
-    cancelDeploy: PropTypes.func.isRequired
+    cancelDeploy: PropTypes.func.isRequired,
+    then: PropTypes.func
   };
 
   show() {
@@ -32,7 +33,7 @@ class CancelDeployModal extends Component {
 }
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
-  cancelDeploy: () => dispatch(CancelDeploy.trigger(ownProps.deployId, ownProps.requestId))
+  cancelDeploy: () => dispatch(CancelDeploy.trigger(ownProps.deployId, ownProps.requestId)).then(response => (ownProps.then && ownProps.then(response)))
 });
 
 export default connect(

--- a/SingularityUI/app/components/requestDetail/header/RequestActionButtons.jsx
+++ b/SingularityUI/app/components/requestDetail/header/RequestActionButtons.jsx
@@ -1,10 +1,13 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
+import { withRouter } from 'react-router';
 
 import { Button } from 'react-bootstrap';
 import { Link } from 'react-router';
 
 import JSONButton from '../../common/JSONButton';
+
+import { FetchRequest } from '../../../actions/api/requests';
 
 import RunNowButton from '../../requests/RunNowButton';
 import RemoveButton from '../../requests/RemoveButton';
@@ -18,7 +21,7 @@ import DisableHealthchecksButton from '../../requests/DisableHealthchecksButton'
 
 import Utils from '../../../utils';
 
-const RequestActionButtons = ({requestParent}) => {
+const RequestActionButtons = ({requestParent, fetchRequest, router}) => {
   if (!requestParent || !requestParent.request) {
     return null;
   }
@@ -38,7 +41,7 @@ const RequestActionButtons = ({requestParent}) => {
   let maybeRunNowButton;
   if (Utils.request.canBeRunNow(requestParent)) {
     maybeRunNowButton = (
-      <RunNowButton requestId={request.id}>
+      <RunNowButton requestId={request.id} then={fetchRequest}>
         <Button bsStyle="primary">
           Run now
         </Button>
@@ -49,7 +52,7 @@ const RequestActionButtons = ({requestParent}) => {
   let maybeExitCooldownButton;
   if (state === 'SYSTEM_COOLDOWN') {
     maybeExitCooldownButton = (
-      <ExitCooldownButton requestId={request.id}>
+      <ExitCooldownButton requestId={request.id} then={fetchRequest}>
         <Button bsStyle="primary">
           Exit Cooldown
         </Button>
@@ -60,7 +63,7 @@ const RequestActionButtons = ({requestParent}) => {
   let maybeScaleButton;
   if (Utils.request.canBeScaled(requestParent)) {
     maybeScaleButton = (
-      <ScaleButton requestId={request.id} currentInstances={request.instances}>
+      <ScaleButton requestId={request.id} currentInstances={request.instances} then={fetchRequest}>
         <Button bsStyle="primary" disabled={Utils.request.scaleDisabled(requestParent)}>
           Scale
         </Button>
@@ -74,7 +77,7 @@ const RequestActionButtons = ({requestParent}) => {
       // make sure the action removes the expiring pause
     }
     togglePauseButton = (
-      <UnpauseButton requestId={request.id}>
+      <UnpauseButton requestId={request.id} then={fetchRequest}>
         <Button bsStyle="primary">
           Unpause
         </Button>
@@ -82,7 +85,7 @@ const RequestActionButtons = ({requestParent}) => {
     );
   } else {
     togglePauseButton = (
-      <PauseButton requestId={request.id} isScheduled={request.requestType === 'SCHEDULED'}>
+      <PauseButton requestId={request.id} isScheduled={request.requestType === 'SCHEDULED'} then={fetchRequest}>
         <Button bsStyle="primary" disabled={Utils.request.pauseDisabled(requestParent)}>
           Pause
         </Button>
@@ -93,7 +96,7 @@ const RequestActionButtons = ({requestParent}) => {
   let maybeBounceButton;
   if (Utils.request.canBeBounced(requestParent)) {
     maybeBounceButton = (
-      <BounceButton requestId={request.id}>
+      <BounceButton requestId={request.id} then={fetchRequest}>
         <Button bsStyle="primary" disabled={Utils.request.bounceDisabled(requestParent)}>
           Bounce
         </Button>
@@ -116,7 +119,7 @@ const RequestActionButtons = ({requestParent}) => {
   if (Utils.request.canDisableHealthchecks(requestParent)) {
     if (request.skipHealthchecks) {
       maybeToggleHealthchecksButton = (
-        <EnableHealthchecksButton requestId={request.id}>
+        <EnableHealthchecksButton requestId={request.id} then={fetchRequest}>
           <Button bsStyle="warning">
             Enable Healthchecks
           </Button>
@@ -124,7 +127,7 @@ const RequestActionButtons = ({requestParent}) => {
       );
     } else {
       maybeToggleHealthchecksButton = (
-        <DisableHealthchecksButton requestId={request.id}>
+        <DisableHealthchecksButton requestId={request.id} then={fetchRequest}>
           <Button bsStyle="primary">
             Disable Healthchecks
           </Button>
@@ -133,9 +136,14 @@ const RequestActionButtons = ({requestParent}) => {
     }
   }
 
-  let removeButton;
-  removeButton = (
-    <RemoveButton requestId={request.id}>
+  const navigateAwayOnSuccess = (response) => {
+    if (response.statusCode === 200) {
+      router.push('/requests');
+    }
+  };
+
+  const removeButton = (
+    <RemoveButton requestId={request.id} then={navigateAwayOnSuccess}>
       <Button bsStyle="danger">
         Remove
       </Button>
@@ -160,13 +168,20 @@ const RequestActionButtons = ({requestParent}) => {
 
 RequestActionButtons.propTypes = {
   requestId: PropTypes.string.isRequired,
-  requestParent: PropTypes.object
+  requestParent: PropTypes.object,
+  fetchRequest: PropTypes.func.isRequired,
+  router: PropTypes.shape({push: PropTypes.func.isRequired}).isRequired
 };
 
 const mapStateToProps = (state, ownProps) => ({
   requestParent: Utils.maybe(state.api.request, [ownProps.requestId, 'data'])
 });
 
-export default connect(
-  mapStateToProps
-)(RequestActionButtons);
+const mapDispatchToProps = (dispatch, ownProps) => ({
+  fetchRequest: () => dispatch(FetchRequest.trigger(ownProps.requestId))
+});
+
+export default withRouter(connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(RequestActionButtons));

--- a/SingularityUI/app/components/requests/BounceButton.jsx
+++ b/SingularityUI/app/components/requests/BounceButton.jsx
@@ -18,7 +18,8 @@ export default class BounceButton extends Component {
 
   static propTypes = {
     requestId: PropTypes.string.isRequired,
-    children: PropTypes.node
+    children: PropTypes.node,
+    then: PropTypes.func
   };
 
   static defaultProps = {
@@ -38,6 +39,7 @@ export default class BounceButton extends Component {
         <BounceModal
           ref="modal"
           requestId={this.props.requestId}
+          then={this.props.then}
         />
       </span>
     );

--- a/SingularityUI/app/components/requests/BounceModal.jsx
+++ b/SingularityUI/app/components/requests/BounceModal.jsx
@@ -71,7 +71,7 @@ class BounceModal extends Component {
 }
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
-  bounceRequest: (data) => dispatch(BounceRequest.trigger(ownProps.requestId, data)),
+  bounceRequest: (data) => dispatch(BounceRequest.trigger(ownProps.requestId, data)).then(response => (ownProps.then && ownProps.then(response))),
 });
 
 export default connect(

--- a/SingularityUI/app/components/requests/DisableHealthchecksButton.jsx
+++ b/SingularityUI/app/components/requests/DisableHealthchecksButton.jsx
@@ -10,7 +10,8 @@ export default class DisableHealthchecksButton extends Component {
 
   static propTypes = {
     requestId: PropTypes.string.isRequired,
-    children: PropTypes.node
+    children: PropTypes.node,
+    then: PropTypes.func
   };
 
   static defaultProps = {
@@ -24,6 +25,7 @@ export default class DisableHealthchecksButton extends Component {
         <DisableHealthchecksModal
           ref="modal"
           requestId={this.props.requestId}
+          then={this.props.then}
         />
       </span>
     );

--- a/SingularityUI/app/components/requests/DisableHealthchecksModal.jsx
+++ b/SingularityUI/app/components/requests/DisableHealthchecksModal.jsx
@@ -8,7 +8,8 @@ import FormModal from '../common/modal/FormModal';
 class DisableHealthchecksModal extends Component {
   static propTypes = {
     requestId: PropTypes.string.isRequired,
-    disableHealthchecks: PropTypes.func.isRequired
+    disableHealthchecks: PropTypes.func.isRequired,
+    then: PropTypes.func
   };
 
   show() {
@@ -71,7 +72,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
   disableHealthchecks: (data) => dispatch(SkipRequestHealthchecks.trigger(
     ownProps.requestId,
     {...data, skipHealthchecks: true}
-  )),
+  )).then(response => (ownProps.then && ownProps.then(response)))
 });
 
 export default connect(

--- a/SingularityUI/app/components/requests/EnableHealthchecksButton.jsx
+++ b/SingularityUI/app/components/requests/EnableHealthchecksButton.jsx
@@ -10,7 +10,8 @@ export default class EnableHealthchecksButton extends Component {
 
   static propTypes = {
     requestId: PropTypes.string.isRequired,
-    children: PropTypes.node
+    children: PropTypes.node,
+    then: PropTypes.func
   };
 
   static defaultProps = {
@@ -24,6 +25,7 @@ export default class EnableHealthchecksButton extends Component {
         <EnableHealthchecksModal
           ref="modal"
           requestId={this.props.requestId}
+          then={this.props.then}
         />
       </span>
     );

--- a/SingularityUI/app/components/requests/EnableHealthchecksModal.jsx
+++ b/SingularityUI/app/components/requests/EnableHealthchecksModal.jsx
@@ -8,7 +8,8 @@ import FormModal from '../common/modal/FormModal';
 class EnableHealthchecksModal extends Component {
   static propTypes = {
     requestId: PropTypes.string.isRequired,
-    enableHealthchecks: PropTypes.func.isRequired
+    enableHealthchecks: PropTypes.func.isRequired,
+    then: PropTypes.func
   };
 
   show() {
@@ -46,7 +47,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
   enableHealthchecks: (data) => dispatch(SkipRequestHealthchecks.trigger(
     ownProps.requestId,
     {...data, skipHealthchecks: false}
-  )),
+  )).then(response => (ownProps.then && ownProps.then(response))),
 });
 
 export default connect(

--- a/SingularityUI/app/components/requests/ExitCooldownButton.jsx
+++ b/SingularityUI/app/components/requests/ExitCooldownButton.jsx
@@ -18,7 +18,8 @@ export default class ExitCooldownButton extends Component {
 
   static propTypes = {
     requestId: PropTypes.string.isRequired,
-    children: PropTypes.node
+    children: PropTypes.node,
+    then: PropTypes.func
   };
 
   static defaultProps = {
@@ -36,6 +37,7 @@ export default class ExitCooldownButton extends Component {
         <ExitCooldownModal
           ref="modal"
           requestId={this.props.requestId}
+          then={this.props.then}
         />
       </span>
     );

--- a/SingularityUI/app/components/requests/ExitCooldownModal.jsx
+++ b/SingularityUI/app/components/requests/ExitCooldownModal.jsx
@@ -8,7 +8,8 @@ import FormModal from '../common/modal/FormModal';
 class ExitCooldownModal extends Component {
   static propTypes = {
     requestId: PropTypes.string.isRequired,
-    exitRequestCooldown: PropTypes.func.isRequired
+    exitRequestCooldown: PropTypes.func.isRequired,
+    then: PropTypes.func
   };
 
   show() {
@@ -42,7 +43,7 @@ class ExitCooldownModal extends Component {
 }
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
-  exitRequestCooldown: (data) => dispatch(ExitRequestCooldown.trigger(ownProps.requestId, data)),
+  exitRequestCooldown: (data) => dispatch(ExitRequestCooldown.trigger(ownProps.requestId, data)).then(response => (ownProps.then && ownProps.then(response)))
 });
 
 export default connect(

--- a/SingularityUI/app/components/requests/PauseButton.jsx
+++ b/SingularityUI/app/components/requests/PauseButton.jsx
@@ -19,7 +19,8 @@ export default class PauseButton extends Component {
   static propTypes = {
     requestId: PropTypes.string.isRequired,
     isScheduled: PropTypes.bool.isRequired,
-    children: PropTypes.node
+    children: PropTypes.node,
+    then: PropTypes.func
   };
 
   static defaultProps = {
@@ -40,6 +41,7 @@ export default class PauseButton extends Component {
           ref="modal"
           requestId={this.props.requestId}
           isScheduled={this.props.isScheduled}
+          then={this.props.then}
         />
       </span>
     );

--- a/SingularityUI/app/components/requests/PauseModal.jsx
+++ b/SingularityUI/app/components/requests/PauseModal.jsx
@@ -9,7 +9,8 @@ class PauseModal extends Component {
   static propTypes = {
     requestId: PropTypes.string.isRequired,
     isScheduled: PropTypes.bool.isRequired,
-    pauseRequest: PropTypes.func.isRequired
+    pauseRequest: PropTypes.func.isRequired,
+    then: PropTypes.func
   };
 
   show() {
@@ -55,7 +56,7 @@ class PauseModal extends Component {
 }
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
-  pauseRequest: (data) => dispatch(PauseRequest.trigger(ownProps.requestId, data)),
+  pauseRequest: (data) => dispatch(PauseRequest.trigger(ownProps.requestId, data)).then((response) => ownProps.then && ownProps.then(response)),
 });
 
 export default connect(

--- a/SingularityUI/app/components/requests/RemoveButton.jsx
+++ b/SingularityUI/app/components/requests/RemoveButton.jsx
@@ -17,7 +17,8 @@ const removeTooltip = (
 export default class RemoveButton extends Component {
   static propTypes = {
     requestId: PropTypes.string.isRequired,
-    children: PropTypes.node
+    children: PropTypes.node,
+    then: PropTypes.func
   };
 
   static defaultProps = {
@@ -34,7 +35,7 @@ export default class RemoveButton extends Component {
     return (
       <span>
         {getClickComponent(this)}
-        <RemoveModal ref="modal" requestId={this.props.requestId} />
+        <RemoveModal ref="modal" requestId={this.props.requestId} then={this.props.then} />
       </span>
     );
   }

--- a/SingularityUI/app/components/requests/RemoveModal.jsx
+++ b/SingularityUI/app/components/requests/RemoveModal.jsx
@@ -20,7 +20,7 @@ class RemoveModal extends Component {
       <FormModal
         ref="removeModal"
         action="Remove Request"
-        onConfirm={(data) => this.props.removeRequest(data)}
+        onConfirm={this.props.removeRequest}
         buttonStyle="danger"
         formElements={[
           {
@@ -38,7 +38,7 @@ class RemoveModal extends Component {
 }
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
-  removeRequest: (data) => dispatch(RemoveRequest.trigger(ownProps.requestId, data)),
+  removeRequest: (data) => dispatch(RemoveRequest.trigger(ownProps.requestId, data)).then(response => (ownProps.then && ownProps.then(response)))
 });
 
 export default connect(

--- a/SingularityUI/app/components/requests/RunNowButton.jsx
+++ b/SingularityUI/app/components/requests/RunNowButton.jsx
@@ -30,7 +30,8 @@ class RunNowButton extends Component {
     children: PropTypes.node,
     router: PropTypes.object,
     taskId: PropTypes.string,
-    task: PropTypes.object
+    task: PropTypes.object,
+    then: PropTypes.func
   };
 
   constructor(props) {
@@ -68,7 +69,14 @@ class RunNowButton extends Component {
     return (
       <span>
         <span>{getClickComponent(this, this.doBeforeOpeningModal)}</span>
-        <RunNowModal ref="modal" requestId={this.props.requestId} task={this.props.task} rerun={!!this.props.taskId} router={this.props.router} />
+        <RunNowModal
+          ref="modal"
+          requestId={this.props.requestId}
+          task={this.props.task}
+          rerun={!!this.props.taskId}
+          router={this.props.router}
+          then={this.props.then}
+        />
       </span>
     );
   }

--- a/SingularityUI/app/components/requests/RunNowModal.jsx
+++ b/SingularityUI/app/components/requests/RunNowModal.jsx
@@ -16,7 +16,8 @@ class RunNowModal extends Component {
     runNow: PropTypes.func.isRequired,
     router: PropTypes.object.isRequired,
     rerun: PropTypes.bool,
-    task: PropTypes.object
+    task: PropTypes.object,
+    then: PropTypes.func
   };
 
   static AFTER_TRIGGER = {
@@ -100,7 +101,7 @@ class RunNowModal extends Component {
 }
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
-  runNow: (data) => dispatch(RunRequest.trigger(ownProps.requestId, data)),
+  runNow: (data) => dispatch(RunRequest.trigger(ownProps.requestId, data)).then(response => (ownProps.then && ownProps.then(response))),
 });
 
 export default connect(

--- a/SingularityUI/app/components/requests/ScaleButton.jsx
+++ b/SingularityUI/app/components/requests/ScaleButton.jsx
@@ -18,7 +18,8 @@ export default class ScaleButton extends Component {
   static propTypes = {
     requestId: PropTypes.string.isRequired,
     currentInstances: PropTypes.number,
-    children: PropTypes.node
+    children: PropTypes.node,
+    then: PropTypes.func
   };
 
   static defaultProps = {
@@ -39,6 +40,7 @@ export default class ScaleButton extends Component {
           ref="modal"
           requestId={this.props.requestId}
           currentInstances={this.props.currentInstances}
+          then={this.props.then}
         />
       </span>
     );

--- a/SingularityUI/app/components/requests/ScaleModal.jsx
+++ b/SingularityUI/app/components/requests/ScaleModal.jsx
@@ -13,7 +13,8 @@ class ScaleModal extends Component {
     requestId: PropTypes.string.isRequired,
     scaleRequest: PropTypes.func.isRequired,
     bounceRequest: PropTypes.func.isRequired,
-    currentInstances: PropTypes.number
+    currentInstances: PropTypes.number,
+    then: PropTypes.func
   };
 
   // NOTE: currentInstances
@@ -102,7 +103,7 @@ class ScaleModal extends Component {
 }
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
-  scaleRequest: (data) => dispatch(ScaleRequest.trigger(ownProps.requestId, data)),
+  scaleRequest: (data) => dispatch(ScaleRequest.trigger(ownProps.requestId, data)).then((response) => ownProps.then && ownProps.then(response)),
   bounceRequest: (data) => dispatch(BounceRequest.trigger(ownProps.requestId, data))
 });
 

--- a/SingularityUI/app/components/requests/UnpauseButton.jsx
+++ b/SingularityUI/app/components/requests/UnpauseButton.jsx
@@ -18,7 +18,8 @@ export default class UnpauseButton extends Component {
 
   static propTypes = {
     requestId: PropTypes.string.isRequired,
-    children: PropTypes.node
+    children: PropTypes.node,
+    then: PropTypes.func
   };
 
   static defaultProps = {
@@ -35,7 +36,7 @@ export default class UnpauseButton extends Component {
     return (
       <span>
         {getClickComponent(this)}
-        <UnpauseModal ref="modal" requestId={this.props.requestId} />
+        <UnpauseModal ref="modal" requestId={this.props.requestId} then={this.props.then} />
       </span>
     );
   }

--- a/SingularityUI/app/components/requests/UnpauseModal.jsx
+++ b/SingularityUI/app/components/requests/UnpauseModal.jsx
@@ -42,7 +42,7 @@ class UnpauseModal extends Component {
 }
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
-  unpauseRequest: (data) => dispatch(UnpauseRequest.trigger(ownProps.requestId, data)),
+  unpauseRequest: (data) => dispatch(UnpauseRequest.trigger(ownProps.requestId, data)).then((response) => ownProps.then && ownProps.then(response)),
 });
 
 export default connect(


### PR DESCRIPTION
After performing an action from the request detail page, refresh the page so that the effects of the action can be seen.

The exception is removing the request - on performing that action, the user will be navigated to the requests page.

Omission from initial PR: It may be nice to add similar capabilities to the requests table, so that, for example, when you remove a request successfully it disappears from the table.

cc @tpetr @kwm4385 @wolfd 