### PR TITLE
Cache files with md5, add more detail for cache misses

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/deploy/Artifact.java
+++ b/SingularityBase/src/main/java/com/hubspot/deploy/Artifact.java
@@ -2,6 +2,7 @@ package com.hubspot.deploy;
 
 import java.util.Objects;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.common.base.Optional;
 
@@ -26,6 +27,15 @@ public abstract class Artifact {
 
   public String getFilename() {
     return filename;
+  }
+
+  @JsonIgnore
+  public String getFilenameForCache() {
+    if (md5sum.isPresent()) {
+      return String.format("%s-%s", md5sum.get(), filename);
+    } else {
+      return filename;
+    }
   }
 
   public Optional<String> getMd5sum() {

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorArtifactFetcher.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorArtifactFetcher.java
@@ -190,7 +190,7 @@ public class SingularityExecutorArtifactFetcher {
       if (Objects.toString(fetched.getFileName()).endsWith(".tar.gz")) {
         artifactManager.untar(fetched, task.getArtifactPath(remoteArtifact, task.getTaskDefinition().getTaskDirectoryPath()));
       } else {
-        artifactManager.copy(fetched, task.getArtifactPath(remoteArtifact, task.getTaskDefinition().getTaskAppDirectoryPath()));
+        artifactManager.copy(fetched, task.getArtifactPath(remoteArtifact, task.getTaskDefinition().getTaskAppDirectoryPath()), remoteArtifact.getFilename());
       }
     }
 

--- a/SingularityS3Base/src/main/java/com/hubspot/singularity/s3/base/ArtifactManager.java
+++ b/SingularityS3Base/src/main/java/com/hubspot/singularity/s3/base/ArtifactManager.java
@@ -157,7 +157,7 @@ public class ArtifactManager extends SimpleProcessManager {
   }
 
   public Path fetch(RemoteArtifact artifact) {
-    String filename = artifact.getFilename();
+    String filename = artifact.getFilenameForCache();
     Path cachedPath = getCachedPath(filename);
 
     Optional<String> maybeCacheMissMessage = checkCached(artifact, cachedPath);

--- a/SingularityS3Base/src/main/java/com/hubspot/singularity/s3/base/ArtifactManager.java
+++ b/SingularityS3Base/src/main/java/com/hubspot/singularity/s3/base/ArtifactManager.java
@@ -13,7 +13,6 @@ import java.util.List;
 
 import org.slf4j.Logger;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.hash.HashCode;

--- a/SingularityS3Base/src/main/java/com/hubspot/singularity/s3/base/ArtifactManager.java
+++ b/SingularityS3Base/src/main/java/com/hubspot/singularity/s3/base/ArtifactManager.java
@@ -194,12 +194,12 @@ public class ArtifactManager extends SimpleProcessManager {
     runCommandAndThrowRuntimeException(command);
   }
 
-  public void copy(Path source, Path destination) {
+  public void copy(Path source, Path destination, String destinationFilename) {
     log.info("Copying {} to {}", source, destination);
 
     try {
       Files.createDirectories(destination);
-      Files.copy(source, destination.resolve(source.getFileName()));
+      Files.copy(source, destination.resolve(destinationFilename));
     } catch (IOException e) {
       throw Throwables.propagate(e);
     }

--- a/SingularityS3Base/src/main/java/com/hubspot/singularity/s3/base/ArtifactManager.java
+++ b/SingularityS3Base/src/main/java/com/hubspot/singularity/s3/base/ArtifactManager.java
@@ -235,27 +235,4 @@ public class ArtifactManager extends SimpleProcessManager {
       throw Throwables.propagate(e);
     }
   }
-
-  private enum CacheCheckResult {
-    FOUND, DOES_NOT_EXIST, FILE_SIZE_MISMATCH, MD5_MISMATCH
-  }
-
-  private class CacheCheck {
-    private final CacheCheckResult cacheCheckResult;
-    private final String message;
-
-    public CacheCheck(CacheCheckResult cacheCheckResult, String message) {
-      this.cacheCheckResult = cacheCheckResult;
-      this.message = message;
-    }
-
-    public CacheCheckResult getCacheCheckResult() {
-      return cacheCheckResult;
-    }
-
-    public String getMessage() {
-      return message;
-    }
-  }
-
 }

--- a/SingularityS3Base/src/main/java/com/hubspot/singularity/s3/base/CacheCheck.java
+++ b/SingularityS3Base/src/main/java/com/hubspot/singularity/s3/base/CacheCheck.java
@@ -1,0 +1,19 @@
+package com.hubspot.singularity.s3.base;
+
+public class CacheCheck {
+  private final CacheCheckResult cacheCheckResult;
+  private final String message;
+
+  public CacheCheck(CacheCheckResult cacheCheckResult, String message) {
+    this.cacheCheckResult = cacheCheckResult;
+    this.message = message;
+  }
+
+  public CacheCheckResult getCacheCheckResult() {
+    return cacheCheckResult;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+}

--- a/SingularityS3Base/src/main/java/com/hubspot/singularity/s3/base/CacheCheckResult.java
+++ b/SingularityS3Base/src/main/java/com/hubspot/singularity/s3/base/CacheCheckResult.java
@@ -1,0 +1,5 @@
+package com.hubspot.singularity.s3.base;
+
+public enum CacheCheckResult {
+  FOUND, DOES_NOT_EXIST, FILE_SIZE_MISMATCH, MD5_MISMATCH
+}

--- a/SingularityS3Downloader/src/main/java/com/hubspot/singularity/s3downloader/server/SingularityS3DownloaderAsyncHandler.java
+++ b/SingularityS3Downloader/src/main/java/com/hubspot/singularity/s3downloader/server/SingularityS3DownloaderAsyncHandler.java
@@ -11,7 +11,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.Timer.Context;
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import com.hubspot.mesos.JavaUtils;
 import com.hubspot.singularity.runner.base.sentry.SingularityRunnerExceptionNotifier;

--- a/SingularityS3Downloader/src/main/java/com/hubspot/singularity/s3downloader/server/SingularityS3DownloaderAsyncHandler.java
+++ b/SingularityS3Downloader/src/main/java/com/hubspot/singularity/s3downloader/server/SingularityS3DownloaderAsyncHandler.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.Timer.Context;
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import com.hubspot.mesos.JavaUtils;
 import com.hubspot.singularity.runner.base.sentry.SingularityRunnerExceptionNotifier;
@@ -57,7 +58,7 @@ public class SingularityS3DownloaderAsyncHandler implements Runnable {
     if (Objects.toString(fetched.getFileName()).endsWith(".tar.gz")) {
       artifactManager.untar(fetched, targetDirectory);
     } else {
-      artifactManager.copy(fetched, targetDirectory);
+      artifactManager.copy(fetched, targetDirectory, artifactDownloadRequest.getS3Artifact().getFilename());
     }
 
     LOG.info("Finishing request {} after {}", artifactDownloadRequest.getTargetDirectory(), JavaUtils.duration(start));


### PR DESCRIPTION
If the md5 of a file changes in s3 without the file name changing, we can run into some issues when we download and try to cache the file. A file with the same name already exists in the cache, but because the md5 does not match we download it again. Some fixes and extra info for clarify:

- [x] Include the reason we attempted to redownloaded an artifact in the exception that gets thrown
- [x] Store files in the cache with md5 when appropriate so same-named files don't overlap