### PR TITLE
Name all the modals that don't already have a name

### DIFF
--- a/SingularityUI/app/components/machines/ModalButton.jsx
+++ b/SingularityUI/app/components/machines/ModalButton.jsx
@@ -22,6 +22,7 @@ class ModalButton extends React.Component {
       <span>
         {this.buttonWithMaybeTooltip()}
         <FormModal
+          name={this.props.name}
           ref="modal"
           action={this.props.action}
           onConfirm={(data) => this.props.onConfirm(data)}
@@ -40,6 +41,7 @@ ModalButton.propTypes = {
   onConfirm: PropTypes.func.isRequired,
   children: PropTypes.node.isRequired,
   tooltipText: PropTypes.string,
+  name: PropTypes.string,
   formElements: PropTypes.arrayOf(PropTypes.shape({
     name: PropTypes.string.isRequired,
     type: PropTypes.string.isRequired,

--- a/SingularityUI/app/components/machines/Racks.jsx
+++ b/SingularityUI/app/components/machines/Racks.jsx
@@ -41,6 +41,7 @@ class Racks extends Component {
   getMaybeReactivateButton(rack) {
     return (Utils.isIn(rack.currentState.state, ['DECOMMISSIONING', 'DECOMMISSIONED', 'STARTING_DECOMMISSION']) &&
       <ModalButton
+        name="Reactivate Rack"
         buttonChildren={<Glyphicon glyph="new-window" />}
         action="Reactivate Rack"
         onConfirm={(data) => this.props.reactivateRack(rack, data.message)}
@@ -57,6 +58,7 @@ class Racks extends Component {
     if (rack.currentState.state === 'ACTIVE') {
       return (
         <ModalButton
+          name="Decommission Rack"
           buttonChildren={<Glyphicon glyph="trash" />}
           action="Decommission Rack"
           onConfirm={(data) => this.props.decommissionRack(rack, data.message)}
@@ -74,6 +76,7 @@ class Racks extends Component {
     }
     return (
       <ModalButton
+        name="Remove Rack"
         buttonChildren={<Glyphicon glyph="remove" />}
         action="Remove Rack"
         onConfirm={(data) => this.props.removeRack(rack, data.message)}

--- a/SingularityUI/app/components/machines/Slaves.jsx
+++ b/SingularityUI/app/components/machines/Slaves.jsx
@@ -36,6 +36,7 @@ class Slaves extends React.Component {
   getMaybeReactivateButton(slave) {
     return (Utils.isIn(slave.currentState.state, ['DECOMMISSIONING', 'DECOMMISSIONED', 'STARTING_DECOMMISSION', 'FROZEN']) &&
       <ModalButton
+        name="Reactivate Slave"
         buttonChildren={<Glyphicon glyph="new-window" />}
         action="Reactivate Slave"
         onConfirm={(data) => this.props.reactivateSlave(slave, data.message)}
@@ -51,6 +52,7 @@ class Slaves extends React.Component {
   getMaybeFreezeButton(slave) {
     return (slave.currentState.state === 'ACTIVE' &&
       <ModalButton
+        name="Freeze Slave"
         buttonChildren={<Glyphicon glyph="stop" />}
         action="Freeze Slave"
         onConfirm={(data) => this.props.freezeSlave(slave, data.message)}
@@ -67,6 +69,7 @@ class Slaves extends React.Component {
     if (Utils.isIn(slave.currentState.state, ['ACTIVE', 'FROZEN'])) {
       return (
         <ModalButton
+          name="Decommission Slave"
           buttonChildren={<Glyphicon glyph="trash" />}
           action="Decommission Slave"
           onConfirm={(data) => this.props.decommissionSlave(slave, data.message)}
@@ -82,6 +85,7 @@ class Slaves extends React.Component {
     }
     return (
       <ModalButton
+        name="Remove Slave"
         buttonChildren={<Glyphicon glyph="remove" />}
         action="Remove Slave"
         onConfirm={(data) => this.props.removeSlave(slave, data.message)}

--- a/SingularityUI/app/components/requestDetail/header/AdvanceDeployModal.jsx
+++ b/SingularityUI/app/components/requestDetail/header/AdvanceDeployModal.jsx
@@ -40,6 +40,7 @@ class AdvanceDeployModal extends Component {
     );
     return (
       <FormModal
+        name="Advance Deploy"
         ref="advanceModal"
         action="Advance Deploy"
         onConfirm={(data) => this.props.advanceDeploy(data.targetActiveInstances)}

--- a/SingularityUI/app/components/requestDetail/header/CancelDeployModal.jsx
+++ b/SingularityUI/app/components/requestDetail/header/CancelDeployModal.jsx
@@ -20,6 +20,7 @@ class CancelDeployModal extends Component {
   render() {
     return (
       <FormModal
+        name="Cancel Deploy"
         ref="cancelModal"
         action="Cancel Deploy"
         onConfirm={() => this.props.cancelDeploy()}

--- a/SingularityUI/app/components/requests/BounceModal.jsx
+++ b/SingularityUI/app/components/requests/BounceModal.jsx
@@ -29,6 +29,7 @@ class BounceModal extends Component {
   render() {
     return (
       <FormModal
+        name="Bounce Request"
         ref="bouceModal"
         action="Bounce Request"
         onConfirm={(data) => this.props.bounceRequest(data)}

--- a/SingularityUI/app/components/requests/DisableHealthchecksModal.jsx
+++ b/SingularityUI/app/components/requests/DisableHealthchecksModal.jsx
@@ -33,6 +33,7 @@ class DisableHealthchecksModal extends Component {
     return (
       <div style={{display: 'inline-block'}}>
         <FormModal
+          name="Disable Healthchecks"
           ref="disableHealthchecksModal"
           action="Disable Healthchecks"
           onConfirm={(data) => this.promptDisableHealthchecksDuration(data)}

--- a/SingularityUI/app/components/requests/EnableHealthchecksModal.jsx
+++ b/SingularityUI/app/components/requests/EnableHealthchecksModal.jsx
@@ -19,6 +19,7 @@ class EnableHealthchecksModal extends Component {
   render() {
     return (
       <FormModal
+        name="Enable Healthchecks"
         ref="enableHealthchecksModal"
         action="Enable Healthchecks"
         onConfirm={(data) => this.props.enableHealthchecks(data)}

--- a/SingularityUI/app/components/requests/ExitCooldownModal.jsx
+++ b/SingularityUI/app/components/requests/ExitCooldownModal.jsx
@@ -19,6 +19,7 @@ class ExitCooldownModal extends Component {
   render() {
     return (
       <FormModal
+        name="Exit Request Cooldown"
         ref="exitCooldownModal"
         action="Exit Request Cooldown"
         onConfirm={(data) => this.props.exitRequestCooldown(data)}

--- a/SingularityUI/app/components/requests/PauseModal.jsx
+++ b/SingularityUI/app/components/requests/PauseModal.jsx
@@ -43,6 +43,7 @@ class PauseModal extends Component {
 
     return (
       <FormModal
+        name="Pause Request"
         ref="pauseModal"
         action="Pause Request"
         onConfirm={(data) => this.props.pauseRequest(data)}

--- a/SingularityUI/app/components/requests/RemoveModal.jsx
+++ b/SingularityUI/app/components/requests/RemoveModal.jsx
@@ -18,6 +18,7 @@ class RemoveModal extends Component {
   render() {
     return (
       <FormModal
+        name="Remove Request"
         ref="removeModal"
         action="Remove Request"
         onConfirm={this.props.removeRequest}

--- a/SingularityUI/app/components/requests/ScaleModal.jsx
+++ b/SingularityUI/app/components/requests/ScaleModal.jsx
@@ -58,6 +58,7 @@ class ScaleModal extends Component {
   render() {
     return (
       <FormModal
+        name="Scale Request"
         ref="scaleModal"
         action="Scale Request"
         onConfirm={(data) => this.handleScale(data)}

--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -225,6 +225,7 @@ class TaskDetail extends Component {
     const removeBtn = this.props.task.isStillRunning && (
       <span>
         <FormModal
+          name={removeText}
           ref="confirmKillTask"
           action={removeText}
           onConfirm={(event) => this.killTask(event)}

--- a/SingularityUI/app/components/tasks/KillTaskModal.jsx
+++ b/SingularityUI/app/components/tasks/KillTaskModal.jsx
@@ -24,6 +24,7 @@ class KillTaskModal extends Component {
   render() {
     return (
       <FormModal
+        name="Kill Task"
         ref="confirmKillTask"
         action="Kill Task"
         onConfirm={(data) => this.props.killTask(data)}

--- a/SingularityUI/app/initialize.jsx
+++ b/SingularityUI/app/initialize.jsx
@@ -36,6 +36,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   return ReactDOM.render(
     <FormModal
+      name="Set API Root"
       action="Set API Root"
       onConfirm={(data) => setApiRoot(data)}
       buttonStyle="primary"


### PR DESCRIPTION
Exactly what it says on the tin - gives a name to all the modals that didn't already have a name.

eg.
![screenshot 2016-08-11 16 50 18](https://cloud.githubusercontent.com/assets/3210505/17604411/b61257d2-5fe3-11e6-8ccf-6bb6efb88e38.png)


cc @tpetr @wolfd @kwm4385 