### PR TITLE
Handle missing logfetch tail data

### DIFF
--- a/scripts/logfetch/errors.py
+++ b/scripts/logfetch/errors.py
@@ -1,0 +1,4 @@
+
+class Error(Exception): pass
+
+class NoTailDataError(Error): pass

--- a/scripts/logfetch/tail.py
+++ b/scripts/logfetch/tail.py
@@ -108,7 +108,7 @@ class LogStreamer(threading.Thread):
         }
         response_obj = requests.get(uri, params=params, headers=args.headers)
         response = response_obj.json()
-        if not hasattr(response, 'data'):
+        if 'data' not in response:
             if response_obj.status_code < 199 or response_obj.status_code > 299:
                 raise errors.NoTailDataError()
             else:


### PR DESCRIPTION
This PR handles the case in which a logfetch tail response has no 'data' field.