### PR TITLE
show seconds in timestamps for healthchecks

### DIFF
--- a/SingularityUI/app/components/taskDetail/TaskAlerts.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskAlerts.jsx
@@ -87,7 +87,7 @@ const TaskAlerts = (props) => {
           label="Timestamp"
           id="timestamp"
           key="timestamp"
-          cellData={(healthcheckResult) => Utils.absoluteTimestamp(healthcheckResult.timestamp)}
+          cellData={(healthcheckResult) => Utils.absoluteTimestampWithSeconds(healthcheckResult.timestamp)}
         />
         <Column
           label="Duration"

--- a/SingularityUI/app/components/taskDetail/TaskHealthchecks.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskHealthchecks.jsx
@@ -34,7 +34,7 @@ function TaskHealthchecks (props) {
           label="Timestamp"
           id="timestamp"
           key="timestamp"
-          cellData={(healthcheckResult) => Utils.absoluteTimestamp(healthcheckResult.timestamp)}
+          cellData={(healthcheckResult) => Utils.absoluteTimestampWithSeconds(healthcheckResult.timestamp)}
         />
         <Column
           label="Duration"


### PR DESCRIPTION
Multiple health checks can run within a minute, it's useful to see the seconds for these.