### PR TITLE
Check for presence of promise before attempting to catch errors

### DIFF
--- a/SingularityUI/app/rootComponent.jsx
+++ b/SingularityUI/app/rootComponent.jsx
@@ -67,12 +67,20 @@ const rootComponent = (Wrapped, title, refresh = _.noop, refreshInterval = true,
   }
 
   handleFocus() {
-    refresh(this.props).catch((reason) => setTimeout(() => { throw new Error(reason); }));
+    const promise = refresh(this.props);
+    if (promise) {
+      promise.catch((reason) => setTimeout(() => { throw new Error(reason); }));
+    }
     this.startRefreshInterval();
   }
 
   startRefreshInterval() {
-    this.refreshInterval = setInterval(() => refresh(this.props).catch((reason) => setTimeout(() => { throw new Error(reason); })), config.globalRefreshInterval);
+    this.refreshInterval = setInterval(() => {
+      const promise = refresh(this.props);
+      if (promise) {
+        promise.catch((reason) => setTimeout(() => { throw new Error(reason); }));
+      }
+    }, config.globalRefreshInterval);
   }
 
   stopRefreshInterval() {


### PR DESCRIPTION
Refresh doesn't require a promise to always be returned, so check for one before attempting to catch errors for sentry. Fixes "catch of undefined sentry".

@tpetr @wolfd @Calvinp 