### PR TITLE
Refresh task lists appropriately

### DIFF
--- a/SingularityUI/app/components/common/table/UITable.jsx
+++ b/SingularityUI/app/components/common/table/UITable.jsx
@@ -28,11 +28,18 @@ class UITable extends Component {
     this.handlePageChange = this.handlePageChange.bind(this);
   }
 
+  componentDidUpdate(prevProps, prevState) {
+    if (this.props.triggerOnDataSizeChange && prevState.data && prevState.data.length != this.state.data.length) {
+      this.props.triggerOnDataSizeChange();
+    }
+  }
+
   componentWillReceiveProps(nextProps) {
     this.updateSort(nextProps.data, this.state.sortBy, this.state.sortDirection);
     if (nextProps.isFetching) {
       return;
     }
+
     if (this.isApiPaginated() && _.isEmpty(nextProps.data) && this.state.chunkNum > 1) {
       this.fetchDataFromApi(this.state.chunkNum - 1, this.state.rowChunkSize, this.state.sortBy);
       this.setState({ pastEnd: true, data: nextProps.data });
@@ -54,7 +61,8 @@ class UITable extends Component {
     defaultSortBy: undefined,
     defaultSortDirection: UITable.SortDirection.DESC,
     asyncSort: false,
-    maxPaginationButtons: 10
+    maxPaginationButtons: 10,
+    triggerOnDataSizeChange: undefined
   };
 
   state;
@@ -468,6 +476,7 @@ UITable.propTypes = {
   isFetching: PropTypes.bool,
   // For long API calls set this to true. As a future upgrade it would be nice to automatically detect if it's taking a long time:
   showPageLoaderWhenFetching: PropTypes.bool,
+  triggerOnDataSizeChange: PropTypes.func,
   rowClassName: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.func

--- a/SingularityUI/app/components/requestDetail/ActiveTasksTable.jsx
+++ b/SingularityUI/app/components/requestDetail/ActiveTasksTable.jsx
@@ -18,9 +18,11 @@ import {
   LogLinkAndJSON
 } from '../tasks/Columns';
 
+import { FetchTaskHistoryForRequest } from '../../actions/api/history';
+
 import TaskStateBreakdown from './TaskStateBreakdown';
 
-const ActiveTasksTable = ({requestId, tasksAPI}) => {
+const ActiveTasksTable = ({requestId, tasksAPI, fetchTaskHistoryForRequest}) => {
   const tasks = tasksAPI ? tasksAPI.data : [];
   const emptyTableMessage = (Utils.api.isFirstLoad(tasksAPI)
     ? <p>Loading...</p>
@@ -47,6 +49,7 @@ const ActiveTasksTable = ({requestId, tasksAPI}) => {
         data={tasks}
         keyGetter={(task) => task.taskId.id}
         emptyTableMessage={emptyTableMessage}
+        triggerOnDataSizeChange={fetchTaskHistoryForRequest}
       >
         {TaskId}
         {LastTaskState}
@@ -61,7 +64,8 @@ const ActiveTasksTable = ({requestId, tasksAPI}) => {
 
 ActiveTasksTable.propTypes = {
   requestId: PropTypes.string.isRequired,
-  tasksAPI: PropTypes.object.isRequired
+  tasksAPI: PropTypes.object.isRequired,
+  fetchTaskHistoryForRequest: PropTypes.func.isRequired
 };
 
 const mapStateToProps = (state, ownProps) => ({
@@ -71,7 +75,11 @@ const mapStateToProps = (state, ownProps) => ({
   )
 });
 
+const mapDispatchToProps = (dispatch, ownProps) => ({
+  fetchTaskHistoryForRequest: () => dispatch(FetchTaskHistoryForRequest.trigger(ownProps.requestId, 5, 1))
+});
+
 export default connect(
   mapStateToProps,
-  null
+  mapDispatchToProps
 )(ActiveTasksTable);


### PR DESCRIPTION
A different way of approaching #1243 . With a periodic refresh of the task history table, we still aren't guaranteed that the refresh will happen at an optimal time to fix the issue of tasks missing from active and not appearing in history. Since we know the situation where we want to refresh the table, I implemented it in that fashion. This will trigger some function whenever the size of the data in the table changes. In this case, it triggers the refresh of the task history if the number of active tasks changes.

@tpetr @darcatron let me know what you think of this approach
