### PR TITLE
extra filtering on fuzzy match

### DIFF
--- a/SingularityUI/app/selectors/requests.es6
+++ b/SingularityUI/app/selectors/requests.es6
@@ -152,7 +152,7 @@ export const getFilteredRequests = createSelector(
       filteredRequests = _.uniq(
         _.pluck(
           _.sortBy(
-            _.union(byUser, byId),
+            _.filter(_.union(byUser, byId), (requestParent) => requestParent.score > 20),
             (requestParent) => {
               return Utils.fuzzyAdjustScore(searchFilter.textFilter, requestParent);
             }

--- a/SingularityUI/app/selectors/requests.es6
+++ b/SingularityUI/app/selectors/requests.es6
@@ -149,17 +149,7 @@ export const getFilteredRequests = createSelector(
         }
       );
 
-      filteredRequests = _.uniq(
-        _.pluck(
-          _.sortBy(
-            _.filter(_.union(byUser, byId), (requestParent) => requestParent.score > 20),
-            (requestParent) => {
-              return Utils.fuzzyAdjustScore(searchFilter.textFilter, requestParent);
-            }
-          ),
-          'original'
-        ).reverse()
-      );
+      filteredRequests = Utils.fuzzyFilter(searchFilter.textFilter, _.union(byUser, byId));
     }
 
     return filteredRequests;

--- a/SingularityUI/app/selectors/requests/filterSelector.es6
+++ b/SingularityUI/app/selectors/requests/filterSelector.es6
@@ -47,7 +47,7 @@ export default createSelector([getRequests, getFilter], (requests, filter) => {
       _.each(filteredRequests, (requestParent) => {requestParent.id = id.extract(requestParent);});
       const res1 = fuzzy.filter(filter.searchFilter, filteredRequests, user);
       const res2 = fuzzy.filter(filter.searchFilter, filteredRequests, id);
-      filteredRequests = _.uniq(_.pluck(_.sortBy(_.filter(_.union(res1, res2), (task) => task.score > 20), (task) => Utils.fuzzyAdjustScore(filter.searchFilter, task)), 'original').reverse());
+      filteredRequests = Utils.fuzzyFilter(filter.searchFilter, _.union(res1, res2));
     }
   }
 

--- a/SingularityUI/app/selectors/requests/filterSelector.es6
+++ b/SingularityUI/app/selectors/requests/filterSelector.es6
@@ -47,7 +47,7 @@ export default createSelector([getRequests, getFilter], (requests, filter) => {
       _.each(filteredRequests, (requestParent) => {requestParent.id = id.extract(requestParent);});
       const res1 = fuzzy.filter(filter.searchFilter, filteredRequests, user);
       const res2 = fuzzy.filter(filter.searchFilter, filteredRequests, id);
-      filteredRequests = _.uniq(_.pluck(_.sortBy(_.union(res1, res2), (task) => Utils.fuzzyAdjustScore(filter.searchFilter, task)), 'original').reverse());
+      filteredRequests = _.uniq(_.pluck(_.sortBy(_.filter(_.union(res1, res2), (task) => task.score > 20), (task) => Utils.fuzzyAdjustScore(filter.searchFilter, task)), 'original').reverse());
     }
   }
 

--- a/SingularityUI/app/selectors/tasks.es6
+++ b/SingularityUI/app/selectors/tasks.es6
@@ -74,8 +74,11 @@ export const getFilteredTasks = createSelector(
         tasks = _.uniq(
           _.pluck(
             _.sortBy(
-              _.union(
-                rackMatch, hostMatch, idMatch
+              _.filter(
+                _.union(
+                  rackMatch, hostMatch, idMatch
+                ),
+                (task) => task.score > 20
               ),
               (task) => Utils.fuzzyAdjustScore(filter.filterText, task)
             ),

--- a/SingularityUI/app/selectors/tasks.es6
+++ b/SingularityUI/app/selectors/tasks.es6
@@ -71,20 +71,7 @@ export const getFilteredTasks = createSelector(
         const hostMatch = fuzzy.filter(filter.filterText.replace(/-/g, '_'), tasks, host);
         const idMatch = fuzzy.filter(filter.filterText, tasks, id);
         const rackMatch = fuzzy.filter(filter.filterText, tasks, rack);
-        tasks = _.uniq(
-          _.pluck(
-            _.sortBy(
-              _.filter(
-                _.union(
-                  rackMatch, hostMatch, idMatch
-                ),
-                (task) => task.score > 20
-              ),
-              (task) => Utils.fuzzyAdjustScore(filter.filterText, task)
-            ),
-            'original'
-          ).reverse()
-        );
+        tasks = Utils.fuzzyFilter(filter.filterText, _.union(rackMatch, hostMatch, idMatch));
       }
     }
 

--- a/SingularityUI/app/utils.es6
+++ b/SingularityUI/app/utils.es6
@@ -104,13 +104,32 @@ const Utils = {
     return false;
   },
 
-  fuzzyAdjustScore(filter, fuzzyObject) {
-    if (fuzzyObject.original.id.toLowerCase().startsWith(filter.toLowerCase())) {
-      return fuzzyObject.score * 10;
-    } else if (fuzzyObject.original.id.toLowerCase().indexOf(filter.toLowerCase()) > -1) {
-      return fuzzyObject.score * 5;
-    }
-    return fuzzyObject.score;
+  fuzzyFilter(filter, fuzzyObjects) {
+    const maxScore = _.max(fuzzyObjects, (fuzzyObject) => fuzzyObject.score).score;
+    _.chain(fuzzyObjects).map((fuzzyObject) => {
+        if (fuzzyObject.original.id.toLowerCase().startsWith(filter.toLowerCase())) {
+          fuzzyObject.score = fuzzyObject.score * 10;
+        } else if (fuzzyObject.original.id.toLowerCase().indexOf(filter.toLowerCase()) > -1) {
+          fuzzyObject.score = fuzzyObject.score * 5;
+        }
+        return fuzzyObject;
+    });
+    return _.uniq(
+      _.pluck(
+        _.sortBy(
+          _.filter(
+            fuzzyObjects,
+            (fuzzyObject) => {
+              return fuzzyObject.score > (maxScore / 10) && fuzzyObject.score > 20;
+            }
+          ),
+          (fuzzyObject) => {
+            return fuzzyObject.score;
+          }
+        ).reverse(),
+        'original'
+      )
+    );
   },
 
   convertMapFromObjectToArray(mapAsObj) {


### PR DESCRIPTION
Replacement for #1228 . Users are used to the fuzzy matching, I think we just need to slim down the results a bit more. The fuzzy lib has no threshold for score. Instead its condition for including the item is if all characters match somewhere in the string.

I consolidated our fuzzy filter tweaks into utils so we don't duplicate things, and added one additional filter to exclude more low-scoring results, especially when we believe we have a good match.
