### PR TITLE
Better messages for sentry reporting

### DIFF
--- a/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/SingularityExecutorCleanup.java
+++ b/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/SingularityExecutorCleanup.java
@@ -97,7 +97,7 @@ public class SingularityExecutorCleanup {
       runningTaskIds = getRunningTaskIds();
     } catch (Exception e) {
       LOG.error("While fetching running tasks from singularity", e);
-      exceptionNotifier.notify(e, Collections.<String, String>emptyMap());
+      exceptionNotifier.notify(String.format("Error fetchign running tasks (%s)", e.getMessage()), e, Collections.<String, String>emptyMap());
       statisticsBldr.setErrorMessage(e.getMessage());
       return statisticsBldr.build();
     }
@@ -109,7 +109,7 @@ public class SingularityExecutorCleanup {
     if (runningTaskIds.isEmpty()) {
       if (!isDecommissioned()) {
         if (cleanupConfiguration.isSafeModeWontRunWithNoTasks()) {
-          final String errorMessage = String.format("Running in safe mode and found 0 running tasks - aborting cleanup");
+          final String errorMessage = "Running in safe mode and found 0 running tasks - aborting cleanup";
           LOG.error(errorMessage);
           statisticsBldr.setErrorMessage(errorMessage);
           return statisticsBldr.build();
@@ -159,7 +159,7 @@ public class SingularityExecutorCleanup {
           taskHistory = singularityClient.getHistoryForTask(taskId);
         } catch (SingularityClientException sce) {
           LOG.error("{} - Failed fetching history", taskId, sce);
-          exceptionNotifier.notify(sce, Collections.<String, String>emptyMap());
+          exceptionNotifier.notify(String.format("Error fetching history (%s)", sce.getMessage()), sce, ImmutableMap.<String, String>of("taskId", taskId));
           statisticsBldr.incrErrorTasks();
           continue;
         }
@@ -184,7 +184,7 @@ public class SingularityExecutorCleanup {
 
       } catch (IOException ioe) {
         LOG.error("Couldn't read file {}", file, ioe);
-        exceptionNotifier.notify(ioe, ImmutableMap.of("file", file.toString()));
+        exceptionNotifier.notify(String.format("Error reading file (%s)", ioe.getMessage()), ioe, ImmutableMap.of("file", file.toString()));
         statisticsBldr.incrIoErrorTasks();
       }
     }
@@ -298,7 +298,7 @@ public class SingularityExecutorCleanup {
           }
         } catch (IOException ioe) {
           LOG.error("Failed to handle empty gz file {}", path, ioe);
-          exceptionNotifier.notify(ioe, ImmutableMap.of("file", path.toString()));
+          exceptionNotifier.notify(String.format("Error handling empty file (%s)", ioe.getMessage()), ioe, ImmutableMap.of("file", path.toString()));
         }
       } else {
         ungzippedFiles.add(path);
@@ -312,7 +312,7 @@ public class SingularityExecutorCleanup {
           new SimpleProcessManager(LOG).runCommand(ImmutableList.<String> of("gzip", path.toString()));
         } catch (InterruptedException | ProcessFailedException e) {
           LOG.error("Failed to gzip {}", path, e);
-          exceptionNotifier.notify(e, ImmutableMap.of("file", path.toString()));
+          exceptionNotifier.notify(String.format("Failed to gzip (%s)", e.getMessage()), e, ImmutableMap.of("file", path.toString()));
         }
       } else {
         LOG.debug("Didn't find matched empty gz file for {}", path);
@@ -333,7 +333,7 @@ public class SingularityExecutorCleanup {
       }
     } catch (Exception e) {
       LOG.error("Could not get list of Docker containers", e);
-      exceptionNotifier.notify(e, Collections.<String, String>emptyMap());
+      exceptionNotifier.notify(String.format("Error listing docker containers (%s)", e.getMessage()), e, Collections.<String, String>emptyMap());
     }
   }
 
@@ -348,7 +348,7 @@ public class SingularityExecutorCleanup {
       LOG.debug("Removed container {}", container.names());
     } catch (Exception e) {
       LOG.error("Failed to stop or remove container {}", container.names(), e);
-      exceptionNotifier.notify(e, Collections.<String, String>emptyMap());
+      exceptionNotifier.notify(String.format("Failed stopping container (%s)", e.getMessage()), e, Collections.<String, String>emptyMap());
     }
   }
 

--- a/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/SingularityExecutorCleanup.java
+++ b/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/SingularityExecutorCleanup.java
@@ -97,7 +97,7 @@ public class SingularityExecutorCleanup {
       runningTaskIds = getRunningTaskIds();
     } catch (Exception e) {
       LOG.error("While fetching running tasks from singularity", e);
-      exceptionNotifier.notify(String.format("Error fetchign running tasks (%s)", e.getMessage()), e, Collections.<String, String>emptyMap());
+      exceptionNotifier.notify(String.format("Error fetching running tasks (%s)", e.getMessage()), e, Collections.<String, String>emptyMap());
       statisticsBldr.setErrorMessage(e.getMessage());
       return statisticsBldr.build();
     }

--- a/SingularityLogWatcher/src/main/java/com/hubspot/singularity/logwatcher/driver/SingularityLogWatcherDriver.java
+++ b/SingularityLogWatcher/src/main/java/com/hubspot/singularity/logwatcher/driver/SingularityLogWatcherDriver.java
@@ -80,7 +80,7 @@ public class SingularityLogWatcherDriver implements TailMetadataListener, Singul
             store.markConsumed(tail);
           }
         } catch (Throwable t) {
-          exceptionNotifier.notify(t, ImmutableMap.of("tailFilename", tail.getFilename()));
+          exceptionNotifier.notify(String.format("Error while tailing (%s)", t.getMessage()), t, ImmutableMap.of("tailFilename", tail.getFilename()));
           if (shutdown) {
             LOG.error("Exception tailing {} while shutting down", tail, t);
           } else {
@@ -110,7 +110,7 @@ public class SingularityLogWatcherDriver implements TailMetadataListener, Singul
           tailChanged(tail);
         } catch (Throwable unexpected) {
           LOG.error("Unexpected exception for {} while attempting retry", tail, unexpected);
-          exceptionNotifier.notify(unexpected, ImmutableMap.of("tailFilename", tail.getFilename()));
+          exceptionNotifier.notify(String.format("Error while tailing (%s)", unexpected.getMessage()), unexpected, ImmutableMap.of("tailFilename", tail.getFilename()));
         }
       }
     }, configuration.getRetryDelaySeconds(), TimeUnit.SECONDS);
@@ -184,14 +184,14 @@ public class SingularityLogWatcherDriver implements TailMetadataListener, Singul
       tailService.awaitTermination(1L, TimeUnit.DAYS);
     } catch (Throwable t) {
       LOG.error("While awaiting tail service", t);
-      exceptionNotifier.notify(t, Collections.<String, String>emptyMap());
+      exceptionNotifier.notify(String.format("Error awaiting tail service (%s)", t.getMessage()), t, Collections.<String, String>emptyMap());
     }
 
     try {
       store.close();
     } catch (Throwable t) {
       LOG.error("While closing store", t);
-      exceptionNotifier.notify(t, Collections.<String, String>emptyMap());
+      exceptionNotifier.notify(String.format("Error closing store (%s)", t.getMessage()), t, Collections.<String, String>emptyMap());
     }
 
     LOG.info("Shutdown after {}", JavaUtils.duration(start));
@@ -203,7 +203,7 @@ public class SingularityLogWatcherDriver implements TailMetadataListener, Singul
       return Optional.of(tailer);
     } catch (Throwable t) {
       LOG.warn("Couldn't create a tailer for {}", tail, t);
-      exceptionNotifier.notify(t, ImmutableMap.of("tailFilename", tail.getFilename()));
+      exceptionNotifier.notify(String.format("Error creating tailer (%s)", t.getMessage()), t, ImmutableMap.of("tailFilename", tail.getFilename()));
       return Optional.absent();
     }
   }

--- a/SingularityOOMKiller/src/main/java/com/hubspot/singularity/oomkiller/SingularityOOMKillerDriver.java
+++ b/SingularityOOMKiller/src/main/java/com/hubspot/singularity/oomkiller/SingularityOOMKillerDriver.java
@@ -52,7 +52,7 @@ public class SingularityOOMKillerDriver implements SingularityDriver {
 
         } catch (Throwable t) {
           LOG.error("Uncaught exception while checking for OOMS", t);
-          exceptionNotifier.notify(t, Collections.<String, String>emptyMap());
+          exceptionNotifier.notify(String.format("Exception while checking for OOM (%s)", t.getMessage()), t, Collections.<String, String>emptyMap());
         } finally {
           LOG.info("Finished checking OOMS after {}", JavaUtils.duration(start));
         }
@@ -64,7 +64,7 @@ public class SingularityOOMKillerDriver implements SingularityDriver {
       future.get();
     } catch (InterruptedException | ExecutionException e) {
       LOG.warn("Unexpected exception while waiting on future", e);
-      exceptionNotifier.notify(e, Collections.<String, String>emptyMap());
+      exceptionNotifier.notify(String.format("Exception waiting for future (%s)", e.getMessage()), e, Collections.<String, String>emptyMap());
     }
 
   }

--- a/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/sentry/SingularityRunnerExceptionNotifier.java
+++ b/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/sentry/SingularityRunnerExceptionNotifier.java
@@ -51,7 +51,7 @@ public class SingularityRunnerExceptionNotifier {
     raven.sendEvent(eventBuilder.build());
   }
 
-  public void notify(Throwable t, Map<String, String> extraData) {
+  public void notify(String message, Throwable t, Map<String, String> extraData) {
     if (!raven.isPresent()) {
       return;
     }
@@ -59,8 +59,8 @@ public class SingularityRunnerExceptionNotifier {
     final StackTraceElement[] currentThreadStackTrace = Thread.currentThread().getStackTrace();
 
     final EventBuilder eventBuilder = new EventBuilder()
-            .setCulprit(getPrefix() + t.getMessage())
-            .setMessage(Strings.nullToEmpty(t.getMessage()))
+            .setCulprit(getPrefix() + message)
+            .setMessage(Strings.nullToEmpty(message))
             .setLevel(Event.Level.ERROR)
             .setLogger(getCallingClassName(currentThreadStackTrace))
             .addSentryInterface(new ExceptionInterface(t));

--- a/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/shared/SingularityRunner.java
+++ b/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/shared/SingularityRunner.java
@@ -46,7 +46,7 @@ public class SingularityRunner {
       System.exit(1);
     } catch (Throwable t) {
       LOG.error("Caught unexpected exception, exiting", t);
-      exceptionNotifier.notify(String.format("Unexcepted excetion in runner (%s)", t.getMessage()), t, Collections.<String, String>emptyMap());
+      exceptionNotifier.notify(String.format("Unexpected exception in runner (%s)", t.getMessage()), t, Collections.<String, String>emptyMap());
       System.exit(1);
     }
 

--- a/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/shared/SingularityRunner.java
+++ b/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/shared/SingularityRunner.java
@@ -46,7 +46,7 @@ public class SingularityRunner {
       System.exit(1);
     } catch (Throwable t) {
       LOG.error("Caught unexpected exception, exiting", t);
-      exceptionNotifier.notify(t, Collections.<String, String>emptyMap());
+      exceptionNotifier.notify(String.format("Unexcepted excetion in runner (%s)", t.getMessage()), t, Collections.<String, String>emptyMap());
       System.exit(1);
     }
 

--- a/SingularityS3Base/src/main/java/com/hubspot/singularity/s3/base/S3ArtifactChunkDownloader.java
+++ b/SingularityS3Base/src/main/java/com/hubspot/singularity/s3/base/S3ArtifactChunkDownloader.java
@@ -67,14 +67,14 @@ public class S3ArtifactChunkDownloader implements Callable<Path> {
           log.error("Chunk {} (retry {}) for {} timed out after {} - total duration {}", chunk, retryNum, s3Artifact.getFilename(), JavaUtils.duration(timeout), JavaUtils.duration(start));
           future.cancel(true);
           if (retryNum == configuration.getS3ChunkRetries()) {
-            exceptionNotifier.notify(te, ImmutableMap.of("filename", s3Artifact.getFilename(), "chunk", Integer.toString(chunk), "retry", Integer.toString(retryNum)));
+            exceptionNotifier.notify("Timeout downloading chunk", te, ImmutableMap.of("filename", s3Artifact.getFilename(), "chunk", Integer.toString(chunk), "retry", Integer.toString(retryNum)));
           }
         } catch (InterruptedException ie) {
           log.warn("Chunk {} (retry {}) for {} interrupted", chunk, retryNum, s3Artifact.getFilename());
-          exceptionNotifier.notify(ie, ImmutableMap.of("filename", s3Artifact.getFilename(), "chunk", Integer.toString(chunk), "retry", Integer.toString(retryNum)));
+          exceptionNotifier.notify("Interrupted during download", ie, ImmutableMap.of("filename", s3Artifact.getFilename(), "chunk", Integer.toString(chunk), "retry", Integer.toString(retryNum)));
         } catch (Throwable t) {
           log.error("Error while downloading chunk {} (retry {}) for {}", chunk, retryNum, s3Artifact.getFilename(), t);
-          exceptionNotifier.notify(t, ImmutableMap.of("filename", s3Artifact.getFilename(), "chunk", Integer.toString(chunk), "retry", Integer.toString(retryNum)));
+          exceptionNotifier.notify(String.format("Error downloading chunk (%s)", t.getMessage()), t, ImmutableMap.of("filename", s3Artifact.getFilename(), "chunk", Integer.toString(chunk), "retry", Integer.toString(retryNum)));
         }
 
         retryNum++;

--- a/SingularityS3Base/src/main/java/com/hubspot/singularity/s3/base/S3ArtifactDownloader.java
+++ b/SingularityS3Base/src/main/java/com/hubspot/singularity/s3/base/S3ArtifactDownloader.java
@@ -143,10 +143,10 @@ public class S3ArtifactDownloader {
     } catch (TimeoutException te) {
       log.error("Chunk {} for {} timed out after {} - had {} remaining", chunk, s3Artifact.getFilename(), JavaUtils.duration(start), JavaUtils.durationFromMillis(remainingMillis));
       future.cancel(true);
-      exceptionNotifier.notify(te, ImmutableMap.of("filename", s3Artifact.getFilename(), "chunk", Integer.toString(chunk)));
+      exceptionNotifier.notify("TimeoutException during download", te, ImmutableMap.of("filename", s3Artifact.getFilename(), "chunk", Integer.toString(chunk)));
     } catch (Throwable t) {
       log.error("Error while handling chunk {} for {}", chunk, s3Artifact.getFilename(), t);
-      exceptionNotifier.notify(t, ImmutableMap.of("filename", s3Artifact.getFilename(), "chunk", Integer.toString(chunk)));
+      exceptionNotifier.notify(String.format("Error handling chunk (%s)", t.getMessage()), t, ImmutableMap.of("filename", s3Artifact.getFilename(), "chunk", Integer.toString(chunk)));
     }
 
     return false;

--- a/SingularityS3Downloader/src/main/java/com/hubspot/singularity/s3downloader/server/SingularityS3DownloaderAsyncHandler.java
+++ b/SingularityS3Downloader/src/main/java/com/hubspot/singularity/s3downloader/server/SingularityS3DownloaderAsyncHandler.java
@@ -76,7 +76,7 @@ public class SingularityS3DownloaderAsyncHandler implements Runnable {
     } catch (Throwable t) {
       metrics.getServerErrorsMeter().mark();
       LOG.error("While handling {}", artifactDownloadRequest.getTargetDirectory(), t);
-      exceptionNotifier.notify(t, ImmutableMap.of("s3Bucket", artifactDownloadRequest.getS3Artifact().getS3Bucket(), "s3Key", artifactDownloadRequest.getS3Artifact().getS3ObjectKey(), "targetDirectory", artifactDownloadRequest.getTargetDirectory()));
+      exceptionNotifier.notify(String.format("Error handling download (%s)", t.getMessage()), t, ImmutableMap.of("s3Bucket", artifactDownloadRequest.getS3Artifact().getS3Bucket(), "s3Key", artifactDownloadRequest.getS3Artifact().getS3ObjectKey(), "targetDirectory", artifactDownloadRequest.getTargetDirectory()));
       try {
         getResponse().sendError(500);
       } catch (Throwable t2) {

--- a/SingularityS3Downloader/src/main/java/com/hubspot/singularity/s3downloader/server/SingularityS3DownloaderCoordinator.java
+++ b/SingularityS3Downloader/src/main/java/com/hubspot/singularity/s3downloader/server/SingularityS3DownloaderCoordinator.java
@@ -123,7 +123,7 @@ public class SingularityS3DownloaderCoordinator {
         }
       } catch (Throwable t) {
         LOG.error("While trying to enqueue {}", artifactDownloadRequest.getTargetDirectory(), t);
-        exceptionNotifier.notify(t, ImmutableMap.of("targetDirectory", artifactDownloadRequest.getTargetDirectory()));
+        exceptionNotifier.notify(String.format("Error enqueuing download (%s)", t.getMessage()), t, ImmutableMap.of("targetDirectory", artifactDownloadRequest.getTargetDirectory()));
         try {
           ((HttpServletResponse) continuation.getServletResponse()).sendError(500);
         } catch (IOException e) {

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3Uploader.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3Uploader.java
@@ -180,15 +180,15 @@ public class SingularityS3Uploader implements Closeable {
         } catch (S3ServiceException se) {
           metrics.error();
           LOG.warn("{} Couldn't upload {} due to {} ({}) - {}", logIdentifier, file, se.getErrorCode(), se.getResponseCode(), se.getErrorMessage(), se);
-          exceptionNotifier.notify(se, ImmutableMap.of("logIdentifier", logIdentifier, "file", file.toString(), "errorCode", se.getErrorCode(), "responseCode", Integer.toString(se.getResponseCode()), "errorMessage", se.getErrorMessage()));
+          exceptionNotifier.notify(String.format("S3ServiceException during upload (%s)", se.getMessage()), se, ImmutableMap.of("logIdentifier", logIdentifier, "file", file.toString(), "errorCode", se.getErrorCode(), "responseCode", Integer.toString(se.getResponseCode()), "errorMessage", se.getErrorMessage()));
         } catch (RetryException re) {
           metrics.error();
           LOG.warn("{} Couldn't upload or delete {}", logIdentifier, file, re);
-          exceptionNotifier.notify(re.getCause(), ImmutableMap.of("logIdentifier", logIdentifier, "file", file.toString(), "failedAttempts", Integer.toString(re.getNumberOfFailedAttempts())));
+          exceptionNotifier.notify(String.format("%s exception during upload", re.getCause().getClass()), re.getCause(), ImmutableMap.of("logIdentifier", logIdentifier, "file", file.toString(), "failedAttempts", Integer.toString(re.getNumberOfFailedAttempts())));
         } catch (Exception e) {
           metrics.error();
           LOG.warn("{} Couldn't upload or delete {}", logIdentifier, file, e);
-          exceptionNotifier.notify(e, ImmutableMap.of("logIdentifier", logIdentifier, "file", file.toString()));
+          exceptionNotifier.notify(String.format("Error during upload (%s)", e.getMessage()), e, ImmutableMap.of("logIdentifier", logIdentifier, "file", file.toString()));
         } finally {
           context.stop();
         }

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3UploaderDriver.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3UploaderDriver.java
@@ -160,7 +160,7 @@ public class SingularityS3UploaderDriver extends WatchServiceHelper implements S
           uploads = checkUploads();
         } catch (Throwable t) {
           LOG.error("Uncaught exception while checking {} upload(s)", uploaders, t);
-          exceptionNotifier.notify(t, Collections.<String, String>emptyMap());
+          exceptionNotifier.notify(String.format("Error checking uploads (%s)", t.getMessage()), t, Collections.<String, String>emptyMap());
         } finally {
           runLock.unlock();
           metrics.finishUploads();
@@ -226,7 +226,7 @@ public class SingularityS3UploaderDriver extends WatchServiceHelper implements S
           } catch (Throwable t) {
             metrics.error();
             LOG.error("Error while processing uploader {}", uploader, t);
-            exceptionNotifier.notify(t, ImmutableMap.of("metadataPath", uploader.getMetadataPath().toString()));
+            exceptionNotifier.notify(String.format("Error processing uploader (%s)", t.getMessage()), t, ImmutableMap.of("metadataPath", uploader.getMetadataPath().toString()));
           }
           return returnValue;
         }
@@ -259,7 +259,7 @@ public class SingularityS3UploaderDriver extends WatchServiceHelper implements S
       } catch (Throwable t) {
         metrics.error();
         LOG.error("Waiting on future", t);
-        exceptionNotifier.notify(t, ImmutableMap.of("metadataPath", uploader.getMetadataPath().toString()));
+        exceptionNotifier.notify(String.format("Error waiting on uploader future (%s)", t.getMessage()), t, ImmutableMap.of("metadataPath", uploader.getMetadataPath().toString()));
       }
     }
 
@@ -279,7 +279,7 @@ public class SingularityS3UploaderDriver extends WatchServiceHelper implements S
         LOG.warn("File {} was alrady deleted");
       } catch (IOException e) {
         LOG.warn("Couldn't delete {}", expiredUploader.getMetadataPath(), e);
-        exceptionNotifier.notify(e, ImmutableMap.of("metadataPath", expiredUploader.getMetadataPath().toString()));
+        exceptionNotifier.notify("Could not delete metadata file", e, ImmutableMap.of("metadataPath", expiredUploader.getMetadataPath().toString()));
       }
     }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityLeaderController.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityLeaderController.java
@@ -84,7 +84,7 @@ public class SingularityLeaderController implements Managed, LeaderLatchListener
         statePoller.wake();
       } catch (Throwable t) {
         LOG.error("While starting driver", t);
-        exceptionNotifier.notify(t);
+        exceptionNotifier.notify(String.format("Error starting driver (%s)", t.getMessage()), t);
         abort.abort(AbortReason.UNRECOVERABLE_ERROR, Optional.of(t));
       }
 
@@ -123,7 +123,7 @@ public class SingularityLeaderController implements Managed, LeaderLatchListener
         statePoller.wake();
       } catch (Throwable t) {
         LOG.error("While stopping driver", t);
-        exceptionNotifier.notify(t);
+        exceptionNotifier.notify(String.format("Error while stopping driver (%s)", t.getMessage()), t);
       } finally {
         abort.abort(AbortReason.LOST_LEADERSHIP, Optional.<Throwable>absent());
       }
@@ -197,7 +197,7 @@ public class SingularityLeaderController implements Managed, LeaderLatchListener
           LOG.trace("Caught interrupted exception, running the loop");
         } catch (Throwable t) {
           LOG.error("Caught exception while saving state", t);
-          exceptionNotifier.notify(t);
+          exceptionNotifier.notify(String.format("Caught exception while saving state (%s)", t.getMessage()), t);
         }
         finally {
           lock.unlock();

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/datastore/SingularityLDAPDatastore.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/datastore/SingularityLDAPDatastore.java
@@ -101,7 +101,7 @@ public class SingularityLDAPDatastore implements SingularityAuthDatastore {
       }
     } catch (LdapException e) {
       LOG.warn("LdapException caught when checking health", e);
-      exceptionNotifier.notify(e);
+      exceptionNotifier.notify(String.format("LdapException caught when checking health (%s)", e.getMessage()), e);
     }
     return Optional.of(false);
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
@@ -343,7 +343,7 @@ public class SingularityMesosScheduler implements Scheduler {
     try {
       return Optional.of(taskIdTranscoder.fromString(taskId));
     } catch (InvalidSingularityTaskIdException | SingularityTranscoderException e) {
-      exceptionNotifier.notify(e);
+      exceptionNotifier.notify(String.format("Unexpected taskId %s", taskId), e);
       LOG.error("Unexpected taskId {} ", taskId, e);
       return Optional.absent();
     }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerDelegator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerDelegator.java
@@ -93,7 +93,7 @@ public class SingularityMesosSchedulerDelegator implements Scheduler {
   private void handleUncaughtSchedulerException(Throwable t) {
     LOG.error("Scheduler threw an uncaught exception - exiting", t);
 
-    exceptionNotifier.notify(t);
+    exceptionNotifier.notify(String.format("Scheduler threw an uncaught exception (%s)", t.getMessage()), t);
 
     abort.abort(AbortReason.UNRECOVERABLE_ERROR, Optional.of(t));
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityHealthcheckAsyncHandler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityHealthcheckAsyncHandler.java
@@ -80,7 +80,7 @@ public class SingularityHealthcheckAsyncHandler extends AsyncCompletionHandler<R
       }
     } catch (Throwable t) {
       LOG.error("Caught throwable while saving health check result for {}, will re-enqueue", task.getTaskId(), t);
-      exceptionNotifier.notify(String.format("Erro saving healthcheck (%s)", t.getMessage()), t, ImmutableMap.of("taskId", task.getTaskId().toString()));
+      exceptionNotifier.notify(String.format("Error saving healthcheck (%s)", t.getMessage()), t, ImmutableMap.of("taskId", task.getTaskId().toString()));
 
       healthchecker.reEnqueueOrAbort(task);
     }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityHealthcheckAsyncHandler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityHealthcheckAsyncHandler.java
@@ -80,7 +80,7 @@ public class SingularityHealthcheckAsyncHandler extends AsyncCompletionHandler<R
       }
     } catch (Throwable t) {
       LOG.error("Caught throwable while saving health check result for {}, will re-enqueue", task.getTaskId(), t);
-      exceptionNotifier.notify(t, ImmutableMap.of("taskId", task.getTaskId().toString()));
+      exceptionNotifier.notify(String.format("Erro saving healthcheck (%s)", t.getMessage()), t, ImmutableMap.of("taskId", task.getTaskId().toString()));
 
       healthchecker.reEnqueueOrAbort(task);
     }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityHealthchecker.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityHealthchecker.java
@@ -142,7 +142,7 @@ public class SingularityHealthchecker {
           asyncHealthcheck(task);
         } catch (Throwable t) {
           LOG.error("Uncaught throwable in async healthcheck", t);
-          exceptionNotifier.notify(t, ImmutableMap.of("taskId", task.getTaskId().toString()));
+          exceptionNotifier.notify(String.format("Uncaught throwable in async healthcheck (%s)", t.getMessage()), t, ImmutableMap.of("taskId", task.getTaskId().toString()));
 
           reEnqueueOrAbort(task);
         }
@@ -156,7 +156,7 @@ public class SingularityHealthchecker {
       enqueueHealthcheck(task, true);
     } catch (Throwable t) {
       LOG.error("Caught throwable while re-enqueuing health check for {}, aborting", task.getTaskId(), t);
-      exceptionNotifier.notify(t, ImmutableMap.of("taskId", task.getTaskId().toString()));
+      exceptionNotifier.notify(String.format("Caught throwable while re-enqueuing health check (%s)", t.getMessage()), t, ImmutableMap.of("taskId", task.getTaskId().toString()));
 
       abort.abort(SingularityAbort.AbortReason.UNRECOVERABLE_ERROR, Optional.of(t));
     }
@@ -243,7 +243,7 @@ public class SingularityHealthchecker {
       http.prepareRequest(builder.build()).execute(handler);
     } catch (Throwable t) {
       LOG.debug("Exception while preparing healthcheck ({}) for task ({})", uri, task.getTaskId(), t);
-      exceptionNotifier.notify(t, ImmutableMap.of("taskId", task.getTaskId().toString()));
+      exceptionNotifier.notify(String.format("Error preparing healthcheck (%s)", t.getMessage()), t, ImmutableMap.of("taskId", task.getTaskId().toString()));
       saveFailure(handler, String.format("Healthcheck failed due to exception: %s", t.getMessage()));
     }
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderOnlyPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderOnlyPoller.java
@@ -108,7 +108,7 @@ public abstract class SingularityLeaderOnlyPoller implements Managed {
       runActionOnPoll();
     } catch (Throwable t) {
       LOG.error("Caught an exception while running {}", getClass().getSimpleName(), t);
-      exceptionNotifier.notify(t);
+      exceptionNotifier.notify(String.format("Caught an exception while running %s", getClass().getSimpleName()), t);
       if (abortsOnError()) {
         abort.abort(AbortReason.UNRECOVERABLE_ERROR, Optional.of(t));
       }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityNewTaskChecker.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityNewTaskChecker.java
@@ -201,7 +201,7 @@ public class SingularityNewTaskChecker {
           }
         } catch (Throwable t) {
           LOG.error("Uncaught throwable in task check for task {}, re-enqueing", task, t);
-          exceptionNotifier.notify(t, ImmutableMap.of("taskId", task.getTaskId().toString()));
+          exceptionNotifier.notify(String.format("Error in task check (%s)", t.getMessage()), t, ImmutableMap.of("taskId", task.getTaskId().toString()));
 
           reEnqueueCheckOrAbort(task, healthchecker);
         }
@@ -214,7 +214,7 @@ public class SingularityNewTaskChecker {
       reEnqueueCheck(task, healthchecker);
     } catch (Throwable t) {
       LOG.error("Uncaught throwable re-enqueuing task check for task {}, aborting", task, t);
-      exceptionNotifier.notify(t, ImmutableMap.of("taskId", task.getTaskId().toString()));
+      exceptionNotifier.notify(String.format("Error in task check (%s)", t.getMessage()), t, ImmutableMap.of("taskId", task.getTaskId().toString()));
       abort.abort(AbortReason.UNRECOVERABLE_ERROR, Optional.of(t));
     }
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduledJobPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduledJobPoller.java
@@ -135,7 +135,7 @@ public class SingularityScheduledJobPoller extends SingularityLeaderOnlyPoller {
 
       } catch (ParseException|InvalidRecurrenceRuleException e) {
         LOG.warn("Unable to parse schedule of type {} for expression {} (taskId: {}, err: {})", request.getRequest().getScheduleTypeSafe(), scheduleExpression, taskId, e);
-        exceptionNotifier.notify(e, ImmutableMap.of("taskId", taskId.toString(), "scheduleExpression", scheduleExpression, "scheduleType", request.getRequest().getScheduleTypeSafe().toString()));
+        exceptionNotifier.notify(String.format("Unable to parse schedule (%s)", e.getMessage()), e, ImmutableMap.of("taskId", taskId.toString(), "scheduleExpression", scheduleExpression, "scheduleType", request.getRequest().getScheduleTypeSafe().toString()));
         return Optional.absent();
       }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityTaskReconciliation.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityTaskReconciliation.java
@@ -115,7 +115,7 @@ public class SingularityTaskReconciliation {
           checkReconciliation(driver, reconciliationStart, remainingTaskIds, numTimes + 1);
         } catch (Throwable t) {
           LOG.error("While checking for reconciliation tasks", t);
-          exceptionNotifier.notify(t);
+          exceptionNotifier.notify(String.format("Error checking for reconciliation tasks (%s)", t.getMessage()), t);
           abort.abort(AbortReason.UNRECOVERABLE_ERROR, Optional.of(t));
         }
       }

--- a/SingularityService/src/main/java/com/hubspot/singularity/sentry/NotifyingExceptionMapper.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/sentry/NotifyingExceptionMapper.java
@@ -20,7 +20,7 @@ public class NotifyingExceptionMapper extends LoggingExceptionMapper<Exception> 
     final Response response = super.toResponse(e);
 
     if (response.getStatus() >= 500) {
-      notifier.notify(e);
+      notifier.notify(String.format("Uncaught Exception (%s)", e.getMessage()), e);
     }
 
     return response;

--- a/SingularityService/src/main/java/com/hubspot/singularity/sentry/NotifyingUncaughtExceptionManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/sentry/NotifyingUncaughtExceptionManager.java
@@ -17,6 +17,6 @@ public class NotifyingUncaughtExceptionManager implements UncaughtExceptionHandl
   @Override
   public void uncaughtException(Thread t, Throwable e) {
     LOG.error("Uncaught exception!", e);
-    notifier.notify(e);
+    notifier.notify(String.format("Uncaught Exception (%s)", e.getMessage()), e);
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/sentry/SingularityExceptionNotifier.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/sentry/SingularityExceptionNotifier.java
@@ -64,11 +64,11 @@ public class SingularityExceptionNotifier {
     raven.sendEvent(eventBuilder.build());
   }
 
-  public void notify(Throwable t) {
-    notify(t, Collections.<String, String>emptyMap());
+  public void notify(String message, Throwable t) {
+    notify(message, t, Collections.<String, String>emptyMap());
   }
 
-  public void notify(Throwable t, Map<String, String> extraData) {
+  public void notify(String message, Throwable t, Map<String, String> extraData) {
     if (!raven.isPresent()) {
       return;
     }
@@ -76,8 +76,8 @@ public class SingularityExceptionNotifier {
     final StackTraceElement[] currentThreadStackTrace = Thread.currentThread().getStackTrace();
 
     final EventBuilder eventBuilder = new EventBuilder()
-            .withCulprit(getPrefix() + t.getMessage())
-            .withMessage(Strings.nullToEmpty(t.getMessage()))
+            .withCulprit(getPrefix() + message)
+            .withMessage(message)
             .withLevel(Event.Level.ERROR)
             .withLogger(getCallingClassName(currentThreadStackTrace))
             .withSentryInterface(new ExceptionInterface(t));

--- a/SingularityService/src/main/java/com/hubspot/singularity/smtp/SingularitySmtpSender.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/smtp/SingularitySmtpSender.java
@@ -137,7 +137,7 @@ public class SingularitySmtpSender implements Managed {
       Transport.send(message);
     } catch (Throwable t) {
       LOG.warn("Unable to send message {}", getEmailLogFormat(toList, subject), t);
-      exceptionNotifier.notify(t, ImmutableMap.of("subject", subject));
+      exceptionNotifier.notify(String.format("Unable to send message (%s)", t.getMessage()), t, ImmutableMap.of("subject", subject));
     }
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/smtp/SmtpMailer.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/smtp/SmtpMailer.java
@@ -367,7 +367,7 @@ public class SmtpMailer implements SingularityMailer, Managed {
           prepareRequestMail(request, type, user, message, additionalProperties);
         } catch (Throwable t) {
           LOG.error("While preparing request mail for {} / {}", request, type, t);
-          exceptionNotifier.notify(t, ImmutableMap.of("requestId", request.getId()));
+          exceptionNotifier.notify(String.format("Error preparing request mail (%s)", t.getMessage()), t, ImmutableMap.of("requestId", request.getId()));
         }
       }
     });
@@ -482,7 +482,7 @@ public class SmtpMailer implements SingularityMailer, Managed {
           prepareRequestInCooldownMail(request);
         } catch (Throwable t) {
           LOG.error("While preparing request in cooldown mail for {}", request, t);
-          exceptionNotifier.notify(t, ImmutableMap.of("requestId", request.getId()));
+          exceptionNotifier.notify(String.format("Error preparing cooldown mail (%s)", t.getMessage()), t, ImmutableMap.of("requestId", request.getId()));
         }
       }
     });


### PR DESCRIPTION
Our sentries normally use the message from the Exception/Throwable they are reporting, which can often be null or not provide much information. This updates most notify calls to provide some context around the exception as well as the exception message.