### PR TITLE
Shortcut to task by instance number

### DIFF
--- a/SingularityUI/app/components/requestDetail/TaskInstanceRedirect.jsx
+++ b/SingularityUI/app/components/requestDetail/TaskInstanceRedirect.jsx
@@ -1,0 +1,52 @@
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import rootComponent from '../../rootComponent';
+import { FetchActiveTasksForRequest } from '../../actions/api/history';
+import { withRouter } from 'react-router';
+
+function refresh(props) {
+  props.fetchActiveTasksForRequest(props.params.requestId);
+}
+
+class TaskInstanceRedirect extends Component {
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.activeTasksForRequest && nextProps.activeTasksForRequest[nextProps.params.requestId].data.length > 0) {
+      let found = false;
+      nextProps.activeTasksForRequest[nextProps.params.requestId].data.forEach((task) => {
+        if (task.taskId.instanceNo == parseInt(nextProps.params.instanceNo)) {
+          found = true;
+          this.props.router.push(`task/${task.taskId.id}`);
+        }
+      });
+      if (!found) {
+        this.props.router.push(`request/${nextProps.params.requestId}`);
+      }
+    }
+  }
+
+  render() {
+    return (
+      <div className="page-loader-with-message"><div className="page-loader" /><p>Fetching active tasks...</p></div>
+    );
+  }
+}
+
+TaskInstanceRedirect.propTypes = {
+  params: PropTypes.object.isRequired,
+  activeTasksForRequest: PropTypes.object
+};
+
+const mapStateToProps = (state, ownProps) => {
+  return {activeTasksForRequest: state.api.activeTasksForRequest}
+};
+
+const mapDispatchToProps = (dispatch, ownProps) => {
+  return {
+    fetchActiveTasksForRequest: (requestId) => dispatch(FetchActiveTasksForRequest.trigger(requestId))
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(rootComponent(withRouter(TaskInstanceRedirect), (props) => props.params.requestId, refresh));

--- a/SingularityUI/app/components/requestDetail/TaskInstanceRedirect.jsx
+++ b/SingularityUI/app/components/requestDetail/TaskInstanceRedirect.jsx
@@ -15,11 +15,11 @@ class TaskInstanceRedirect extends Component {
       nextProps.activeTasksForRequest[nextProps.params.requestId].data.forEach((task) => {
         if (task.taskId.instanceNo == parseInt(nextProps.params.instanceNo) && !found) {
           found = true;
-          this.props.router.push(`task/${task.taskId.id}`);
+          this.props.router.replace(`task/${task.taskId.id}`);
         }
       });
       if (!found) {
-        this.props.router.push(`request/${nextProps.params.requestId}`);
+        this.props.router.replace(`request/${nextProps.params.requestId}`);
       }
     }
   }

--- a/SingularityUI/app/components/requestDetail/TaskInstanceRedirect.jsx
+++ b/SingularityUI/app/components/requestDetail/TaskInstanceRedirect.jsx
@@ -13,7 +13,7 @@ class TaskInstanceRedirect extends Component {
     if (nextProps.activeTasksForRequest && nextProps.activeTasksForRequest[nextProps.params.requestId].data.length > 0) {
       let found = false;
       nextProps.activeTasksForRequest[nextProps.params.requestId].data.forEach((task) => {
-        if (task.taskId.instanceNo == parseInt(nextProps.params.instanceNo)) {
+        if (task.taskId.instanceNo == parseInt(nextProps.params.instanceNo) && !found) {
           found = true;
           this.props.router.push(`task/${task.taskId.id}`);
         }

--- a/SingularityUI/app/router.jsx
+++ b/SingularityUI/app/router.jsx
@@ -20,6 +20,7 @@ import DeployDetail from './components/deployDetail/DeployDetail';
 import RequestForm from './components/requestForm/RequestForm';
 import NewDeployForm from './components/newDeployForm/NewDeployForm';
 import { Tail, AggregateTail } from './components/logs/Tail';
+import TaskInstanceRedirect from './components/requestDetail/TaskInstanceRedirect'
 import RequestDetailPage from './components/requestDetail/RequestDetailPage';
 import Group from './components/groupDetail/GroupDetail.jsx';
 import Disasters from './components/disasters/Disasters';
@@ -47,6 +48,7 @@ const AppRouter = (props) => {
             <Route path=":requestId/deploy" component={NewDeployForm} />
             <Route path=":requestId/deploy/:deployId" component={DeployDetail} store={props.store} />
             <Route path=":requestId/tail/**" component={AggregateTail} />
+            <Route path=":requestId/instance/:instanceNo" component={TaskInstanceRedirect} />
           </Route>
           <Route path="tasks(/:state)(/:requestsSubFilter)(/:searchFilter)" component={TasksPage} />
           <Route path="task">


### PR DESCRIPTION
This will make it easier to programmatically link when another app may not have the full task id. Redirects to the request page if there is no active task found with that instance number

`request/{requestId}/instance/{instanceNo}`