### PR TITLE
Fix duration field overflowing modal in firefox

### DIFF
--- a/SingularityUI/app/components/common/formItems/Duration.jsx
+++ b/SingularityUI/app/components/common/formItems/Duration.jsx
@@ -1,12 +1,14 @@
 import React, { PropTypes } from 'react';
 
 import moment from 'moment';
+import classNames from 'classnames';
 
 export default class Duration extends React.Component {
 
   static propTypes = {
     value: PropTypes.number, // Duration in millis
-    onChange: PropTypes.func
+    onChange: PropTypes.func,
+    isSubForm: PropTypes.bool
   };
 
   handleChange(event) {
@@ -30,8 +32,8 @@ export default class Duration extends React.Component {
   render() {
     const duration = moment.duration(this.props.value);
     return (
-      <div className="form-inline duration-input row">
-        <div className="form-group col-md-4">
+      <div className={classNames('duration-input', 'row', {'form-inline': !this.props.isSubForm})}>
+        <div className={classNames('col-md-4', {'form-group': !this.props.isSubForm})}>
           <label htmlFor="hours">Hours</label>
           <input
             id="hours"
@@ -44,7 +46,7 @@ export default class Duration extends React.Component {
             onChange={(e) => this.handleChange(e)}
           />
         </div>
-        <div className="form-group col-md-4">
+        <div className={classNames('col-md-4', {'form-group': !this.props.isSubForm})}>
           <label htmlFor="minutes">Minutes</label>
           <input
             id="minutes"
@@ -57,7 +59,7 @@ export default class Duration extends React.Component {
             onChange={(e) => this.handleChange(e)}
           />
         </div>
-        <div className="form-group col-md-4">
+        <div className={classNames('col-md-4', {'form-group': !this.props.isSubForm})}>
           <label htmlFor="seconds">Seconds</label>
           <input
             id="seconds"

--- a/SingularityUI/app/components/common/modal/FormModal.jsx
+++ b/SingularityUI/app/components/common/modal/FormModal.jsx
@@ -275,9 +275,11 @@ export default class FormModal extends React.Component {
             <FormModal.FormItem element={formElement} formState={this.state.formState} key={formElement.name}>
               <div className={classNames('form-group', {'has-error': !!error})}>
                 <label className="control-label" htmlFor={formElement.name}>{formElement.label}</label>
-                <Duration type="text"
+                <Duration
+                  type="text"
                   value={this.state.formState[formElement.name] || 0}
                   onChange={(value) => this.handleFormChange(formElement.name, value)}
+                  isSubForm={true}
                 />
                 {errorBlock}
                 {help}


### PR DESCRIPTION
This fixes the bug that caused duration fields to overflow the modal in firefox.
Before:
![screenshot 2016-08-11 15 57 40](https://cloud.githubusercontent.com/assets/3210505/17604007/be3e4f62-5fe1-11e6-9c07-54f77e0e3a1e.png)

After:
![screenshot 2016-08-11 16 36 37](https://cloud.githubusercontent.com/assets/3210505/17604017/ca8d741e-5fe1-11e6-8ca2-983e28ba9e22.png)

cc @tpetr @wolfd @kwm4385 