### PR TITLE
Ignore empty logs in logfetch

### DIFF
--- a/scripts/logfetch/live_logs.py
+++ b/scripts/logfetch/live_logs.py
@@ -84,9 +84,9 @@ def logs_folder_files(args, task):
     files_json = logfetch_base.get_json_response(uri, args, {'path' : '{0}/logs'.format(task)}, True)
     if 'files' in files_json:
         files = files_json['files']
-        return [f['name'] for f in files if logfetch_base.is_in_date_range(args, f['mtime'])]
+        return [f['name'] for f in files if valid_logfile(args, f)]
     else:
-        return [f['path'].rsplit('/')[-1] for f in files_json if logfetch_base.is_in_date_range(args, f['mtime'])]
+        return [f['path'].rsplit('/')[-1] for f in files_json if valid_logfile(args, f)]
 
 def base_directory_files(args, task, files_json):
     if 'files' in files_json:

--- a/scripts/logfetch/live_logs.py
+++ b/scripts/logfetch/live_logs.py
@@ -97,9 +97,7 @@ def base_directory_files(args, task, files_json):
 
 def is_valid_live_log(args, file_data):
     is_in_range = logfetch_base.is_in_date_range(args, file_data['mtime'])
-    not_a_directory = not file_data['mode'].startswith('d')
-    is_a_logfile = fnmatch.fnmatch(file_data['name'], '*.log') or fnmatch.fnmatch(file_data['name'], '*.out') or fnmatch.fnmatch(file_data['name'], '*.err')
-    return is_in_range and not_a_directory and is_a_logfile
+    return is_in_range and logfetch_base.is_valid_log(file_data)
 
 def should_download(args, filename, task):
     if args.use_cache and already_downloaded(args, filename):

--- a/scripts/logfetch/live_logs.py
+++ b/scripts/logfetch/live_logs.py
@@ -84,18 +84,18 @@ def logs_folder_files(args, task):
     files_json = logfetch_base.get_json_response(uri, args, {'path' : '{0}/logs'.format(task)}, True)
     if 'files' in files_json:
         files = files_json['files']
-        return [f['name'] for f in files if valid_logfile(args, f)]
+        return [f['name'] for f in files if is_valid_live_log(args, f)]
     else:
-        return [f['path'].rsplit('/')[-1] for f in files_json if valid_logfile(args, f)]
+        return [f['path'].rsplit('/')[-1] for f in files_json if is_valid_live_log(args, f)]
 
 def base_directory_files(args, task, files_json):
     if 'files' in files_json:
         files = files_json['files']
-        return [f['name'] for f in files if valid_logfile(args, f)]
+        return [f['name'] for f in files if is_valid_live_log(args, f)]
     else:
-        return [f['path'].rsplit('/')[-1] for f in files_json if valid_logfile(args, f)]
+        return [f['path'].rsplit('/')[-1] for f in files_json if is_valid_live_log(args, f)]
 
-def valid_logfile(args, file_data):
+def is_valid_live_log(args, file_data):
     is_in_range = logfetch_base.is_in_date_range(args, file_data['mtime'])
     not_a_directory = not file_data['mode'].startswith('d')
     is_a_logfile = fnmatch.fnmatch(file_data['name'], '*.log') or fnmatch.fnmatch(file_data['name'], '*.out') or fnmatch.fnmatch(file_data['name'], '*.err')

--- a/scripts/logfetch/live_logs.py
+++ b/scripts/logfetch/live_logs.py
@@ -95,10 +95,10 @@ def base_directory_files(args, task, files_json):
     else:
         return [f['path'].rsplit('/')[-1] for f in files_json if valid_logfile(args, f)]
 
-def valid_logfile(args, fileData):
-    is_in_range = logfetch_base.is_in_date_range(args, fileData['mtime'])
-    not_a_directory = not fileData['mode'].startswith('d')
-    is_a_logfile = fnmatch.fnmatch(fileData['name'], '*.log') or fnmatch.fnmatch(fileData['name'], '*.out') or fnmatch.fnmatch(fileData['name'], '*.err')
+def valid_logfile(args, file_data):
+    is_in_range = logfetch_base.is_in_date_range(args, file_data['mtime'])
+    not_a_directory = not file_data['mode'].startswith('d')
+    is_a_logfile = fnmatch.fnmatch(file_data['name'], '*.log') or fnmatch.fnmatch(file_data['name'], '*.out') or fnmatch.fnmatch(file_data['name'], '*.err')
     return is_in_range and not_a_directory and is_a_logfile
 
 def should_download(args, filename, task):

--- a/scripts/logfetch/live_logs.py
+++ b/scripts/logfetch/live_logs.py
@@ -96,10 +96,10 @@ def base_directory_files(args, task, files_json):
         return [f['path'].rsplit('/')[-1] for f in files_json if valid_logfile(args, f)]
 
 def valid_logfile(args, fileData):
-        is_in_range = logfetch_base.is_in_date_range(args, fileData['mtime'])
-        not_a_directory = not fileData['mode'].startswith('d')
-        is_a_logfile = fnmatch.fnmatch(fileData['name'], '*.log') or fnmatch.fnmatch(fileData['name'], '*.out') or fnmatch.fnmatch(fileData['name'], '*.err')
-        return is_in_range and not_a_directory and is_a_logfile
+    is_in_range = logfetch_base.is_in_date_range(args, fileData['mtime'])
+    not_a_directory = not fileData['mode'].startswith('d')
+    is_a_logfile = fnmatch.fnmatch(fileData['name'], '*.log') or fnmatch.fnmatch(fileData['name'], '*.out') or fnmatch.fnmatch(fileData['name'], '*.err')
+    return is_in_range and not_a_directory and is_a_logfile
 
 def should_download(args, filename, task):
     if args.use_cache and already_downloaded(args, filename):

--- a/scripts/logfetch/live_logs.py
+++ b/scripts/logfetch/live_logs.py
@@ -97,7 +97,8 @@ def base_directory_files(args, task, files_json):
 
 def is_valid_live_log(args, file_data):
     is_in_range = logfetch_base.is_in_date_range(args, file_data['mtime'])
-    return is_in_range and logfetch_base.is_valid_log(file_data)
+    has_data = logfetch_base.logfile_has_data(file_data)
+    return is_in_range and has_data and logfetch_base.is_valid_log(file_data)
 
 def should_download(args, filename, task):
     if args.use_cache and already_downloaded(args, filename):

--- a/scripts/logfetch/logfetch_base.py
+++ b/scripts/logfetch/logfetch_base.py
@@ -136,7 +136,7 @@ def get_json_response(uri, args, params={}, skip404ErrMessage=False):
 def is_valid_log(file_data):
     not_a_directory = not file_data['mode'].startswith('d')
     is_a_logfile = fnmatch.fnmatch(file_data['name'], '*.log') or fnmatch.fnmatch(file_data['name'], '*.out') or fnmatch.fnmatch(file_data['name'], '*.err')
-    return not_a_directory and is_a_logfile and has_data
+    return not_a_directory and is_a_logfile
 
 
 def logfile_has_data(file_data):

--- a/scripts/logfetch/logfetch_base.py
+++ b/scripts/logfetch/logfetch_base.py
@@ -131,3 +131,7 @@ def get_json_response(uri, args, params={}, skip404ErrMessage=False):
             log(colored(singularity_response.text, 'red') + '\n', args, False)
         return {}
     return singularity_response.json()
+
+
+def logfile_has_data(file_data):
+    return file_data['size'] > 0

--- a/scripts/logfetch/logfetch_base.py
+++ b/scripts/logfetch/logfetch_base.py
@@ -133,5 +133,12 @@ def get_json_response(uri, args, params={}, skip404ErrMessage=False):
     return singularity_response.json()
 
 
+def is_valid_log(file_data):
+    not_a_directory = not file_data['mode'].startswith('d')
+    is_a_logfile = fnmatch.fnmatch(file_data['name'], '*.log') or fnmatch.fnmatch(file_data['name'], '*.out') or fnmatch.fnmatch(file_data['name'], '*.err')
+    has_data = logfile_has_data(file_data)
+    return not_a_directory and is_a_logfile and has_data
+
+
 def logfile_has_data(file_data):
     return file_data['size'] > 0

--- a/scripts/logfetch/logfetch_base.py
+++ b/scripts/logfetch/logfetch_base.py
@@ -136,7 +136,6 @@ def get_json_response(uri, args, params={}, skip404ErrMessage=False):
 def is_valid_log(file_data):
     not_a_directory = not file_data['mode'].startswith('d')
     is_a_logfile = fnmatch.fnmatch(file_data['name'], '*.log') or fnmatch.fnmatch(file_data['name'], '*.out') or fnmatch.fnmatch(file_data['name'], '*.err')
-    has_data = logfile_has_data(file_data)
     return not_a_directory and is_a_logfile and has_data
 
 

--- a/scripts/logfetch/tail.py
+++ b/scripts/logfetch/tail.py
@@ -57,9 +57,9 @@ def base_directory_files(args, task):
     else:
         return [f['path'].rsplit('/')[-1] for f in files_json if valid_logfile(f)]
 
-def valid_logfile(fileData):
-    not_a_directory = not fileData['mode'].startswith('d')
-    is_a_logfile = fnmatch.fnmatch(fileData['name'], '*.log') or fnmatch.fnmatch(fileData['name'], '*.out') or fnmatch.fnmatch(fileData['name'], '*.err')
+def valid_logfile(file_data):
+    not_a_directory = not file_data['mode'].startswith('d')
+    is_a_logfile = fnmatch.fnmatch(file_data['name'], '*.log') or fnmatch.fnmatch(file_data['name'], '*.out') or fnmatch.fnmatch(file_data['name'], '*.err')
     return not_a_directory and is_a_logfile
 
 class LogStreamer(threading.Thread):

--- a/scripts/logfetch/tail.py
+++ b/scripts/logfetch/tail.py
@@ -58,9 +58,7 @@ def base_directory_files(args, task):
         return [f['path'].rsplit('/')[-1] for f in files_json if is_valid_tail_log(f)]
 
 def is_valid_tail_log(file_data):
-    not_a_directory = not file_data['mode'].startswith('d')
-    is_a_logfile = fnmatch.fnmatch(file_data['name'], '*.log') or fnmatch.fnmatch(file_data['name'], '*.out') or fnmatch.fnmatch(file_data['name'], '*.err')
-    return not_a_directory and is_a_logfile
+    return logfetch_base.is_valid_log(file_data)
 
 class LogStreamer(threading.Thread):
     def __init__(self, args, task):

--- a/scripts/logfetch/tail.py
+++ b/scripts/logfetch/tail.py
@@ -44,9 +44,9 @@ def logs_folder_files(args, task):
     files_json = get_json_response(uri, args, {'path' : '{0}/logs'.format(task)})
     if 'files' in files_json:
         files = files_json['files']
-        return [f['name'] for f in files if valid_logfile(f)]
+        return [f['name'] for f in files if is_valid_tail_log(f)]
     else:
-        return [f['path'].rsplit('/')[-1] for f in files_json if valid_logfile(f)]
+        return [f['path'].rsplit('/')[-1] for f in files_json if is_valid_tail_log(f)]
 
 def base_directory_files(args, task):
     uri = BROWSE_FOLDER_FORMAT.format(logfetch_base.base_uri(args), task)

--- a/scripts/logfetch/tail.py
+++ b/scripts/logfetch/tail.py
@@ -53,11 +53,11 @@ def base_directory_files(args, task):
     files_json = get_json_response(uri, args)
     if 'files' in files_json:
         files = files_json['files']
-        return [f['name'] for f in files if valid_logfile(f)]
+        return [f['name'] for f in files if is_valid_tail_log(f)]
     else:
-        return [f['path'].rsplit('/')[-1] for f in files_json if valid_logfile(f)]
+        return [f['path'].rsplit('/')[-1] for f in files_json if is_valid_tail_log(f)]
 
-def valid_logfile(file_data):
+def is_valid_tail_log(file_data):
     not_a_directory = not file_data['mode'].startswith('d')
     is_a_logfile = fnmatch.fnmatch(file_data['name'], '*.log') or fnmatch.fnmatch(file_data['name'], '*.out') or fnmatch.fnmatch(file_data['name'], '*.err')
     return not_a_directory and is_a_logfile


### PR DESCRIPTION
This PR modifies logfetch to ignore logfiles whose size is 0.  This should prevent logfetch from downloading logs with no content.

/cc @ssalinas @tpetr 