### PR TITLE
Deploy history bytes update

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityDeployHistoryPersister.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityDeployHistoryPersister.java
@@ -112,7 +112,7 @@ public class SingularityDeployHistoryPersister extends SingularityHistoryPersist
     try {
       historyManager.saveDeployHistory(deployHistory);
     } catch (Throwable t) {
-      LOG.warn("Failed to persist deploy {} history ({})", SingularityDeployKey.fromDeployMarker(deployHistory.getDeployMarker()), deployHistory, t);
+      LOG.warn("Failed to persist deploy {}", SingularityDeployKey.fromDeployMarker(deployHistory.getDeployMarker()), t);
       return false;
     }
 

--- a/mysql/migrations.sql
+++ b/mysql/migrations.sql
@@ -109,3 +109,5 @@ UPDATE `taskHistory` SET `startedAt` = FROM_UNIXTIME(SUBSTRING_INDEX(SUBSTRING_I
 ALTER TABLE `taskHistory`
   ADD KEY `updatedAt` (`updatedAt`, `requestId`)
 
+--changeset ssalinas:13 dbms:mysql
+ALTER TABLE `deployHistory` MODIFY `bytes` MEDIUMBLOB NOT NULL;


### PR DESCRIPTION
We updated the `bytes` for `taskHistory` to be a MEDIUMBLOB instead of a BLOB a while back. Most of the data that was taking up that space was part of the deploy. So, this updates the `deployHistory` `bytes` to also be a MEDIUMBLOB, as well as no longer loggin the full deploy history object on error since it already gets logged as part of the mysql error

@tpetr 