### PR TITLE
Fix the back button when navigating through files on the task detail page

### DIFF
--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -108,7 +108,7 @@ class TaskDetail extends Component {
       files: PropTypes.array,
       currentDirectory: PropTypes.string
     }),
-    filePath: PropTypes.string,
+    currentFilePath: PropTypes.string,
     taskId: PropTypes.string.isRequired,
     params: PropTypes.object,
     fetchTaskHistory: PropTypes.func.isRequired,
@@ -121,8 +121,7 @@ class TaskDetail extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      previousUsage: null,
-      currentFilePath: props.params.splat || props.params.taskId
+      previousUsage: null
     };
   }
 
@@ -192,9 +191,6 @@ class TaskDetail extends Component {
           changeDir={(path) => {
             if (path.startsWith('/')) path = path.substring(1);
             this.props.fetchTaskFiles(this.props.params.taskId, path).then(() => {
-              this.setState({
-                currentFilePath: path
-              });
               this.props.router.push(Utils.joinPath(`task/${this.props.params.taskId}/files/`, path));
             });
           }}
@@ -371,7 +367,7 @@ class TaskDetail extends Component {
     const cleanup = _.find(this.props.taskCleanups, (cleanupToTest) => {
       return cleanupToTest.taskId.id === this.props.taskId;
     });
-    const filesToDisplay = this.props.files[`${this.props.params.taskId}/${this.state.currentFilePath}`] && this.analyzeFiles(this.props.files[`${this.props.taskId}/${this.state.currentFilePath}`].data);
+    const filesToDisplay = this.props.files[`${this.props.params.taskId}/${this.props.currentFilePath}`] && this.analyzeFiles(this.props.files[`${this.props.taskId}/${this.props.currentFilePath}`].data);
 
     return (
       <div className="task-detail detail-view">
@@ -446,6 +442,7 @@ function mapStateToProps(state, ownProps) {
   return {
     task,
     taskId: ownProps.params.taskId,
+    currentFilePath: _.isUndefined(ownProps.params.splat) ? ownProps.params.taskId : ownProps.params.splat,
     taskCleanups: state.api.taskCleanups.data,
     files: state.api.taskFiles,
     resourceUsage: state.api.taskResourceUsage.data,


### PR DESCRIPTION
Fixes the bug that caused the back button not to work while navigating through file system on the TaskDetail page.

The problem was it wasn't actually using the route to determine the file path, but to set state that determined the file path. The state wouldn't be updated when the back button was hit. The fix was to not use state at all.

cc @tpetr @kwm4385 @wolfd 