### PR TITLE
Properly handle deleted requests

### DIFF
--- a/SingularityUI/app/components/common/NotFound.jsx
+++ b/SingularityUI/app/components/common/NotFound.jsx
@@ -21,3 +21,4 @@ NotFound.propTypes = {
 };
 
 export default rootComponent(NotFound, 'Not Found');
+export const NotFoundNoRoot = NotFound;

--- a/SingularityUI/app/components/requestDetail/RequestDetailPage.jsx
+++ b/SingularityUI/app/components/requestDetail/RequestDetailPage.jsx
@@ -53,14 +53,15 @@ class RequestDetailPage extends Component {
 
   render() {
     const { requestId } = this.props.params;
+    const { deleted } = this.props;
     return (
       <div>
-        <RequestHeader requestId={requestId} showBreadcrumbs={this.props.showBreadcrumbs} />
-        <RequestExpiringActions requestId={requestId} />
-        <ActiveTasksTable requestId={requestId} />
-        <PendingTasksTable requestId={requestId} />
-        <TaskHistoryTable requestId={requestId} />
-        <DeployHistoryTable requestId={requestId} />
+        <RequestHeader requestId={requestId} showBreadcrumbs={this.props.showBreadcrumbs} deleted={this.props.deleted} />
+        {deleted || <RequestExpiringActions requestId={requestId} />}
+        {deleted || <ActiveTasksTable requestId={requestId} />}
+        {deleted || <PendingTasksTable requestId={requestId} />}
+        {deleted || <TaskHistoryTable requestId={requestId} />}
+        {deleted || <DeployHistoryTable requestId={requestId} />}
         <RequestHistoryTable requestId={requestId} />
       </div>
     );
@@ -71,20 +72,23 @@ RequestDetailPage.propTypes = {
   params: PropTypes.object.isRequired,
   refresh: PropTypes.func.isRequired,
   cancelRefresh: PropTypes.func.isRequired,
+  deleted: PropTypes.bool,
   showBreadcrumbs: PropTypes.bool
 };
 
 const mapStateToProps = (state, ownProps) => {
   const statusCode = Utils.maybe(state, ['api', 'request', ownProps.params.requestId, 'statusCode']);
+  const history = Utils.maybe(state, ['api', 'requestHistory', ownProps.params.requestId, 'data']);
   return {
-    notFound: statusCode === 404,
+    notFound: statusCode === 404 && _.isEmpty(history),
+    deleted: statusCode === 404 && !_.isEmpty(history),
     pathname: ownProps.location.pathname
   };
 };
 
 const mapDispatchToProps = (dispatch, ownProps) => {
   const refreshActions = [
-    FetchRequest.trigger(ownProps.params.requestId),
+    FetchRequest.trigger(ownProps.params.requestId, true),
     FetchActiveTasksForRequest.trigger(ownProps.params.requestId),
     FetchScheduledTasksForRequest.trigger(ownProps.params.requestId),
     FetchTaskCleanups.trigger()

--- a/SingularityUI/app/components/requestDetail/RequestHeader.jsx
+++ b/SingularityUI/app/components/requestDetail/RequestHeader.jsx
@@ -8,7 +8,7 @@ import RequestActionButtons from './header/RequestActionButtons';
 import RequestAlerts from './header/RequestAlerts';
 import Breadcrumbs from '../common/Breadcrumbs';
 
-const RequestHeader = ({requestId, group, showBreadcrumbs = true}) => {
+const RequestHeader = ({requestId, group, deleted, showBreadcrumbs = true}) => {
   const breadcrumbs = showBreadcrumbs && group && (
     <Row>
       <Col md={12}>
@@ -25,7 +25,7 @@ const RequestHeader = ({requestId, group, showBreadcrumbs = true}) => {
       {breadcrumbs}
       <Row>
         <Col md={7} lg={6}>
-          <RequestTitle requestId={requestId} />
+          <RequestTitle requestId={requestId} deleted={deleted} />
         </Col>
         <Col md={5} lg={6} className="button-container">
           <RequestActionButtons requestId={requestId} />
@@ -33,7 +33,7 @@ const RequestHeader = ({requestId, group, showBreadcrumbs = true}) => {
       </Row>
       <Row>
         <Col md={12}>
-          <RequestAlerts requestId={requestId} />
+          <RequestAlerts requestId={requestId} deleted={deleted} />
         </Col>
       </Row>
     </header>
@@ -43,7 +43,8 @@ const RequestHeader = ({requestId, group, showBreadcrumbs = true}) => {
 RequestHeader.propTypes = {
   requestId: PropTypes.string.isRequired,
   group: PropTypes.object,
-  showBreadcrumbs: PropTypes.bool
+  showBreadcrumbs: PropTypes.bool,
+  deleted: PropTypes.bool
 };
 
 function mapStateToProps(state, ownProps) {

--- a/SingularityUI/app/components/requestDetail/header/RequestActionButtons.jsx
+++ b/SingularityUI/app/components/requestDetail/header/RequestActionButtons.jsx
@@ -178,7 +178,7 @@ const mapStateToProps = (state, ownProps) => ({
 });
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
-  fetchRequest: () => dispatch(FetchRequest.trigger(ownProps.requestId))
+  fetchRequest: () => dispatch(FetchRequest.trigger(ownProps.requestId, true))
 });
 
 export default withRouter(connect(

--- a/SingularityUI/app/components/requestDetail/header/RequestAlerts.jsx
+++ b/SingularityUI/app/components/requestDetail/header/RequestAlerts.jsx
@@ -11,7 +11,14 @@ import { getBouncesForRequest } from '../../../selectors/tasks';
 import CancelDeployButton from '../../common/modalButtons/CancelDeployButton';
 import AdvanceDeployButton from '../../common/modalButtons/AdvanceDeployButton';
 
-const RequestAlerts = ({requestId, requestAPI, bounces, activeTasksForRequest}) => {
+const RequestAlerts = ({requestId, requestAPI, bounces, activeTasksForRequest, deleted}) => {
+  if (deleted) {
+    return (
+      <Alert bsStyle="warning">
+        <b>This request has been deleted.</b>
+      </Alert>
+    );
+  }
   if (!requestAPI) {
     return undefined;
   }
@@ -176,7 +183,8 @@ RequestAlerts.propTypes = {
   requestId: PropTypes.string.isRequired,
   requestAPI: PropTypes.object.isRequired,
   bounces: PropTypes.arrayOf(PropTypes.object).isRequired,
-  activeTasksForRequest: PropTypes.object.isRequired
+  activeTasksForRequest: PropTypes.object.isRequired,
+  deleted: PropTypes.bool
 };
 
 const mapStateToProps = (state, ownProps) => {

--- a/SingularityUI/app/components/requestDetail/header/RequestTitle.jsx
+++ b/SingularityUI/app/components/requestDetail/header/RequestTitle.jsx
@@ -17,13 +17,15 @@ const errorDescription = (requestAPI) => {
   }
 };
 
-const RequestTitle = ({requestId, requestAPI}) => {
+const RequestTitle = ({requestId, requestAPI, deleted}) => {
   let maybeInfo;
   if (Utils.api.isFirstLoad(requestAPI)) {
     maybeInfo = <em>Loading...</em>;
   } else if (requestAPI.error) {
-    const errorText = errorDescription(requestAPI);
-    maybeInfo = <p className="text-danger">{requestAPI.statusCode}: {errorText}</p>;
+    if (!deleted) {
+      const errorText = errorDescription(requestAPI);
+      maybeInfo = <p className="text-danger">{requestAPI.statusCode}: {errorText}</p>;
+    }
   } else {
     const requestParent = requestAPI.data;
     const {request, state} = requestParent;
@@ -62,7 +64,8 @@ const RequestTitle = ({requestId, requestAPI}) => {
 
 RequestTitle.propTypes = {
   requestId: PropTypes.string.isRequired,
-  requestAPI: PropTypes.object
+  requestAPI: PropTypes.object,
+  deleted: PropTypes.bool
 };
 
 const mapStateToProps = (state, ownProps) => ({

--- a/SingularityUI/app/rootComponent.jsx
+++ b/SingularityUI/app/rootComponent.jsx
@@ -1,6 +1,6 @@
 import React, { PropTypes, Component } from 'react';
 import classNames from 'classnames';
-import NotFound from 'components/common/NotFound';
+import { NotFoundNoRoot } from 'components/common/NotFound';
 
 const rootComponent = (Wrapped, title, refresh = _.noop, refreshInterval = true, pageMargin = true, initialize) => class extends Component {
 
@@ -23,8 +23,7 @@ const rootComponent = (Wrapped, title, refresh = _.noop, refreshInterval = true,
   }
 
   componentWillMount() {
-    const titleString = typeof title === 'function' ? title(this.props) : title;
-    document.title = `${titleString} - ${config.title}`;
+    this.setTitle();
 
     const promise = initialize ? initialize(this.props) : refresh(this.props);
     if (promise) {
@@ -87,14 +86,21 @@ const rootComponent = (Wrapped, title, refresh = _.noop, refreshInterval = true,
     clearInterval(this.refreshInterval);
   }
 
+  setTitle() {
+    const titleString = typeof title === 'function' ? title(this.props) : title;
+    document.title = `${titleString} - ${config.title}`;
+  }
+
   render() {
     if (this.props.notFound) {
+      document.title = 'Not Found';
       return (
         <div className={classNames({'page container-fluid': pageMargin})}>
-          <NotFound location={{pathname: this.props.pathname}} />
+          <NotFoundNoRoot location={{pathname: this.props.pathname}} />
         </div>
       );
     }
+    this.setTitle();
     const loader = this.state.loading && <div className="page-loader fixed" />;
     const page = !this.state.loading && <Wrapped {...this.props} />;
     return (


### PR DESCRIPTION
Instead of showing the not found page when a user navigates to the detail page of a deleted request, show the requestId, an alert saying that the request has been deleted, and the request history.

![screenshot 2016-08-19 15 47 34](https://cloud.githubusercontent.com/assets/3210505/17822340/91c0d0ba-6624-11e6-9bdc-bf4f4a43ba81.png)

cc @tpetr @ssalinas @wolfd 