### PR TITLE
More even distribution among racks

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/TaskCleanupType.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/TaskCleanupType.java
@@ -4,7 +4,7 @@ public enum TaskCleanupType {
 
   USER_REQUESTED(true, true), USER_REQUESTED_TASK_BOUNCE(false, false), DECOMISSIONING(false, false), SCALING_DOWN(true, false), BOUNCING(false, false), INCREMENTAL_BOUNCE(false, false),
   DEPLOY_FAILED(true, true), NEW_DEPLOY_SUCCEEDED(true, false), DEPLOY_STEP_FINISHED(true, false), DEPLOY_CANCELED(true, true), TASK_EXCEEDED_TIME_LIMIT(true, true), UNHEALTHY_NEW_TASK(true, true),
-  OVERDUE_NEW_TASK(true, true), USER_REQUESTED_DESTROY(true, true), INCREMENTAL_DEPLOY_FAILED(false, true), INCREMENTAL_DEPLOY_CANCELLED(false, true), PRIORITY_KILL(true, true);
+  OVERDUE_NEW_TASK(true, true), USER_REQUESTED_DESTROY(true, true), INCREMENTAL_DEPLOY_FAILED(false, true), INCREMENTAL_DEPLOY_CANCELLED(false, true), PRIORITY_KILL(true, true), REBALANCE_RACKS(false, false);
 
   private final boolean killLongRunningTaskInstantly;
   private final boolean killNonLongRunningTaskInstantly;

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -282,6 +282,8 @@ public class SingularityConfiguration extends Configuration {
   @Max(5)
   private double schedulerPriorityWeightFactor = 1.0;
 
+  private boolean rebalanceRacksOnScaleDown = false;
+
   public long getAskDriverToKillTasksAgainAfterMillis() {
     return askDriverToKillTasksAgainAfterMillis;
   }
@@ -1113,5 +1115,13 @@ public class SingularityConfiguration extends Configuration {
 
   public void setSchedulerPriorityWeightFactor(double schedulerPriorityWeightFactor) {
     this.schedulerPriorityWeightFactor = schedulerPriorityWeightFactor;
+  }
+
+  public boolean isRebalanceRacksOnScaleDown() {
+    return rebalanceRacksOnScaleDown;
+  }
+
+  public void setRebalanceRacksOnScaleDown(boolean rebalanceRacksOnScaleDown) {
+    this.rebalanceRacksOnScaleDown = rebalanceRacksOnScaleDown;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
@@ -17,8 +17,10 @@ import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.annotation.Timed;
 import com.google.common.base.Optional;
+import com.google.common.collect.HashMultiset;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Multiset;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.hubspot.mesos.JavaUtils;
@@ -129,7 +131,7 @@ class SingularitySlaveAndRackManager {
     }
 
     final int numDesiredInstances = taskRequest.getRequest().getInstancesSafe();
-    double numOnRack = 0;
+    Multiset<String> countPerRack = HashMultiset.create(stateCache.getNumActiveRacks());
     double numOnSlave = 0;
     double numCleaningOnSlave = 0;
     double numOtherDeploysOnSlave = 0;
@@ -151,18 +153,13 @@ class SingularitySlaveAndRackManager {
           numOtherDeploysOnSlave++;
         }
       }
-      if (taskId.getSanitizedRackId().equals(sanitizedRackId) && !cleaningTasks.contains(taskId) && taskRequest.getDeploy().getId().equals(taskId.getDeployId())) {
-        numOnRack++;
-      }
+      countPerRack.add(taskId.getSanitizedRackId());
     }
 
     if (taskRequest.getRequest().isRackSensitive()) {
-      final double numPerRack = numDesiredInstances / (double) stateCache.getNumActiveRacks();
-
-      final boolean isRackOk = numOnRack < numPerRack;
+      final boolean isRackOk = isRackOk(countPerRack, sanitizedRackId, numDesiredInstances, taskRequest.getRequest().getId(), slaveId, host, numCleaningOnSlave, stateCache);
 
       if (!isRackOk) {
-        LOG.trace("Rejecting RackSensitive task {} from slave {} ({}) due to numOnRack {} and cleaningOnSlave {}", taskRequest.getRequest().getId(), slaveId, host, numOnRack, numCleaningOnSlave);
         return SlaveMatchState.RACK_SATURATED;
       }
     }
@@ -195,6 +192,33 @@ class SingularitySlaveAndRackManager {
     }
 
     return SlaveMatchState.OK;
+  }
+
+  private boolean isRackOk(Multiset<String> countPerRack, String sanitizedRackId, int numDesiredInstances, String requestId, String slaveId, String host, double numCleaningOnSlave, SingularitySchedulerStateCache stateCache) {
+    int racksAccountedFor = countPerRack.elementSet().size();
+    double numPerRack = numDesiredInstances / (double) stateCache.getNumActiveRacks();
+    if (racksAccountedFor < stateCache.getNumActiveRacks()) {
+      if (countPerRack.count(sanitizedRackId) < (int) numPerRack) {
+        return true;
+      }
+    } else {
+      Integer rackMin = null;
+      for (String rackId : countPerRack.elementSet()) {
+        if (rackMin == null || countPerRack.count(rackId) < rackMin) {
+          rackMin = countPerRack.count(rackId);
+        }
+      }
+      if (rackMin == null || rackMin < (int) numPerRack) {
+        if (countPerRack.count(sanitizedRackId) < (int) numPerRack) {
+          return true;
+        }
+      } else if (countPerRack.count(sanitizedRackId) < numPerRack) {
+        return true;
+      }
+    }
+
+    LOG.trace("Rejecting RackSensitive task {} from slave {} ({}) due to numOnRack {} and cleaningOnSlave {}", requestId, slaveId, host, countPerRack.count(sanitizedRackId), numCleaningOnSlave);
+    return false;
   }
 
   public void slaveLost(SlaveID slaveIdObj) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
@@ -198,7 +198,7 @@ class SingularitySlaveAndRackManager {
     int racksAccountedFor = countPerRack.elementSet().size();
     double numPerRack = numDesiredInstances / (double) stateCache.getNumActiveRacks();
     if (racksAccountedFor < stateCache.getNumActiveRacks()) {
-      if (countPerRack.count(sanitizedRackId) < (int) numPerRack) {
+      if (countPerRack.count(sanitizedRackId) < Math.max(numPerRack, 1)) {
         return true;
       }
     } else {

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
@@ -153,7 +153,9 @@ class SingularitySlaveAndRackManager {
           numOtherDeploysOnSlave++;
         }
       }
-      countPerRack.add(taskId.getSanitizedRackId());
+      if (!cleaningTasks.contains(taskId) && taskRequest.getDeploy().getId().equals(taskId.getDeployId())) {
+        countPerRack.add(taskId.getSanitizedRackId());
+      }
     }
 
     if (taskRequest.getRequest().isRackSensitive()) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -433,7 +433,7 @@ public class SingularityScheduler {
           }
         }
         if (extraCleanedTasks > 0) {
-          schedule(extraCleanedTasks, matchingTaskIds, request, state, deployStatistics, pendingRequest, maybePendingDeploy);
+          schedule(extraCleanedTasks, remainingActiveTasks, request, state, deployStatistics, pendingRequest, maybePendingDeploy);
         }
       }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -417,7 +417,7 @@ public class SingularityScheduler {
         taskManager.createTaskCleanup(new SingularityTaskCleanup(pendingRequest.getUser(), TaskCleanupType.SCALING_DOWN, now, toCleanup, Optional.<String>absent(), Optional.<String>absent()));
       }
 
-      if (request.isRackSensitive()) {
+      if (request.isRackSensitive() && configuration.isRebalanceRacksOnScaleDown()) {
         int extraCleanedTasks = 0;
         int numActiveRacks = stateCache.getNumActiveRacks();
         double perRack = request.getInstancesSafe() / (double) numActiveRacks;
@@ -429,7 +429,7 @@ public class SingularityScheduler {
           if (countPerRack.count(taskId.getRackId()) > perRack && extraCleanedTasks < numActiveRacks - 1) {
             extraCleanedTasks++;
             remainingTaskIds.remove(taskId);
-            LOG.info("Cleanup up task {} to evenly distribute tasks among racks", taskId);
+            LOG.info("Cleaning up task {} to evenly distribute tasks among racks", taskId);
             taskManager.createTaskCleanup(new SingularityTaskCleanup(pendingRequest.getUser(), TaskCleanupType.REBALANCE_RACKS, now, taskId, Optional.<String>absent(), Optional.<String>absent()));
           }
         }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -418,22 +418,23 @@ public class SingularityScheduler {
       }
 
       if (request.isRackSensitive() && configuration.isRebalanceRacksOnScaleDown()) {
-        int extraCleanedTasks = 0;
+        List<SingularityTaskId> extraCleanedTasks = new ArrayList<>();
         int numActiveRacks = stateCache.getNumActiveRacks();
         double perRack = request.getInstancesSafe() / (double) numActiveRacks;
 
         Multiset<String> countPerRack = HashMultiset.create();
         for (SingularityTaskId taskId : remainingActiveTasks) {
           countPerRack.add(taskId.getRackId());
-          LOG.info("{} - {} - {} - {}", countPerRack, perRack, extraCleanedTasks, taskId);
-          if (countPerRack.count(taskId.getRackId()) > perRack && extraCleanedTasks < numActiveRacks / 2) {
-            extraCleanedTasks++;
+          LOG.info("{} - {} - {} - {}", countPerRack, perRack, extraCleanedTasks.size(), taskId);
+          if (countPerRack.count(taskId.getRackId()) > perRack && extraCleanedTasks.size() < numActiveRacks / 2) {
+            extraCleanedTasks.add(taskId);
             LOG.info("Cleaning up task {} to evenly distribute tasks among racks", taskId);
             taskManager.createTaskCleanup(new SingularityTaskCleanup(pendingRequest.getUser(), TaskCleanupType.REBALANCE_RACKS, now, taskId, Optional.<String>absent(), Optional.<String>absent()));
           }
         }
-        if (extraCleanedTasks > 0) {
-          schedule(extraCleanedTasks, remainingActiveTasks, request, state, deployStatistics, pendingRequest, maybePendingDeploy);
+        remainingActiveTasks.removeAll(extraCleanedTasks);
+        if (extraCleanedTasks.size() > 0) {
+          schedule(extraCleanedTasks.size(), remainingActiveTasks, request, state, deployStatistics, pendingRequest, maybePendingDeploy);
         }
       }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -422,14 +422,12 @@ public class SingularityScheduler {
         int numActiveRacks = stateCache.getNumActiveRacks();
         double perRack = request.getInstancesSafe() / (double) numActiveRacks;
 
-        List<SingularityTaskId> remainingTaskIds = new ArrayList<>(matchingTaskIds);
         Multiset<String> countPerRack = HashMultiset.create();
         for (SingularityTaskId taskId : remainingActiveTasks) {
           countPerRack.add(taskId.getRackId());
           LOG.info("{} - {} - {} - {}", countPerRack, perRack, extraCleanedTasks, taskId);
           if (countPerRack.count(taskId.getRackId()) > perRack && extraCleanedTasks < numActiveRacks / 2) {
             extraCleanedTasks++;
-            remainingTaskIds.remove(taskId);
             LOG.info("Cleaning up task {} to evenly distribute tasks among racks", taskId);
             taskManager.createTaskCleanup(new SingularityTaskCleanup(pendingRequest.getUser(), TaskCleanupType.REBALANCE_RACKS, now, taskId, Optional.<String>absent(), Optional.<String>absent()));
           }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -412,7 +412,7 @@ public class SingularityScheduler {
       List<SingularityTaskId> remainingActiveTasks = new ArrayList<>(matchingTaskIds);
       for (int i = 0; i < Math.abs(numMissingInstances); i++) {
         final SingularityTaskId toCleanup = matchingTaskIds.get(i);
-        remainingActiveTasks.remove(matchingTaskIds.get(i));
+        remainingActiveTasks.remove(toCleanup);
         LOG.info("Cleaning up task {} due to new request {} - scaling down to {} instances", toCleanup.getId(), request.getId(), request.getInstancesSafe());
         taskManager.createTaskCleanup(new SingularityTaskCleanup(pendingRequest.getUser(), TaskCleanupType.SCALING_DOWN, now, toCleanup, Optional.<String>absent(), Optional.<String>absent()));
       }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -426,7 +426,8 @@ public class SingularityScheduler {
         Multiset<String> countPerRack = HashMultiset.create();
         for (SingularityTaskId taskId : remainingActiveTasks) {
           countPerRack.add(taskId.getRackId());
-          if (countPerRack.count(taskId.getRackId()) > perRack && extraCleanedTasks < numActiveRacks - 1) {
+          LOG.info("{} - {} - {} - {}", countPerRack, perRack, extraCleanedTasks, taskId);
+          if (countPerRack.count(taskId.getRackId()) > perRack && extraCleanedTasks < numActiveRacks / 2) {
             extraCleanedTasks++;
             remainingTaskIds.remove(taskId);
             LOG.info("Cleaning up task {} to evenly distribute tasks among racks", taskId);

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -1,6 +1,7 @@
 package com.hubspot.singularity.scheduler;
 
 import java.text.ParseException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -24,15 +25,16 @@ import com.codahale.metrics.annotation.Timed;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicates;
 import com.google.common.base.Throwables;
+import com.google.common.collect.HashMultiset;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Multiset;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.hubspot.mesos.JavaUtils;
-import com.hubspot.mesos.Resources;
 import com.hubspot.singularity.DeployState;
 import com.hubspot.singularity.ExtendedTaskState;
 import com.hubspot.singularity.MachineState;
@@ -397,19 +399,7 @@ public class SingularityScheduler {
       maybePendingDeploy);
 
     if (numMissingInstances > 0) {
-      final List<SingularityPendingTask> scheduledTasks =
-        getScheduledTaskIds(numMissingInstances, matchingTaskIds, request, state, deployStatistics, pendingRequest.getDeployId(), pendingRequest, maybePendingDeploy);
-
-      if (!scheduledTasks.isEmpty()) {
-        LOG.trace("Scheduling tasks: {}", scheduledTasks);
-
-        for (SingularityPendingTask scheduledTask : scheduledTasks) {
-          taskManager.savePendingTask(scheduledTask);
-        }
-      } else {
-        LOG.info("No new scheduled tasks found for {}, setting state to {}", request.getId(), RequestState.FINISHED);
-        requestManager.finish(request, System.currentTimeMillis());
-      }
+      schedule(numMissingInstances, matchingTaskIds, request, state, deployStatistics, pendingRequest, maybePendingDeploy);
     } else if (numMissingInstances < 0) {
       final long now = System.currentTimeMillis();
 
@@ -419,16 +409,55 @@ public class SingularityScheduler {
         Collections.sort(matchingTaskIds, Collections.reverseOrder(SingularityTaskId.INSTANCE_NO_COMPARATOR)); // clean the highest numbers
       }
 
+      List<SingularityTaskId> remainingActiveTasks = new ArrayList<>(matchingTaskIds);
       for (int i = 0; i < Math.abs(numMissingInstances); i++) {
         final SingularityTaskId toCleanup = matchingTaskIds.get(i);
-
+        remainingActiveTasks.remove(matchingTaskIds.get(i));
         LOG.info("Cleaning up task {} due to new request {} - scaling down to {} instances", toCleanup.getId(), request.getId(), request.getInstancesSafe());
-
         taskManager.createTaskCleanup(new SingularityTaskCleanup(pendingRequest.getUser(), TaskCleanupType.SCALING_DOWN, now, toCleanup, Optional.<String>absent(), Optional.<String>absent()));
       }
+
+      if (request.isRackSensitive()) {
+        int extraCleanedTasks = 0;
+        int numActiveRacks = stateCache.getNumActiveRacks();
+        double perRack = request.getInstancesSafe() / (double) numActiveRacks;
+
+        List<SingularityTaskId> remainingTaskIds = new ArrayList<>(matchingTaskIds);
+        Multiset<String> countPerRack = HashMultiset.create();
+        for (SingularityTaskId taskId : remainingActiveTasks) {
+          countPerRack.add(taskId.getRackId());
+          if (countPerRack.count(taskId.getRackId()) > perRack && extraCleanedTasks < numActiveRacks - 1) {
+            extraCleanedTasks++;
+            remainingTaskIds.remove(taskId);
+            LOG.info("Cleanup up task {} to evenly distribute tasks among racks", taskId);
+            taskManager.createTaskCleanup(new SingularityTaskCleanup(pendingRequest.getUser(), TaskCleanupType.REBALANCE_RACKS, now, taskId, Optional.<String>absent(), Optional.<String>absent()));
+          }
+        }
+        if (extraCleanedTasks > 0) {
+          schedule(extraCleanedTasks, matchingTaskIds, request, state, deployStatistics, pendingRequest, maybePendingDeploy);
+        }
+      }
+
     }
 
     return numMissingInstances;
+  }
+
+  private void schedule(int numMissingInstances, List<SingularityTaskId> matchingTaskIds, SingularityRequest request, RequestState state, SingularityDeployStatistics deployStatistics,
+    SingularityPendingRequest pendingRequest, Optional<SingularityPendingDeploy> maybePendingDeploy) {
+    final List<SingularityPendingTask> scheduledTasks =
+      getScheduledTaskIds(numMissingInstances, matchingTaskIds, request, state, deployStatistics, pendingRequest.getDeployId(), pendingRequest, maybePendingDeploy);
+
+    if (!scheduledTasks.isEmpty()) {
+      LOG.trace("Scheduling tasks: {}", scheduledTasks);
+
+      for (SingularityPendingTask scheduledTask : scheduledTasks) {
+        taskManager.savePendingTask(scheduledTask);
+      }
+    } else {
+      LOG.info("No new scheduled tasks found for {}, setting state to {}", request.getId(), RequestState.FINISHED);
+      requestManager.finish(request, System.currentTimeMillis());
+    }
   }
 
   private boolean isRequestActive(Optional<SingularityRequestWithState> maybeRequestWithState) {

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySlavePlacementTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySlavePlacementTest.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import com.hubspot.singularity.ExtendedTaskState;

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySlavePlacementTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySlavePlacementTest.java
@@ -205,4 +205,9 @@ public class SingularitySlavePlacementTest extends SingularitySchedulerTestBase 
 
     Assert.assertTrue(taskManager.getActiveTaskIds().size() == 1);
   }
+
+  @Test
+  public void testRackSensitivePlacement() {
+    
+  }
 }

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySlavePlacementTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySlavePlacementTest.java
@@ -260,7 +260,6 @@ public class SingularitySlavePlacementTest extends SingularitySchedulerTestBase 
       initFirstDeploy();
       saveAndSchedule(request.toBuilder().setInstances(Optional.of(7)).setRackSensitive(Optional.of(true)));
 
-      // rack1 -> [1,2], rack2 -> [3,4], rack3 -> [5,6,7]
       sms.resourceOffers(driver, Arrays.asList(createOffer(2, 256, "slave1", "host1", Optional.of("rack1"))));
       sms.resourceOffers(driver, Arrays.asList(createOffer(2, 256, "slave2", "host2", Optional.of("rack2"))));
       sms.resourceOffers(driver, Arrays.asList(createOffer(3, 384, "slave3", "host3", Optional.of("rack3"))));
@@ -271,7 +270,6 @@ public class SingularitySlavePlacementTest extends SingularitySchedulerTestBase 
 
       scheduler.drainPendingQueue(stateCacheProvider.get());
 
-      // [5,6,7] -> scale down, 1 other -> rack rebalance
       Assert.assertEquals(4, taskManager.getNumCleanupTasks());
 
       int rebalanceRackCleanups = 0;
@@ -281,6 +279,7 @@ public class SingularitySlavePlacementTest extends SingularitySchedulerTestBase 
         }
       }
       Assert.assertEquals(1, rebalanceRackCleanups);
+      Assert.assertEquals(1, taskManager.getPendingTaskIds().size());
     } finally {
       configuration.setRebalanceRacksOnScaleDown(false);
     }

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySlavePlacementTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySlavePlacementTest.java
@@ -8,11 +8,14 @@ import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import com.hubspot.singularity.ExtendedTaskState;
+import com.hubspot.singularity.SingularityTaskCleanup;
 import com.hubspot.singularity.SingularityTaskHistoryUpdate;
 import com.hubspot.singularity.SlavePlacement;
+import com.hubspot.singularity.TaskCleanupType;
 
 public class SingularitySlavePlacementTest extends SingularitySchedulerTestBase {
 
@@ -207,7 +210,74 @@ public class SingularitySlavePlacementTest extends SingularitySchedulerTestBase 
   }
 
   @Test
-  public void testRackSensitivePlacement() {
-    
+  public void testEvenRackPlacement() {
+    // Set up 3 active racks
+    sms.resourceOffers(driver, Arrays.asList(createOffer(1, 128, "slave1", "host1", Optional.of("rack1"))));
+    sms.resourceOffers(driver, Arrays.asList(createOffer(1, 128, "slave2", "host2", Optional.of("rack2"))));
+    sms.resourceOffers(driver, Arrays.asList(createOffer(1, 128, "slave3", "host3", Optional.of("rack3"))));
+
+    initRequest();
+    initFirstDeploy();
+    saveAndSchedule(request.toBuilder().setInstances(Optional.of(7)).setRackSensitive(Optional.of(true)));
+
+    // rack1 -> 1, rack2 -> 2, rack3 -> 3
+    sms.resourceOffers(driver, Arrays.asList(createOffer(1, 128, "slave1", "host1", Optional.of("rack1"))));
+    sms.resourceOffers(driver, Arrays.asList(createOffer(1, 128, "slave2", "host2", Optional.of("rack2"))));
+    sms.resourceOffers(driver, Arrays.asList(createOffer(1, 128, "slave3", "host3", Optional.of("rack3"))));
+
+    Assert.assertEquals(3, taskManager.getActiveTaskIds().size());
+
+    sms.resourceOffers(driver, Arrays.asList(createOffer(1, 128, "slave1", "host1", Optional.of("rack1"))));
+    Assert.assertEquals(4, taskManager.getActiveTaskIds().size());
+
+    sms.resourceOffers(driver, Arrays.asList(createOffer(1, 128, "slave1", "host1", Optional.of("rack1"))));
+    Assert.assertEquals(4, taskManager.getActiveTaskIds().size());
+
+    sms.resourceOffers(driver, Arrays.asList(createOffer(1, 128, "slave2", "host2", Optional.of("rack2"))));
+    Assert.assertEquals(5, taskManager.getActiveTaskIds().size());
+
+    // rack1 should not get a third instance until rack3 has a second
+    sms.resourceOffers(driver, Arrays.asList(createOffer(1, 128, "slave1", "host1", Optional.of("rack1"))));
+    Assert.assertEquals(5, taskManager.getActiveTaskIds().size());
+
+    sms.resourceOffers(driver, Arrays.asList(createOffer(1, 128, "slave3", "host3", Optional.of("rack3"))));
+    Assert.assertEquals(6, taskManager.getActiveTaskIds().size());
+
+    sms.resourceOffers(driver, Arrays.asList(createOffer(1, 128, "slave1", "host1", Optional.of("rack1"))));
+    Assert.assertEquals(7, taskManager.getActiveTaskIds().size());
+  }
+
+  @Test
+  public void testRackPlacementOnScaleDown() {
+    // Set up 3 active racks
+    sms.resourceOffers(driver, Arrays.asList(createOffer(1, 128, "slave1", "host1", Optional.of("rack1"))));
+    sms.resourceOffers(driver, Arrays.asList(createOffer(1, 128, "slave2", "host2", Optional.of("rack2"))));
+    sms.resourceOffers(driver, Arrays.asList(createOffer(1, 128, "slave3", "host3", Optional.of("rack3"))));
+
+    initRequest();
+    initFirstDeploy();
+    saveAndSchedule(request.toBuilder().setInstances(Optional.of(7)).setRackSensitive(Optional.of(true)));
+
+    // rack1 -> [1,2], rack2 -> [3,4], rack3 -> [5,6,7]
+    sms.resourceOffers(driver, Arrays.asList(createOffer(2, 256, "slave1", "host1", Optional.of("rack1"))));
+    sms.resourceOffers(driver, Arrays.asList(createOffer(2, 256, "slave2", "host2", Optional.of("rack2"))));
+    sms.resourceOffers(driver, Arrays.asList(createOffer(3, 384, "slave3", "host3", Optional.of("rack3"))));
+
+    Assert.assertEquals(7, taskManager.getActiveTaskIds().size());
+
+    requestResource.postRequest(request.toBuilder().setInstances(Optional.of(4)).setRackSensitive(Optional.of(true)).build());
+
+    scheduler.drainPendingQueue(stateCacheProvider.get());
+
+    // [5,6,7] -> scale down, 1 other -> rack rebalance
+    Assert.assertEquals(4, taskManager.getNumCleanupTasks());
+
+    int rebalanceRackCleanups = 0;
+    for (SingularityTaskCleanup cleanup : taskManager.getCleanupTasks()) {
+      if (cleanup.getCleanupType() == TaskCleanupType.REBALANCE_RACKS) {
+        rebalanceRackCleanups ++;
+      }
+    }
+    Assert.assertEquals(1, rebalanceRackCleanups);
   }
 }


### PR DESCRIPTION
This PR tackles 2 issues

1. When `# instances` mod `# racks` was not `0`, we could get very uneven placement (e.g. 3,3,1 for 7 instances on 3 racks. I've updated the `SlaveAndRackManager` to make sure we distribute these cases evenly. In this example, no rack would be allowed a third instance until the others all had at least 2.

2. When scaling down, we always clean up the highest instance numbers. But it is often the case that these are all on the same rack. I added code to the scheduler to (configurably) create extra cleanups when scaling down so that new tasks can be started which will fill in the correct racks based on the ones that have been left as active. While this does create a slight bit of extra churn, I think it is still an easier solution than trying to restrict racks based on instance number as new tasks are being started

/cc @tpetr @darcatron 