### PR TITLE
Make the history purger query more efficient

### DIFF
--- a/SingularityService/singularity_test.sql
+++ b/SingularityService/singularity_test.sql
@@ -30,4 +30,5 @@ CREATE TABLE taskHistory (
   lastTaskStatus VARCHAR(25) NULL,
   runId VARCHAR(100) NULL,
   bytes BLOB NOT NULL,
+  purged BOOLEAN NOT NULL DEFAULT false,
 );

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/HistoryJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/HistoryJDBI.java
@@ -74,6 +74,13 @@ public abstract class HistoryJDBI implements GetHandle {
   @SqlUpdate("DELETE FROM taskHistory WHERE requestId = :requestId AND updatedAt \\< :updatedAtBefore")
   abstract void deleteTaskHistoryForRequestBefore(@Bind("requestId") String requestId, @Bind("updatedAtBefore") Date updatedAtBefore);
 
+  @SqlQuery("SELECT DISTINCT requestId FROM taskHistory")
+  abstract List<String> getRequestIdsInTaskHistory();
+
+  @SqlQuery("SELECT COUNT(*) FROM taskHistory WHERE requestId = :requestId AND purged = false AND updatedAt \\< :updatedAtBefore")
+  abstract int getUnpurgedTaskHistoryCountByRequestBefore(@Bind("requestId") String requestId, @Bind("updatedAtBefore") Date updatedAtBefore);
+
+
   abstract void close();
 
   private static final String GET_TASK_ID_HISTORY_QUERY = "SELECT taskId, requestId, updatedAt, lastTaskStatus, runId FROM taskHistory";

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/HistoryJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/HistoryJDBI.java
@@ -65,7 +65,7 @@ public abstract class HistoryJDBI implements GetHandle {
   @SqlQuery("SELECT requestId, COUNT(*) as count FROM taskHistory WHERE updatedAt \\< :updatedAt GROUP BY requestId")
   abstract List<SingularityRequestIdCount> getRequestIdCounts(@Bind("updatedAt") Date updatedAt);
 
-  @SqlQuery("SELECT MIN(updatedAt) FROM taskHistory WHERE requestId = :requestId ORDER BY updatedAt DESC LIMIT :limit")
+  @SqlQuery("SELECT MIN(updatedAt) FROM taskHistory WHERE requestId = :requestId GROUP BY updatedAt ORDER BY updatedAt DESC LIMIT :limit")
   abstract Date getMinUpdatedAtWithLimitForRequest(@Bind("requestId") String requestId, @Bind("limit") Integer limit);
 
   @SqlUpdate("UPDATE taskHistory SET bytes = '', purged = true WHERE requestId = :requestId AND purged = false AND updatedAt \\< :updatedAtBefore")

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/HistoryJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/HistoryJDBI.java
@@ -65,7 +65,7 @@ public abstract class HistoryJDBI implements GetHandle {
   @SqlQuery("SELECT requestId, COUNT(*) as count FROM taskHistory WHERE updatedAt \\< :updatedAt GROUP BY requestId")
   abstract List<SingularityRequestIdCount> getRequestIdCounts(@Bind("updatedAt") Date updatedAt);
 
-  @SqlQuery("SELECT MIN(updatedAt) from (SELECT updatedAt FROM taskHistory WHERE requestId = :requestId ORDER BY updatedAt DESC LIMIT :limit) as alias")
+  @SqlQuery("SELECT MIN(updatedAt) FROM taskHistory WHERE requestId = :requestId ORDER BY updatedAt DESC LIMIT :limit")
   abstract Date getMinUpdatedAtWithLimitForRequest(@Bind("requestId") String requestId, @Bind("limit") Integer limit);
 
   @SqlUpdate("UPDATE taskHistory SET bytes = '', purged = true WHERE requestId = :requestId AND purged = false AND updatedAt \\< :updatedAtBefore")

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/HistoryJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/HistoryJDBI.java
@@ -65,7 +65,7 @@ public abstract class HistoryJDBI implements GetHandle {
   @SqlQuery("SELECT requestId, COUNT(*) as count FROM taskHistory WHERE updatedAt \\< :updatedAt GROUP BY requestId")
   abstract List<SingularityRequestIdCount> getRequestIdCounts(@Bind("updatedAt") Date updatedAt);
 
-  @SqlQuery("SELECT MIN(updatedAt) FROM taskHistory WHERE requestId = :requestId GROUP BY updatedAt ORDER BY updatedAt DESC LIMIT :limit")
+  @SqlQuery("SELECT MIN(updatedAt) from (SELECT updatedAt FROM taskHistory WHERE requestId = :requestId ORDER BY updatedAt DESC LIMIT :limit) as alias")
   abstract Date getMinUpdatedAtWithLimitForRequest(@Bind("requestId") String requestId, @Bind("limit") Integer limit);
 
   @SqlUpdate("UPDATE taskHistory SET bytes = '', purged = true WHERE requestId = :requestId AND purged = false AND updatedAt \\< :updatedAtBefore")

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/HistoryJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/HistoryJDBI.java
@@ -33,7 +33,7 @@ public abstract class HistoryJDBI implements GetHandle {
   @SqlUpdate("INSERT INTO deployHistory (requestId, deployId, createdAt, user, message, deployStateAt, deployState, bytes) VALUES (:requestId, :deployId, :createdAt, :user, :message, :deployStateAt, :deployState, :bytes)")
   abstract void insertDeployHistory(@Bind("requestId") String requestId, @Bind("deployId") String deployId, @Bind("createdAt") Date createdAt, @Bind("user") String user, @Bind("message") String message, @Bind("deployStateAt") Date deployStateAt, @Bind("deployState") String deployState, @Bind("bytes") byte[] bytes);
 
-  @SqlUpdate("INSERT INTO taskHistory (requestId, taskId, bytes, updatedAt, lastTaskStatus, runId, deployId, host, startedAt) VALUES (:requestId, :taskId, :bytes, :updatedAt, :lastTaskStatus, :runId, :deployId, :host, :startedAt)")
+  @SqlUpdate("INSERT INTO taskHistory (requestId, taskId, bytes, updatedAt, lastTaskStatus, runId, deployId, host, startedAt, purged) VALUES (:requestId, :taskId, :bytes, :updatedAt, :lastTaskStatus, :runId, :deployId, :host, :startedAt, false)")
   abstract void insertTaskHistory(@Bind("requestId") String requestId, @Bind("taskId") String taskId, @Bind("bytes") byte[] bytes, @Bind("updatedAt") Date updatedAt,
       @Bind("lastTaskStatus") String lastTaskStatus, @Bind("runId") String runId, @Bind("deployId") String deployId, @Bind("host") String host,
       @Bind("startedAt") Date startedAt);
@@ -68,7 +68,7 @@ public abstract class HistoryJDBI implements GetHandle {
   @SqlQuery("SELECT MIN(updatedAt) from (SELECT updatedAt FROM taskHistory WHERE requestId = :requestId ORDER BY updatedAt DESC LIMIT :limit) as alias")
   abstract Date getMinUpdatedAtWithLimitForRequest(@Bind("requestId") String requestId, @Bind("limit") Integer limit);
 
-  @SqlUpdate("UPDATE taskHistory SET bytes = '' WHERE requestId = :requestId AND updatedAt \\< :updatedAtBefore")
+  @SqlUpdate("UPDATE taskHistory SET bytes = '', purged = true WHERE requestId = :requestId AND purged = false AND updatedAt \\< :updatedAtBefore")
   abstract void updateTaskHistoryNullBytesForRequestBefore(@Bind("requestId") String requestId, @Bind("updatedAtBefore") Date updatedAtBefore);
 
   @SqlUpdate("DELETE FROM taskHistory WHERE requestId = :requestId AND updatedAt \\< :updatedAtBefore")

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/HistoryManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/HistoryManager.java
@@ -46,6 +46,10 @@ public interface HistoryManager {
 
   List<SingularityRequestIdCount> getRequestIdCounts(Date before);
 
+  List<String> getRequestIdsInTaskHistory();
+
+  int getUnpurgedTaskHistoryCountByRequestBefore(String requestId, Date before);
+
   void purgeTaskHistory(String requestId, int count, Optional<Integer> limit, Optional<Date> purgeBefore, boolean deleteRowInsteadOfUpdate);
 
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/JDBIHistoryManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/JDBIHistoryManager.java
@@ -176,6 +176,16 @@ public class JDBIHistoryManager implements HistoryManager {
   }
 
   @Override
+  public List<String> getRequestIdsInTaskHistory() {
+    return history.getRequestIdsInTaskHistory();
+  }
+
+  @Override
+  public int getUnpurgedTaskHistoryCountByRequestBefore(String requestId, Date before) {
+    return history.getUnpurgedTaskHistoryCountByRequestBefore(requestId, before);
+  }
+
+  @Override
   public void purgeTaskHistory(String requestId, int count, Optional<Integer> limit, Optional<Date> purgeBefore, boolean deleteRowInsteadOfUpdate) {
     if (limit.isPresent() && count > limit.get()) {
       Date beforeBasedOnLimit = history.getMinUpdatedAtWithLimitForRequest(requestId, limit.get());

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/NoopHistoryManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/NoopHistoryManager.java
@@ -94,6 +94,16 @@ public class NoopHistoryManager implements HistoryManager {
   }
 
   @Override
+  public List<String> getRequestIdsInTaskHistory() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public int getUnpurgedTaskHistoryCountByRequestBefore(String requestId, Date before) {
+    return 0;
+  }
+
+  @Override
   public void purgeTaskHistory(String requestId, int count, Optional<Integer> limit, Optional<Date> purgeBefore, boolean deleteRowInsteadOfUpdate) {
     throw new UnsupportedOperationException("NoopHistoryManager can not update/delete");
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityHistoryPurger.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityHistoryPurger.java
@@ -52,28 +52,23 @@ public class SingularityHistoryPurger extends SingularityLeaderOnlyPoller {
       LOG.debug("Purging taskHistory before {}", purgeBefore.get());
     }
 
-    final long start = System.currentTimeMillis();
-
     LOG.info("Finding taskHistory counts before {} (purging tasks over limit of {})", checkBefore, historyPurgingConfiguration.getDeleteTaskHistoryAfterTasksPerRequest());
 
-    final List<SingularityRequestIdCount> requestIdCounts = historyManager.getRequestIdCounts(checkBefore);
-
-    LOG.info("Found {} counts in {}", requestIdCounts.size(), JavaUtils.duration(start));
-
-    for (SingularityRequestIdCount requestIdCount : requestIdCounts) {
+    for (String requestId : historyManager.getRequestIdsInTaskHistory()) {
+      int unpurgedCount = historyManager.getUnpurgedTaskHistoryCountByRequestBefore(requestId, checkBefore);
       if (!historyPurgingConfiguration.getDeleteTaskHistoryAfterDays().isPresent() && historyPurgingConfiguration.getDeleteTaskHistoryAfterTasksPerRequest().isPresent() &&
-          requestIdCount.getCount() < historyPurgingConfiguration.getDeleteTaskHistoryAfterTasksPerRequest().get()) {
-        LOG.debug("Not purging old taskHistory for {} - {} count is less than {}", requestIdCount.getRequestId(), requestIdCount.getCount(),
+        unpurgedCount < historyPurgingConfiguration.getDeleteTaskHistoryAfterTasksPerRequest().get()) {
+        LOG.debug("Not purging old taskHistory for {} - {} count is less than {}", requestId, unpurgedCount,
             historyPurgingConfiguration.getDeleteTaskHistoryAfterTasksPerRequest().get());
         continue;
       }
 
       final long startRequestId = System.currentTimeMillis();
 
-      historyManager.purgeTaskHistory(requestIdCount.getRequestId(), requestIdCount.getCount(), historyPurgingConfiguration.getDeleteTaskHistoryAfterTasksPerRequest(), purgeBefore,
+      historyManager.purgeTaskHistory(requestId, unpurgedCount, historyPurgingConfiguration.getDeleteTaskHistoryAfterTasksPerRequest(), purgeBefore,
           historyPurgingConfiguration.isDeleteTaskHistoryBytesInsteadOfEntireRow());
 
-      LOG.info("Purged old taskHistory for {} ({} count) in {}", requestIdCount.getRequestId(), requestIdCount.getCount(), JavaUtils.duration(startRequestId));
+      LOG.info("Purged old taskHistory for {} ({} count) in {}", requestId, unpurgedCount, JavaUtils.duration(startRequestId));
     }
   }
 

--- a/mysql/migrations.sql
+++ b/mysql/migrations.sql
@@ -111,3 +111,9 @@ ALTER TABLE `taskHistory`
 
 --changeset ssalinas:13 dbms:mysql
 ALTER TABLE `deployHistory` MODIFY `bytes` MEDIUMBLOB NOT NULL;
+
+--changeset ssalinas:14 dbms:mysql
+ALTER TABLE `taskHistory`
+  ADD COLUMN `purged` BOOLEAN NOT NULL DEFAULT false,
+  ADD KEY `purged` (`requestId`, `purged`);
+UPDATE `taskHistory` SET `purged` = true WHERE `bytes` = '';

--- a/mysql/migrations.sql
+++ b/mysql/migrations.sql
@@ -115,4 +115,4 @@ ALTER TABLE `deployHistory` MODIFY `bytes` MEDIUMBLOB NOT NULL;
 --changeset ssalinas:14 dbms:mysql
 ALTER TABLE `taskHistory`
   ADD COLUMN `purged` BOOLEAN NOT NULL DEFAULT false,
-  ADD KEY `purged` (`requestId`, `purged`);
+  ADD KEY `purged` (`requestId`, `purged`, `updatedAt`);

--- a/mysql/migrations.sql
+++ b/mysql/migrations.sql
@@ -116,4 +116,3 @@ ALTER TABLE `deployHistory` MODIFY `bytes` MEDIUMBLOB NOT NULL;
 ALTER TABLE `taskHistory`
   ADD COLUMN `purged` BOOLEAN NOT NULL DEFAULT false,
   ADD KEY `purged` (`requestId`, `purged`);
-UPDATE `taskHistory` SET `purged` = true WHERE `bytes` = '';


### PR DESCRIPTION
Currently the purger query can grow in an unbounded manner when in the mode to set bytes to `''` rather than deleting, since the query just goes by `updatedAt < x`. This PR updates the `taskHistory` table to have an additional indexed `purged` column. This way we can limit our query to only tasks we have not already purged.

/cc @tpetr @darcatron 