### PR TITLE
expand requestHistory.createdAt column to millisecond precision

### DIFF
--- a/mysql/migrations.sql
+++ b/mysql/migrations.sql
@@ -111,3 +111,6 @@ ALTER TABLE `taskHistory`
 
 --changeset ssalinas:13 dbms:mysql
 ALTER TABLE `deployHistory` MODIFY `bytes` MEDIUMBLOB NOT NULL;
+
+--changeset tpetr:14 dbms:mysql
+ALTER TABLE `requestHistory` MODIFY `createdAt` TIMESTAMP(3) NOT NULL DEFAULT '1971-01-01 00:00:01'


### PR DESCRIPTION
This PR fixes the issue where Request updates that occur during the same second fail to be persisted to MySQL (Note: the updates are not lost, just continue to stay in ZK). This is due to the fact that the `createdAt` column is a `TIMESTAMP`, which only has second precision. The DB migration expands the column to `TIMESTAMP(3)`, which matches the millisecond precision used elsewhere in Singularity.