### PR TITLE
allow searching of deleted request logs

### DIFF
--- a/scripts/logfetch/entrypoint.py
+++ b/scripts/logfetch/entrypoint.py
@@ -147,6 +147,7 @@ def fetch():
     parser.add_argument("-L", "--skip-live", dest="skip_live", help="Don't download/search live logs", action='store_true')
     parser.add_argument("-U", "--use-cache", dest="use_cache", help="Use cache for live logs, don't re-download them", action='store_true')
     parser.add_argument("--search", dest="search", help="run logsearch on the local cache of downloaded files", action='store_true')
+    parser.add_argument("-i", "--show-file-info", dest='show_file_info', help="Print the file name before printing log lines", action='store_true')
     parser.add_argument("-V", "--verbose", dest="verbose", help="Print more verbose output", action='store_true')
     parser.add_argument("--silent", dest="silent", help="No stderr (progress, file names, etc) output", action='store_true')
     parser.add_argument("-D" ,"--download-only", dest="download_only", help="Only download files, don't unzip or grep", action='store_true')
@@ -209,6 +210,7 @@ def search():
     parser.add_argument("-p", "--file-pattern", dest="file_pattern", help="S3 uploader file pattern")
     parser.add_argument("-g", "--grep", dest="grep", help="Regex to grep for (normal grep syntax) or a full grep command")
     parser.add_argument("-z", "--local-zone", dest="zone", help="If specified, input times in the local time zone and convert to UTC, if not specified inputs are assumed to be UTC", action="store_true")
+    parser.add_argument("-i", "--show-file-info", dest='show_file_info', help="Print the file name before printing log lines", action='store_true')
     parser.add_argument("-V", "--verbose", dest="verbose", help="Print more verbose output", action='store_true')
     parser.add_argument("--silent", dest="silent", help="No stderr (progress, file names, etc) output", action='store_true')
 
@@ -277,6 +279,7 @@ def cat():
     parser.add_argument("-U", "--use-cache", dest="use_cache", help="Use cache for live logs, don't re-download them", action='store_true')
     parser.add_argument("-V", "--verbose", dest="verbose", help="Print more verbose output", action='store_true')
     parser.add_argument("--silent", dest="silent", help="No stderr (progress, file names, etc) output", action='store_true')
+    parser.add_argument("-i", "--show-file-info", dest='show_file_info', help="Print the file name before printing log lines", action='store_true')
     parser.add_argument("-D" ,"--download-only", dest="download_only", help="Only download files, don't unzip or grep", action='store_true')
 
     args = parser.parse_args(remaining_argv)

--- a/scripts/logfetch/grep.py
+++ b/scripts/logfetch/grep.py
@@ -1,6 +1,6 @@
 import sys
 import subprocess
-from logfetch_base import log
+from logfetch_base import log, get_timestamp
 from termcolor import colored
 
 DEFAULT_GREP_COMMAND = 'grep --color=always \'{0}\''
@@ -13,7 +13,7 @@ def grep_files(args, all_logs):
             grep_cmd = grep_command(args)
             log(colored('Running grep command ({0})\n'.format(grep_cmd), 'cyan'), args, False)
             for filename in all_logs:
-                log('=> ' + colored(filename, 'cyan') + '\n', args, True)
+                log(colored(str(get_timestamp(filename)) + ' => ' + filename, 'cyan') + '\n', args, not args.show_file_info)
                 content = subprocess.Popen(['cat', filename], stdout=subprocess.PIPE)
                 if filename.endswith('.gz'):
                     zcat = subprocess.Popen('zcat', stdin=content.stdout, stdout=subprocess.PIPE)

--- a/scripts/logfetch/logfetch_base.py
+++ b/scripts/logfetch/logfetch_base.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 import gzip
 import fnmatch
@@ -65,6 +66,13 @@ def is_in_date_range(args, timestamp):
         return False if (timstamp_datetime < args.start or timstamp_datetime > args.end) else True
     else:
         return False if timedelta.days < args.start else True
+
+def get_timestamp(filename):
+    timestamps = re.findall(r"-\d{13}-", filename)
+    if timestamps:
+        return datetime.utcfromtimestamp(int(str(timestamps[-1]).replace("-", "")[0:-3]))
+    else:
+        return ""
 
 def update_progress_bar(progress, goal, progress_type, silent):
     bar_length = 30


### PR DESCRIPTION
The prefixes and files for deleted requests will still be in s3, so we should be able to search them. Updates to just return an absent group if we can't find the request and continue our searching.

@tpetr 