### PR TITLE
Fix js TypeError on task detail page

### DIFF
--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -430,7 +430,7 @@ function mapTaskToProps(task) {
   task.isCleaning = task.lastKnownState && task.lastKnownState.taskState === 'TASK_CLEANING';
 
   const ports = [];
-  if (task.task && task.task.taskRequest.deploy.resources.numPorts > 0) {
+  if (task.task && task.task.taskRequest.deploy.resources && task.task.taskRequest.deploy.resources.numPorts > 0) {
     for (const resource of task.task.mesosTask.resources) {
       if (resource.name === 'ports') {
         for (const range of resource.ranges.range) {


### PR DESCRIPTION
Submitting a deploy with no "resources" constraint would result in a js error on the task detail page

```
TypeError: undefined is not an object (evaluating 't.task.taskRequest.deploy.resources.numPorts')
```
