### PR TITLE
Fix decom in SingularityClient

### DIFF
--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
@@ -777,7 +777,7 @@ public class SingularityClient {
   public void decomissionSlave(String slaveId) {
     final String requestUri = String.format(SLAVES_DECOMISSION_FORMAT, getHost(), contextPath, slaveId);
 
-    post(requestUri, String.format("decomission slave %s", slaveId), Optional.absent());
+    post(requestUri, String.format("decomission slave %s", slaveId), Optional.of(ImmutableMap.of()));
   }
 
   public void deleteSlave(String slaveId) {


### PR DESCRIPTION

@ssalinas 
unless there's a better way we want to do this? In chrome, when we hit decom, it sends `{}` as the request body, but when I use the client now, it sends over nothing and the API sends a 415 error