### PR TITLE
Don't rely on Singularity active requests list

### DIFF
--- a/scripts/logfetch/logfetch_base.py
+++ b/scripts/logfetch/logfetch_base.py
@@ -55,12 +55,14 @@ def all_tasks_for_request(args, request):
         return active_tasks
 
 def all_requests(args):
-    uri = '{0}{1}'.format(base_uri(args),    ALL_REQUESTS)
+    uri = '{0}{1}'.format(base_uri(args), ALL_REQUESTS)
     requests = get_json_response(uri, args)
     included_requests = []
     for request in requests:
         if fnmatch.fnmatch(request['request']['id'], args.requestId):
             included_requests.append(request['request']['id'])
+    if not included_requests and not '*' in args.requestId:
+        included_requests.append(args.requestId)
     return included_requests
 
 def is_in_date_range(args, timestamp):

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -11,7 +11,7 @@ requirements = [
 
 setup(
     name='singularity-logfetch',
-    version='0.27.2',
+    version='0.27.3',
     description='Singularity log fetching and searching',
     author="HubSpot",
     author_email='singularity-users@googlegroups.com',


### PR DESCRIPTION
If trying to search logs for a request that has been deleted, it won't show up in the list of active requests. If it does not show up in that list and we are not using a glob to specify the request(s), use the exact value from the argument