### PR TITLE
fix finished log link

### DIFF
--- a/SingularityUI/app/components/logs/FileNotFound.jsx
+++ b/SingularityUI/app/components/logs/FileNotFound.jsx
@@ -5,7 +5,7 @@ function buildNewRoute(currentPath) {
   const newRoute = currentPath.split('/');
   config.runningTaskLogPath.split('/').map(() => newRoute.pop());
   newRoute.push(config.finishedTaskLogPath);
-  return `${ config.appRoot }/${ newRoute.join('/') }`;
+  return `${ config.appRoot }${ newRoute.join('/') }`;
 }
 
 function FileNotFound (props) {

--- a/SingularityUI/app/components/logs/FileNotFound.jsx
+++ b/SingularityUI/app/components/logs/FileNotFound.jsx
@@ -5,7 +5,8 @@ function buildNewRoute(currentPath) {
   const newRoute = currentPath.split('/');
   config.runningTaskLogPath.split('/').map(() => newRoute.pop());
   newRoute.push(config.finishedTaskLogPath);
-  return `${ config.appRoot }${ newRoute.join('/') }`;
+  const newPath = newRoute.join('/');
+  return `${ config.appRoot }/${ newPath.startsWith('/') ? newPath.substring(1) : newPath }`;
 }
 
 function FileNotFound (props) {


### PR DESCRIPTION
`buildNewRoute` was adding an extra `/` in there, causing a 404 in some cases. This will handle a currentPath starting with/without a `/`