### PR TITLE
remove bogus label from file browser actions column

### DIFF
--- a/SingularityUI/app/components/taskDetail/TaskFileBrowser.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskFileBrowser.jsx
@@ -112,7 +112,7 @@ function TaskFileBrowser (props) {
           sortData={sortData}
         />
         <Column
-          label="actions-column"
+          label=""
           id="actions-column"
           key="actions-column"
           className="actions-column"


### PR DESCRIPTION
re: https://github.com/HubSpot/Singularity/commit/763ba3440d24686c4ed66d550af71139868e5cef#diff-a018f0e147f367bea0081983476e2c48R114

/cc @ssalinas 