### PR TITLE
Consider tasks with skipped healthchecks in cleaner

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
@@ -302,38 +302,38 @@ public class SingularityRequest {
     return taskPriorityLevel;
   }
 
-  @Override
-  public String toString() {
-    return "SingularityRequest[" +
-            "id='" + id + '\'' +
-            ", requestType=" + requestType +
-            ", owners=" + owners +
-            ", numRetriesOnFailure=" + numRetriesOnFailure +
-            ", schedule=" + schedule +
-            ", quartzSchedule=" + quartzSchedule +
-            ", scheduleTimeZone=" + scheduleTimeZone +
-            ", scheduleType=" + scheduleType +
-            ", killOldNonLongRunningTasksAfterMillis=" + killOldNonLongRunningTasksAfterMillis +
-            ", taskExecutionTimeLimitMillis=" + taskExecutionTimeLimitMillis +
-            ", scheduledExpectedRuntimeMillis=" + scheduledExpectedRuntimeMillis +
-            ", waitAtLeastMillisAfterTaskFinishesForReschedule=" + waitAtLeastMillisAfterTaskFinishesForReschedule +
-            ", instances=" + instances +
-            ", rackSensitive=" + rackSensitive +
-            ", rackAffinity=" + rackAffinity +
-            ", slavePlacement=" + slavePlacement +
-            ", requiredSlaveAttributes=" + requiredSlaveAttributes +
-            ", allowedSlaveAttributes=" + allowedSlaveAttributes +
-            ", loadBalanced=" + loadBalanced +
-            ", group=" + group +
-            ", readWriteGroups" + readWriteGroups +
-            ", readOnlyGroups=" + readOnlyGroups +
-            ", bounceAfterScale=" + bounceAfterScale +
-            ", emailConfigurationOverrides=" + emailConfigurationOverrides +
-            ", hideEvenNumberAcrossRacksHint=" + hideEvenNumberAcrossRacksHint +
-            ", taskLogErrorRegex=" + taskLogErrorRegex +
-            ", taskLogErrorRegexCaseSensitive=" + taskLogErrorRegexCaseSensitive +
-            ", taskPriorityLevel=" + taskPriorityLevel +
-            ']';
+  @Override public String toString() {
+    return com.google.common.base.Objects.toStringHelper(this)
+      .add("id", id)
+      .add("requestType", requestType)
+      .add("owners", owners)
+      .add("numRetriesOnFailure", numRetriesOnFailure)
+      .add("schedule", schedule)
+      .add("quartzSchedule", quartzSchedule)
+      .add("scheduleType", scheduleType)
+      .add("scheduleTimeZone", scheduleTimeZone)
+      .add("killOldNonLongRunningTasksAfterMillis", killOldNonLongRunningTasksAfterMillis)
+      .add("taskExecutionTimeLimitMillis", taskExecutionTimeLimitMillis)
+      .add("scheduledExpectedRuntimeMillis", scheduledExpectedRuntimeMillis)
+      .add("waitAtLeastMillisAfterTaskFinishesForReschedule", waitAtLeastMillisAfterTaskFinishesForReschedule)
+      .add("instances", instances)
+      .add("skipHealthchecks", skipHealthchecks)
+      .add("rackSensitive", rackSensitive)
+      .add("rackAffinity", rackAffinity)
+      .add("slavePlacement", slavePlacement)
+      .add("requiredSlaveAttributes", requiredSlaveAttributes)
+      .add("allowedSlaveAttributes", allowedSlaveAttributes)
+      .add("loadBalanced", loadBalanced)
+      .add("group", group)
+      .add("readWriteGroups", readWriteGroups)
+      .add("readOnlyGroups", readOnlyGroups)
+      .add("bounceAfterScale", bounceAfterScale)
+      .add("emailConfigurationOverrides", emailConfigurationOverrides)
+      .add("hideEvenNumberAcrossRacksHint", hideEvenNumberAcrossRacksHint)
+      .add("taskLogErrorRegex", taskLogErrorRegex)
+      .add("taskLogErrorRegexCaseSensitive", taskLogErrorRegexCaseSensitive)
+      .add("taskPriorityLevel", taskPriorityLevel)
+      .toString();
   }
 
   @Override

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
@@ -228,8 +228,7 @@ public class RequestManager extends CuratorAsyncManager {
     return getData(getPendingPath(requestId, deployId), pendingRequestTranscoder);
   }
 
-  @VisibleForTesting
-  protected SingularityCreateResult saveHistory(SingularityRequestHistory history) {
+  public SingularityCreateResult saveHistory(SingularityRequestHistory history) {
     final String path = getHistoryPath(history);
 
     singularityEventListener.requestHistoryEvent(history);

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityDeployHealthHelper.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityDeployHealthHelper.java
@@ -16,17 +16,14 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import com.hubspot.mesos.JavaUtils;
-import com.hubspot.singularity.DeployState;
 import com.hubspot.singularity.ExtendedTaskState;
 import com.hubspot.singularity.SingularityDeploy;
 import com.hubspot.singularity.SingularityDeployFailure;
 import com.hubspot.singularity.SingularityDeployFailureReason;
-import com.hubspot.singularity.SingularityDeployResult;
 import com.hubspot.singularity.SingularityRequest;
 import com.hubspot.singularity.SingularityRequestHistory;
 import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.SingularityTaskHealthcheckResult;
-import com.hubspot.singularity.SingularityTaskHistory;
 import com.hubspot.singularity.SingularityTaskHistoryUpdate;
 import com.hubspot.singularity.SingularityTaskHistoryUpdate.SimplifiedTaskState;
 import com.hubspot.singularity.SingularityTaskId;
@@ -43,14 +40,12 @@ public class SingularityDeployHealthHelper {
   private final TaskManager taskManager;
   private final SingularityConfiguration configuration;
   private final RequestManager requestManager;
-  private final DeployManager deployManager;
 
   @Inject
-  public SingularityDeployHealthHelper(TaskManager taskManager, SingularityConfiguration configuration, RequestManager requestManager, DeployManager deployManager) {
+  public SingularityDeployHealthHelper(TaskManager taskManager, SingularityConfiguration configuration, RequestManager requestManager) {
     this.taskManager = taskManager;
     this.configuration = configuration;
     this.requestManager = requestManager;
-    this.deployManager = deployManager;
   }
 
   public enum DeployHealth {

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityDeployHealthHelper.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityDeployHealthHelper.java
@@ -179,6 +179,7 @@ public class SingularityDeployHealthHelper {
     for (SingularityTaskId taskId : matchingActiveTasks) {
       DeployHealth individualTaskHealth;
       if (healthchecksSkipped(taskId, requestHistories, deploy)) {
+        LOG.trace("Detected skipped healthchecks for {}", taskId);
         individualTaskHealth = DeployHealth.HEALTHY;
       } else {
         individualTaskHealth = getTaskHealth(deploy, isDeployPending, Optional.fromNullable(healthcheckResults.get(taskId)), taskId);
@@ -204,7 +205,6 @@ public class SingularityDeployHealthHelper {
 
       Optional<Long> runningStartTime = Optional.absent();
       for (SingularityTaskHistoryUpdate historyUpdate : taskManager.getTaskHistoryUpdates(taskId)) {
-        LOG.info("{}", historyUpdate);
         if (historyUpdate.getTaskState() == ExtendedTaskState.TASK_RUNNING) {
           runningStartTime = Optional.of(historyUpdate.getTimestamp());
         }

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -78,6 +78,7 @@ import com.hubspot.singularity.api.SingularityScaleRequest;
 import com.hubspot.singularity.api.SingularityUnpauseRequest;
 import com.hubspot.singularity.data.AbstractMachineManager.StateChangeResult;
 import com.hubspot.singularity.data.SingularityValidator;
+import com.hubspot.singularity.scheduler.SingularityDeployHealthHelper.DeployHealth;
 import com.hubspot.singularity.scheduler.SingularityTaskReconciliation.ReconciliationState;
 
 public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
@@ -1683,5 +1684,9 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     List<SingularityTaskId> healthyTaskIds = deployHealthHelper.getHealthyTasks(updatedRequest, Optional.of(firstDeploy), activeTaskIds, false);
     Assert.assertTrue(!healthyTaskIds.contains(unhealthyTaskThree.getTaskId()));
     Assert.assertEquals(2, healthyTaskIds.size()); // Healthchecked and skip-healthchecked tasks should both be here
+    Assert.assertEquals(DeployHealth.WAITING, deployHealthHelper.getDeployHealth(updatedRequest, Optional.of(firstDeploy), activeTaskIds, false));
+
+    taskManager.saveHealthcheckResult(new SingularityTaskHealthcheckResult(Optional.of(200), Optional.of(1000L), now + 6000, Optional.<String> absent(), Optional.<String> absent(), unhealthyTaskThree.getTaskId()));
+    Assert.assertEquals(DeployHealth.HEALTHY, deployHealthHelper.getDeployHealth(updatedRequest, Optional.of(firstDeploy), activeTaskIds, false));
   }
 }


### PR DESCRIPTION
Currently, if a task is launched during a period when `skipHealthchecks: true` is set on the corresponding request, the resulting task has no health checks. So if, for example, a slave is decommissioned, the cleaner will check for the presence of health checks on _all_ tasks before shutting old ones down. Because the task in question skipped checks, the total healthy task count will never be correct and old tasks will not get shut down properly.

This PR updates the `DeployHealthHelper`'s `getTaskHealth` method to also check for skipped health checks. If the deploy or pending task had the property set or the `SingularityRequest` data that was active when the task entered `TASK_RUNNING` had it set, we know health checks had been skipped for that task, and we consider it healthy.

The one caveat of this is if the request was updated to have health checks skipped after the task entered running but before the checker ran. However, we do not currently save any timestamp or even for considering a task as healthy, so we cannot tackle that case without some more involved changes.