### PR TITLE
abort if the status update thread has stopped running

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityAbort.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityAbort.java
@@ -58,7 +58,7 @@ public class SingularityAbort implements ConnectionStateListener {
   }
 
   public enum AbortReason {
-    LOST_ZK_CONNECTION, LOST_LEADERSHIP, UNRECOVERABLE_ERROR, TEST_ABORT, MESOS_ERROR;
+    LOST_ZK_CONNECTION, LOST_LEADERSHIP, UNRECOVERABLE_ERROR, TEST_ABORT, MESOS_ERROR, NO_RUNNING_STATUS_UPDATE_THREAD;
   }
 
   public void abort(AbortReason abortReason, Optional<Throwable> throwable) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosStatusUpdateHandler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosStatusUpdateHandler.java
@@ -3,6 +3,7 @@ package com.hubspot.singularity.mesos;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
@@ -23,6 +24,7 @@ import com.google.inject.name.Named;
 import com.hubspot.singularity.ExtendedTaskState;
 import com.hubspot.singularity.InvalidSingularityTaskIdException;
 import com.hubspot.singularity.SingularityAbort;
+import com.hubspot.singularity.SingularityAbort.AbortReason;
 import com.hubspot.singularity.SingularityCreateResult;
 import com.hubspot.singularity.SingularityMainModule;
 import com.hubspot.singularity.SingularityPendingDeploy;
@@ -70,6 +72,8 @@ public class SingularityMesosStatusUpdateHandler implements Managed {
     private final SingularityAbort singularityAbort;
     private final SingularityConfiguration configuration;
     private final Multiset<Protos.TaskStatus.Reason> taskLostReasons;
+
+    private Future statusUpdateFuture;
 
     @Inject
     public SingularityMesosStatusUpdateHandler(TaskManager taskManager, DeployManager deployManager, RequestManager requestManager,
@@ -278,9 +282,13 @@ public class SingularityMesosStatusUpdateHandler implements Managed {
     public void enqueueStatusUpdate(Protos.TaskStatus status) {
         if (processStatusUpdatesInSeparateThread) {
             try {
+                if (statusUpdateFuture == null || statusUpdateFuture.isDone()) {
+                    singularityAbort.abort(AbortReason.NO_RUNNING_STATUS_UPDATE_THREAD, Optional.<Throwable>absent());
+                }
                 statusUpdateQueue.put(status);
             } catch (InterruptedException ie) {
-                // TODO: what's the best thing to do here?
+                // If we do not ack the status update it will be resent, can log this and move on
+                LOG.error("Interrupted while adding status update to queue", ie);
             }
         } else {
             processStatusUpdate(status);
@@ -298,7 +306,7 @@ public class SingularityMesosStatusUpdateHandler implements Managed {
             return;
         }
 
-        executorService.submit(new Runnable() {
+        statusUpdateFuture = executorService.submit(new Runnable() {
             @Override
             public void run() {
                 LOG.info("Status update handler thread started");


### PR DESCRIPTION
@tpetr the addition to the status update changes we were talking about
- Abort if there isn't a status update thread running since status updates are such a core piece of things
- Update the InterruptedException on adding to the queue to just keep going. Since we won't have acked the status update, it will just be sent again and we'll get it on the next go.