### PR TITLE
Updates to slave information and reconciling slaves

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosFrameworkObject.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosFrameworkObject.java
@@ -10,55 +10,105 @@ public class MesosFrameworkObject {
 
   private final String name;
   private final String id;
+  private final String pid;
+  private final String hostname;
+  private final String webuiUrl;
+  private final String user;
+  private final String role;
   private final long registeredTime;
-  private final Object active;
+  private final long unregisteredTime;
+  private final long reregisteredTime;
+  private final boolean active;
+  private final boolean checkpoint;
   private final MesosResourcesObject resources;
+  private final MesosResourcesObject usedResources;
+  private final MesosResourcesObject offeredResources;
   private final List<MesosTaskObject> tasks;
 
   @JsonCreator
-  public MesosFrameworkObject(@JsonProperty("name") String name, @JsonProperty("id") String id, @JsonProperty("registered_time") long registeredTime, @JsonProperty("active") Object active,
-      @JsonProperty("resources") MesosResourcesObject resources, @JsonProperty("tasks") List<MesosTaskObject> tasks) {
+  public MesosFrameworkObject(@JsonProperty("name") String name, @JsonProperty("id") String id, @JsonProperty("pid") String pid, @JsonProperty("hostname") String hostname, @JsonProperty("webui_url") String webuiUrl,
+      @JsonProperty("user") String user, @JsonProperty("role") String role, @JsonProperty("registered_time") long registeredTime, @JsonProperty("unregistered_time") long unregisteredTime, @JsonProperty("reregistered_time") long reregisteredTime,
+      @JsonProperty("active") boolean active, @JsonProperty("checkpoint") boolean checkpoint, @JsonProperty("resources") MesosResourcesObject resources, @JsonProperty("used_resources") MesosResourcesObject usedResources,
+      @JsonProperty("offered_resources") MesosResourcesObject offeredResources, @JsonProperty("tasks") List<MesosTaskObject> tasks) {
     this.name = name;
     this.id = id;
+    this.pid = pid;
+    this.hostname = hostname;
+    this.webuiUrl = webuiUrl;
+    this.user = user;
+    this.role = role;
+    this.checkpoint = checkpoint;
     this.registeredTime = registeredTime;
+    this.unregisteredTime = unregisteredTime;
+    this.reregisteredTime = reregisteredTime;
     this.resources = resources;
+    this.usedResources = usedResources;
+    this.offeredResources = offeredResources;
     this.tasks = tasks;
     this.active = active;
-  }
-
-  public String getId() {
-    return id;
-  }
-
-  public List<MesosTaskObject> getTasks() {
-    return tasks;
-  }
-
-  public MesosResourcesObject getResources() {
-    return resources;
   }
 
   public String getName() {
     return name;
   }
 
+  public String getId() {
+    return id;
+  }
+
+  public String getPid() {
+    return pid;
+  }
+
+  public String getHostname() {
+    return hostname;
+  }
+
+  public String getWebuiUrl() {
+    return webuiUrl;
+  }
+
+  public String getUser() {
+    return user;
+  }
+
+  public String getRole() {
+    return role;
+  }
+
   public long getRegisteredTime() {
     return registeredTime;
   }
 
-  public Object getActive() {
+  public long getUnregisteredTime() {
+    return unregisteredTime;
+  }
+
+  public long getReregisteredTime() {
+    return reregisteredTime;
+  }
+
+  public boolean isActive() {
     return active;
   }
 
-  @JsonIgnore
-  public boolean isActive() {
-    // hack to get around json changes in 0.19.1
-    if (active instanceof Integer) {
-      return (Integer) active > 0;
-    } else {
-      return Boolean.parseBoolean(active.toString());
-    }
-
+  public boolean isCheckpoint() {
+    return checkpoint;
   }
 
+  public MesosResourcesObject getResources() {
+    return resources;
+  }
+
+  public MesosResourcesObject getUsedResources() {
+    return usedResources;
+  }
+
+  public MesosResourcesObject getOfferedResources() {
+    return offeredResources;
+  }
+
+  public List<MesosTaskObject> getTasks() {
+    return tasks;
+  }
 }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosMasterSlaveObject.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosMasterSlaveObject.java
@@ -13,16 +13,30 @@ public class MesosMasterSlaveObject {
   private final Map<String, String> attributes;
   private final long registeredTime;
   private final MesosResourcesObject resources;
+  private final MesosResourcesObject usedResources;
+  private final MesosResourcesObject offeredResources;
+  private final MesosResourcesObject reservedResources;
+  private final MesosResourcesObject unreservedResources;
+  private final String version;
+  private final boolean active;
 
   @JsonCreator
   public MesosMasterSlaveObject(@JsonProperty("id") String id, @JsonProperty("pid") String pid, @JsonProperty("hostname") String hostname, @JsonProperty("registered_time") long registeredTime,
-      @JsonProperty("resources") MesosResourcesObject resources, @JsonProperty("attributes") Map<String, String> attributes) {
+      @JsonProperty("resources") MesosResourcesObject resources, @JsonProperty("attributes") Map<String, String> attributes, @JsonProperty("used_resources") MesosResourcesObject usedResources,
+      @JsonProperty("offered_resources") MesosResourcesObject offeredResources, @JsonProperty("reserved_resources") MesosResourcesObject reservedResources, @JsonProperty("unreserved_resources") MesosResourcesObject unreservedResources,
+      @JsonProperty("version") String version, @JsonProperty("active") boolean active) {
     this.id = id;
     this.pid = pid;
     this.hostname = hostname;
     this.registeredTime = registeredTime;
     this.resources = resources;
     this.attributes = attributes;
+    this.usedResources = usedResources;
+    this.offeredResources = offeredResources;
+    this.reservedResources = reservedResources;
+    this.unreservedResources = unreservedResources;
+    this.version = version;
+    this.active = active;
   }
 
   public Map<String, String> getAttributes() {
@@ -49,4 +63,27 @@ public class MesosMasterSlaveObject {
     return resources;
   }
 
+  public MesosResourcesObject getUsedResources() {
+    return usedResources;
+  }
+
+  public MesosResourcesObject getOfferedResources() {
+    return offeredResources;
+  }
+
+  public MesosResourcesObject getReservedResources() {
+    return reservedResources;
+  }
+
+  public MesosResourcesObject getUnreservedResources() {
+    return unreservedResources;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public boolean isActive() {
+    return active;
+  }
 }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosMasterStateObject.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosMasterStateObject.java
@@ -29,25 +29,11 @@ public class MesosMasterStateObject {
   private final List<MesosFrameworkObject> frameworks;
 
   @JsonCreator
-  public MesosMasterStateObject(@JsonProperty("version") String version,
-                                @JsonProperty("git_sha") String gitSha,
-                                @JsonProperty("git_tag") String gitTag,
-                                @JsonProperty("build_date") String buildDate,
-                                @JsonProperty("build_time") long buildTime,
-                                @JsonProperty("build_user") String buildUser,
-                                @JsonProperty("start_time") double startTime,
-                                @JsonProperty("elected_time") double electedTime,
-                                @JsonProperty("id") String id,
-                                @JsonProperty("pid") String pid,
-                                @JsonProperty("hostname") String hostname,
-                                @JsonProperty("activated_slaves") int activatedSlaves,
-                                @JsonProperty("deactivated_slaves") int deactivatedSlaves,
-                                @JsonProperty("cluster") String cluster,
-                                @JsonProperty("leader") String leader,
-                                @JsonProperty("log_dir") String logDir,
-                                @JsonProperty("flags") Map<String, String> flags,
-                                @JsonProperty("slaves") List<MesosMasterSlaveObject> slaves,
-                                @JsonProperty("frameworks") List<MesosFrameworkObject> frameworks) {
+  public MesosMasterStateObject(@JsonProperty("version") String version, @JsonProperty("git_sha") String gitSha, @JsonProperty("git_tag") String gitTag, @JsonProperty("build_date") String buildDate,
+      @JsonProperty("build_time") long buildTime, @JsonProperty("build_user") String buildUser, @JsonProperty("start_time") double startTime, @JsonProperty("elected_time") double electedTime,
+      @JsonProperty("id") String id, @JsonProperty("pid") String pid, @JsonProperty("hostname") String hostname, @JsonProperty("activated_slaves") int activatedSlaves,
+      @JsonProperty("deactivated_slaves") int deactivatedSlaves, @JsonProperty("cluster") String cluster, @JsonProperty("leader") String leader, @JsonProperty("log_dir") String logDir,
+      @JsonProperty("flags") Map<String, String> flags, @JsonProperty("slaves") List<MesosMasterSlaveObject> slaves, @JsonProperty("frameworks") List<MesosFrameworkObject> frameworks) {
     this.version = version;
     this.gitSha = gitSha;
     this.gitTag = gitTag;

--- a/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosMasterStateObject.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosMasterStateObject.java
@@ -1,44 +1,116 @@
 package com.hubspot.mesos.json;
 
 import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class MesosMasterStateObject {
 
+  private final String version;
+  private final String gitSha;
+  private final String gitTag;
+  private final String buildDate;
+  private final long buildTime;
+  private final String buildUser;
+  private final double startTime;
+  private final double electedTime;
+  private final String id;
+  private final String pid;
+  private final String hostname;
   private final int activatedSlaves;
   private final int deactivatedSlaves;
-
-  private final int failedTasks;
-  private final int killedTasks;
-  private final int startedTasks;
-  private final int stagedTasks;
-
+  private final String cluster;
   private final String leader;
-  private final String pid;
-
-  private final long startTime;
-
+  private final String logDir;
+  private final Map<String, String> flags;
   private final List<MesosMasterSlaveObject> slaves;
   private final List<MesosFrameworkObject> frameworks;
 
   @JsonCreator
-  public MesosMasterStateObject(@JsonProperty("activated_slaves") int activatedSlaves, @JsonProperty("deactivated_slaves") int deactivatedSlaves, @JsonProperty("failed_tasks") int failedTasks,
-      @JsonProperty("killed_tasks") int killedTasks, @JsonProperty("started_tasks") int startedTasks, @JsonProperty("staged_tasks") int stagedTasks,
-      @JsonProperty("leader") String leader, @JsonProperty("pid") String pid, @JsonProperty("start_time") long startTime,
-      @JsonProperty("slaves") List<MesosMasterSlaveObject> slaves, @JsonProperty("frameworks") List<MesosFrameworkObject> frameworks) {
+  public MesosMasterStateObject(@JsonProperty("version") String version,
+                                @JsonProperty("git_sha") String gitSha,
+                                @JsonProperty("git_tag") String gitTag,
+                                @JsonProperty("build_date") String buildDate,
+                                @JsonProperty("build_time") long buildTime,
+                                @JsonProperty("build_user") String buildUser,
+                                @JsonProperty("start_time") double startTime,
+                                @JsonProperty("elected_time") double electedTime,
+                                @JsonProperty("id") String id,
+                                @JsonProperty("pid") String pid,
+                                @JsonProperty("hostname") String hostname,
+                                @JsonProperty("activated_slaves") int activatedSlaves,
+                                @JsonProperty("deactivated_slaves") int deactivatedSlaves,
+                                @JsonProperty("cluster") String cluster,
+                                @JsonProperty("leader") String leader,
+                                @JsonProperty("log_dir") String logDir,
+                                @JsonProperty("flags") Map<String, String> flags,
+                                @JsonProperty("slaves") List<MesosMasterSlaveObject> slaves,
+                                @JsonProperty("frameworks") List<MesosFrameworkObject> frameworks) {
+    this.version = version;
+    this.gitSha = gitSha;
+    this.gitTag = gitTag;
+    this.buildDate = buildDate;
+    this.buildTime = buildTime;
+    this.buildUser = buildUser;
+    this.startTime = startTime;
+    this.electedTime = electedTime;
+    this.id = id;
+    this.pid = pid;
+    this.hostname = hostname;
     this.activatedSlaves = activatedSlaves;
     this.deactivatedSlaves = deactivatedSlaves;
-    this.failedTasks = failedTasks;
-    this.killedTasks = killedTasks;
-    this.startedTasks = startedTasks;
-    this.stagedTasks = stagedTasks;
+    this.cluster = cluster;
     this.leader = leader;
-    this.pid = pid;
-    this.startTime = startTime;
+    this.logDir = logDir;
+    this.flags = flags;
     this.slaves = slaves;
     this.frameworks = frameworks;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public String getGitSha() {
+    return gitSha;
+  }
+
+  public String getGitTag() {
+    return gitTag;
+  }
+
+  public String getBuildDate() {
+    return buildDate;
+  }
+
+  public long getBuildTime() {
+    return buildTime;
+  }
+
+  public String getBuildUser() {
+    return buildUser;
+  }
+
+  public double getStartTime() {
+    return startTime;
+  }
+
+  public double getElectedTime() {
+    return electedTime;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getPid() {
+    return pid;
+  }
+
+  public String getHostname() {
+    return hostname;
   }
 
   public int getActivatedSlaves() {
@@ -49,32 +121,20 @@ public class MesosMasterStateObject {
     return deactivatedSlaves;
   }
 
-  public int getFailedTasks() {
-    return failedTasks;
-  }
-
-  public int getKilledTasks() {
-    return killedTasks;
-  }
-
-  public int getStartedTasks() {
-    return startedTasks;
-  }
-
-  public int getStagedTasks() {
-    return stagedTasks;
+  public String getCluster() {
+    return cluster;
   }
 
   public String getLeader() {
     return leader;
   }
 
-  public String getPid() {
-    return pid;
+  public String getLogDir() {
+    return logDir;
   }
 
-  public long getStartTime() {
-    return startTime;
+  public Map<String, String> getFlags() {
+    return flags;
   }
 
   public List<MesosMasterSlaveObject> getSlaves() {
@@ -84,5 +144,4 @@ public class MesosMasterStateObject {
   public List<MesosFrameworkObject> getFrameworks() {
     return frameworks;
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosResourcesObject.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosResourcesObject.java
@@ -4,7 +4,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
@@ -18,18 +20,22 @@ public class MesosResourcesObject {
     this.properties = ImmutableMap.copyOf(checkNotNull(properties, "properties is null"));
   }
 
+  @JsonIgnore
   public Optional<Integer> getNumCpus() {
     return getResourceAsInteger("cpus");
   }
 
+  @JsonIgnore
   public Optional<Long> getDiskSpace() {
     return getResourceAsLong("disk");
   }
 
+  @JsonIgnore
   public Optional<Integer> getMemoryMegaBytes() {
     return getResourceAsInteger("mem");
   }
 
+  @JsonIgnore
   public Optional<String> getPorts() {
     return getResourceAsString("ports");
   }
@@ -52,6 +58,11 @@ public class MesosResourcesObject {
   public Optional<Object> getResourceAsObject(String resourceName) {
     checkNotNull(resourceName, "resourceName is null");
     return Optional.fromNullable(properties.get(resourceName));
+  }
+
+  @JsonAnyGetter
+  public Map<String, Object> getProperties() {
+    return properties;
   }
 
   @Override

--- a/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosResourcesObject.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosResourcesObject.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 
@@ -51,5 +52,28 @@ public class MesosResourcesObject {
   public Optional<Object> getResourceAsObject(String resourceName) {
     checkNotNull(resourceName, "resourceName is null");
     return Optional.fromNullable(properties.get(resourceName));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o)
+      return true;
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    MesosResourcesObject that = (MesosResourcesObject) o;
+    return Objects.equal(properties, that.properties);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(properties);
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+      .add("properties", properties)
+      .toString();
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosResourcesObject.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosResourcesObject.java
@@ -56,8 +56,9 @@ public class MesosResourcesObject {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o)
+    if (this == o) {
       return true;
+    }
     if (o == null || getClass() != o.getClass()) {
       return false;
     }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosTaskObject.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosTaskObject.java
@@ -1,7 +1,10 @@
 package com.hubspot.mesos.json;
 
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.hubspot.mesos.SingularityMesosTaskLabel;
 
 public class MesosTaskObject {
 
@@ -10,14 +13,19 @@ public class MesosTaskObject {
   private final String id;
   private final String name;
   private final String slaveId;
+  private final String frameworkId;
+  private final String executorId;
 
   @JsonCreator
-  public MesosTaskObject(@JsonProperty("resources") MesosResourcesObject resources, @JsonProperty("state") String state, @JsonProperty("id") String id, @JsonProperty("name") String name, @JsonProperty("slave_id") String slaveId) {
+  public MesosTaskObject(@JsonProperty("resources") MesosResourcesObject resources, @JsonProperty("state") String state, @JsonProperty("id") String id, @JsonProperty("name") String name, @JsonProperty("slave_id") String slaveId,
+    @JsonProperty("framework_id") String frameworkId, @JsonProperty("executor_id") String executorId) {
     this.resources = resources;
     this.state = state;
     this.id = id;
     this.name = name;
     this.slaveId = slaveId;
+    this.frameworkId = frameworkId;
+    this.executorId = executorId;
   }
 
   public String getSlaveId() {
@@ -40,4 +48,11 @@ public class MesosTaskObject {
     return name;
   }
 
+  public String getFrameworkId() {
+    return frameworkId;
+  }
+
+  public String getExecutorId() {
+    return executorId;
+  }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularitySlave.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularitySlave.java
@@ -60,6 +60,11 @@ public class SingularitySlave extends SingularityMachineAbstraction<SingularityS
     return "Slave";
   }
 
+  @JsonIgnore
+  public SingularitySlave withResources(MesosResourcesObject resources) {
+    return new SingularitySlave(getId(), getFirstSeenAt(), getCurrentState(), host, rackId, attributes, Optional.of(resources));
+  }
+
   @ApiModelProperty("Slave rack ID")
   public String getRackId() {
     return rackId;

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularitySlave.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularitySlave.java
@@ -5,6 +5,9 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+import com.google.common.base.Optional;
+import com.hubspot.mesos.json.MesosResourcesObject;
 import com.wordnik.swagger.annotations.ApiModel;
 import com.wordnik.swagger.annotations.ApiModelProperty;
 
@@ -14,27 +17,30 @@ public class SingularitySlave extends SingularityMachineAbstraction<SingularityS
   private final String host;
   private final String rackId;
   private final Map<String, String> attributes;
+  private final Optional<MesosResourcesObject> resources;
 
-  public SingularitySlave(String slaveId, String host, String rackId, Map<String, String> attributes) {
+  public SingularitySlave(String slaveId, String host, String rackId, Map<String, String> attributes, Optional<MesosResourcesObject> resources) {
     super(slaveId);
 
     this.host = host;
     this.rackId = rackId;
     this.attributes = attributes;
+    this.resources = resources;
   }
 
   @JsonCreator
   public SingularitySlave(@JsonProperty("slaveId") String slaveId, @JsonProperty("firstSeenAt") long firstSeenAt, @JsonProperty("currentState") SingularityMachineStateHistoryUpdate currentState,
-      @JsonProperty("host") String host, @JsonProperty("rackId") String rackId, @JsonProperty("attributes") Map<String, String> attributes) {
+      @JsonProperty("host") String host, @JsonProperty("rackId") String rackId, @JsonProperty("attributes") Map<String, String> attributes, @JsonProperty("resources") Optional<MesosResourcesObject> resources) {
     super(slaveId, firstSeenAt, currentState);
     this.host = host;
     this.rackId = rackId;
     this.attributes = attributes;
+    this.resources = resources;
   }
 
   @Override
   public SingularitySlave changeState(SingularityMachineStateHistoryUpdate newState) {
-    return new SingularitySlave(getId(), getFirstSeenAt(), newState, host, rackId, attributes);
+    return new SingularitySlave(getId(), getFirstSeenAt(), newState, host, rackId, attributes, resources);
   }
 
   @ApiModelProperty("Slave hostname")
@@ -63,9 +69,17 @@ public class SingularitySlave extends SingularityMachineAbstraction<SingularityS
     return attributes;
   }
 
-  @Override
-  public String toString() {
-    return "SingularitySlave [host=" + host + ", rackId=" + rackId + ", getId()=" + getId() + ", getFirstSeenAt()=" + getFirstSeenAt() + ", getCurrentState()=" + getCurrentState() + "]";
+  public Optional<MesosResourcesObject> getResources() {
+    return resources;
   }
 
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+      .add("host", host)
+      .add("rackId", rackId)
+      .add("attributes", attributes)
+      .add("resources", resources)
+      .toString();
+  }
 }

--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
@@ -77,6 +77,7 @@ public class SingularityClient {
   private static final String RACKS_DELETE_DECOMISSIONING_FORMAT = RACKS_FORMAT + "/rack/%s/decomissioning";
 
   private static final String SLAVES_FORMAT = "http://%s/%s/slaves";
+  private static final String SLAVE_DETAIL_FORMAT = SLAVES_FORMAT + "/slave/%s/details";
   private static final String SLAVES_DECOMISSION_FORMAT = SLAVES_FORMAT + "/slave/%s/decommission";
   private static final String SLAVES_DELETE_FORMAT = SLAVES_FORMAT + "/slave/%s/decomissioning";
 
@@ -765,6 +766,12 @@ public class SingularityClient {
     }
 
     return getCollectionWithParams(requestUri, type, maybeQueryParams, SLAVES_COLLECTION);
+  }
+
+  public Optional<SingularitySlave> getSlave(String slaveId) {
+    final String requestUri = String.format(SLAVE_DETAIL_FORMAT, getHost(), contextPath, slaveId);
+
+    return getSingle(requestUri, "slave", slaveId, SingularitySlave.class);
   }
 
   public void decomissionSlave(String slaveId) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -182,6 +182,8 @@ public class SingularityConfiguration extends Configuration {
 
   private long persistHistoryEverySeconds = TimeUnit.HOURS.toSeconds(1);
 
+  private long reconcileSlavesEveryMinutes = TimeUnit.HOURS.toMinutes(1);
+
   @JsonProperty("s3")
   private S3Configuration s3Configuration;
 
@@ -939,6 +941,14 @@ public class SingularityConfiguration extends Configuration {
 
   public void setZooKeeperConfiguration(ZooKeeperConfiguration zooKeeperConfiguration) {
     this.zooKeeperConfiguration = zooKeeperConfiguration;
+  }
+
+  public long getReconcileSlavesEveryMinutes() {
+    return reconcileSlavesEveryMinutes;
+  }
+
+  public void setReconcileSlavesEveryMinutes(long reconcileSlavesEveryMinutes) {
+    this.reconcileSlavesEveryMinutes = reconcileSlavesEveryMinutes;
   }
 
   public long getCacheTasksForMillis() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackHelper.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackHelper.java
@@ -7,15 +7,10 @@ import java.util.Map;
 import javax.inject.Singleton;
 
 import org.apache.mesos.Protos.Attribute;
-import org.apache.mesos.Protos.MasterInfo;
 import org.apache.mesos.Protos.Offer;
 
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
-import com.hubspot.mesos.MesosUtils;
-import com.hubspot.mesos.client.MesosClient;
-import com.hubspot.mesos.json.MesosMasterStateObject;
-import com.hubspot.singularity.SingularityDriverManager;
 import com.hubspot.singularity.config.MesosConfiguration;
 import com.hubspot.singularity.config.SingularityConfiguration;
 
@@ -26,21 +21,16 @@ public class SingularitySlaveAndRackHelper {
   private final String defaultRackId;
 
   private final SingularityConfiguration configuration;
-  private final SingularitySlaveAndRackManager slaveAndRackManager;
-  private final MesosClient mesosClient;
-  private final SingularityDriverManager driverManager;
 
   @Inject
-  public SingularitySlaveAndRackHelper(SingularityConfiguration configuration, SingularitySlaveAndRackManager slaveAndRackManager, MesosClient mesosClient, SingularityDriverManager driverManager) {
+  public SingularitySlaveAndRackHelper(SingularityConfiguration configuration) {
     this.configuration = configuration;
 
     MesosConfiguration mesosConfiguration = configuration.getMesosConfiguration();
 
     this.rackIdAttributeKey = mesosConfiguration.getRackIdAttributeKey();
     this.defaultRackId = mesosConfiguration.getDefaultRackId();
-    this.slaveAndRackManager = slaveAndRackManager;
-    this.mesosClient = mesosClient;
-    this.driverManager = driverManager;
+
   }
 
   public String getMaybeTruncatedHost(String hostname) {
@@ -124,16 +114,6 @@ public class SingularitySlaveAndRackHelper {
       }
     }
     return true;
-  }
-
-  public void refreshSlavesAndRacks() {
-    Optional<MasterInfo> maybeMasterInfo = driverManager.getMaster();
-    if (maybeMasterInfo.isPresent()) {
-      final String uri = mesosClient.getMasterUri(MesosUtils.getMasterHostAndPort(maybeMasterInfo.get()));
-      MesosMasterStateObject state = mesosClient.getMasterState(uri);
-
-      slaveAndRackManager.loadSlavesAndRacksFromMaster(state, false);
-    }
   }
 
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackHelper.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackHelper.java
@@ -7,10 +7,15 @@ import java.util.Map;
 import javax.inject.Singleton;
 
 import org.apache.mesos.Protos.Attribute;
+import org.apache.mesos.Protos.MasterInfo;
 import org.apache.mesos.Protos.Offer;
 
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
+import com.hubspot.mesos.MesosUtils;
+import com.hubspot.mesos.client.MesosClient;
+import com.hubspot.mesos.json.MesosMasterStateObject;
+import com.hubspot.singularity.SingularityDriverManager;
 import com.hubspot.singularity.config.MesosConfiguration;
 import com.hubspot.singularity.config.SingularityConfiguration;
 
@@ -21,15 +26,21 @@ public class SingularitySlaveAndRackHelper {
   private final String defaultRackId;
 
   private final SingularityConfiguration configuration;
+  private final SingularitySlaveAndRackManager slaveAndRackManager;
+  private final MesosClient mesosClient;
+  private final SingularityDriverManager driverManager;
 
   @Inject
-  public SingularitySlaveAndRackHelper(SingularityConfiguration configuration) {
+  public SingularitySlaveAndRackHelper(SingularityConfiguration configuration, SingularitySlaveAndRackManager slaveAndRackManager, MesosClient mesosClient, SingularityDriverManager driverManager) {
     this.configuration = configuration;
 
     MesosConfiguration mesosConfiguration = configuration.getMesosConfiguration();
 
     this.rackIdAttributeKey = mesosConfiguration.getRackIdAttributeKey();
     this.defaultRackId = mesosConfiguration.getDefaultRackId();
+    this.slaveAndRackManager = slaveAndRackManager;
+    this.mesosClient = mesosClient;
+    this.driverManager = driverManager;
   }
 
   public String getMaybeTruncatedHost(String hostname) {
@@ -113,6 +124,16 @@ public class SingularitySlaveAndRackHelper {
       }
     }
     return true;
+  }
+
+  public void refreshSlavesAndRacks() {
+    Optional<MasterInfo> maybeMasterInfo = driverManager.getMaster();
+    if (maybeMasterInfo.isPresent()) {
+      final String uri = mesosClient.getMasterUri(MesosUtils.getMasterHostAndPort(maybeMasterInfo.get()));
+      MesosMasterStateObject state = mesosClient.getMasterState(uri);
+
+      slaveAndRackManager.loadSlavesAndRacksFromMaster(state, false);
+    }
   }
 
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
@@ -24,6 +24,7 @@ import com.google.inject.name.Named;
 import com.hubspot.mesos.JavaUtils;
 import com.hubspot.mesos.json.MesosMasterSlaveObject;
 import com.hubspot.mesos.json.MesosMasterStateObject;
+import com.hubspot.mesos.json.MesosResourcesObject;
 import com.hubspot.singularity.MachineState;
 import com.hubspot.singularity.SingularityMachineAbstraction;
 import com.hubspot.singularity.SingularityRack;
@@ -257,7 +258,7 @@ public class SingularitySlaveAndRackManager {
       if (activeSlavesById.containsKey(slaveId)) {
         activeSlavesById.remove(slaveId);
       } else {
-        SingularitySlave newSlave = new SingularitySlave(slaveId, host, rackId, textAttributes);
+        SingularitySlave newSlave = new SingularitySlave(slaveId, host, rackId, textAttributes, Optional.of(slaveJsonObject.getResources()));
 
         if (check(newSlave, slaveManager) == CheckResult.NEW) {
           slaves++;
@@ -325,7 +326,7 @@ public class SingularitySlaveAndRackManager {
     final String host = slaveAndRackHelper.getMaybeTruncatedHost(offer);
     final Map<String, String> textAttributes = slaveAndRackHelper.getTextAttributes(offer);
 
-    final SingularitySlave slave = new SingularitySlave(slaveId, host, rackId, textAttributes);
+    final SingularitySlave slave = new SingularitySlave(slaveId, host, rackId, textAttributes, Optional.<MesosResourcesObject>absent());
 
     if (check(slave, slaveManager) == CheckResult.NEW) {
       LOG.info("Offer revealed a new slave {}", slave);

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
@@ -257,7 +257,9 @@ public class SingularitySlaveAndRackManager {
 
       if (activeSlavesById.containsKey(slaveId)) {
         SingularitySlave slave = activeSlavesById.get(slaveId);
+        LOG.debug("Checking slaves {} against json {}", slave, slaveJsonObject);
         if (slave != null && (!slave.getResources().isPresent() || !slave.getResources().get().equals(slaveJsonObject.getResources()))) {
+          LOG.trace("Found updated resources ({}) for slave {}", slaveJsonObject.getResources(), slave);
           slaveManager.saveObject(slave.withResources(slaveJsonObject.getResources()));
         }
         activeSlavesById.remove(slaveId);

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
@@ -257,7 +257,6 @@ public class SingularitySlaveAndRackManager {
 
       if (activeSlavesById.containsKey(slaveId)) {
         SingularitySlave slave = activeSlavesById.get(slaveId);
-        LOG.debug("Checking slaves {} against json {}", slave, slaveJsonObject);
         if (slave != null && (!slave.getResources().isPresent() || !slave.getResources().get().equals(slaveJsonObject.getResources()))) {
           LOG.trace("Found updated resources ({}) for slave {}", slaveJsonObject.getResources(), slave);
           slaveManager.saveObject(slave.withResources(slaveJsonObject.getResources()));

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
@@ -239,7 +239,7 @@ class SingularitySlaveAndRackManager {
     }
   }
 
-  public void loadSlavesAndRacksFromMaster(MesosMasterStateObject state) {
+  public void loadSlavesAndRacksFromMaster(MesosMasterStateObject state, boolean isStartup) {
     Map<String, SingularitySlave> activeSlavesById = slaveManager.getObjectsByIdForState(MachineState.ACTIVE);
     Map<String, SingularityRack> activeRacksById = rackManager.getObjectsByIdForState(MachineState.ACTIVE);
 
@@ -276,11 +276,11 @@ class SingularitySlaveAndRackManager {
     }
 
     for (SingularitySlave leftOverSlave : activeSlavesById.values()) {
-      slaveManager.changeState(leftOverSlave, MachineState.MISSING_ON_STARTUP, Optional.<String> absent(), Optional.<String> absent());
+      slaveManager.changeState(leftOverSlave, isStartup ? MachineState.MISSING_ON_STARTUP : MachineState.DEAD, Optional.<String> absent(), Optional.<String> absent());
     }
 
     for (SingularityRack leftOverRack : remainingActiveRacks.values()) {
-      rackManager.changeState(leftOverRack, MachineState.MISSING_ON_STARTUP, Optional.<String> absent(), Optional.<String> absent());
+      rackManager.changeState(leftOverRack, isStartup ? MachineState.MISSING_ON_STARTUP : MachineState.DEAD, Optional.<String> absent(), Optional.<String> absent());
     }
 
     LOG.info("Found {} new racks ({} missing) and {} new slaves ({} missing)", racks, remainingActiveRacks.size(), slaves, activeSlavesById.size());

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
@@ -42,7 +42,7 @@ import com.hubspot.singularity.scheduler.SingularitySchedulerStateCache;
 import com.hubspot.singularity.sentry.SingularityExceptionNotifier;
 
 @Singleton
-class SingularitySlaveAndRackManager {
+public class SingularitySlaveAndRackManager {
 
   private static final Logger LOG = LoggerFactory.getLogger(SingularitySlaveAndRackManager.class);
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
@@ -256,6 +256,10 @@ public class SingularitySlaveAndRackManager {
       String host = slaveAndRackHelper.getMaybeTruncatedHost(slaveJsonObject.getHostname());
 
       if (activeSlavesById.containsKey(slaveId)) {
+        SingularitySlave slave = activeSlavesById.get(slaveId);
+        if (slave != null && (!slave.getResources().isPresent() || slave.getResources().get() != slaveJsonObject.getResources())) {
+          slaveManager.saveObject(slave.withResources(slaveJsonObject.getResources()));
+        }
         activeSlavesById.remove(slaveId);
       } else {
         SingularitySlave newSlave = new SingularitySlave(slaveId, host, rackId, textAttributes, Optional.of(slaveJsonObject.getResources()));

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
@@ -257,7 +257,7 @@ public class SingularitySlaveAndRackManager {
 
       if (activeSlavesById.containsKey(slaveId)) {
         SingularitySlave slave = activeSlavesById.get(slaveId);
-        if (slave != null && (!slave.getResources().isPresent() || slave.getResources().get() != slaveJsonObject.getResources())) {
+        if (slave != null && (!slave.getResources().isPresent() || !slave.getResources().get().equals(slaveJsonObject.getResources()))) {
           slaveManager.saveObject(slave.withResources(slaveJsonObject.getResources()));
         }
         activeSlavesById.remove(slaveId);

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityStartup.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityStartup.java
@@ -81,7 +81,7 @@ class SingularityStartup {
 
     MesosMasterStateObject state = mesosClient.getMasterState(uri);
 
-    slaveAndRackManager.loadSlavesAndRacksFromMaster(state);
+    slaveAndRackManager.loadSlavesAndRacksFromMaster(state, true);
 
     checkSchedulerForInconsistentState();
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/SlaveResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/SlaveResource.java
@@ -58,6 +58,13 @@ public class SlaveResource extends AbstractMachineResource<SingularitySlave> {
     return manager.getHistory(slaveId);
   }
 
+  @GET
+  @Path("/slave/{slaveId}/details")
+  @ApiOperation("Get information about a particular slave")
+  public Optional<SingularitySlave> getSlave(@ApiParam("Slave ID") @PathParam("slaveId") String slaveId) {
+    return manager.getObject(slaveId);
+  }
+
   @DELETE
   @Path("/slave/{slaveId}")
   @ApiOperation("Remove a known slave, erasing history. This operation will cancel decomissioning of the slave")

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularitySchedulerModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularitySchedulerModule.java
@@ -13,7 +13,7 @@ public class SingularitySchedulerModule extends AbstractModule {
     bind(SingularityCleanupPoller.class).in(Scopes.SINGLETON);
     bind(SingularityExpiringUserActionPoller.class).in(Scopes.SINGLETON);
     bind(SingularityHistoryPurger.class).in(Scopes.SINGLETON);
-    bind(SingularityDeadSlavePoller.class).in(Scopes.SINGLETON);
+    bind(SingularitySlaveReconciliationPoller.class).in(Scopes.SINGLETON);
     bind(SingularityCooldownPoller.class).in(Scopes.SINGLETON);
     bind(SingularityDeployPoller.class).in(Scopes.SINGLETON);
     bind(SingularityCooldownPoller.class).in(Scopes.SINGLETON);

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityMachineStatesTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityMachineStatesTest.java
@@ -44,8 +44,8 @@ public class SingularityMachineStatesTest extends SingularitySchedulerTestBase {
 
   @Test
   public void testDeadSlavesArePurged() {
-    SingularitySlave liveSlave = new SingularitySlave("1", "h1", "r1", ImmutableMap.of("uniqueAttribute", "1"));
-    SingularitySlave deadSlave = new SingularitySlave("2", "h1", "r1", ImmutableMap.of("uniqueAttribute", "2"));
+    SingularitySlave liveSlave = new SingularitySlave("1", "h1", "r1", ImmutableMap.of("uniqueAttribute", "1"), Optional.<MesosResourcesObject>absent());
+    SingularitySlave deadSlave = new SingularitySlave("2", "h1", "r1", ImmutableMap.of("uniqueAttribute", "2"), Optional.<MesosResourcesObject>absent());
 
     final long now = System.currentTimeMillis();
 
@@ -415,12 +415,12 @@ public class SingularityMachineStatesTest extends SingularitySchedulerTestBase {
 
     List<MesosMasterSlaveObject> slaves = new ArrayList<>();
     for (Integer i = 0; i < numSlaves; i++) {
-      slaves.add(new MesosMasterSlaveObject(i.toString(), i.toString(), String.format("localhost:505%s", i), now, new MesosResourcesObject(resources), attributes));
+      slaves.add(new MesosMasterSlaveObject(i.toString(), i.toString(), String.format("localhost:505%s", i), now, new MesosResourcesObject(resources), attributes, new MesosResourcesObject(resources), new MesosResourcesObject(resources), new MesosResourcesObject(resources), new MesosResourcesObject(resources), "", true));
     }
 
-    MesosFrameworkObject framework = new MesosFrameworkObject("test", "test", now, "active", new MesosResourcesObject(resources), Collections.<MesosTaskObject>emptyList());
+    MesosFrameworkObject framework = new MesosFrameworkObject("", "", "", "", "", "", "", now, now, now, true, true, new MesosResourcesObject(resources), new MesosResourcesObject(resources), new MesosResourcesObject(resources), Collections.<MesosTaskObject>emptyList());
 
-    return new MesosMasterStateObject(1, 1, 0, 0, 0, 0, "YES", "10", now, slaves, Collections.singletonList(framework));
+    return new MesosMasterStateObject("", "", "", "", now, "", now, now, "", "", "", 0, 0, "", "", "", Collections.<String, String>emptyMap(), slaves, Collections.singletonList(framework));
   }
 
 }

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityMachineStatesTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityMachineStatesTest.java
@@ -1,6 +1,11 @@
 package com.hubspot.singularity.scheduler;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.mesos.Protos.SlaveID;
@@ -11,6 +16,11 @@ import org.junit.Test;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
+import com.hubspot.mesos.json.MesosFrameworkObject;
+import com.hubspot.mesos.json.MesosMasterSlaveObject;
+import com.hubspot.mesos.json.MesosMasterStateObject;
+import com.hubspot.mesos.json.MesosResourcesObject;
+import com.hubspot.mesos.json.MesosTaskObject;
 import com.hubspot.singularity.MachineState;
 import com.hubspot.singularity.SingularityMachineStateHistoryUpdate;
 import com.hubspot.singularity.SingularitySlave;
@@ -18,11 +28,15 @@ import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.SlavePlacement;
 import com.hubspot.singularity.api.SingularityMachineChangeRequest;
 import com.hubspot.singularity.data.AbstractMachineManager.StateChangeResult;
+import com.hubspot.singularity.mesos.SingularitySlaveAndRackManager;
 
 public class SingularityMachineStatesTest extends SingularitySchedulerTestBase {
 
   @Inject
-  protected SingularityDeadSlavePoller deadSlavePoller;
+  protected SingularitySlaveReconciliationPoller slaveReconciliationPoller;
+
+  @Inject
+  private SingularitySlaveAndRackManager singularitySlaveAndRackManager;
 
   public SingularityMachineStatesTest() {
     super(false);
@@ -41,14 +55,14 @@ public class SingularityMachineStatesTest extends SingularitySchedulerTestBase {
     slaveManager.saveObject(liveSlave);
     slaveManager.saveObject(deadSlave);
 
-    deadSlavePoller.runActionOnPoll();
+    slaveReconciliationPoller.runActionOnPoll();
 
     Assert.assertEquals(1, slaveManager.getObjectsFiltered(MachineState.ACTIVE).size());
     Assert.assertEquals(1, slaveManager.getObjectsFiltered(MachineState.DEAD).size());
 
     configuration.setDeleteDeadSlavesAfterHours(1);
 
-    deadSlavePoller.runActionOnPoll();
+    slaveReconciliationPoller.runActionOnPoll();
 
     Assert.assertEquals(1, slaveManager.getObjectsFiltered(MachineState.ACTIVE).size());
     Assert.assertEquals(0, slaveManager.getObjectsFiltered(MachineState.DEAD).size());
@@ -354,6 +368,59 @@ public class SingularityMachineStatesTest extends SingularitySchedulerTestBase {
     Assert.assertEquals(0, taskManager.getTasksOnSlave(taskManager.getActiveTaskIds(), slaveManager.getObject("slave1").get()).size());
     Assert.assertEquals(2, taskManager.getTasksOnSlave(taskManager.getActiveTaskIds(), slaveManager.getObject("slave2").get()).size());
     Assert.assertTrue(slaveManager.getObject("slave1").get().getCurrentState().getState() == MachineState.DECOMMISSIONED);
+  }
+
+  @Test
+  public void testLoadSlavesFromMasterDataOnStartup() {
+    MesosMasterStateObject state = getMasterState(3);
+    singularitySlaveAndRackManager.loadSlavesAndRacksFromMaster(state, true);
+
+    List<SingularitySlave> slaves = slaveManager.getObjects();
+
+    Assert.assertEquals(3, slaves.size());
+    for (SingularitySlave slave : slaves) {
+      Assert.assertEquals(MachineState.ACTIVE, slave.getCurrentState().getState());
+    }
+  }
+
+  @Test
+  public void testReconcileSlaves() {
+    // Load 3 slaves on startup
+    MesosMasterStateObject state = getMasterState(3);
+    singularitySlaveAndRackManager.loadSlavesAndRacksFromMaster(state, true);
+
+    MesosMasterStateObject newState = getMasterState(2); // 2 slaves, third has died
+    singularitySlaveAndRackManager.loadSlavesAndRacksFromMaster(newState, false);
+    List<SingularitySlave> slaves = slaveManager.getObjects();
+
+    Assert.assertEquals(3, slaves.size());
+
+    for (SingularitySlave slave : slaves) {
+      if (slave.getId().equals("2")) {
+        Assert.assertEquals(MachineState.DEAD, slave.getCurrentState().getState());
+      } else {
+        Assert.assertEquals(MachineState.ACTIVE, slave.getCurrentState().getState());
+      }
+    }
+  }
+
+  private MesosMasterStateObject getMasterState(int numSlaves) {
+    long now = System.currentTimeMillis();
+    Map<String, Object> resources = new HashMap<>();
+    resources.put("cpus", 10);
+    resources.put("mem", 2000);
+
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put("testKey", "testValue");
+
+    List<MesosMasterSlaveObject> slaves = new ArrayList<>();
+    for (Integer i = 0; i < numSlaves; i++) {
+      slaves.add(new MesosMasterSlaveObject(i.toString(), i.toString(), String.format("localhost:505%s", i), now, new MesosResourcesObject(resources), attributes));
+    }
+
+    MesosFrameworkObject framework = new MesosFrameworkObject("test", "test", now, "active", new MesosResourcesObject(resources), Collections.<MesosTaskObject>emptyList());
+
+    return new MesosMasterStateObject(1, 1, 0, 0, 0, 0, "YES", "10", now, slaves, Collections.singletonList(framework));
   }
 
 }


### PR DESCRIPTION
A few things in this PR:
- Updates the POJOs representing the mesos master state json. They have changed quite a bit since we last visited those
- Adds the resources to the `SingularitySlave` object so we can have that as extra information
- Updates the dead slave poller to run on a configurable interval and also reconcile the list of slaves with the mesos master /fixes #637 
- Added a `slave/{slaveId}/details` endpoint to get the full json (not just history) for a particular slave /fixes #621 