### PR TITLE
Render every row on dashboard tables

### DIFF
--- a/SingularityUI/app/components/common/table/UITable.jsx
+++ b/SingularityUI/app/components/common/table/UITable.jsx
@@ -452,7 +452,7 @@ UITable.propTypes = {
   keyGetter: PropTypes.func.isRequired,
   children: PropTypes.arrayOf(PropTypes.node).isRequired,
   paginated: PropTypes.bool,
-  renderAllRows: PropTypes.bool, // Will render all rows even if there are 1,000,000
+  renderAllRows: PropTypes.bool,
   rowChunkSize: PropTypes.number,
   rowChunkSizeChoices: PropTypes.arrayOf(PropTypes.number),
   maxPaginationButtons: PropTypes.number,

--- a/SingularityUI/app/components/common/table/UITable.jsx
+++ b/SingularityUI/app/components/common/table/UITable.jsx
@@ -288,7 +288,7 @@ class UITable extends Component {
     // infinite scrolling
     // Only render a number of rows at a time
     // check to see if we can render of everything
-    const maxVisibleRows = this.props.isTruelyInfinite ? this.state.data.length : this.state.chunkNum * this.state.rowChunkSize;
+    const maxVisibleRows = this.props.renderAllRows ? this.state.data.length : this.state.chunkNum * this.state.rowChunkSize;
     const rows = this.state.data.slice(0, maxVisibleRows).map((row) => {
       return this.renderTableRow(row);
     });
@@ -452,7 +452,7 @@ UITable.propTypes = {
   keyGetter: PropTypes.func.isRequired,
   children: PropTypes.arrayOf(PropTypes.node).isRequired,
   paginated: PropTypes.bool,
-  isTruelyInfinite: PropTypes.bool, // Will render all rows even if there are 1,000,000
+  renderAllRows: PropTypes.bool, // Will render all rows even if there are 1,000,000
   rowChunkSize: PropTypes.number,
   rowChunkSizeChoices: PropTypes.arrayOf(PropTypes.number),
   maxPaginationButtons: PropTypes.number,

--- a/SingularityUI/app/components/common/table/UITable.jsx
+++ b/SingularityUI/app/components/common/table/UITable.jsx
@@ -288,7 +288,7 @@ class UITable extends Component {
     // infinite scrolling
     // Only render a number of rows at a time
     // check to see if we can render of everything
-    const maxVisibleRows = this.state.chunkNum * this.state.rowChunkSize;
+    const maxVisibleRows = this.props.isTruelyInfinite ? this.state.data.length : this.state.chunkNum * this.state.rowChunkSize;
     const rows = this.state.data.slice(0, maxVisibleRows).map((row) => {
       return this.renderTableRow(row);
     });
@@ -452,6 +452,7 @@ UITable.propTypes = {
   keyGetter: PropTypes.func.isRequired,
   children: PropTypes.arrayOf(PropTypes.node).isRequired,
   paginated: PropTypes.bool,
+  isTruelyInfinite: PropTypes.bool, // Will render all rows even if there are 1,000,000
   rowChunkSize: PropTypes.number,
   rowChunkSizeChoices: PropTypes.arrayOf(PropTypes.number),
   maxPaginationButtons: PropTypes.number,

--- a/SingularityUI/app/components/dashboard/MyPausedRequests.jsx
+++ b/SingularityUI/app/components/dashboard/MyPausedRequests.jsx
@@ -21,7 +21,7 @@ const MyPausedRequests = ({userRequests}) => {
         data={pausedRequests}
         keyGetter={(r) => r.request.id}
         asyncSort={true}
-        isTruelyInfinite={true}
+        renderAllRows={true}
       >
         {RequestId}
         {Type}

--- a/SingularityUI/app/components/dashboard/MyPausedRequests.jsx
+++ b/SingularityUI/app/components/dashboard/MyPausedRequests.jsx
@@ -21,8 +21,7 @@ const MyPausedRequests = ({userRequests}) => {
         data={pausedRequests}
         keyGetter={(r) => r.request.id}
         asyncSort={true}
-        paginated={true}
-        rowChunkSize={10}
+        isTruelyInfinite={true}
       >
         {RequestId}
         {Type}

--- a/SingularityUI/app/components/dashboard/MyStarredRequests.jsx
+++ b/SingularityUI/app/components/dashboard/MyStarredRequests.jsx
@@ -19,7 +19,7 @@ const MyStarredRequests = ({starredRequests}) => {
         data={starredRequests}
         keyGetter={(r) => r.request.id}
         asyncSort={true}
-        isTruelyInfinite={true}
+        renderAllRows={true}
       >
         {Starred}
         {RequestId}

--- a/SingularityUI/app/components/dashboard/MyStarredRequests.jsx
+++ b/SingularityUI/app/components/dashboard/MyStarredRequests.jsx
@@ -19,8 +19,7 @@ const MyStarredRequests = ({starredRequests}) => {
         data={starredRequests}
         keyGetter={(r) => r.request.id}
         asyncSort={true}
-        paginated={true}
-        rowChunkSize={10}
+        isTruelyInfinite={true}
       >
         {Starred}
         {RequestId}


### PR DESCRIPTION
Renders every row on the `My Paused Requests` and `My Starred Requests` tables on the dashboard page.

Note that this will render every row even if there are thousands - but there won't be thousands unless a user stars every request in the system for some reason.

cc @tpetr @wolfd @kwm4385 