### PR TITLE
UI development docs Backbone/Coffeescript => es6/React/Redux (WIP)

### DIFF
--- a/Docs/development/ui.md
+++ b/Docs/development/ui.md
@@ -173,8 +173,8 @@ There are some libraries/classes in SingularityUI which you should be aware of i
 
 * [Initialize](../SingularityUI/app/initialize.jsx) sets up the Redux store, user settings, and the router. It also prompts the user for API
 * [Router](../SingularityUI/app/router.jsx) points requests to their respective components.
-* [Base](../SingularityUI/app/actions/api/base.es6) is responsible for API call behavior, including error-handling.
 * [Application](../SingularityUI/app/components/common/Application.jsx) provides the naviagtion header and global search functionality.
+* [Base](../SingularityUI/app/actions/api/base.es6) is responsible for API call behavior, including error-handling.
 * [Utils](../SingularityUI/app/utils.jsx) contains a bunch of reusable static functions.
 * [UITable](../SingularityUI/app/components/common/table/UITable.jsx) is a comprehensive table component that provides sorting, pagination and other utilities. Data is provided by child [Column](../SingularityUI/app/components/common/table/Column.jsx) components.
 * [FormModal](../SingularityUI/app/components/common/modal/FormModal.jsx) provides a base for most of Singularity's modals, such as the Run Now and Pause Request modals.

--- a/Docs/development/ui.md
+++ b/Docs/development/ui.md
@@ -171,6 +171,7 @@ To summarise:
 
 There are some libraries/classes in SingularityUI which you should be aware of if you plan on working on it:
 
+* [Initialize](../SingularityUI/app/initialize.jsx) sets up the Redux store, user settings, and the router. It also prompts the user for API
 * [Router](../SingularityUI/app/router.jsx) points requests to their respective components.
 * [Base](../SingularityUI/app/actions/api/base.es6) is responsible for API call behavior, including error-handling.
 * [Application](../SingularityUI/app/components/common/Application.jsx) provides the naviagtion header and global search functionality.

--- a/Docs/development/ui.md
+++ b/Docs/development/ui.md
@@ -150,7 +150,7 @@ First you request `/singularity/webhooks`. This triggers [our router](../Singula
 
 When the Webhooks component is called, the initial action occurs in the `connect()` function call at the bottom of the page.
 
-First, `connect()` calls `mapStateToProps()`. Though it is called with the redux state and the component's own props, the Webhooks page doesn't have props passed into it. This returns props that are obtained from the redux store, such as API calls.
+First, `connect()` calls `mapStateToProps()`. Though it is called with the redux store and the component's own props, the Webhooks page doesn't have props passed into it. This returns props that are obtained from the redux store, such as API calls.
 
 Then `connect()` calles `mapDispatchToProps()`. This is called with the redux dispatch and the component's own props, and returns props are functions which can perform actions.
 

--- a/Docs/development/ui.md
+++ b/Docs/development/ui.md
@@ -20,11 +20,11 @@ The compiled static files are placed in `../SingularityService/target/generated-
 
 SingularityUI is a single page webapp that relies on SingularityService for its data.
 
-The app is built using Gulp (i.e. compiling es6, etc), with npm being used to manage its dependencies (e.g. React, Bootstrap).
+The app is built using Gulp (i.e. compiling ES6, etc), with npm being used to manage its dependencies (e.g. React, Bootstrap).
 
 We recommend you familiarise yourself with the following if you haven't used them before:
 
-* [es6](http://es6-features.org/#Constants) is the language used for all logic.
+* [ES6](http://es6-features.org/#Constants) is the language used for all logic.
 * [Stylus](http://learnboost.github.io/stylus/) is used instead of CSS.
 * [React](https://facebook.github.io/react/) acts as the front-end framework and templating library.
 * [Redux](http://redux.js.org/docs/introduction/) provides state managment.

--- a/Docs/development/ui.md
+++ b/Docs/development/ui.md
@@ -22,7 +22,7 @@ SingularityUI is a single page webapp that relies on SingularityService for its 
 
 The app is built using Gulp (i.e. compiling ES6, etc), with npm being used to manage its dependencies (e.g. React, Bootstrap).
 
-We recommend you familiarise yourself with the following if you haven't used them before:
+We recommend you familiarize yourself with the following if you haven't used them before:
 
 * [ES6](http://es6-features.org/#Constants) is the language used for all logic.
 * [Stylus](http://learnboost.github.io/stylus/) is used instead of CSS.
@@ -142,7 +142,7 @@ localStorage.setItem('suppressRefresh', true)
 
 ## Code structure
 
-As mentioned before, SingularityUI uses [React](https://facebook.github.io/react/) and [Redux](http://redux.js.org/docs/introduction/). If you're not familiar with how it does things, please look into it and familiarise yourself with React's lifecycle and the Redux store and dispatch.
+As mentioned before, SingularityUI uses [React](https://facebook.github.io/react/) and [Redux](http://redux.js.org/docs/introduction/). If you're not familiar with how it does things, please look into it and familiarize yourself with React's lifecycle and the Redux store and dispatch.
 
 What follows is a run-down of how things work in Singularity, using the Webhooks page as an example.
 
@@ -162,7 +162,7 @@ Finally, once the API call does complete, `rootComponent` takes the props provid
 
 Everything else is standard [React](https://facebook.github.io/react/)-structured code. Please refer to the official docs for how to do things like respond to UI events, etc.
 
-To summarise:
+To summarize:
 * React Router bootstraps everything for the page.
 * All API calls necessary for rendering the page are performed in the primary component's `refresh()` or `initialize()` function.
 * Use React conventions wherever possible. Try to rely on props, not component state.

--- a/Docs/development/ui.md
+++ b/Docs/development/ui.md
@@ -142,7 +142,7 @@ localStorage.setItem('suppressRefresh', true)
 
 ## Code structure
 
-As mentioned before, SingularityUI uses [React](https://facebook.github.io/react/) and [Redux](http://redux.js.org/docs/introduction/). If you're not familiar with how it does things, please look into it and familiarise yourself with Views, Models, Collections, and the event-based interaction between them all.
+As mentioned before, SingularityUI uses [React](https://facebook.github.io/react/) and [Redux](http://redux.js.org/docs/introduction/). If you're not familiar with how it does things, please look into it and familiarise yourself with React's lifecycle and the Redux store and dispatch.
 
 What follows is a run-down of how things work in Singularity, using the Webhooks page as an example.
 

--- a/Docs/development/ui.md
+++ b/Docs/development/ui.md
@@ -142,7 +142,7 @@ localStorage.setItem('suppressRefresh', true)
 
 ## Code structure
 
-As mentioned before, SingularityUI uses [React](https://facebook.github.io/react/) and [Redux](http://redux.js.org/docs/introduction/). If you're not familiar with how it does things, please look into it and familiarize yourself with React's lifecycle and the Redux store and dispatch.
+As mentioned before, SingularityUI uses [React](https://facebook.github.io/react/) and [Redux](http://redux.js.org/docs/introduction/). If you're not familiar with how they do things, please look into them and familiarize yourself with React's lifecycle and the Redux store and dispatch.
 
 What follows is a run-down of how things work in Singularity, using the Webhooks page as an example.
 

--- a/Docs/development/ui.md
+++ b/Docs/development/ui.md
@@ -171,7 +171,9 @@ To summarise:
 
 There are some libraries/classes in SingularityUI which you should be aware of if you plan on working on it:
 
-* [Base](../SingularityUI/app/actions/api/base.es6) is responsible for API call behavior, including error-handling.
 * [Router](../SingularityUI/app/router.jsx) points requests to their respective components.
+* [Base](../SingularityUI/app/actions/api/base.es6) is responsible for API call behavior, including error-handling.
+* [Application](../SingularityUI/app/components/common/Application.jsx) provides the naviagtion header and global search functionality.
 * [Utils](../SingularityUI/app/utils.jsx) contains a bunch of reusable static functions.
 * [UITable](../SingularityUI/app/components/common/table/UITable.jsx) is a comprehensive table component that provides sorting, pagination and other utilities. Data is provided by child [Column](../SingularityUI/app/components/common/table/Column.jsx) components.
+* [FormModal](../SingularityUI/app/components/common/modal/FormModal.jsx) provides a base for most of Singularity's modals, such as the Run Now and Pause Request modals.

--- a/Docs/development/ui.md
+++ b/Docs/development/ui.md
@@ -171,7 +171,7 @@ To summarise:
 
 There are some libraries/classes in SingularityUI which you should be aware of if you plan on working on it:
 
-* [Initialize](../SingularityUI/app/initialize.jsx) sets up the Redux store, user settings, and the router. It also prompts the user for API
+* [Initialize](../SingularityUI/app/initialize.jsx) sets up the Redux store, user settings, and the router. It also prompts the user for API root if necessary.
 * [Router](../SingularityUI/app/router.jsx) points requests to their respective components.
 * [Application](../SingularityUI/app/components/common/Application.jsx) provides the naviagtion header and global search functionality.
 * [Base](../SingularityUI/app/actions/api/base.es6) is responsible for API call behavior, including error-handling.

--- a/Docs/development/ui.md
+++ b/Docs/development/ui.md
@@ -20,14 +20,15 @@ The compiled static files are placed in `../SingularityService/target/generated-
 
 SingularityUI is a single page webapp that relies on SingularityService for its data.
 
-The app is built using Gulp (i.e. compiling CoffeeScript, etc), with npm being used to manage its dependencies (e.g. jQuery, Backbone).
+The app is built using Gulp (i.e. compiling es6, etc), with npm being used to manage its dependencies (e.g. React, Bootstrap).
 
 We recommend you familiarise yourself with the following if you haven't used them before:
 
-* [CoffeeScript](http://coffeescript.org/) is the language used for all logic.
+* [es6](http://es6-features.org/#Constants) is the language used for all logic.
 * [Stylus](http://learnboost.github.io/stylus/) is used instead of CSS.
-* [Handlebars](http://handlebarsjs.com/) is the templating library.
-* [Backbone](http://backbonejs.org/) acts as the front-end framework.
+* [React](https://facebook.github.io/react/) acts as the front-end framework and templating library.
+* [Redux](http://redux.js.org/docs/introduction/) provides state managment.
+* [Bootstrap](http://getbootstrap.com/) provides standard responsive components, and [react-bootstrap](https://react-bootstrap.github.io/) provides react versions of said components.
 
 ## Set-up
 
@@ -141,42 +142,36 @@ localStorage.setItem('suppressRefresh', true)
 
 ## Code structure
 
-As mentioned before, SingularityUI uses [Backbone](http://backbonejs.org/). If you're not familiar with how it does things, please look into it and familiarise yourself with Views, Models, Collections, and the event-based interaction between them all.
+As mentioned before, SingularityUI uses [React](https://facebook.github.io/react/) and [Redux](http://redux.js.org/docs/introduction/). If you're not familiar with how it does things, please look into it and familiarise yourself with Views, Models, Collections, and the event-based interaction between them all.
 
-What follows is a run-down of how things work in Singularity, using the Slaves page as an example.
+What follows is a run-down of how things work in Singularity, using the Webhooks page as an example.
 
-First you request `/singularity/slaves`. This triggers [our router](../SingularityUI/app/router.coffee) to fire up [`SlavesController`](../SingularityUI/app/controllers/Slaves.coffee).
+First you request `/singularity/webhooks`. This triggers [our router](../SingularityUI/app/router.jsx) to fire up [`Webhooks`](../SingularityUI/app/components/webhooks/webhooks.jsx).
 
-The controller bootstraps the things we need for the requested page. First, it creates 3 collections--one for each API endpoint we're going to hit.
+When the Webhooks component is called, the initial action occurs in the `connect()` function call at the bottom of the page.
 
-Afterwards, it creates 3 instances of [`SimpleSubview`](../SingularityUI/app/views/simpleSubview.coffee) and gives each one a template to render and a collection to use for data.
+First, `connect()` calls `mapStateToProps()`. Though it is called with the redux state and the component's own props, the Webhooks page doesn't have props passed into it. This returns props that are obtained from the redux store, such as API calls.
 
-`SimpleSubview` is a reusable class that renders its template in response to change events from the collection you gave it. For the slaves page, when one of the collections receives a response from the service `SimpleSubview` renders the required table and nothing more, therefore giving it ownership over one component of the page, with the collection telling it when to render it.
+Then `connect()` calles `mapDispatchToProps()`. This is called with the redux dispatch and the component's own props, and returns props are functions which can perform actions.
 
-The controller also creates a [`SlavesView`](../SingularityUI/app/views/slaves.coffee) and assigns it as its primary view using `Controller.setView(View)`. This view is special because it represents the entire page being rendered. We feed it with references to our sub-views so that it can embed them into itself.
+`connect()` combines the outputs of `mapStateToProps()` and `mapDispatchToProps()` into one object and passes that in as props to the component the result of `connect()` is called with.
 
-Finally, we tell the app to render this main view of ours and to start all of the collection fetches, which will eventually trigger the subview renders when completed.
+The result of `connect()` is called with the [`rootComponent`](../SingularityUI/app/rootComponent.jsx). `rootComponent` sets up automatically refreshing the page and can display a 404 page if the component sets a `notFound` prop. The passed-in `refresh()` function fetches the page data from the API (in some cases in which initial data needs to not be fetched again, an `initialize()` function is also passed in to perform only initial calls). While the `rootComponent` is waiting for this to finish, the loading animation is displayed.
 
-Everything else is standard [Backbone](http://backbonejs.org/)-structured code. Please refer to the official docs for how to do things like respond to UI events, etc.
+Finally, once the API call does complete, `rootComponent` takes the props provided by `connect()` and passes them into the Webhooks component itself, which will render the table of webhooks that you see.
+
+Everything else is standard [React](https://facebook.github.io/react/)-structured code. Please refer to the official docs for how to do things like respond to UI events, etc.
 
 To summarise:
-* A controller bootstraps everything (collections, models, views) for a page.
-* If there is more than one collection/model involved, we split the view up into subviews in order to keep things modular and easy to change/render. A primary view glues everything together.
-* If there is one/no collection/model being used, we just use the primary view for everything.
-* Use Backbone conventions wherever possible. Try to rely on events, not callbacks.
+* React Router bootstraps everything for the page.
+* All API calls necessary for rendering the page are performed in the primary component's `refresh()` or `initialize()` function.
+* Use React conventions wherever possible. Try to rely on props, not component state.
 
 ### Useful links
 
 There are some libraries/classes in SingularityUI which you should be aware of if you plan on working on it:
 
-* [Application](../SingularityUI/app/application.coffee) is responsible for a lot of global behaviour, including error-handling.
-* [Router](../SingularityUI/app/router.coffee) points requests to their respective controllers.
-* [Utils](../SingularityUI/app/utils.coffee) contains a bunch of reusable static functions.
-* The base classes. The various components extend the following:
-  * [Model](../SingularityUI/app/models/model.coffee)
-  * [Collection](../SingularityUI/app/collections/collection.coffee) & [PaginableCollection](../SingularityUI/app/collections/PaginableCollection.coffee)
-  * [View](../SingularityUI/app/views/view.coffee)
-  * [Controller](../SingularityUI/app/controllers/Controller.coffee)
-* Reusable components:
-  * [SimpleSubview](../SingularityUI/app/views/simpleSubview.coffee)
-  * [ExpandableTableSubview](../SingularityUI/app/views/expandableTableSubview.coffee)
+* [Base](../SingularityUI/app/actions/api/base.es6) is responsible for API call behavior, including error-handling.
+* [Router](../SingularityUI/app/router.jsx) points requests to their respective components.
+* [Utils](../SingularityUI/app/utils.jsx) contains a bunch of reusable static functions.
+* [UITable](../SingularityUI/app/components/common/table/UITable.jsx) is a comprehensive table component that provides sorting, pagination and other utilities. Data is provided by child [Column](../SingularityUI/app/components/common/table/Column.jsx) components.


### PR DESCRIPTION
Rewrites the UI development docs to properly mention that React and es6 are being used instead of Backbone and Coffeescript.

This is a first draft. I'm sure there are things I could do better, so please review and rip into this.

cc @tpetr @ssalinas @wolfd 