### PR TITLE
Don't show the wait for replacement task option when killing tasks in certain request types

### DIFF
--- a/SingularityUI/app/components/tasks/Columns.jsx
+++ b/SingularityUI/app/components/tasks/Columns.jsx
@@ -213,7 +213,10 @@ export const ActiveActions = (
     className="actions-column"
     cellRender={(cellData) => (
       <div className="hidden-xs">
-        <KillTaskButton taskId={cellData.taskId.id} />
+        <KillTaskButton
+          taskId={cellData.taskId.id}
+          shouldShowWaitForReplacementTask={Utils.isIn(cellData.taskRequest.request.requestType, ['SERVICE', 'WORKER'])}
+        />
         <JSONButton className="inline" object={cellData} showOverlay={true}>
           {'{ }'}
         </JSONButton>

--- a/SingularityUI/app/components/tasks/KillTaskButton.jsx
+++ b/SingularityUI/app/components/tasks/KillTaskButton.jsx
@@ -17,7 +17,9 @@ const killTooltip = (
 export default class KillTaskButton extends Component {
   static propTypes = {
     taskId: PropTypes.string.isRequired,
-    children: PropTypes.node
+    shouldShowWaitForReplacementTask: PropTypes.bool,
+    children: PropTypes.node,
+    name: PropTypes.string
   };
 
   static defaultProps = {
@@ -34,7 +36,12 @@ export default class KillTaskButton extends Component {
     return (
       <span>
         {getClickComponent(this)}
-        <KillTaskModal ref="modal" taskId={this.props.taskId} />
+        <KillTaskModal
+          name={this.props.name}
+          ref="modal"
+          taskId={this.props.taskId}
+          shouldShowWaitForReplacementTask={this.props.shouldShowWaitForReplacementTask}
+        />
       </span>
     );
   }

--- a/SingularityUI/app/components/tasks/KillTaskModal.jsx
+++ b/SingularityUI/app/components/tasks/KillTaskModal.jsx
@@ -8,7 +8,9 @@ import FormModal from '../common/modal/FormModal';
 class KillTaskModal extends Component {
   static propTypes = {
     taskId: PropTypes.string.isRequired,
-    killTask: PropTypes.func.isRequired
+    shouldShowWaitForReplacementTask: PropTypes.bool,
+    killTask: PropTypes.func.isRequired,
+    name: PropTypes.string
   };
 
   constructor() {
@@ -17,31 +19,37 @@ class KillTaskModal extends Component {
     this.show = this.show.bind(this);
   }
 
+  static defaultProps = {
+    name: 'Kill Task'
+  };
+
   show() {
     this.refs.confirmKillTask.show();
   }
 
   render() {
+    let formElements = [];
+    if (this.props.shouldShowWaitForReplacementTask) {
+      formElements = [{
+        name: 'waitForReplacementTask',
+        type: FormModal.INPUT_TYPES.BOOLEAN,
+        label: 'Wait for replacement task to start before killing task',
+        defaultValue: true
+      }];
+    }
+    formElements.push({
+      name: 'message',
+      type: FormModal.INPUT_TYPES.STRING,
+      label: 'Message (optional)'
+    });
     return (
       <FormModal
-        name="Kill Task"
+        name={this.props.name}
         ref="confirmKillTask"
-        action="Kill Task"
+        action={this.props.name}
         onConfirm={(data) => this.props.killTask(data)}
         buttonStyle="danger"
-        formElements={[
-          {
-            name: 'waitForReplacementTask',
-            type: FormModal.INPUT_TYPES.BOOLEAN,
-            label: 'Wait for replacement task to start before killing task',
-            defaultValue: true
-          },
-          {
-            name: 'message',
-            type: FormModal.INPUT_TYPES.STRING,
-            label: 'Message (optional)'
-          }
-        ]}>
+        formElements={formElements}>
         <span>
           <p>Are you sure you want to kill this task?</p>
           <pre>{this.props.taskId}</pre>


### PR DESCRIPTION
It doesn't make sense to show that option if there won't be a replacement task - so don't show it for scheduled, on demand, or run once requests.

cc @tpetr @kwm4385 @wolfd 