### PR TITLE
Reduce usage of for...of construct on things that aren't always ES6-iterable

### DIFF
--- a/SingularityUI/app/components/newDeployForm/fields.es6
+++ b/SingularityUI/app/components/newDeployForm/fields.es6
@@ -126,7 +126,8 @@ export const DOCKER_VOLUME_FIELDS = [
 
 function makeIndexedFields(fields) {
   const indexedFields = {};
-  for (const field of fields) {
+  for (var i = 0; i < fields.length; i++) {
+    const field = fields[i];
     if (field.type === 'object') {
       _.extend(indexedFields, makeIndexedFields(field.values));
     } else {

--- a/SingularityUI/app/components/requestForm/fields.es6
+++ b/SingularityUI/app/components/requestForm/fields.es6
@@ -103,7 +103,8 @@ export const FIELDS_BY_REQUEST_TYPE = {
 
 function makeIndexedFields(fields) {
   const indexedFields = {};
-  for (const field of fields) {
+  for (var i = 0; i < fields.length; i++) {
+    const field = fields[i];
     if (field.type === 'object') {
       _.extend(indexedFields, makeIndexedFields(field.values));
     } else {

--- a/SingularityUI/app/selectors/requests.es6
+++ b/SingularityUI/app/selectors/requests.es6
@@ -54,7 +54,8 @@ export const getUserRequests = createSelector(
         return false;
       }
 
-      for (const owner of requestOwners) {
+      for (var i = 0; i < requestOwners.length; i++) {
+        const owner = requestOwners[i];
         if (deployUserTrimmed === owner.split('@')[0]) {
           return true;
         }
@@ -78,7 +79,8 @@ export const getUserRequestTotals = createSelector(
       SERVICE: 0
     };
 
-    for (const requestParent of userRequests) {
+    for (var i = 0; i < userRequests.length; i++) {
+      const requestParent = userRequests[i];
       userRequestTotals[requestParent.request.requestType] += 1;
     }
 


### PR DESCRIPTION
The `core-js` `Symbol` polyfill has a number of limitations.  This removes usage of `for...of` on things that are iterable in Chrome but not polyfilled environments.