### PR TITLE
UI support for absent deploy field

### DIFF
--- a/SingularityUI/app/components/deployDetail/DeployDetail.jsx
+++ b/SingularityUI/app/components/deployDetail/DeployDetail.jsx
@@ -323,7 +323,6 @@ class DeployDetail extends React.Component {
 
   render() {
     const { deploy, activeTasks, taskHistory, latestHealthchecks } = this.props;
-    delete deploy.deploy;
     const emptyMessage = !deploy.deploy && <div className="empty-table-message">Deploy data not found</div>;
     return (
       <div>

--- a/SingularityUI/app/components/deployDetail/DeployDetail.jsx
+++ b/SingularityUI/app/components/deployDetail/DeployDetail.jsx
@@ -95,12 +95,12 @@ class DeployDetail extends React.Component {
     const breadcrumbs = [
       {
         label: 'Request',
-        text: deploy.deploy.requestId,
-        link: `request/${deploy.deploy.requestId}`
+        text: this.props.params.requestId,
+        link: `request/${this.props.params.requestId}`
       },
       {
         label: 'Deploy',
-        text: deploy.deploy.id
+        text: this.props.params.deployId
       }
     ];
     if (this.props.group) {
@@ -123,7 +123,7 @@ class DeployDetail extends React.Component {
           <div className="col-md-8">
             <h1>
               <OverlayTrigger trigger={['hover', 'focus', 'click']} placement="left" overlay={copyLinkPopover}>
-                <span className="copy-btn" data-clipboard-text={deploy.deploy.id}>{deploy.deploy.id}</span>
+                <span className="copy-btn" data-clipboard-text={this.props.params.deployId}>{this.props.params.deployId}</span>
               </OverlayTrigger>
               <DeployState state={deploy.deployResult && deploy.deployResult.deployState || 'PENDING'} />
             </h1>
@@ -323,13 +323,18 @@ class DeployDetail extends React.Component {
 
   render() {
     const { deploy, activeTasks, taskHistory, latestHealthchecks } = this.props;
-    return (
+    const deploySections = deploy.deploy ? (
       <div>
-        {this.renderHeader(deploy)}
         {this.renderActiveTasks(deploy, activeTasks)}
         {this.renderTaskHistory(deploy, taskHistory)}
         {this.renderInfo(deploy)}
         {this.renderHealthchecks(deploy, latestHealthchecks)}
+      </div>
+    ) : <div className="empty-table-message">Deploy data not found</div>;
+    return (
+      <div>
+        {this.renderHeader(deploy)}
+        {deploySections}
       </div>
     );
   }

--- a/SingularityUI/app/components/deployDetail/DeployDetail.jsx
+++ b/SingularityUI/app/components/deployDetail/DeployDetail.jsx
@@ -162,7 +162,7 @@ class DeployDetail extends React.Component {
           keyGetter={(task) => task.taskId.id}
           rowChunkSize={5}
           paginated={true}
-          fetchDataFromApi={(page, numberPerPage) => this.props.fetchTaskHistoryForDeploy(deploy.deploy.requestId, deploy.deploy.id, numberPerPage, page)}
+          fetchDataFromApi={(page, numberPerPage) => this.props.fetchTaskHistoryForDeploy(this.props.params.requestId, this.props.params.deployId, numberPerPage, page)}
           isFetching={this.props.isTaskHistoryFetching}
         >
           <Column
@@ -323,18 +323,16 @@ class DeployDetail extends React.Component {
 
   render() {
     const { deploy, activeTasks, taskHistory, latestHealthchecks } = this.props;
-    const deploySections = deploy.deploy ? (
-      <div>
-        {this.renderActiveTasks(deploy, activeTasks)}
-        {this.renderTaskHistory(deploy, taskHistory)}
-        {this.renderInfo(deploy)}
-        {this.renderHealthchecks(deploy, latestHealthchecks)}
-      </div>
-    ) : <div className="empty-table-message">Deploy data not found</div>;
+    delete deploy.deploy;
+    const emptyMessage = !deploy.deploy && <div className="empty-table-message">Deploy data not found</div>;
     return (
       <div>
         {this.renderHeader(deploy)}
-        {deploySections}
+        {this.renderActiveTasks(deploy, activeTasks)}
+        {this.renderTaskHistory(deploy, taskHistory)}
+        {emptyMessage}
+        {deploy.deploy && this.renderInfo(deploy)}
+        {deploy.deploy && this.renderHealthchecks(deploy, latestHealthchecks)}
       </div>
     );
   }


### PR DESCRIPTION
In cases where the `deploy` field was absent from the deploy object, the UI would fail. This PR short circuits the render to display an empty message in this case.

![image](https://cloud.githubusercontent.com/assets/3221272/17602017/c859eeec-5fd8-11e6-9436-79ba701cfedd.png)

@tpetr @wolfd @Calvinp @ssalinas 