### PR TITLE
Ability to run shell command before killing task

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestCleanup.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestCleanup.java
@@ -15,13 +15,13 @@ public class SingularityRequestCleanup {
   private final String requestId;
   private final Optional<String> message;
   private final Optional<String> actionId;
-  private final Optional<SingularityShellCommand> runBeforeKill;
+  private final Optional<SingularityShellCommand> runShellCommandBeforeKill;
 
   @JsonCreator
   public SingularityRequestCleanup(@JsonProperty("user") Optional<String> user, @JsonProperty("cleanupType") RequestCleanupType cleanupType, @JsonProperty("timestamp") long timestamp,
       @JsonProperty("killTasks") Optional<Boolean> killTasks, @JsonProperty("requestId") String requestId, @JsonProperty("deployId") Optional<String> deployId,
       @JsonProperty("skipHealthchecks") Optional<Boolean> skipHealthchecks, @JsonProperty("message") Optional<String> message, @JsonProperty("actionId") Optional<String> actionId,
-      @JsonProperty("runBeforeKill") Optional<SingularityShellCommand> runBeforeKill) {
+      @JsonProperty("runShellCommandBeforeKill") Optional<SingularityShellCommand> runShellCommandBeforeKill) {
     this.user = user;
     this.cleanupType = cleanupType;
     this.timestamp = timestamp;
@@ -31,7 +31,7 @@ public class SingularityRequestCleanup {
     this.skipHealthchecks = skipHealthchecks;
     this.actionId = actionId;
     this.message = message;
-    this.runBeforeKill = runBeforeKill;
+    this.runShellCommandBeforeKill = runShellCommandBeforeKill;
   }
 
   public Optional<Boolean> getSkipHealthchecks() {
@@ -70,14 +70,14 @@ public class SingularityRequestCleanup {
     return actionId;
   }
 
-  public Optional<SingularityShellCommand> getRunBeforeKill() {
-    return runBeforeKill;
+  public Optional<SingularityShellCommand> getRunShellCommandBeforeKill() {
+    return runShellCommandBeforeKill;
   }
 
   @Override
   public String toString() {
     return "SingularityRequestCleanup [user=" + user + ", cleanupType=" + cleanupType + ", killTasks=" + killTasks + ", skipHealthchecks=" + skipHealthchecks + ", deployId=" + deployId
-        + ", timestamp=" + timestamp + ", requestId=" + requestId + ", message=" + message + ", actionId=" + actionId + ", runBeforeKill=" + runBeforeKill + "]";
+        + ", timestamp=" + timestamp + ", requestId=" + requestId + ", message=" + message + ", actionId=" + actionId + ", runShellCommandBeforeKill=" + runShellCommandBeforeKill + "]";
   }
 
 

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestCleanup.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestCleanup.java
@@ -15,11 +15,13 @@ public class SingularityRequestCleanup {
   private final String requestId;
   private final Optional<String> message;
   private final Optional<String> actionId;
+  private final Optional<SingularityShellCommand> runBeforeKill;
 
   @JsonCreator
   public SingularityRequestCleanup(@JsonProperty("user") Optional<String> user, @JsonProperty("cleanupType") RequestCleanupType cleanupType, @JsonProperty("timestamp") long timestamp,
       @JsonProperty("killTasks") Optional<Boolean> killTasks, @JsonProperty("requestId") String requestId, @JsonProperty("deployId") Optional<String> deployId,
-      @JsonProperty("skipHealthchecks") Optional<Boolean> skipHealthchecks, @JsonProperty("message") Optional<String> message, @JsonProperty("actionId") Optional<String> actionId) {
+      @JsonProperty("skipHealthchecks") Optional<Boolean> skipHealthchecks, @JsonProperty("message") Optional<String> message, @JsonProperty("actionId") Optional<String> actionId,
+      @JsonProperty("runBeforeKill") Optional<SingularityShellCommand> runBeforeKill) {
     this.user = user;
     this.cleanupType = cleanupType;
     this.timestamp = timestamp;
@@ -29,6 +31,7 @@ public class SingularityRequestCleanup {
     this.skipHealthchecks = skipHealthchecks;
     this.actionId = actionId;
     this.message = message;
+    this.runBeforeKill = runBeforeKill;
   }
 
   public Optional<Boolean> getSkipHealthchecks() {
@@ -67,10 +70,14 @@ public class SingularityRequestCleanup {
     return actionId;
   }
 
+  public Optional<SingularityShellCommand> getRunBeforeKill() {
+    return runBeforeKill;
+  }
+
   @Override
   public String toString() {
     return "SingularityRequestCleanup [user=" + user + ", cleanupType=" + cleanupType + ", killTasks=" + killTasks + ", skipHealthchecks=" + skipHealthchecks + ", deployId=" + deployId
-        + ", timestamp=" + timestamp + ", requestId=" + requestId + ", message=" + message + ", actionId=" + actionId + "]";
+        + ", timestamp=" + timestamp + ", requestId=" + requestId + ", message=" + message + ", actionId=" + actionId + ", runBeforeKill=" + runBeforeKill + "]";
   }
 
 

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskCleanup.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskCleanup.java
@@ -2,6 +2,7 @@ package com.hubspot.singularity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 
 public class SingularityTaskCleanup {
@@ -12,16 +13,19 @@ public class SingularityTaskCleanup {
   private final SingularityTaskId taskId;
   private final Optional<String> message;
   private final Optional<String> actionId;
+  private final Optional<SingularityTaskShellCommandRequestId> runBeforeKillId;
 
   @JsonCreator
   public SingularityTaskCleanup(@JsonProperty("user") Optional<String> user, @JsonProperty("cleanupType") TaskCleanupType cleanupType, @JsonProperty("timestamp") long timestamp,
-      @JsonProperty("taskId") SingularityTaskId taskId, @JsonProperty("message") Optional<String> message, @JsonProperty("actionId") Optional<String> actionId) {
+      @JsonProperty("taskId") SingularityTaskId taskId, @JsonProperty("message") Optional<String> message, @JsonProperty("actionId") Optional<String> actionId,
+      @JsonProperty("runBeforeKillId") Optional<SingularityTaskShellCommandRequestId> runBeforeKillId) {
     this.user = user;
     this.cleanupType = cleanupType;
     this.timestamp = timestamp;
     this.taskId = taskId;
     this.message = message;
     this.actionId = actionId;
+    this.runBeforeKillId = runBeforeKillId;
   }
 
   public Optional<String> getActionId() {
@@ -48,9 +52,20 @@ public class SingularityTaskCleanup {
     return taskId;
   }
 
-  @Override
-  public String toString() {
-    return "SingularityTaskCleanup [user=" + user + ", cleanupType=" + cleanupType + ", timestamp=" + timestamp + ", taskId=" + taskId + ", message=" + message + ", actionId=" + actionId + "]";
+  public Optional<SingularityTaskShellCommandRequestId> getRunBeforeKillId() {
+    return runBeforeKillId;
   }
 
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+      .add("user", user)
+      .add("cleanupType", cleanupType)
+      .add("timestamp", timestamp)
+      .add("taskId", taskId)
+      .add("message", message)
+      .add("actionId", actionId)
+      .add("runBeforeKillId", runBeforeKillId)
+      .toString();
+  }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskShellCommandUpdate.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskShellCommandUpdate.java
@@ -7,7 +7,17 @@ import com.google.common.base.Optional;
 public class SingularityTaskShellCommandUpdate {
 
   public enum UpdateType {
-    INVALID, ACKED, STARTED, FINISHED, FAILED;
+    INVALID(true), ACKED(false), STARTED(false), FINISHED(true), FAILED(true);
+
+    private boolean finished;
+
+    UpdateType(boolean finished) {
+      this.finished = finished;
+    }
+
+    public boolean isFinished() {
+      return finished;
+    }
   }
 
   private final SingularityTaskShellCommandRequestId shellRequestId;

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskShellCommandUpdate.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskShellCommandUpdate.java
@@ -9,7 +9,7 @@ public class SingularityTaskShellCommandUpdate {
   public enum UpdateType {
     INVALID(true), ACKED(false), STARTED(false), FINISHED(true), FAILED(true);
 
-    private boolean finished;
+    private final boolean finished;
 
     UpdateType(boolean finished) {
       this.finished = finished;

--- a/SingularityBase/src/main/java/com/hubspot/singularity/TaskCleanupType.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/TaskCleanupType.java
@@ -4,7 +4,8 @@ public enum TaskCleanupType {
 
   USER_REQUESTED(true, true), USER_REQUESTED_TASK_BOUNCE(false, false), DECOMISSIONING(false, false), SCALING_DOWN(true, false), BOUNCING(false, false), INCREMENTAL_BOUNCE(false, false),
   DEPLOY_FAILED(true, true), NEW_DEPLOY_SUCCEEDED(true, false), DEPLOY_STEP_FINISHED(true, false), DEPLOY_CANCELED(true, true), TASK_EXCEEDED_TIME_LIMIT(true, true), UNHEALTHY_NEW_TASK(true, true),
-  OVERDUE_NEW_TASK(true, true), USER_REQUESTED_DESTROY(true, true), INCREMENTAL_DEPLOY_FAILED(false, true), INCREMENTAL_DEPLOY_CANCELLED(false, true), PRIORITY_KILL(true, true);
+  OVERDUE_NEW_TASK(true, true), USER_REQUESTED_DESTROY(true, true), INCREMENTAL_DEPLOY_FAILED(false, true), INCREMENTAL_DEPLOY_CANCELLED(false, true), PRIORITY_KILL(true, true),
+  PAUSING(false, false), PAUSE(true, true);
 
   private final boolean killLongRunningTaskInstantly;
   private final boolean killNonLongRunningTaskInstantly;

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityBounceRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityBounceRequest.java
@@ -5,23 +5,27 @@ import java.util.UUID;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
+import com.hubspot.singularity.SingularityShellCommand;
 import com.wordnik.swagger.annotations.ApiModelProperty;
 
 public class SingularityBounceRequest extends SingularityExpiringRequestParent {
 
   private final Optional<Boolean> incremental;
   private final Optional<Boolean> skipHealthchecks;
+  private final Optional<SingularityShellCommand> runBeforeKill;
 
   @JsonCreator
   public SingularityBounceRequest(@JsonProperty("incremental") Optional<Boolean> incremental, @JsonProperty("skipHealthchecks") Optional<Boolean> skipHealthchecks,
-      @JsonProperty("durationMillis") Optional<Long> durationMillis, @JsonProperty("actionId") Optional<String> actionId, @JsonProperty("message") Optional<String> message) {
+      @JsonProperty("durationMillis") Optional<Long> durationMillis, @JsonProperty("actionId") Optional<String> actionId, @JsonProperty("message") Optional<String> message,
+      @JsonProperty("runBeforeKill") Optional<SingularityShellCommand> runBeforeKill) {
     super(durationMillis, actionId, message);
     this.incremental = incremental;
     this.skipHealthchecks = skipHealthchecks;
+    this.runBeforeKill = runBeforeKill;
   }
 
   public static SingularityBounceRequest defaultRequest() {
-    return new SingularityBounceRequest(Optional.<Boolean>absent(), Optional.<Boolean>absent(), Optional.<Long>absent(), Optional.of(UUID.randomUUID().toString()), Optional.<String>absent());
+    return new SingularityBounceRequest(Optional.<Boolean>absent(), Optional.<Boolean>absent(), Optional.<Long>absent(), Optional.of(UUID.randomUUID().toString()), Optional.<String>absent(), Optional.<SingularityShellCommand>absent());
   }
 
   public SingularityBounceRequestBuilder toBuilder() {
@@ -30,7 +34,8 @@ public class SingularityBounceRequest extends SingularityExpiringRequestParent {
         .setSkipHealthchecks(skipHealthchecks)
         .setDurationMillis(getDurationMillis())
         .setActionId(getActionId())
-        .setMessage(getMessage());
+        .setMessage(getMessage())
+        .setRunBeforeKill(getRunBeforeKill());
   }
 
   @ApiModelProperty(required=false, value="If present and set to true, old tasks will be killed as soon as replacement tasks are available, instead of waiting for all replacement tasks to be healthy")
@@ -43,9 +48,14 @@ public class SingularityBounceRequest extends SingularityExpiringRequestParent {
     return skipHealthchecks;
   }
 
+  @ApiModelProperty(required=false, value="Attempt to run this shell command on each task before it is shut down")
+  public Optional<SingularityShellCommand> getRunBeforeKill() {
+    return runBeforeKill;
+  }
+
   @Override
   public String toString() {
-    return "SingularityBounceRequest [incremental=" + incremental + ", skipHealthchecks=" + skipHealthchecks + ", toString()=" + super.toString() + "]";
+    return "SingularityBounceRequest [incremental=" + incremental + ", skipHealthchecks=" + skipHealthchecks + ", runBeforeKill=" + runBeforeKill + ", toString()=" + super.toString() + "]";
   }
 
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityBounceRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityBounceRequest.java
@@ -12,16 +12,16 @@ public class SingularityBounceRequest extends SingularityExpiringRequestParent {
 
   private final Optional<Boolean> incremental;
   private final Optional<Boolean> skipHealthchecks;
-  private final Optional<SingularityShellCommand> runBeforeKill;
+  private final Optional<SingularityShellCommand> runShellCommandBeforeKill;
 
   @JsonCreator
   public SingularityBounceRequest(@JsonProperty("incremental") Optional<Boolean> incremental, @JsonProperty("skipHealthchecks") Optional<Boolean> skipHealthchecks,
       @JsonProperty("durationMillis") Optional<Long> durationMillis, @JsonProperty("actionId") Optional<String> actionId, @JsonProperty("message") Optional<String> message,
-      @JsonProperty("runBeforeKill") Optional<SingularityShellCommand> runBeforeKill) {
+      @JsonProperty("runShellCommandBeforeKill") Optional<SingularityShellCommand> runShellCommandBeforeKill) {
     super(durationMillis, actionId, message);
     this.incremental = incremental;
     this.skipHealthchecks = skipHealthchecks;
-    this.runBeforeKill = runBeforeKill;
+    this.runShellCommandBeforeKill = runShellCommandBeforeKill;
   }
 
   public static SingularityBounceRequest defaultRequest() {
@@ -35,7 +35,7 @@ public class SingularityBounceRequest extends SingularityExpiringRequestParent {
         .setDurationMillis(getDurationMillis())
         .setActionId(getActionId())
         .setMessage(getMessage())
-        .setRunBeforeKill(getRunBeforeKill());
+        .setRunShellCommandBeforeKill(getRunShellCommandBeforeKill());
   }
 
   @ApiModelProperty(required=false, value="If present and set to true, old tasks will be killed as soon as replacement tasks are available, instead of waiting for all replacement tasks to be healthy")
@@ -49,13 +49,13 @@ public class SingularityBounceRequest extends SingularityExpiringRequestParent {
   }
 
   @ApiModelProperty(required=false, value="Attempt to run this shell command on each task before it is shut down")
-  public Optional<SingularityShellCommand> getRunBeforeKill() {
-    return runBeforeKill;
+  public Optional<SingularityShellCommand> getRunShellCommandBeforeKill() {
+    return runShellCommandBeforeKill;
   }
 
   @Override
   public String toString() {
-    return "SingularityBounceRequest [incremental=" + incremental + ", skipHealthchecks=" + skipHealthchecks + ", runBeforeKill=" + runBeforeKill + ", toString()=" + super.toString() + "]";
+    return "SingularityBounceRequest [incremental=" + incremental + ", skipHealthchecks=" + skipHealthchecks + ", runShellCommandBeforeKill=" + runShellCommandBeforeKill + ", toString()=" + super.toString() + "]";
   }
 
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityBounceRequestBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityBounceRequestBuilder.java
@@ -8,7 +8,7 @@ public class SingularityBounceRequestBuilder {
 
   private Optional<Boolean> incremental;
   private Optional<Boolean> skipHealthchecks;
-  private Optional<SingularityShellCommand> runBeforeKill;
+  private Optional<SingularityShellCommand> runShellCommandBeforeKill;
 
   private Optional<Long> durationMillis;
   private Optional<String> actionId;
@@ -17,7 +17,7 @@ public class SingularityBounceRequestBuilder {
   public SingularityBounceRequestBuilder() {
     this.incremental = Optional.absent();
     this.skipHealthchecks = Optional.absent();
-    this.runBeforeKill = Optional.absent();
+    this.runShellCommandBeforeKill = Optional.absent();
 
     this.durationMillis = Optional.absent();
     this.actionId = Optional.absent();
@@ -25,7 +25,7 @@ public class SingularityBounceRequestBuilder {
   }
 
   public SingularityBounceRequest build() {
-    return new SingularityBounceRequest(incremental, skipHealthchecks, durationMillis, actionId, message, runBeforeKill);
+    return new SingularityBounceRequest(incremental, skipHealthchecks, durationMillis, actionId, message, runShellCommandBeforeKill);
   }
 
   public Optional<Long> getDurationMillis() {
@@ -73,12 +73,12 @@ public class SingularityBounceRequestBuilder {
     return this;
   }
 
-  public Optional<SingularityShellCommand> getRunBeforeKill() {
-    return runBeforeKill;
+  public Optional<SingularityShellCommand> getRunShellCommandBeforeKill() {
+    return runShellCommandBeforeKill;
   }
 
-  public SingularityBounceRequestBuilder setRunBeforeKill(Optional<SingularityShellCommand> runBeforeKill) {
-    this.runBeforeKill = runBeforeKill;
+  public SingularityBounceRequestBuilder setRunShellCommandBeforeKill(Optional<SingularityShellCommand> runShellCommandBeforeKill) {
+    this.runShellCommandBeforeKill = runShellCommandBeforeKill;
     return this;
   }
 
@@ -87,7 +87,7 @@ public class SingularityBounceRequestBuilder {
     return Objects.toStringHelper(this)
       .add("incremental", incremental)
       .add("skipHealthchecks", skipHealthchecks)
-      .add("runBeforeKill", runBeforeKill)
+      .add("runShellCommandBeforeKill", runShellCommandBeforeKill)
       .add("durationMillis", durationMillis)
       .add("actionId", actionId)
       .add("message", message)

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityBounceRequestBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityBounceRequestBuilder.java
@@ -1,11 +1,14 @@
 package com.hubspot.singularity.api;
 
+import com.google.common.base.Objects;
 import com.google.common.base.Optional;
+import com.hubspot.singularity.SingularityShellCommand;
 
 public class SingularityBounceRequestBuilder {
 
   private Optional<Boolean> incremental;
   private Optional<Boolean> skipHealthchecks;
+  private Optional<SingularityShellCommand> runBeforeKill;
 
   private Optional<Long> durationMillis;
   private Optional<String> actionId;
@@ -14,6 +17,7 @@ public class SingularityBounceRequestBuilder {
   public SingularityBounceRequestBuilder() {
     this.incremental = Optional.absent();
     this.skipHealthchecks = Optional.absent();
+    this.runBeforeKill = Optional.absent();
 
     this.durationMillis = Optional.absent();
     this.actionId = Optional.absent();
@@ -21,7 +25,7 @@ public class SingularityBounceRequestBuilder {
   }
 
   public SingularityBounceRequest build() {
-    return new SingularityBounceRequest(incremental, skipHealthchecks, durationMillis, actionId, message);
+    return new SingularityBounceRequest(incremental, skipHealthchecks, durationMillis, actionId, message, runBeforeKill);
   }
 
   public Optional<Long> getDurationMillis() {
@@ -69,14 +73,24 @@ public class SingularityBounceRequestBuilder {
     return this;
   }
 
+  public Optional<SingularityShellCommand> getRunBeforeKill() {
+    return runBeforeKill;
+  }
+
+  public SingularityBounceRequestBuilder setRunBeforeKill(Optional<SingularityShellCommand> runBeforeKill) {
+    this.runBeforeKill = runBeforeKill;
+    return this;
+  }
+
   @Override
   public String toString() {
-    return "SingularityBounceRequestBuilder{" +
-        "durationMillis='" + durationMillis + '\'' +
-        ", actionId='" + actionId + '\'' +
-        ", message='" + message + '\'' +
-        ", incremental='" + incremental + '\'' +
-        ", skipHealthchecks='" + skipHealthchecks + '\'' +
-        "}";
+    return Objects.toStringHelper(this)
+      .add("incremental", incremental)
+      .add("skipHealthchecks", skipHealthchecks)
+      .add("runBeforeKill", runBeforeKill)
+      .add("durationMillis", durationMillis)
+      .add("actionId", actionId)
+      .add("message", message)
+      .toString();
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityKillTaskRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityKillTaskRequest.java
@@ -3,6 +3,7 @@ package com.hubspot.singularity.api;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
+import com.hubspot.singularity.SingularityShellCommand;
 import com.wordnik.swagger.annotations.ApiModelProperty;
 
 public class SingularityKillTaskRequest {
@@ -11,14 +12,17 @@ public class SingularityKillTaskRequest {
   private final Optional<Boolean> override;
   private final Optional<String> actionId;
   private final Optional<Boolean> waitForReplacementTask;
+  private final Optional<SingularityShellCommand> runBeforeKill;
 
   @JsonCreator
   public SingularityKillTaskRequest(@JsonProperty("override") Optional<Boolean> override, @JsonProperty("message") Optional<String> message,
-      @JsonProperty("actionId") Optional<String> actionId, @JsonProperty("waitForReplacementTask") Optional<Boolean> waitForReplacementTask) {
+      @JsonProperty("actionId") Optional<String> actionId, @JsonProperty("waitForReplacementTask") Optional<Boolean> waitForReplacementTask,
+      @JsonProperty("runBeforeKill") Optional<SingularityShellCommand> runBeforeKill) {
     this.override = override;
     this.message = message;
     this.actionId = actionId;
     this.waitForReplacementTask = waitForReplacementTask;
+    this.runBeforeKill = runBeforeKill;
   }
 
   @ApiModelProperty(required=false, value="A message to show to users about why this action was taken")
@@ -41,9 +45,14 @@ public class SingularityKillTaskRequest {
     return waitForReplacementTask;
   }
 
+  @ApiModelProperty(required=false, value="Attempt to run this shell command on each task before it is shut down")
+  public Optional<SingularityShellCommand> getRunBeforeKill() {
+    return runBeforeKill;
+  }
+
   @Override
   public String toString() {
-    return "SingularityKillTaskRequest [message=" + message + ", override=" + override + ", actionId=" + actionId + ", waitForReplacementTask=" + waitForReplacementTask + "]";
+    return "SingularityKillTaskRequest [message=" + message + ", override=" + override + ", actionId=" + actionId + ", waitForReplacementTask=" + waitForReplacementTask + ", runBeforeKill=" + runBeforeKill + "]";
   }
 
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityKillTaskRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityKillTaskRequest.java
@@ -12,17 +12,17 @@ public class SingularityKillTaskRequest {
   private final Optional<Boolean> override;
   private final Optional<String> actionId;
   private final Optional<Boolean> waitForReplacementTask;
-  private final Optional<SingularityShellCommand> runBeforeKill;
+  private final Optional<SingularityShellCommand> runShellCommandBeforeKill;
 
   @JsonCreator
   public SingularityKillTaskRequest(@JsonProperty("override") Optional<Boolean> override, @JsonProperty("message") Optional<String> message,
       @JsonProperty("actionId") Optional<String> actionId, @JsonProperty("waitForReplacementTask") Optional<Boolean> waitForReplacementTask,
-      @JsonProperty("runBeforeKill") Optional<SingularityShellCommand> runBeforeKill) {
+      @JsonProperty("runShellCommandBeforeKill") Optional<SingularityShellCommand> runShellCommandBeforeKill) {
     this.override = override;
     this.message = message;
     this.actionId = actionId;
     this.waitForReplacementTask = waitForReplacementTask;
-    this.runBeforeKill = runBeforeKill;
+    this.runShellCommandBeforeKill = runShellCommandBeforeKill;
   }
 
   @ApiModelProperty(required=false, value="A message to show to users about why this action was taken")
@@ -46,13 +46,14 @@ public class SingularityKillTaskRequest {
   }
 
   @ApiModelProperty(required=false, value="Attempt to run this shell command on each task before it is shut down")
-  public Optional<SingularityShellCommand> getRunBeforeKill() {
-    return runBeforeKill;
+  public Optional<SingularityShellCommand> getRunShellCommandBeforeKill() {
+    return runShellCommandBeforeKill;
   }
 
   @Override
   public String toString() {
-    return "SingularityKillTaskRequest [message=" + message + ", override=" + override + ", actionId=" + actionId + ", waitForReplacementTask=" + waitForReplacementTask + ", runBeforeKill=" + runBeforeKill + "]";
+    return "SingularityKillTaskRequest [message=" + message + ", override=" + override + ", actionId=" + actionId + ", waitForReplacementTask=" + waitForReplacementTask + ", runShellCommandBeforeKill=" + runShellCommandBeforeKill
+      + "]";
   }
 
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityPauseRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityPauseRequest.java
@@ -3,23 +3,32 @@ package com.hubspot.singularity.api;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
+import com.hubspot.singularity.SingularityShellCommand;
 import com.wordnik.swagger.annotations.ApiModelProperty;
 
 public class SingularityPauseRequest extends SingularityExpiringRequestParent {
 
   private final Optional<Boolean> killTasks;
+  private final Optional<SingularityShellCommand> runBeforeKill;
+
 
   @JsonCreator
   public SingularityPauseRequest(@JsonProperty("killTasks") Optional<Boolean> killTasks,@JsonProperty("durationMillis") Optional<Long> durationMillis,
-      @JsonProperty("actionId") Optional<String> actionId, @JsonProperty("message") Optional<String> message) {
+      @JsonProperty("actionId") Optional<String> actionId, @JsonProperty("message") Optional<String> message, @JsonProperty("runBeforeKill") Optional<SingularityShellCommand> runBeforeKill) {
     super(durationMillis, actionId, message);
 
     this.killTasks = killTasks;
+    this.runBeforeKill = runBeforeKill;
   }
 
   @ApiModelProperty(required=false, value="If set to false, tasks will be allowed to finish instead of killed immediately")
   public Optional<Boolean> getKillTasks() {
     return killTasks;
+  }
+
+  @ApiModelProperty(required=false, value="Attempt to run this shell command on each task before it is shut down")
+  public Optional<SingularityShellCommand> getRunBeforeKill() {
+    return runBeforeKill;
   }
 
   @Override

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityPauseRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityPauseRequest.java
@@ -9,16 +9,16 @@ import com.wordnik.swagger.annotations.ApiModelProperty;
 public class SingularityPauseRequest extends SingularityExpiringRequestParent {
 
   private final Optional<Boolean> killTasks;
-  private final Optional<SingularityShellCommand> runBeforeKill;
+  private final Optional<SingularityShellCommand> runShellCommandBeforeKill;
 
 
   @JsonCreator
   public SingularityPauseRequest(@JsonProperty("killTasks") Optional<Boolean> killTasks,@JsonProperty("durationMillis") Optional<Long> durationMillis,
-      @JsonProperty("actionId") Optional<String> actionId, @JsonProperty("message") Optional<String> message, @JsonProperty("runBeforeKill") Optional<SingularityShellCommand> runBeforeKill) {
+      @JsonProperty("actionId") Optional<String> actionId, @JsonProperty("message") Optional<String> message, @JsonProperty("runShellCommandBeforeKill") Optional<SingularityShellCommand> runShellCommandBeforeKill) {
     super(durationMillis, actionId, message);
 
     this.killTasks = killTasks;
-    this.runBeforeKill = runBeforeKill;
+    this.runShellCommandBeforeKill = runShellCommandBeforeKill;
   }
 
   @ApiModelProperty(required=false, value="If set to false, tasks will be allowed to finish instead of killed immediately")
@@ -27,8 +27,8 @@ public class SingularityPauseRequest extends SingularityExpiringRequestParent {
   }
 
   @ApiModelProperty(required=false, value="Attempt to run this shell command on each task before it is shut down")
-  public Optional<SingularityShellCommand> getRunBeforeKill() {
-    return runBeforeKill;
+  public Optional<SingularityShellCommand> getRunShellCommandBeforeKill() {
+    return runShellCommandBeforeKill;
   }
 
   @Override

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
@@ -31,6 +31,7 @@ import com.hubspot.singularity.SingularityRequestHistory;
 import com.hubspot.singularity.SingularityRequestHistory.RequestHistoryType;
 import com.hubspot.singularity.SingularityRequestLbCleanup;
 import com.hubspot.singularity.SingularityRequestWithState;
+import com.hubspot.singularity.SingularityShellCommand;
 import com.hubspot.singularity.api.SingularityExpiringRequestParent;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.transcoders.Transcoder;
@@ -322,7 +323,7 @@ public class RequestManager extends CuratorAsyncManager {
 
     // delete it no matter if the delete request already exists.
     createCleanupRequest(new SingularityRequestCleanup(user, RequestCleanupType.DELETING, now, Optional.of(Boolean.TRUE), request.getId(), Optional.<String> absent(),
-        Optional.<Boolean> absent(), message, actionId));
+        Optional.<Boolean> absent(), message, actionId, Optional.<SingularityShellCommand>absent()));
 
     saveHistory(new SingularityRequestHistory(now, user, RequestHistoryType.DELETED, request, message));
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
@@ -571,7 +571,7 @@ public class SingularityValidator {
     });
 
     if (!commandDescriptor.isPresent()) {
-      throw WebExceptions.forbidden("Shell command %s not in %s", shellCommand.getName(), uiConfiguration.getShellCommands());
+      throw WebExceptions.badRequest("Shell command %s not in %s", shellCommand.getName(), uiConfiguration.getShellCommands());
     }
 
     Set<String> options = Sets.newHashSetWithExpectedSize(commandDescriptor.get().getOptions().size());

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TimeZone;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -26,7 +27,10 @@ import org.quartz.CronExpression;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.google.common.hash.Hashing;
 import com.google.inject.Inject;
 import com.hubspot.mesos.Resources;
@@ -46,11 +50,15 @@ import com.hubspot.singularity.SingularityAction;
 import com.hubspot.singularity.SingularityPriorityFreezeParent;
 import com.hubspot.singularity.SingularityRequest;
 import com.hubspot.singularity.SingularityRequestGroup;
+import com.hubspot.singularity.SingularityShellCommand;
 import com.hubspot.singularity.SingularityWebhook;
 import com.hubspot.singularity.SlavePlacement;
+import com.hubspot.singularity.WebExceptions;
 import com.hubspot.singularity.api.SingularityPriorityFreeze;
 import com.hubspot.singularity.api.SingularityBounceRequest;
 import com.hubspot.singularity.config.SingularityConfiguration;
+import com.hubspot.singularity.config.shell.ShellCommandDescriptor;
+import com.hubspot.singularity.config.shell.ShellCommandOptionDescriptor;
 import com.hubspot.singularity.data.history.DeployHistoryHelper;
 
 @Singleton
@@ -72,6 +80,7 @@ public class SingularityValidator {
   private final boolean allowRequestsWithoutOwners;
   private final boolean createDeployIds;
   private final int deployIdLength;
+  private final List<ShellCommandDescriptor> shellCommands;
   private final SlavePlacement defaultSlavePlacement;
   private final DeployHistoryHelper deployHistoryHelper;
   private final Resources defaultResources;
@@ -102,6 +111,8 @@ public class SingularityValidator {
     this.maxMemoryMbPerInstance = configuration.getMesosConfiguration().getMaxMemoryMbPerInstance();
     this.maxMemoryMbPerRequest = configuration.getMesosConfiguration().getMaxMemoryMbPerRequest();
     this.maxInstancesPerRequest = configuration.getMesosConfiguration().getMaxNumInstancesPerRequest();
+
+    this.shellCommands = configuration.getUiConfiguration().getShellCommands();
 
     this.disasterManager = disasterManager;
     this.slaveManager = slaveManager;
@@ -548,5 +559,31 @@ public class SingularityValidator {
     checkBadRequest(requestGroup.getId().length() < maxRequestIdSize, "Id must be less than %s characters, it is %s (%s)", maxRequestIdSize, requestGroup.getId().length(), requestGroup.getId());
 
     checkBadRequest(requestGroup.getRequestIds() != null, "requestIds cannot be null");
+  }
+
+  public void checkValidShellCommand(final SingularityShellCommand shellCommand) {
+    Optional<ShellCommandDescriptor> commandDescriptor = Iterables.tryFind(shellCommands, new Predicate<ShellCommandDescriptor>() {
+      @Override
+      public boolean apply(ShellCommandDescriptor input) {
+        return input.getName().equals(shellCommand.getName());
+      }
+    });
+
+    if (!commandDescriptor.isPresent()) {
+      throw WebExceptions.forbidden("Shell command %s not in %s", shellCommand.getName(), shellCommands);
+    }
+
+    Set<String> options = Sets.newHashSetWithExpectedSize(commandDescriptor.get().getOptions().size());
+    for (ShellCommandOptionDescriptor option : commandDescriptor.get().getOptions()) {
+      options.add(option.getName());
+    }
+
+    if (shellCommand.getOptions().isPresent()) {
+      for (String option : shellCommand.getOptions().get()) {
+        if (!options.contains(option)) {
+          throw WebExceptions.badRequest("Shell command %s does not have option %s (%s)", shellCommand.getName(), option, options);
+        }
+      }
+    }
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -184,9 +184,9 @@ public class RequestResource extends AbstractRequestResource {
     if (bounceRequest.isPresent()) {
       actionId = bounceRequest.get().getActionId();
       message = bounceRequest.get().getMessage();
-      if (bounceRequest.get().getRunBeforeKill().isPresent()) {
-        validator.checkValidShellCommand(bounceRequest.get().getRunBeforeKill().get());
-        runBeforeKill = bounceRequest.get().getRunBeforeKill();
+      if (bounceRequest.get().getRunShellCommandBeforeKill().isPresent()) {
+        validator.checkValidShellCommand(bounceRequest.get().getRunShellCommandBeforeKill().get());
+        runBeforeKill = bounceRequest.get().getRunShellCommandBeforeKill();
       }
     }
 
@@ -314,9 +314,9 @@ public class RequestResource extends AbstractRequestResource {
     if (pauseRequest.isPresent()) {
       killTasks = pauseRequest.get().getKillTasks();
       message = pauseRequest.get().getMessage();
-      if (pauseRequest.get().getRunBeforeKill().isPresent()) {
-        validator.checkValidShellCommand(pauseRequest.get().getRunBeforeKill().get());
-        runBeforeKill = pauseRequest.get().getRunBeforeKill();
+      if (pauseRequest.get().getRunShellCommandBeforeKill().isPresent()) {
+        validator.checkValidShellCommand(pauseRequest.get().getRunShellCommandBeforeKill().get());
+        runBeforeKill = pauseRequest.get().getRunShellCommandBeforeKill();
       }
 
       if (pauseRequest.get().getDurationMillis().isPresent() && !actionId.isPresent()) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
@@ -6,7 +6,6 @@ import static com.hubspot.singularity.WebExceptions.notFound;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -21,11 +20,9 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
 import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.hubspot.jackson.jaxrs.PropertyFiltering;
 import com.hubspot.mesos.JavaUtils;
@@ -60,8 +57,6 @@ import com.hubspot.singularity.api.SingularityTaskMetadataRequest;
 import com.hubspot.singularity.auth.SingularityAuthorizationHelper;
 import com.hubspot.singularity.config.SingularityTaskMetadataConfiguration;
 import com.hubspot.singularity.config.UIConfiguration;
-import com.hubspot.singularity.config.shell.ShellCommandDescriptor;
-import com.hubspot.singularity.config.shell.ShellCommandOptionDescriptor;
 import com.hubspot.singularity.data.RequestManager;
 import com.hubspot.singularity.data.SingularityValidator;
 import com.hubspot.singularity.data.SlaveManager;
@@ -86,12 +81,11 @@ public class TaskResource {
   private final SingularityAuthorizationHelper authorizationHelper;
   private final Optional<SingularityUser> user;
   private final SingularityTaskMetadataConfiguration taskMetadataConfiguration;
-  private final UIConfiguration uiConfiguration;
   private final SingularityValidator validator;
 
   @Inject
   public TaskResource(TaskRequestManager taskRequestManager, TaskManager taskManager, SlaveManager slaveManager, MesosClient mesosClient, SingularityTaskMetadataConfiguration taskMetadataConfiguration,
-      SingularityAuthorizationHelper authorizationHelper, Optional<SingularityUser> user, UIConfiguration uiConfiguration, RequestManager requestManager, SingularityValidator validator) {
+      SingularityAuthorizationHelper authorizationHelper, Optional<SingularityUser> user, RequestManager requestManager, SingularityValidator validator) {
     this.taskManager = taskManager;
     this.taskRequestManager = taskRequestManager;
     this.taskMetadataConfiguration = taskMetadataConfiguration;
@@ -100,7 +94,6 @@ public class TaskResource {
     this.requestManager = requestManager;
     this.authorizationHelper = authorizationHelper;
     this.user = user;
-    this.uiConfiguration = uiConfiguration;
     this.validator = validator;
   }
 
@@ -288,8 +281,8 @@ public class TaskResource {
       message = killTaskRequest.get().getMessage();
       override = killTaskRequest.get().getOverride();
       waitForReplacementTask = killTaskRequest.get().getWaitForReplacementTask();
-      if (killTaskRequest.get().getRunBeforeKill().isPresent()) {
-        SingularityTaskShellCommandRequest shellCommandRequest = startShellCommand(task.getTaskId(), killTaskRequest.get().getRunBeforeKill().get());
+      if (killTaskRequest.get().getRunShellCommandBeforeKill().isPresent()) {
+        SingularityTaskShellCommandRequest shellCommandRequest = startShellCommand(task.getTaskId(), killTaskRequest.get().getRunShellCommandBeforeKill().get());
         runBeforeKillId = Optional.of(shellCommandRequest.getId());
       }
     }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
@@ -417,8 +417,8 @@ public class SingularityCleaner {
 
       Optional<SingularityTaskShellCommandRequestId> runBeforeKillId = Optional.absent();
 
-      if (requestCleanup.getRunBeforeKill().isPresent()) {
-        SingularityTaskShellCommandRequest shellRequest = new SingularityTaskShellCommandRequest(matchingTaskId, requestCleanup.getUser(), System.currentTimeMillis(), requestCleanup.getRunBeforeKill().get());
+      if (requestCleanup.getRunShellCommandBeforeKill().isPresent()) {
+        SingularityTaskShellCommandRequest shellRequest = new SingularityTaskShellCommandRequest(matchingTaskId, requestCleanup.getUser(), System.currentTimeMillis(), requestCleanup.getRunShellCommandBeforeKill().get());
         taskManager.saveTaskShellCommandRequestToQueue(shellRequest);
         runBeforeKillId = Optional.of(shellRequest.getId());
       }
@@ -435,7 +435,7 @@ public class SingularityCleaner {
   private TaskCleanupType pause(SingularityRequestCleanup requestCleanup, Iterable<SingularityTaskId> activeTaskIds, boolean killActiveTasks) {
     final long start = System.currentTimeMillis();
     boolean killTasks = requestCleanup.getKillTasks().or(configuration.isDefaultValueForKillTasksOfPausedRequests());
-    if (requestCleanup.getRunBeforeKill().isPresent()) {
+    if (requestCleanup.getRunShellCommandBeforeKill().isPresent()) {
       killTasks = false;
     }
 
@@ -446,8 +446,8 @@ public class SingularityCleaner {
 
       Optional<SingularityTaskShellCommandRequestId> runBeforeKillId = Optional.absent();
 
-      if (requestCleanup.getRunBeforeKill().isPresent()) {
-        SingularityTaskShellCommandRequest shellRequest = new SingularityTaskShellCommandRequest(taskId, requestCleanup.getUser(), System.currentTimeMillis(), requestCleanup.getRunBeforeKill().get());
+      if (requestCleanup.getRunShellCommandBeforeKill().isPresent()) {
+        SingularityTaskShellCommandRequest shellRequest = new SingularityTaskShellCommandRequest(taskId, requestCleanup.getUser(), System.currentTimeMillis(), requestCleanup.getRunShellCommandBeforeKill().get());
         taskManager.saveTaskShellCommandRequestToQueue(shellRequest);
         runBeforeKillId = Optional.of(shellRequest.getId());
       }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
@@ -121,7 +121,7 @@ public class SingularityCleaner {
       return true;
     }
 
-    if (requestWithState.get().getState() == RequestState.PAUSED && !(taskCleanup.getCleanupType() == TaskCleanupType.PAUSING)) {
+    if (requestWithState.get().getState() == RequestState.PAUSED && !(taskCleanup.getCleanupType() == TaskCleanupType.PAUSING && !request.isLongRunning())) {
       LOG.debug("Killing a task {} immediately because the request was paused", taskCleanup);
       return true;
     }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
@@ -121,7 +121,10 @@ public class SingularityCleaner {
       return true;
     }
 
-    if (requestWithState.get().getState() == RequestState.PAUSED && !(taskCleanup.getCleanupType() == TaskCleanupType.PAUSING && !request.isLongRunning())) {
+    // If pausing, must be a long-running task to kill here
+    if (requestWithState.get().getState() == RequestState.PAUSED &&
+      ((taskCleanup.getCleanupType() == TaskCleanupType.PAUSING && request.isLongRunning())
+        || !(taskCleanup.getCleanupType() == TaskCleanupType.PAUSING))) {
       LOG.debug("Killing a task {} immediately because the request was paused", taskCleanup);
       return true;
     }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityDeployChecker.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityDeployChecker.java
@@ -47,6 +47,7 @@ import com.hubspot.singularity.SingularityRequestWithState;
 import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.SingularityTaskCleanup;
 import com.hubspot.singularity.SingularityTaskId;
+import com.hubspot.singularity.SingularityTaskShellCommandRequestId;
 import com.hubspot.singularity.SingularityUpdatePendingDeployRequest;
 import com.hubspot.singularity.TaskCleanupType;
 import com.hubspot.singularity.config.SingularityConfiguration;
@@ -210,7 +211,7 @@ public class SingularityDeployChecker {
   private void cleanupTasks(SingularityPendingDeploy pendingDeploy, SingularityRequest request, SingularityDeployResult deployResult, Iterable<SingularityTaskId> tasksToKill) {
     for (SingularityTaskId matchingTask : tasksToKill) {
       taskManager.createTaskCleanup(new SingularityTaskCleanup(pendingDeploy.getDeployMarker().getUser(), getCleanupType(pendingDeploy, request, deployResult), deployResult.getTimestamp(), matchingTask,
-        Optional.of(String.format("Deploy %s - %s", pendingDeploy.getDeployMarker().getDeployId(), deployResult.getDeployState().name())), Optional.<String> absent()));
+        Optional.of(String.format("Deploy %s - %s", pendingDeploy.getDeployMarker().getDeployId(), deployResult.getDeployState().name())), Optional.<String> absent(), Optional.<SingularityTaskShellCommandRequestId>absent()));
     }
   }
 
@@ -656,7 +657,7 @@ public class SingularityDeployChecker {
     for (SingularityTaskId taskId : tasksToShutDown(deployProgress, otherActiveTasks, request)) {
       taskManager.createTaskCleanup(
         new SingularityTaskCleanup(Optional.<String> absent(), TaskCleanupType.DEPLOY_STEP_FINISHED, System.currentTimeMillis(), taskId, Optional.of(message),
-          Optional.<String> absent()));
+          Optional.<String> absent(), Optional.<SingularityTaskShellCommandRequestId>absent()));
     }
     return new SingularityDeployResult(deployState);
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityJobPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityJobPoller.java
@@ -27,6 +27,7 @@ import com.hubspot.singularity.SingularityRequest;
 import com.hubspot.singularity.SingularityRequestWithState;
 import com.hubspot.singularity.SingularityTaskCleanup;
 import com.hubspot.singularity.SingularityTaskId;
+import com.hubspot.singularity.SingularityTaskShellCommandRequestId;
 import com.hubspot.singularity.TaskCleanupType;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.DeployManager;
@@ -129,7 +130,8 @@ public class SingularityJobPoller extends SingularityLeaderOnlyPoller {
               DurationFormatUtils.formatDurationHMS(runtime),
               DurationFormatUtils.formatDurationHMS(request.getTaskExecutionTimeLimitMillis().or(configuration.getTaskExecutionTimeLimitMillis()).get()))
           ),
-          Optional.of(UUID.randomUUID().toString()))
+          Optional.of(UUID.randomUUID().toString()),
+          Optional.<SingularityTaskShellCommandRequestId>absent())
       );
     }
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityNewTaskChecker.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityNewTaskChecker.java
@@ -36,6 +36,7 @@ import com.hubspot.singularity.SingularityTaskCleanup;
 import com.hubspot.singularity.SingularityTaskHealthcheckResult;
 import com.hubspot.singularity.SingularityTaskHistoryUpdate;
 import com.hubspot.singularity.SingularityTaskHistoryUpdate.SimplifiedTaskState;
+import com.hubspot.singularity.SingularityTaskShellCommandRequestId;
 import com.hubspot.singularity.TaskCleanupType;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.RequestManager;
@@ -248,7 +249,7 @@ public class SingularityNewTaskChecker {
           LOG.info("Killing {} because it did not become healthy after {}", task.getTaskId(), JavaUtils.durationFromMillis(getKillAfterUnhealthyMillis()));
 
           taskManager.createTaskCleanup(new SingularityTaskCleanup(Optional.<String> absent(), TaskCleanupType.OVERDUE_NEW_TASK, System.currentTimeMillis(),
-              task.getTaskId(), Optional.of(String.format("Task did not become healthy after %s", JavaUtils.durationFromMillis(getKillAfterUnhealthyMillis()))), Optional.<String>absent()));
+              task.getTaskId(), Optional.of(String.format("Task did not become healthy after %s", JavaUtils.durationFromMillis(getKillAfterUnhealthyMillis()))), Optional.<String>absent(), Optional.<SingularityTaskShellCommandRequestId>absent()));
           return false;
         } else {
           return true;
@@ -259,7 +260,7 @@ public class SingularityNewTaskChecker {
         LOG.info("Killing {} because it failed healthchecks", task.getTaskId());
 
         taskManager.createTaskCleanup(new SingularityTaskCleanup(Optional.<String> absent(), TaskCleanupType.UNHEALTHY_NEW_TASK, System.currentTimeMillis(),
-            task.getTaskId(), Optional.of("Task is not healthy"), Optional.<String> absent()));
+            task.getTaskId(), Optional.of("Task is not healthy"), Optional.<String> absent(), Optional.<SingularityTaskShellCommandRequestId>absent()));
         return false;
       case HEALTHY:
       case OBSOLETE:

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityPriorityKillPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityPriorityKillPoller.java
@@ -15,6 +15,7 @@ import com.hubspot.singularity.SingularityPriorityFreezeParent;
 import com.hubspot.singularity.SingularityRequestWithState;
 import com.hubspot.singularity.SingularityTaskCleanup;
 import com.hubspot.singularity.SingularityTaskId;
+import com.hubspot.singularity.SingularityTaskShellCommandRequestId;
 import com.hubspot.singularity.TaskCleanupType;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.PriorityManager;
@@ -82,7 +83,7 @@ public class SingularityPriorityKillPoller extends SingularityLeaderOnlyPoller {
                     LOG.info("Killing active task {} since priority level {} is less than {}", taskId.getId(), taskPriorityLevel, minPriorityLevel);
                     taskManager.createTaskCleanup(
                         new SingularityTaskCleanup(maybePriorityFreeze.get().getUser(), TaskCleanupType.PRIORITY_KILL, now, taskId, maybePriorityFreeze.get().getPriorityFreeze().getMessage(),
-                            maybePriorityFreeze.get().getPriorityFreeze().getActionId()));
+                            maybePriorityFreeze.get().getPriorityFreeze().getActionId(), Optional.<SingularityTaskShellCommandRequestId>absent()));
                     killedTaskCount++;
                 }
             }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -60,6 +60,7 @@ import com.hubspot.singularity.SingularityTaskCleanup;
 import com.hubspot.singularity.SingularityTaskHistoryUpdate;
 import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.SingularityTaskRequest;
+import com.hubspot.singularity.SingularityTaskShellCommandRequestId;
 import com.hubspot.singularity.TaskCleanupType;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.AbstractMachineManager;
@@ -113,7 +114,7 @@ public class SingularityScheduler {
     LOG.trace("Scheduling a cleanup task for {} due to decomissioning {}", task.getTaskId(), decommissioningObject);
 
     taskManager.createTaskCleanup(new SingularityTaskCleanup(decommissioningObject.getCurrentState().getUser(), TaskCleanupType.DECOMISSIONING, System.currentTimeMillis(),
-      task.getTaskId(), Optional.of(String.format("%s %s is decomissioning", decommissioningObject.getTypeName(), decommissioningObject.getName())), Optional.<String>absent()));
+      task.getTaskId(), Optional.of(String.format("%s %s is decomissioning", decommissioningObject.getTypeName(), decommissioningObject.getName())), Optional.<String>absent(), Optional.<SingularityTaskShellCommandRequestId>absent()));
   }
 
   private <T extends SingularityMachineAbstraction<T>> Map<T, MachineState> getDefaultMap(List<T> objects) {
@@ -424,7 +425,7 @@ public class SingularityScheduler {
 
         LOG.info("Cleaning up task {} due to new request {} - scaling down to {} instances", toCleanup.getId(), request.getId(), request.getInstancesSafe());
 
-        taskManager.createTaskCleanup(new SingularityTaskCleanup(pendingRequest.getUser(), TaskCleanupType.SCALING_DOWN, now, toCleanup, Optional.<String>absent(), Optional.<String>absent()));
+        taskManager.createTaskCleanup(new SingularityTaskCleanup(pendingRequest.getUser(), TaskCleanupType.SCALING_DOWN, now, toCleanup, Optional.<String>absent(), Optional.<String>absent(), Optional.<SingularityTaskShellCommandRequestId>absent()));
       }
     }
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityTaskShellCommandTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityTaskShellCommandTest.java
@@ -63,7 +63,7 @@ public class SingularityTaskShellCommandTest extends SingularitySchedulerTestBas
     try {
       taskResource.runShellCommand(task.getTaskId().getId(), new SingularityShellCommand("test-cmd", Optional.of(Arrays.asList("one", "two")), user, Optional.<String>absent()));
     } catch (WebApplicationException exception) {
-      assertEquals(403, exception.getResponse().getStatus());
+      assertEquals(400, exception.getResponse().getStatus());
     }
 
     // bad option

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityTaskShellCommandTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityTaskShellCommandTest.java
@@ -10,17 +10,20 @@ import java.util.List;
 import javax.ws.rs.WebApplicationException;
 
 import org.apache.mesos.Protos.TaskState;
+import org.junit.Assert;
 import org.junit.Test;
 
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.hubspot.singularity.SingularityShellCommand;
 import com.hubspot.singularity.SingularityTask;
+import com.hubspot.singularity.SingularityTaskCleanup;
 import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.SingularityTaskShellCommandRequest;
 import com.hubspot.singularity.SingularityTaskShellCommandRequestId;
 import com.hubspot.singularity.SingularityTaskShellCommandUpdate;
 import com.hubspot.singularity.SingularityTaskShellCommandUpdate.UpdateType;
+import com.hubspot.singularity.api.SingularityBounceRequest;
 import com.hubspot.singularity.config.UIConfiguration;
 import com.hubspot.singularity.config.shell.ShellCommandDescriptor;
 import com.hubspot.singularity.config.shell.ShellCommandOptionDescriptor;
@@ -54,20 +57,7 @@ public class SingularityTaskShellCommandTest extends SingularitySchedulerTestBas
     SingularityTask task = launchTask(request, firstDeploy, 1, TaskState.TASK_RUNNING);
 
     // test bad command first:
-
-    List<ShellCommandDescriptor> descriptors = new ArrayList<>();
-
-    ShellCommandDescriptor descriptor1 = new ShellCommandDescriptor();
-    descriptor1.setName("d1");
-    descriptor1.setOptions(Arrays.asList(new ShellCommandOptionDescriptor().setName("o1"), new ShellCommandOptionDescriptor().setName("o2")));
-    ShellCommandDescriptor descriptor2 = new ShellCommandDescriptor();
-    descriptor2.setName("d2");
-    descriptor2.setOptions(Collections.<ShellCommandOptionDescriptor> emptyList());
-
-    descriptors.add(descriptor1);
-    descriptors.add(descriptor2);
-
-    uiConfiguration.setShellCommands(descriptors);
+    setShellCommandsConfiguration();
 
     // bad shell cmd
     try {
@@ -120,5 +110,55 @@ public class SingularityTaskShellCommandTest extends SingularitySchedulerTestBas
     assertEquals(0, taskManager.getTaskShellCommandUpdates(secondShellRequest.getId()).size());
   }
 
+  @Test
+  public void testRunCommandBeforeBounceKill() {
+    setShellCommandsConfiguration();
 
+    initRequest();
+    initFirstDeploy();
+
+    launchTask(request, firstDeploy, 1, TaskState.TASK_RUNNING);
+
+    requestResource.bounce(requestId, Optional.of(new SingularityBounceRequest(Optional.<Boolean>absent(), Optional.<Boolean>absent(), Optional.<Long>absent(), Optional.<String>absent(), Optional.<String>absent(),
+      Optional.of(new SingularityShellCommand("d1", Optional.of(Arrays.asList("o1", "o2")), user, Optional.<String>absent())))));
+
+    cleaner.drainCleanupQueue();
+
+    List<SingularityTaskCleanup> taskCleanups = taskManager.getCleanupTasks();
+    Assert.assertTrue(taskCleanups.get(0).getRunBeforeKillId().isPresent());
+    SingularityTaskShellCommandRequestId shellCommandRequestId = taskCleanups.get(0).getRunBeforeKillId().get();
+
+    cleaner.drainCleanupQueue();
+    Assert.assertEquals(1, taskManager.getCleanupTaskIds().size());
+
+    launchTask(request, firstDeploy, 1, TaskState.TASK_RUNNING);
+    Assert.assertEquals(2, taskManager.getActiveTaskIdsForRequest(requestId).size());
+
+    cleaner.drainCleanupQueue();
+    Assert.assertEquals(2, taskManager.getActiveTaskIdsForRequest(requestId).size());
+
+    taskManager.saveTaskShellCommandUpdate(new SingularityTaskShellCommandUpdate(shellCommandRequestId, System.currentTimeMillis(), Optional.<String>absent(), Optional.<String>absent(), UpdateType.ACKED));
+    cleaner.drainCleanupQueue();
+    Assert.assertEquals(2, taskManager.getActiveTaskIdsForRequest(requestId).size());
+
+    taskManager.saveTaskShellCommandUpdate(new SingularityTaskShellCommandUpdate(shellCommandRequestId, System.currentTimeMillis(), Optional.<String>absent(), Optional.<String>absent(), UpdateType.FINISHED));
+    cleaner.drainCleanupQueue();
+    Assert.assertEquals(1, taskManager.getKilledTaskIdRecords().size());
+  }
+
+  private void setShellCommandsConfiguration() {
+    List<ShellCommandDescriptor> descriptors = new ArrayList<>();
+
+    ShellCommandDescriptor descriptor1 = new ShellCommandDescriptor();
+    descriptor1.setName("d1");
+    descriptor1.setOptions(Arrays.asList(new ShellCommandOptionDescriptor().setName("o1"), new ShellCommandOptionDescriptor().setName("o2")));
+    ShellCommandDescriptor descriptor2 = new ShellCommandDescriptor();
+    descriptor2.setName("d2");
+    descriptor2.setOptions(Collections.<ShellCommandOptionDescriptor> emptyList());
+
+    descriptors.add(descriptor1);
+    descriptors.add(descriptor2);
+
+    uiConfiguration.setShellCommands(descriptors);
+  }
 }

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityExpiringActionsTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityExpiringActionsTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 
 import com.google.common.base.Optional;
 import com.hubspot.singularity.RequestState;
+import com.hubspot.singularity.SingularityShellCommand;
 import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.api.SingularityBounceRequest;
 import com.hubspot.singularity.api.SingularityPauseRequest;
@@ -25,7 +26,7 @@ public class SingularityExpiringActionsTest extends SingularitySchedulerTestBase
 
     SingularityTask taskOne = startTask(firstDeploy);
 
-    requestResource.pause(requestId, Optional.of(new SingularityPauseRequest(Optional.<Boolean> absent(), Optional.of(1L), Optional.<String> absent(), Optional.<String>absent())));
+    requestResource.pause(requestId, Optional.of(new SingularityPauseRequest(Optional.<Boolean> absent(), Optional.of(1L), Optional.<String> absent(), Optional.<String>absent(), Optional.<SingularityShellCommand>absent())));
 
     cleaner.drainCleanupQueue();
 
@@ -64,7 +65,7 @@ public class SingularityExpiringActionsTest extends SingularitySchedulerTestBase
     startTask(firstDeploy, 1);
 
     requestResource.bounce(requestId,
-      Optional.of(new SingularityBounceRequest(Optional.of(false), Optional.<Boolean> absent(), Optional.of(1L), Optional.<String> absent(), Optional.of("msg"))));
+      Optional.of(new SingularityBounceRequest(Optional.of(false), Optional.<Boolean> absent(), Optional.of(1L), Optional.<String> absent(), Optional.of("msg"), Optional.<SingularityShellCommand>absent())));
 
     cleaner.drainCleanupQueue();
     resourceOffers();
@@ -83,7 +84,7 @@ public class SingularityExpiringActionsTest extends SingularitySchedulerTestBase
     initWithTasks(3);
 
     requestResource.bounce(requestId,
-      Optional.of(new SingularityBounceRequest(Optional.<Boolean> absent(), Optional.<Boolean> absent(), Optional.of(1L), Optional.of("aid"), Optional.<String> absent())));
+      Optional.of(new SingularityBounceRequest(Optional.<Boolean> absent(), Optional.<Boolean> absent(), Optional.of(1L), Optional.of("aid"), Optional.<String> absent(), Optional.<SingularityShellCommand>absent())));
 
     Assert.assertTrue(!requestManager.getCleanupRequests().get(0).getMessage().isPresent());
     Assert.assertEquals("aid", requestManager.getCleanupRequests().get(0).getActionId().get());
@@ -136,7 +137,7 @@ public class SingularityExpiringActionsTest extends SingularitySchedulerTestBase
     startTask(firstDeploy, 3);
 
     requestResource.bounce(requestId,
-      Optional.of(new SingularityBounceRequest(Optional.of(true), Optional.<Boolean> absent(), Optional.of(1L), Optional.<String> absent(), Optional.of("msg"))));
+      Optional.of(new SingularityBounceRequest(Optional.of(true), Optional.<Boolean> absent(), Optional.of(1L), Optional.<String> absent(), Optional.of("msg"), Optional.<SingularityShellCommand>absent())));
 
     Assert.assertTrue(requestManager.cleanupRequestExists(requestId));
     Assert.assertEquals("msg", requestManager.getCleanupRequests().get(0).getMessage().get());

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityHealthchecksTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityHealthchecksTest.java
@@ -14,6 +14,7 @@ import com.hubspot.mesos.Resources;
 import com.hubspot.singularity.DeployState;
 import com.hubspot.singularity.SingularityDeploy;
 import com.hubspot.singularity.SingularityDeployBuilder;
+import com.hubspot.singularity.SingularityShellCommand;
 import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.SingularityTaskHealthcheckResult;
 import com.hubspot.singularity.SingularityTaskId;
@@ -71,7 +72,7 @@ public class SingularityHealthchecksTest extends SingularitySchedulerTestBase {
 
     SingularityTask firstTask = startTask(firstDeploy, 1);
 
-    requestResource.bounce(requestId, Optional.of(new SingularityBounceRequest(Optional.<Boolean> absent(), Optional.of(true), Optional.<Long> absent(), Optional.<String> absent(), Optional.<String>absent())));
+    requestResource.bounce(requestId, Optional.of(new SingularityBounceRequest(Optional.<Boolean> absent(), Optional.of(true), Optional.<Long> absent(), Optional.<String> absent(), Optional.<String>absent(), Optional.<SingularityShellCommand>absent())));
 
     configuration.setNewTaskCheckerBaseDelaySeconds(0);
     configuration.setHealthcheckIntervalSeconds(0);

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -60,6 +60,7 @@ import com.hubspot.singularity.SingularityRequestCleanup;
 import com.hubspot.singularity.SingularityRequestHistory;
 import com.hubspot.singularity.SingularityRequestHistory.RequestHistoryType;
 import com.hubspot.singularity.SingularityRequestLbCleanup;
+import com.hubspot.singularity.SingularityShellCommand;
 import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.SingularityTaskHealthcheckResult;
 import com.hubspot.singularity.SingularityTaskId;
@@ -145,7 +146,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     SingularityTask firstTask = launchTask(request, firstDeploy, 1, TaskState.TASK_RUNNING);
     createAndSchedulePendingTask(firstDeployId);
 
-    requestResource.pause(requestId, Optional.of(new SingularityPauseRequest(Optional.of(false), Optional.<Long> absent(), Optional.<String> absent(), Optional.<String>absent())));
+    requestResource.pause(requestId, Optional.of(new SingularityPauseRequest(Optional.of(false), Optional.<Long> absent(), Optional.<String> absent(), Optional.<String>absent(), Optional.<SingularityShellCommand>absent())));
 
     cleaner.drainCleanupQueue();
 
@@ -183,7 +184,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     SingularityTask firstTask = startTask(firstDeploy);
 
     taskResource.killTask(firstTask.getTaskId().getId(), Optional.of(
-        new SingularityKillTaskRequest(Optional.<Boolean> absent(), Optional.of("msg"), Optional.<String> absent(), Optional.of(true))));
+        new SingularityKillTaskRequest(Optional.<Boolean> absent(), Optional.of("msg"), Optional.<String> absent(), Optional.of(true), Optional.<SingularityShellCommand>absent())));
 
     cleaner.drainCleanupQueue();
 
@@ -876,7 +877,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     initRequest();
 
     requestManager.createCleanupRequest(new SingularityRequestCleanup(Optional.<String>absent(), RequestCleanupType.PAUSING, System.currentTimeMillis(),
-        Optional.<Boolean>absent(), requestId, Optional.<String>absent(), Optional.<Boolean> absent(), Optional.<String>absent(), Optional.<String>absent()));
+        Optional.<Boolean>absent(), requestId, Optional.<String>absent(), Optional.<Boolean> absent(), Optional.<String>absent(), Optional.<String>absent(), Optional.<SingularityShellCommand>absent()));
 
     cleaner.drainCleanupQueue();
 
@@ -1016,7 +1017,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     startTask(firstDeploy, 3);
 
     requestResource.bounce(requestId,
-        Optional.of(new SingularityBounceRequest(Optional.of(true), Optional.<Boolean>absent(), Optional.of(1L), Optional.<String>absent(), Optional.of("msg"))));
+        Optional.of(new SingularityBounceRequest(Optional.of(true), Optional.<Boolean>absent(), Optional.of(1L), Optional.<String>absent(), Optional.of("msg"), Optional.<SingularityShellCommand>absent())));
 
     Assert.assertTrue(requestManager.cleanupRequestExists(requestId));
 
@@ -1058,7 +1059,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     SingularityTask taskTwo = startSeparatePlacementTask(firstDeploy, 2);
 
     requestManager.createCleanupRequest(new SingularityRequestCleanup(user, RequestCleanupType.INCREMENTAL_BOUNCE, System.currentTimeMillis(),
-        Optional.<Boolean>absent(), requestId, Optional.of(firstDeployId), Optional.<Boolean> absent(), Optional.<String>absent(), Optional.<String>absent()));
+        Optional.<Boolean>absent(), requestId, Optional.of(firstDeployId), Optional.<Boolean> absent(), Optional.<String>absent(), Optional.<String>absent(), Optional.<SingularityShellCommand>absent()));
 
     Assert.assertTrue(requestManager.cleanupRequestExists(requestId));
 

--- a/SingularityUI/app/actions/api/requests.es6
+++ b/SingularityUI/app/actions/api/requests.es6
@@ -65,9 +65,9 @@ export const FetchRequestRun = buildApiAction(
 export const PauseRequest = buildJsonApiAction(
   'PAUSE_REQUEST',
   'POST',
-  (requestId, { durationMillis, killTasks, message, actionId, runBeforeKill }) => ({
+  (requestId, { durationMillis, killTasks, message, actionId, runShellCommandBeforeKill }) => ({
     url: `/requests/request/${requestId}/pause`,
-    body: { durationMillis, killTasks, message, actionId, runBeforeKill }
+    body: { durationMillis, killTasks, message, actionId, runShellCommandBeforeKill }
   })
 );
 

--- a/SingularityUI/app/actions/api/requests.es6
+++ b/SingularityUI/app/actions/api/requests.es6
@@ -65,9 +65,9 @@ export const FetchRequestRun = buildApiAction(
 export const PauseRequest = buildJsonApiAction(
   'PAUSE_REQUEST',
   'POST',
-  (requestId, { durationMillis, killTasks, message, actionId }) => ({
+  (requestId, { durationMillis, killTasks, message, actionId, runBeforeKill }) => ({
     url: `/requests/request/${requestId}/pause`,
-    body: { durationMillis, killTasks, message, actionId }
+    body: { durationMillis, killTasks, message, actionId, runBeforeKill }
   })
 );
 

--- a/SingularityUI/app/components/common/modalButtons/BounceModal.jsx
+++ b/SingularityUI/app/components/common/modalButtons/BounceModal.jsx
@@ -32,7 +32,12 @@ class BounceModal extends Component {
         name="Bounce Request"
         ref="bouceModal"
         action="Bounce Request"
-        onConfirm={(data) => this.props.bounceRequest(data)}
+        onConfirm={(data) => {
+          if (data.runShellCommand) {
+            data.runBeforeKill = {name: data.runBeforeKill};
+          }
+          this.props.bounceRequest(data)
+        }}
         buttonStyle="primary"
         formElements={[
           {
@@ -45,6 +50,21 @@ class BounceModal extends Component {
             name: 'skipHealthchecks',
             type: FormModal.INPUT_TYPES.BOOLEAN,
             label: 'Skip healthchecks during bounce'
+          },
+          {
+            name: 'runShellCommand',
+            type: FormModal.INPUT_TYPES.BOOLEAN,
+            label: 'Run shell command before killing tasks',
+            defaultValue: false
+          },
+          {
+            name: 'runBeforeKill',
+            type: FormModal.INPUT_TYPES.SELECT,
+            dependsOn: 'runShellCommand',
+            options: config.shellCommands.map((shellCommand) => ({
+              label: shellCommand.name,
+              value: shellCommand.name
+            }))
           },
           {
             name: 'durationMillis',

--- a/SingularityUI/app/components/common/modalButtons/BounceModal.jsx
+++ b/SingularityUI/app/components/common/modalButtons/BounceModal.jsx
@@ -50,7 +50,7 @@ class BounceModal extends Component {
         defaultValue: false
         },
         {
-          name: 'runBeforeKill',
+          name: 'runShellCommandBeforeKill',
           type: FormModal.INPUT_TYPES.SELECT,
           dependsOn: 'runShellCommand',
           defaultValue: config.shellCommands[0].name,
@@ -88,9 +88,9 @@ class BounceModal extends Component {
         action="Bounce Request"
         onConfirm={(data) => {
           if (data.runShellCommand) {
-            data.runBeforeKill = {name: data.runBeforeKill};
+            data.runShellCommandBeforeKill = {name: data.runShellCommandBeforeKill};
           } else {
-            delete data.runBeforeKill;
+            delete data.runShellCommandBeforeKill;
           }
           this.props.bounceRequest(data)
         }}

--- a/SingularityUI/app/components/common/modalButtons/BounceModal.jsx
+++ b/SingularityUI/app/components/common/modalButtons/BounceModal.jsx
@@ -27,6 +27,59 @@ class BounceModal extends Component {
   };
 
   render() {
+    let formElements = [
+      {
+        name: 'incremental',
+        type: FormModal.INPUT_TYPES.RADIO,
+        values: _.values(BounceModal.INCREMENTAL_BOUNCE_VALUE),
+        defaultValue: BounceModal.INCREMENTAL_BOUNCE_VALUE.INCREMENTAL.value
+      },
+      {
+        name: 'skipHealthchecks',
+        type: FormModal.INPUT_TYPES.BOOLEAN,
+        label: 'Skip healthchecks during bounce'
+      }
+    ]
+
+    if (config.shellCommands.length > 0) {
+      formElements.push(
+        {
+        name: 'runShellCommand',
+        type: FormModal.INPUT_TYPES.BOOLEAN,
+        label: 'Run shell command before killing tasks',
+        defaultValue: false
+        },
+        {
+          name: 'runBeforeKill',
+          type: FormModal.INPUT_TYPES.SELECT,
+          dependsOn: 'runShellCommand',
+          options: config.shellCommands.map((shellCommand) => ({
+            label: shellCommand.name,
+            value: shellCommand.name
+          }))
+        }
+      );
+    }
+
+    formElements.push(
+      {
+        name: 'durationMillis',
+        type: FormModal.INPUT_TYPES.DURATION,
+        label: 'Expiration (optional)',
+        help: (
+          <div>
+            <p>If an expiration duration is specified, this bounce will be aborted if not finished.</p>
+            <p>Default value {config.defaultBounceExpirationMinutes} minutes</p>
+          </div>
+        )
+      },
+      {
+        name: 'message',
+        type: FormModal.INPUT_TYPES.STRING,
+        label: 'Message (optional)'
+      }
+    );
+
     return (
       <FormModal
         name="Bounce Request"
@@ -39,50 +92,7 @@ class BounceModal extends Component {
           this.props.bounceRequest(data)
         }}
         buttonStyle="primary"
-        formElements={[
-          {
-            name: 'incremental',
-            type: FormModal.INPUT_TYPES.RADIO,
-            values: _.values(BounceModal.INCREMENTAL_BOUNCE_VALUE),
-            defaultValue: BounceModal.INCREMENTAL_BOUNCE_VALUE.INCREMENTAL.value
-          },
-          {
-            name: 'skipHealthchecks',
-            type: FormModal.INPUT_TYPES.BOOLEAN,
-            label: 'Skip healthchecks during bounce'
-          },
-          {
-            name: 'runShellCommand',
-            type: FormModal.INPUT_TYPES.BOOLEAN,
-            label: 'Run shell command before killing tasks',
-            defaultValue: false
-          },
-          {
-            name: 'runBeforeKill',
-            type: FormModal.INPUT_TYPES.SELECT,
-            dependsOn: 'runShellCommand',
-            options: config.shellCommands.map((shellCommand) => ({
-              label: shellCommand.name,
-              value: shellCommand.name
-            }))
-          },
-          {
-            name: 'durationMillis',
-            type: FormModal.INPUT_TYPES.DURATION,
-            label: 'Expiration (optional)',
-            help: (
-              <div>
-                <p>If an expiration duration is specified, this bounce will be aborted if not finished.</p>
-                <p>Default value {config.defaultBounceExpirationMinutes} minutes</p>
-              </div>
-            )
-          },
-          {
-            name: 'message',
-            type: FormModal.INPUT_TYPES.STRING,
-            label: 'Message (optional)'
-          }
-        ]}>
+        formElements={formElements}>
         <p>Are you sure you want to bounce this request?</p>
         <pre>{this.props.requestId}</pre>
         <p>Bouncing a request will cause replacement tasks to be scheduled and (under normal conditions) executed immediately.</p>

--- a/SingularityUI/app/components/common/modalButtons/BounceModal.jsx
+++ b/SingularityUI/app/components/common/modalButtons/BounceModal.jsx
@@ -53,6 +53,7 @@ class BounceModal extends Component {
           name: 'runBeforeKill',
           type: FormModal.INPUT_TYPES.SELECT,
           dependsOn: 'runShellCommand',
+          defaultValue: config.shellCommands[0].name,
           options: config.shellCommands.map((shellCommand) => ({
             label: shellCommand.name,
             value: shellCommand.name
@@ -88,6 +89,8 @@ class BounceModal extends Component {
         onConfirm={(data) => {
           if (data.runShellCommand) {
             data.runBeforeKill = {name: data.runBeforeKill};
+          } else {
+            delete data.runBeforeKill;
           }
           this.props.bounceRequest(data)
         }}

--- a/SingularityUI/app/components/common/modalButtons/KillTaskModal.jsx
+++ b/SingularityUI/app/components/common/modalButtons/KillTaskModal.jsx
@@ -35,6 +35,21 @@ class KillTaskModal extends Component {
         type: FormModal.INPUT_TYPES.BOOLEAN,
         label: 'Wait for replacement task to start before killing task',
         defaultValue: true
+      },
+      {
+        name: 'runShellCommand',
+        type: FormModal.INPUT_TYPES.BOOLEAN,
+        label: 'Run shell command before killing tasks',
+        defaultValue: false
+      },
+      {
+        name: 'runBeforeKill',
+        type: FormModal.INPUT_TYPES.SELECT,
+        dependsOn: 'runShellCommand',
+        options: config.shellCommands.map((shellCommand) => ({
+          label: shellCommand.name,
+          value: shellCommand.name
+        }))
       }];
     }
     formElements.push({
@@ -47,7 +62,13 @@ class KillTaskModal extends Component {
         name={this.props.name}
         ref="confirmKillTask"
         action={this.props.name}
-        onConfirm={(data) => this.props.killTask(data)}
+        onConfirm={(data) => {
+          if (data.runShellCommand) {
+            data.runBeforeKill = {name: data.runBeforeKill};
+          }
+          console.log(data);
+          this.props.killTask(data)
+        }}
         buttonStyle="danger"
         formElements={formElements}>
         <span>

--- a/SingularityUI/app/components/common/modalButtons/KillTaskModal.jsx
+++ b/SingularityUI/app/components/common/modalButtons/KillTaskModal.jsx
@@ -50,6 +50,7 @@ class KillTaskModal extends Component {
           name: 'runBeforeKill',
           type: FormModal.INPUT_TYPES.SELECT,
           dependsOn: 'runShellCommand',
+          defaultValue: config.shellCommands[0].name,
           options: config.shellCommands.map((shellCommand) => ({
             label: shellCommand.name,
             value: shellCommand.name
@@ -71,6 +72,8 @@ class KillTaskModal extends Component {
         onConfirm={(data) => {
           if (data.runShellCommand) {
             data.runBeforeKill = {name: data.runBeforeKill};
+          } else {
+            delete data.runBeforeKill;
           }
           console.log(data);
           this.props.killTask(data)

--- a/SingularityUI/app/components/common/modalButtons/KillTaskModal.jsx
+++ b/SingularityUI/app/components/common/modalButtons/KillTaskModal.jsx
@@ -35,23 +35,29 @@ class KillTaskModal extends Component {
         type: FormModal.INPUT_TYPES.BOOLEAN,
         label: 'Wait for replacement task to start before killing task',
         defaultValue: true
-      },
-      {
+      }];
+    }
+
+    if (config.shellCommands.length > 0) {
+      formElements.push(
+        {
         name: 'runShellCommand',
         type: FormModal.INPUT_TYPES.BOOLEAN,
         label: 'Run shell command before killing tasks',
         defaultValue: false
-      },
-      {
-        name: 'runBeforeKill',
-        type: FormModal.INPUT_TYPES.SELECT,
-        dependsOn: 'runShellCommand',
-        options: config.shellCommands.map((shellCommand) => ({
-          label: shellCommand.name,
-          value: shellCommand.name
-        }))
-      }];
+        },
+        {
+          name: 'runBeforeKill',
+          type: FormModal.INPUT_TYPES.SELECT,
+          dependsOn: 'runShellCommand',
+          options: config.shellCommands.map((shellCommand) => ({
+            label: shellCommand.name,
+            value: shellCommand.name
+          }))
+        }
+      );
     }
+
     formElements.push({
       name: 'message',
       type: FormModal.INPUT_TYPES.STRING,

--- a/SingularityUI/app/components/common/modalButtons/KillTaskModal.jsx
+++ b/SingularityUI/app/components/common/modalButtons/KillTaskModal.jsx
@@ -47,7 +47,7 @@ class KillTaskModal extends Component {
         defaultValue: false
         },
         {
-          name: 'runBeforeKill',
+          name: 'runShellCommandBeforeKill',
           type: FormModal.INPUT_TYPES.SELECT,
           dependsOn: 'runShellCommand',
           defaultValue: config.shellCommands[0].name,
@@ -71,9 +71,9 @@ class KillTaskModal extends Component {
         action={this.props.name}
         onConfirm={(data) => {
           if (data.runShellCommand) {
-            data.runBeforeKill = {name: data.runBeforeKill};
+            data.runShellCommandBeforeKill = {name: data.runShellCommandBeforeKill};
           } else {
-            delete data.runBeforeKill;
+            delete data.runShellCommandBeforeKill;
           }
           console.log(data);
           this.props.killTask(data)

--- a/SingularityUI/app/components/common/modalButtons/PauseModal.jsx
+++ b/SingularityUI/app/components/common/modalButtons/PauseModal.jsx
@@ -28,6 +28,21 @@ class PauseModal extends Component {
         name: 'message',
         type: FormModal.INPUT_TYPES.STRING,
         label: 'Message (optional)'
+      },
+      {
+        name: 'runShellCommand',
+        type: FormModal.INPUT_TYPES.BOOLEAN,
+        label: 'Run shell command before killing tasks',
+        defaultValue: false
+      },
+      {
+        name: 'runBeforeKill',
+        type: FormModal.INPUT_TYPES.SELECT,
+        dependsOn: 'runShellCommand',
+        options: config.shellCommands.map((shellCommand) => ({
+          label: shellCommand.name,
+          value: shellCommand.name
+        }))
       }
     ];
     if (this.props.isScheduled) {
@@ -46,7 +61,12 @@ class PauseModal extends Component {
         name="Pause Request"
         ref="pauseModal"
         action="Pause Request"
-        onConfirm={(data) => this.props.pauseRequest(data)}
+        onConfirm={(data) => {
+          if (data.runShellCommand) {
+            data.runBeforeKill = {name: data.runBeforeKill};
+          }
+          this.props.pauseRequest(data)
+        }}
         buttonStyle="primary"
         formElements={formElements}>
         <p>Are you sure you want to pause this request?</p>

--- a/SingularityUI/app/components/common/modalButtons/PauseModal.jsx
+++ b/SingularityUI/app/components/common/modalButtons/PauseModal.jsx
@@ -28,23 +28,29 @@ class PauseModal extends Component {
         name: 'message',
         type: FormModal.INPUT_TYPES.STRING,
         label: 'Message (optional)'
-      },
-      {
+      }
+    ];
+
+    if (config.shellCommands.length > 0) {
+      formElements.push(
+        {
         name: 'runShellCommand',
         type: FormModal.INPUT_TYPES.BOOLEAN,
         label: 'Run shell command before killing tasks',
         defaultValue: false
-      },
-      {
-        name: 'runBeforeKill',
-        type: FormModal.INPUT_TYPES.SELECT,
-        dependsOn: 'runShellCommand',
-        options: config.shellCommands.map((shellCommand) => ({
-          label: shellCommand.name,
-          value: shellCommand.name
-        }))
-      }
-    ];
+        },
+        {
+          name: 'runBeforeKill',
+          type: FormModal.INPUT_TYPES.SELECT,
+          dependsOn: 'runShellCommand',
+          options: config.shellCommands.map((shellCommand) => ({
+            label: shellCommand.name,
+            value: shellCommand.name
+          }))
+        }
+      );
+    }
+
     if (this.props.isScheduled) {
       formElements = [
         {

--- a/SingularityUI/app/components/common/modalButtons/PauseModal.jsx
+++ b/SingularityUI/app/components/common/modalButtons/PauseModal.jsx
@@ -43,6 +43,7 @@ class PauseModal extends Component {
           name: 'runBeforeKill',
           type: FormModal.INPUT_TYPES.SELECT,
           dependsOn: 'runShellCommand',
+          defaultValue: config.shellCommands[0].name,
           options: config.shellCommands.map((shellCommand) => ({
             label: shellCommand.name,
             value: shellCommand.name
@@ -70,6 +71,8 @@ class PauseModal extends Component {
         onConfirm={(data) => {
           if (data.runShellCommand) {
             data.runBeforeKill = {name: data.runBeforeKill};
+          } else {
+            delete data.runBeforeKill;
           }
           this.props.pauseRequest(data)
         }}

--- a/SingularityUI/app/components/common/modalButtons/PauseModal.jsx
+++ b/SingularityUI/app/components/common/modalButtons/PauseModal.jsx
@@ -40,7 +40,7 @@ class PauseModal extends Component {
         defaultValue: false
         },
         {
-          name: 'runBeforeKill',
+          name: 'runShellCommandBeforeKill',
           type: FormModal.INPUT_TYPES.SELECT,
           dependsOn: 'runShellCommand',
           defaultValue: config.shellCommands[0].name,
@@ -70,9 +70,9 @@ class PauseModal extends Component {
         action="Pause Request"
         onConfirm={(data) => {
           if (data.runShellCommand) {
-            data.runBeforeKill = {name: data.runBeforeKill};
+            data.runShellCommandBeforeKill = {name: data.runShellCommandBeforeKill};
           } else {
-            delete data.runBeforeKill;
+            delete data.runShellCommandBeforeKill;
           }
           this.props.pauseRequest(data)
         }}


### PR DESCRIPTION
On a request pause, request bounce, or task bounce, it can be useful to run something like a heap dump before the task shuts down. This PR adds the ability to request that a shell command run and finish before a task is killed.

Still TODO:
- [x] Add shell command ui options to bounce/pause/kill modals