### PR TITLE
Run Now UI Service Restoration

### DIFF
--- a/SingularityUI/app/components/common/modal/FormModal.jsx
+++ b/SingularityUI/app/components/common/modal/FormModal.jsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import { Modal, Button, Popover, OverlayTrigger } from 'react-bootstrap';
 import TagsInput from 'react-tagsinput';
 import Duration from '../formItems/Duration';
+import MultiInput from '../formItems/MultiInput';
 import Select from 'react-select';
 import Utils from '../../../utils';
 
@@ -59,6 +60,7 @@ export default class FormModal extends React.Component {
     STRING: 'STRING',
     RADIO: 'RADIO',
     TAGS: 'TAGS',
+    MULTIINPUT: 'MULTIINPUT',
     NUMBER: 'NUMBER',
     DURATION: 'DURATION',
     SELECT: 'SELECT'
@@ -257,6 +259,20 @@ export default class FormModal extends React.Component {
                   addOnBlur={true}
                   renderInput={(props) => this.renderTagsInput(props)}
                   renderTag={this.renderTag}
+                />
+              </label>
+            </FormModal.FormItem>
+          );
+
+        case FormModal.INPUT_TYPES.MULTIINPUT:
+          return (
+            <FormModal.FormItem element={formElement} formState={this.state.formState} key={formElement.name}>
+              <label style={{display: 'block', width: '100%'}}>
+                {formElement.label}
+                <MultiInput
+                  id={`${formElement.name}-input`}
+                  value={this.state.formState[formElement.name] || []}
+                  onChange={(values) => this.handleFormChange(formElement.name, values)}
                 />
               </label>
             </FormModal.FormItem>

--- a/SingularityUI/app/components/common/modalButtons/RunNowModal.jsx
+++ b/SingularityUI/app/components/common/modalButtons/RunNowModal.jsx
@@ -38,7 +38,8 @@ class RunNowModal extends Component {
     this.refs.runNowModal.show();
   }
 
-  handleRunNow(data) {
+  handleRunNow(dataFromForm) {
+    const data = Utils.deepClone(dataFromForm);
     localStorage.setItem(LOCAL_STORAGE_AFTER_TRIGGER_VALUE, data.afterTrigger);
     const runId = uuid.v4();
     data.runId = runId;

--- a/SingularityUI/app/components/common/modalButtons/RunNowModal.jsx
+++ b/SingularityUI/app/components/common/modalButtons/RunNowModal.jsx
@@ -86,7 +86,7 @@ class RunNowModal extends Component {
           formElements={[
             {
               name: 'commandLineArgs',
-              type: FormModal.INPUT_TYPES.TAGS,
+              type: FormModal.INPUT_TYPES.MULTIINPUT,
               label: 'Additional command line arguments: (optional)',
               defaultValue: this.defaultCommandLineArgs()
             },

--- a/SingularityUI/app/components/common/modalButtons/RunNowModal.jsx
+++ b/SingularityUI/app/components/common/modalButtons/RunNowModal.jsx
@@ -50,7 +50,7 @@ class RunNowModal extends Component {
           type: 'error'
         });
       } else if (_.contains([RunNowModal.AFTER_TRIGGER.SANDBOX.value, RunNowModal.AFTER_TRIGGER.TAIL.value], data.afterTrigger)) {
-        const requestId = Utils.maybe(response, ['data', 'request', 'id']);
+        const requestId = undefined;
         this.refs.taskLauncher.getWrappedInstance().startPolling(
           requestId,
           runId,
@@ -62,8 +62,8 @@ class RunNowModal extends Component {
 
   getDefaultFileToTail() {
     const previousFile = localStorage.getItem(LOCAL_STORAGE_TAIL_AFTER_TRIGGER_FILENAME);
-    if (previousFile) return previousFile;
-    if (config.runningTaskLogPath.indexOf('/') === -1) return config.runningTaskLogPath;
+    if (previousFile) { return previousFile; }
+    if (config.runningTaskLogPath.indexOf('/') === -1) { return config.runningTaskLogPath; }
     return _.rest(config.runningTaskLogPath.split('/'), '1').join('/');
   }
 

--- a/SingularityUI/app/components/common/modalButtons/RunNowModal.jsx
+++ b/SingularityUI/app/components/common/modalButtons/RunNowModal.jsx
@@ -50,7 +50,7 @@ class RunNowModal extends Component {
           type: 'error'
         });
       } else if (_.contains([RunNowModal.AFTER_TRIGGER.SANDBOX.value, RunNowModal.AFTER_TRIGGER.TAIL.value], data.afterTrigger)) {
-        const requestId = undefined;
+        const requestId = Utils.maybe(response, ['data', 'request', 'id']);
         this.refs.taskLauncher.getWrappedInstance().startPolling(
           requestId,
           runId,

--- a/SingularityUI/app/components/common/modalButtons/RunNowModal.jsx
+++ b/SingularityUI/app/components/common/modalButtons/RunNowModal.jsx
@@ -51,7 +51,7 @@ class RunNowModal extends Component {
         });
       } else if (_.contains([RunNowModal.AFTER_TRIGGER.SANDBOX.value, RunNowModal.AFTER_TRIGGER.TAIL.value], data.afterTrigger)) {
         const requestId = Utils.maybe(response, ['data', 'request', 'id']);
-        if (requestId) { return; }
+        if (!requestId) { return; }
         this.refs.taskLauncher.getWrappedInstance().startPolling(
           requestId,
           runId,

--- a/SingularityUI/app/components/common/modalButtons/RunNowModal.jsx
+++ b/SingularityUI/app/components/common/modalButtons/RunNowModal.jsx
@@ -51,6 +51,7 @@ class RunNowModal extends Component {
         });
       } else if (_.contains([RunNowModal.AFTER_TRIGGER.SANDBOX.value, RunNowModal.AFTER_TRIGGER.TAIL.value], data.afterTrigger)) {
         const requestId = Utils.maybe(response, ['data', 'request', 'id']);
+        if (requestId) { return; }
         this.refs.taskLauncher.getWrappedInstance().startPolling(
           requestId,
           runId,


### PR DESCRIPTION
Fixes the following:
- Run now modal wasn't able to find the task being run to browse to its sandbox or tail the file.
- Run now modal used to save in local storage the file you chose to tail and the after-run setting. 
- Compared to using a multi-input, a tagsinput made it difficult to properly enter multiple command line arguments as separate arguments if there was a space in one of them.
This brings that functionality back.

cc @tpetr @wolfd 