### PR TITLE
make deleteTaskHistoryBytes property do what it says it does

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityHistoryPurger.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityHistoryPurger.java
@@ -1,11 +1,9 @@
 package com.hubspot.singularity.data.history;
 
 import java.util.Date;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Singleton;
-import javax.ws.rs.HEAD;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,7 +12,6 @@ import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.hubspot.mesos.JavaUtils;
 import com.hubspot.singularity.config.HistoryPurgingConfiguration;
-import com.hubspot.singularity.data.history.SingularityMappers.SingularityRequestIdCount;
 import com.hubspot.singularity.scheduler.SingularityLeaderOnlyPoller;
 
 @Singleton

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityHistoryPurger.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityHistoryPurger.java
@@ -71,7 +71,7 @@ public class SingularityHistoryPurger extends SingularityLeaderOnlyPoller {
       final long startRequestId = System.currentTimeMillis();
 
       historyManager.purgeTaskHistory(requestIdCount.getRequestId(), requestIdCount.getCount(), historyPurgingConfiguration.getDeleteTaskHistoryAfterTasksPerRequest(), purgeBefore,
-          historyPurgingConfiguration.isDeleteTaskHistoryBytesInsteadOfEntireRow());
+          !historyPurgingConfiguration.isDeleteTaskHistoryBytesInsteadOfEntireRow());
 
       LOG.info("Purged old taskHistory for {} ({} count) in {}", requestIdCount.getRequestId(), requestIdCount.getCount(), JavaUtils.duration(startRequestId));
     }

--- a/SingularityService/src/test/java/com/hubspot/singularity/SingularityHistoryTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/SingularityHistoryTest.java
@@ -132,7 +132,7 @@ public class SingularityHistoryTest extends SingularitySchedulerTestBase {
 
     HistoryPurgingConfiguration historyPurgingConfiguration = new HistoryPurgingConfiguration();
     historyPurgingConfiguration.setEnabled(true);
-    historyPurgingConfiguration.setDeleteTaskHistoryBytesInsteadOfEntireRow(false);
+    historyPurgingConfiguration.setDeleteTaskHistoryBytesInsteadOfEntireRow(true);
     historyPurgingConfiguration.setDeleteTaskHistoryAfterDays(1);
 
     SingularityTaskHistory taskHistory = buildTask(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(3));
@@ -163,7 +163,7 @@ public class SingularityHistoryTest extends SingularitySchedulerTestBase {
 
     HistoryPurgingConfiguration historyPurgingConfiguration = new HistoryPurgingConfiguration();
     historyPurgingConfiguration.setEnabled(true);
-    historyPurgingConfiguration.setDeleteTaskHistoryBytesInsteadOfEntireRow(true);
+    historyPurgingConfiguration.setDeleteTaskHistoryBytesInsteadOfEntireRow(false);
     historyPurgingConfiguration.setDeleteTaskHistoryAfterDays(10);
 
     SingularityHistoryPurger purger = new SingularityHistoryPurger(historyPurgingConfiguration, historyManager);


### PR DESCRIPTION
Looks like we had this boolean flipped. `deleteTaskHistoryBytesInsteadOfEntireRow` set to `true` was actually deleting the row, while `false` was clearing bytes and keeping the row. This switches it so the property functions the way it is named.

/cc @tpetr 