### PR TITLE
Show launching tasks separate from active in status

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityState.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityState.java
@@ -9,6 +9,7 @@ import com.google.common.base.Optional;
 public class SingularityState {
 
   private final int activeTasks;
+  private final int launchingTasks;
   private final int pausedRequests;
   private final int activeRequests;
   private final int cooldownRequests;
@@ -53,7 +54,7 @@ public class SingularityState {
   private final Optional<Double> minimumPriorityLevel;
 
   @JsonCreator
-  public SingularityState(@JsonProperty("activeTasks") int activeTasks, @JsonProperty("activeRequests") int activeRequests, @JsonProperty("cooldownRequests") int cooldownRequests,
+  public SingularityState(@JsonProperty("activeTasks") int activeTasks, @JsonProperty("launchingTasks") int launchingTasks, @JsonProperty("activeRequests") int activeRequests, @JsonProperty("cooldownRequests") int cooldownRequests,
       @JsonProperty("pausedRequests") int pausedRequests, @JsonProperty("scheduledTasks") int scheduledTasks, @JsonProperty("pendingRequests") int pendingRequests, @JsonProperty("lbCleanupTasks") int lbCleanupTasks,
       @JsonProperty("lbCleanupRequests") int lbCleanupRequests, @JsonProperty("cleaningRequests") int cleaningRequests, @JsonProperty("activeSlaves") int activeSlaves, @JsonProperty("deadSlaves") int deadSlaves,
       @JsonProperty("decommissioningSlaves") int decommissioningSlaves, @JsonProperty("activeRacks") int activeRacks, @JsonProperty("deadRacks") int deadRacks, @JsonProperty("decommissioningRacks") int decommissioningRacks,
@@ -63,6 +64,7 @@ public class SingularityState {
       @JsonProperty("overProvisionedRequests") int overProvisionedRequests, @JsonProperty("underProvisionedRequests") int underProvisionedRequests, @JsonProperty("finishedRequests") int finishedRequests,
       @JsonProperty("unknownRacks") int unknownRacks, @JsonProperty("unknownSlaves") int unknownSlaves, @JsonProperty("authDatastoreHealthy") Optional<Boolean> authDatastoreHealthy, @JsonProperty("minimumPriorityLevel") Optional<Double> minimumPriorityLevel) {
     this.activeTasks = activeTasks;
+    this.launchingTasks = launchingTasks;
     this.activeRequests = activeRequests;
     this.pausedRequests = pausedRequests;
     this.cooldownRequests = cooldownRequests;
@@ -162,6 +164,10 @@ public class SingularityState {
     return activeTasks;
   }
 
+  public int getLaunchingTasks() {
+    return launchingTasks;
+  }
+
   public int getAllRequests() {
     return getActiveRequests() + getCooldownRequests() + getPausedRequests();
   }
@@ -240,7 +246,7 @@ public class SingularityState {
 
   @Override
   public String toString() {
-    return "SingularityState [activeTasks=" + activeTasks + ", pausedRequests=" + pausedRequests + ", activeRequests=" + activeRequests + ", cooldownRequests=" + cooldownRequests + ", scheduledTasks=" + scheduledTasks
+    return "SingularityState [activeTasks=" + activeTasks + ", launchingTasks=" + launchingTasks + ", pausedRequests=" + pausedRequests + ", activeRequests=" + activeRequests + ", cooldownRequests=" + cooldownRequests + ", scheduledTasks=" + scheduledTasks
         + ", lateTasks=" + lateTasks + ", futureTasks=" + futureTasks + ", cleaningTasks=" + cleaningTasks + ", lbCleanupTasks=" + lbCleanupTasks + ", lbCleanupRequests=" + lbCleanupRequests
         + ", maxTaskLag=" + maxTaskLag + ", pendingRequests=" + pendingRequests + ", cleaningRequests=" + cleaningRequests + ", finishedRequests=" + finishedRequests + ", activeSlaves="
         + activeSlaves + ", deadSlaves=" + deadSlaves + ", decommissioningSlaves=" + decommissioningSlaves + ", unknownSlaves=" + unknownSlaves + ", activeRacks=" + activeRacks + ", deadRacks="

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/StateManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/StateManager.java
@@ -154,7 +154,8 @@ public class StateManager extends CuratorManager {
   }
 
   public SingularityState generateState(boolean includeRequestIds) {
-    final int activeTasks = taskManager.getNumActiveTasks();
+    final int launchingTasks = taskManager.getNumLaunchingTasks();
+    final int activeTasks = taskManager.getNumActiveTasks() - launchingTasks;
     final int scheduledTasks = taskManager.getNumScheduledTasks();
     final int cleaningTasks = taskManager.getNumCleanupTasks();
     final int lbCleanupTasks = taskManager.getNumLbCleanupTasks();
@@ -303,7 +304,7 @@ public class StateManager extends CuratorManager {
       minimumPriorityLevel = Optional.absent();
     }
 
-    return new SingularityState(activeTasks, numActiveRequests, cooldownRequests, numPausedRequests, scheduledTasks, pendingRequests, lbCleanupTasks, lbCleanupRequests, cleaningRequests, activeSlaves,
+    return new SingularityState(activeTasks, launchingTasks, numActiveRequests, cooldownRequests, numPausedRequests, scheduledTasks, pendingRequests, lbCleanupTasks, lbCleanupRequests, cleaningRequests, activeSlaves,
         deadSlaves, decommissioningSlaves, activeRacks, deadRacks, decommissioningRacks, cleaningTasks, states, oldestDeploy, numDeploys, scheduledTasksInfo.getNumLateTasks(),
         scheduledTasksInfo.getNumFutureTasks(), scheduledTasksInfo.getMaxTaskLag(), System.currentTimeMillis(), includeRequestIds ? overProvisionedRequestIds : null,
             includeRequestIds ? underProvisionedRequestIds : null, overProvisionedRequestIds.size(), underProvisionedRequestIds.size(), numFinishedRequests, unknownRacks, unknownSlaves, authDatastoreHealthy, minimumPriorityLevel);

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -465,6 +465,18 @@ public class TaskManager extends CuratorAsyncManager {
     return exists(ACTIVE_PATH_ROOT, paths, taskIdTranscoder);
   }
 
+  public int getNumLaunchingTasks() {
+    List<SingularityTaskId> activeTaskIds = getActiveTaskIds();
+
+    final Map<String, SingularityTaskId> paths = Maps.newHashMapWithExpectedSize(activeTaskIds.size());
+
+    for (SingularityTaskId taskId : activeTaskIds) {
+      paths.put(getUpdatePath(taskId, ExtendedTaskState.TASK_RUNNING), taskId);
+    }
+
+    return notExists(ACTIVE_PATH_ROOT, paths).size();
+  }
+
   public List<SingularityTaskId> filterInactiveTaskIds(List<SingularityTaskId> taskIds) {
     final Map<String, SingularityTaskId> pathsMap = Maps.newHashMap();
 

--- a/SingularityUI/app/components/status/StatusPage.jsx
+++ b/SingularityUI/app/components/status/StatusPage.jsx
@@ -68,7 +68,7 @@ const StatusPage = (props) => {
   };
 
   const taskDetail = (status) => {
-    const totalTasks = status.activeTasks + status.lateTasks + status.scheduledTasks + status.cleaningTasks + status.lbCleanupTasks;
+    const totalTasks = status.activeTasks + status.launchingTasks + status.lateTasks + status.scheduledTasks + status.cleaningTasks + status.lbCleanupTasks;
     const tasks = [
       {
         type: 'active',
@@ -76,6 +76,14 @@ const StatusPage = (props) => {
         label: 'active',
         count: status.activeTasks,
         percent: status.activeTasks / totalTasks * 100,
+        link: '/tasks'
+      },
+      {
+        type: 'launching',
+        attribute: 'launchingTasks',
+        label: 'launching',
+        count: status.launchingTasks,
+        percent: status.launchingTasks / totalTasks * 100,
         link: '/tasks'
       },
       {

--- a/SingularityUI/app/styles/charts.styl
+++ b/SingularityUI/app/styles/charts.styl
@@ -45,3 +45,6 @@
 
 .chart-fill-blank
     background: $base-bg
+
+.chart-fill-launching
+    background $blue-light


### PR DESCRIPTION
It's useful to see how many of the active tasks are actually running vs those that may be stuck in launching/starting for a long time. This separates out launching from active in the SingularityState. Launching tasks in this case are defined as any that do not yet have a `TASK_RUNNING` history update.

@tpetr 