### PR TITLE
Make critical task lag require more than a single overdue task

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityDisasterDetectionPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityDisasterDetectionPoller.java
@@ -184,7 +184,7 @@ public class SingularityDisasterDetectionPoller extends SingularityLeaderOnlyPol
       double overdueTaskPortion = dataPoint.getNumLateTasks() / (double) Math.max((dataPoint.getNumActiveTasks() + dataPoint.getNumPendingTasks()), 1);
       boolean criticalOverdueTasksPortion = overdueTaskPortion > disasterConfiguration.getCriticalOverdueTaskPortion();
       boolean warningOverdueTasksPortion = overdueTaskPortion > disasterConfiguration.getWarningOverdueTaskPortion();
-      boolean criticalAvgTaskLag = dataPoint.getAvgTaskLagMillis() > disasterConfiguration.getCriticalAvgTaskLagMillis();
+      boolean criticalAvgTaskLag = dataPoint.getAvgTaskLagMillis() > disasterConfiguration.getCriticalAvgTaskLagMillis() && warningOverdueTasksPortion;
       boolean warningAvgTaskLag = dataPoint.getAvgTaskLagMillis() > disasterConfiguration.getWarningAvgTaskLagMillis();
 
       if (criticalOverdueTasksPortion) {


### PR DESCRIPTION
Currently average task lag is the average for ll overdue tasks. So, if only one task is overdue, it can trigger a disaster action when there isn't one needed. This updates it so that to trigger an alert on critical task lag (higher task lag but shorter amount of time) we need to have hit at least the warning threshold for the portion of tasks that are overdue.

/cc @tpetr 