### PR TITLE
add team requests to dashboard

### DIFF
--- a/SingularityUI/app/actions/ui/dashboard.es6
+++ b/SingularityUI/app/actions/ui/dashboard.es6
@@ -1,0 +1,11 @@
+export const SET_DASHBOARD_GROUP = 'SET_DASHBOARD_GROUP';
+
+export const SetDashboardGroup = (group) => {
+  return (dispatch) => {
+    localStorage['dashboard.currentGroup'] = group;
+    dispatch({
+      type: SET_DASHBOARD_GROUP,
+      group
+    });
+  };
+};

--- a/SingularityUI/app/components/dashboard/DashboardPage.jsx
+++ b/SingularityUI/app/components/dashboard/DashboardPage.jsx
@@ -14,9 +14,9 @@ const DashboardPage = () => (
   <div>
     <Header />
     <MyRequests />
-    <MyGroupRequests />
     <MyPausedRequests />
     <MyStarredRequests />
+    <MyGroupRequests />
   </div>
 );
 

--- a/SingularityUI/app/components/dashboard/DashboardPage.jsx
+++ b/SingularityUI/app/components/dashboard/DashboardPage.jsx
@@ -14,7 +14,7 @@ const DashboardPage = () => (
   <div>
     <Header />
     <MyRequests />
-    <MyGroupRequests group={'hs-salesproduct'} />
+    <MyGroupRequests />
     <MyPausedRequests />
     <MyStarredRequests />
   </div>

--- a/SingularityUI/app/components/dashboard/DashboardPage.jsx
+++ b/SingularityUI/app/components/dashboard/DashboardPage.jsx
@@ -4,6 +4,7 @@ import rootComponent from '../../rootComponent';
 
 import Header from './Header';
 import MyRequests from './MyRequests';
+import MyGroupRequests from './MyGroupRequests';
 import MyPausedRequests from './MyPausedRequests';
 import MyStarredRequests from './MyStarredRequests';
 
@@ -13,6 +14,7 @@ const DashboardPage = () => (
   <div>
     <Header />
     <MyRequests />
+    <MyGroupRequests group={'hs-salesproduct'} />
     <MyPausedRequests />
     <MyStarredRequests />
   </div>

--- a/SingularityUI/app/components/dashboard/MyGroupRequests.jsx
+++ b/SingularityUI/app/components/dashboard/MyGroupRequests.jsx
@@ -35,9 +35,10 @@ const MyGroupRequests = ({groupRequests, groups, currentGroup, setCurrentGroup})
     <Row>
       <Col md={12} className="table-staged">
         <div className="page-header">
-          <h2><ButtonGroup>
-            <DropdownButton id="groups-dropdown" title={ currentGroup }>{ groupDropdown }</DropdownButton>
-          </ButtonGroup> requests</h2>
+          <ButtonGroup className="pull-right">
+            <DropdownButton pullRight id="groups-dropdown" title={ currentGroup }>{ groupDropdown }</DropdownButton>
+          </ButtonGroup>
+          <h2>Group Requests</h2>
         </div>
         {requestsSection}
       </Col>

--- a/SingularityUI/app/components/dashboard/MyGroupRequests.jsx
+++ b/SingularityUI/app/components/dashboard/MyGroupRequests.jsx
@@ -10,29 +10,24 @@ import { SetDashboardGroup } from '../../actions/ui/dashboard';
 import * as RequestsSelectors from '../../selectors/requests';
 
 const MyGroupRequests = ({groupRequests, groups, currentGroup, setCurrentGroup}) => {
-  if (groups.length == 0) {
+  if (groups.length === 0) {
     return null;
   }
 
-  let requestsSection = (
-    <div className="empty-table-message"><p>No requests</p></div>
+  const requestsSection = (
+    <UITable
+      data={groupRequests}
+      keyGetter={(requestParent) => requestParent.request.id}
+      asyncSort={true}
+      renderAllRows={true}
+      emptyTableMessage="No requests"
+    >
+      {RequestId}
+      {Type}
+      {LastDeploy}
+      {Actions}
+    </UITable>
   );
-
-  if (groupRequests.length > 0) {
-    requestsSection = (
-      <UITable
-        data={groupRequests}
-        keyGetter={(requestParent) => requestParent.request.id}
-        asyncSort={true}
-        renderAllRows={true}
-      >
-        {RequestId}
-        {Type}
-        {LastDeploy}
-        {Actions}
-      </UITable>
-    );
-  }
 
   const groupDropdown = groups.map((group, index) => (<MenuItem key={index} onClick={() => setCurrentGroup(group)}>{group}</MenuItem>));
 
@@ -53,22 +48,19 @@ const MyGroupRequests = ({groupRequests, groups, currentGroup, setCurrentGroup})
 MyGroupRequests.propTypes = {
   groupRequests: PropTypes.arrayOf(PropTypes.object).isRequired,
   groups: PropTypes.arrayOf(PropTypes.string).isRequired,
-  currentGroup: PropTypes.string
+  currentGroup: PropTypes.string,
+  setCurrentGroup: PropTypes.func.isRequired
 };
 
-const mapStateToProps = (state) => {
-  return {
-    groupRequests: RequestsSelectors.getUserGroupRequests(state),
-    groups: Utils.maybe(state.api.user, ['data', 'user', 'groups']) || [],
-    currentGroup: state.ui.dashboard.currentGroup
-  };
-};
+const mapStateToProps = (state) => ({
+  groupRequests: RequestsSelectors.getUserGroupRequests(state),
+  groups: Utils.maybe(state.api.user, ['data', 'user', 'groups']) || [],
+  currentGroup: state.ui.dashboard.currentGroup
+});
 
-const mapDispatchToProps = (dispatch) => {
-  return {
-    setCurrentGroup: (group) => dispatch(SetDashboardGroup(group))
-  };
-}
+const mapDispatchToProps = (dispatch) => ({
+  setCurrentGroup: (group) => dispatch(SetDashboardGroup(group))
+});
 
 export default connect(
   mapStateToProps,

--- a/SingularityUI/app/components/dashboard/MyGroupRequests.jsx
+++ b/SingularityUI/app/components/dashboard/MyGroupRequests.jsx
@@ -1,0 +1,76 @@
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+import { Row, Col, ButtonGroup, DropdownButton, MenuItem } from 'react-bootstrap';
+
+import UITable from '../common/table/UITable';
+import { RequestId, Type, LastDeploy, Actions } from '../requests/Columns';
+import Utils from '../../utils';
+import { SetDashboardGroup } from '../../actions/ui/dashboard';
+import * as RequestsSelectors from '../../selectors/requests';
+
+const MyGroupRequests = ({groupRequests, groups, currentGroup, setCurrentGroup}) => {
+  if (groups.length == 0) {
+    return null;
+  }
+
+  let requestsSection = (
+    <div className="empty-table-message"><p>No requests</p></div>
+  );
+
+  if (groupRequests.length > 0) {
+    requestsSection = (
+      <UITable
+        data={groupRequests}
+        keyGetter={(requestParent) => requestParent.request.id}
+        asyncSort={true}
+        renderAllRows={true}
+      >
+        {RequestId}
+        {Type}
+        {LastDeploy}
+        {Actions}
+      </UITable>
+    );
+  }
+
+  const groupDropdown = groups.map((group, index) => (<MenuItem key={index} onClick={() => setCurrentGroup(group)}>{group}</MenuItem>));
+
+  return (
+    <Row>
+      <Col md={12} className="table-staged">
+        <div className="page-header">
+          <h2><ButtonGroup>
+            <DropdownButton id="groups-dropdown" title={ currentGroup }>{ groupDropdown }</DropdownButton>
+          </ButtonGroup> requests</h2>
+        </div>
+        {requestsSection}
+      </Col>
+    </Row>
+  );
+};
+
+MyGroupRequests.propTypes = {
+  groupRequests: PropTypes.arrayOf(PropTypes.object).isRequired,
+  groups: PropTypes.arrayOf(PropTypes.string).isRequired,
+  currentGroup: PropTypes.string
+};
+
+const mapStateToProps = (state) => {
+  return {
+    groupRequests: RequestsSelectors.getUserGroupRequests(state),
+    groups: Utils.maybe(state.api.user, ['data', 'user', 'groups']) || [],
+    currentGroup: state.ui.dashboard.currentGroup
+  };
+};
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    setCurrentGroup: (group) => dispatch(SetDashboardGroup(group))
+  };
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(MyGroupRequests);

--- a/SingularityUI/app/reducers/ui/dashboard.es6
+++ b/SingularityUI/app/reducers/ui/dashboard.es6
@@ -1,0 +1,25 @@
+import * as DashboardActions from '../../actions/ui/dashboard';
+import { FetchUser } from '../../actions/api/auth';
+import Utils from '../../utils';
+
+const initialState = {
+  currentGroup: localStorage['dashboard.currentGroup']
+};
+
+export default (state = initialState, action) => {
+  switch (action.type) {
+    case DashboardActions.SET_DASHBOARD_GROUP:
+      return {
+        currentGroup: action.group
+      };
+    case FetchUser.SUCCESS:
+      if (state.currentGroup === undefined) {
+        return {
+          currentGroup: (Utils.maybe(action, ['data', 'user', 'groups']) || [])[0]
+        }
+      }
+      return state;
+    default:
+      return state;
+  }
+};

--- a/SingularityUI/app/reducers/ui/index.es6
+++ b/SingularityUI/app/reducers/ui/index.es6
@@ -4,10 +4,12 @@ import starred from './starred';
 import refresh from './refresh';
 import form from './form';
 import globalSearch from './globalSearch';
+import dashboard from './dashboard';
 
 export default combineReducers({
   starred,
   refresh,
   form,
-  globalSearch
+  globalSearch,
+  dashboard
 });

--- a/SingularityUI/app/selectors/requests.es6
+++ b/SingularityUI/app/selectors/requests.es6
@@ -8,6 +8,7 @@ import Utils from '../utils';
 const getRequestsAPI = (state) => state.api.requests;
 const getUserAPI = (state) => state.api.user;
 const getSearchFilter = (state) => state.ui.requestsPage;
+const getCurrentGroup = (state) => state.ui.dashboard.currentGroup;
 
 function findRequestIds(requests) {
   return _.map(requests, (request) => {
@@ -22,6 +23,14 @@ export const getStarredRequests = createSelector(
   (starredData, requestsAPI) => {
     const requests = findRequestIds(requestsAPI.data);
     return requests.filter((requestParent) => starredData.has(requestParent.request.id));
+  }
+);
+
+export const getUserGroupRequests = createSelector(
+  [getCurrentGroup, getRequestsAPI],
+  (currentGroup, requestsAPI) => {
+    const requests = findRequestIds(requestsAPI.data);
+    return requests.filter((requestParent) => requestParent.request.group === currentGroup);
   }
 );
 


### PR DESCRIPTION
This was a little exercise to make sure I fully understand how our actions, reducers, selectors, and UITable all work together. It allows users to view all requests belonging to a specific group. If no groups are available to the user, this component doesn't render.
