### PR TITLE
Update message when no files found

### DIFF
--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -175,9 +175,9 @@ class TaskDetail extends Component {
     if (!files || _.isUndefined(files.currentDirectory)) {
       let message;
       if (props.task.isStillRunning) {
-        message = 'Could not retrieve files. The task may still be starting.'
+        message = 'Could not retrieve files. The task may still be starting.';
       } else {
-        message = 'Could not retrieve files. The directory may have already been cleaned up.'
+        message = 'Could not retrieve files. The directory may have already been cleaned up.';
       }
       return (
         <Section title="Files">

--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -174,7 +174,7 @@ class TaskDetail extends Component {
   renderFiles(files) {
     if (!files || _.isUndefined(files.currentDirectory)) {
       let message;
-      if (props.task.isStillRunning) {
+      if (this.props.task.isStillRunning) {
         message = 'Could not retrieve files. The task may still be starting.';
       } else {
         message = 'Could not retrieve files. The directory may have already been cleaned up.';

--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -173,10 +173,16 @@ class TaskDetail extends Component {
 
   renderFiles(files) {
     if (!files || _.isUndefined(files.currentDirectory)) {
+      let message;
+      if (props.task.isStillRunning) {
+        message = 'Could not retrieve files. The task may still be starting.'
+      } else {
+        message = 'Could not retrieve files. The directory may have already been cleaned up.'
+      }
       return (
         <Section title="Files">
           <div className="empty-table-message">
-            {'Could not retrieve files. The host of this task is likely offline or its directory has been cleaned up.'}
+            {message}
           </div>
         </Section>
       );


### PR DESCRIPTION
Previously we could get the message about 'The host of this task is likely offline' when a task was still in a launching or starting state. This updates the message to be different when a task is still starting/launching, and only mention directory cleanup when for a terminal state ('host of this task is likely offline' was worrying for some users)