### PR TITLE
show dropdown of previous command line args

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/HistoryResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/HistoryResource.java
@@ -390,7 +390,10 @@ public class HistoryResource extends AbstractHistoryResource {
     for (SingularityTaskIdHistory taskIdHistory : historiesToCheck) {
       Optional<SingularityTask> maybeTask = taskHistoryHelper.getTask(taskIdHistory.getTaskId());
       if (maybeTask.isPresent() && maybeTask.get().getTaskRequest().getPendingTask().getCmdLineArgsList().isPresent()) {
-        args.add(maybeTask.get().getTaskRequest().getPendingTask().getCmdLineArgsList().get());
+        List<String> taskArgs = maybeTask.get().getTaskRequest().getPendingTask().getCmdLineArgsList().get();
+        if (!taskArgs.isEmpty()) {
+          args.add(maybeTask.get().getTaskRequest().getPendingTask().getCmdLineArgsList().get());
+        }
       }
     }
     return args;

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/HistoryResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/HistoryResource.java
@@ -2,6 +2,7 @@ package com.hubspot.singularity.resources;
 
 import static com.hubspot.singularity.WebExceptions.checkBadRequest;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -386,6 +387,7 @@ public class HistoryResource extends AbstractHistoryResource {
     List<SingularityTaskIdHistory> historiesToCheck = taskHistoryHelper.getBlendedHistory(new SingularityTaskHistoryQuery(
       Optional.of(requestId), Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(), Optional.<ExtendedTaskState>absent(), Optional.<Long>absent(), Optional.<Long>absent(),
       Optional.<Long>absent(), Optional.<Long>absent(), Optional.<OrderDirection>absent()), 0, argCount);
+    Collections.sort(historiesToCheck);
     Set<List<String>> args = new HashSet<>();
     for (SingularityTaskIdHistory taskIdHistory : historiesToCheck) {
       Optional<SingularityTask> maybeTask = taskHistoryHelper.getTask(taskIdHistory.getTaskId());

--- a/SingularityUI/app/actions/api/history.es6
+++ b/SingularityUI/app/actions/api/history.es6
@@ -3,9 +3,10 @@ import Utils from '../../utils';
 
 export const FetchTaskHistory = buildApiAction(
   'FETCH_TASK_HISTORY',
-  (taskId, renderNotFoundIf404) => ({
+  (taskId, renderNotFoundIf404, catchStatusCodes = []) => ({
     url: `/history/task/${taskId}`,
-    renderNotFoundIf404
+    renderNotFoundIf404,
+    catchStatusCodes
   }),
   (taskId) => taskId
 );
@@ -94,3 +95,13 @@ export const FetchRequestHistory = buildApiAction(
   }),
   (requestId) => requestId
 );
+
+export const FetchRequestArgHistory = buildApiAction(
+  'FETCH_REQUEST_ARG_HISTORY',
+  (requestId) => ({
+    url: `/history/request/${requestId}/command-line-args`,
+    catchStatusCodes: [400, 404]
+  }),
+  (requestId) => requestId
+);
+

--- a/SingularityUI/app/components/common/modal/FormModal.jsx
+++ b/SingularityUI/app/components/common/modal/FormModal.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 
-import { Modal, Button, Popover, OverlayTrigger } from 'react-bootstrap';
+import { Modal, Button, Popover, OverlayTrigger, DropdownButton, MenuItem } from 'react-bootstrap';
 import TagsInput from 'react-tagsinput';
 import MultiInput from '../formItems/MultiInput';
 import Select from 'react-select';
@@ -188,6 +188,19 @@ export default class FormModal extends React.Component {
     );
   }
 
+  renderFormattedOptions(optionValue) {
+    if (_.isArray(optionValue)) {
+      let optionLines = optionValue.map((value) =>
+        (<li key={value}>{value}</li>)
+      );
+      return (
+        <ul>{optionLines}</ul>
+      );
+    } else {
+      return optionValue;
+    }
+  }
+
   renderForm() {
     const inputs = this.props.formElements.map((formElement) => {
       const error = this.state.errors[formElement.name];
@@ -209,6 +222,36 @@ export default class FormModal extends React.Component {
           </div>
         );
       });
+
+      const selectOptions = () => {
+        if (formElement.valueOptions && formElement.valueOptions.length > 0) {
+          const menuItems = []
+          _.each(formElement.valueOptions, (optionValue, index) => {
+            if (index < 5) {
+              menuItems.push(
+                <MenuItem
+                  eventKey={index}
+                  onSelect={() => this.handleFormChange(formElement.name, optionValue)}
+                >
+                  {this.renderFormattedOptions(optionValue)}
+                </MenuItem>
+              );
+              menuItems.push(<MenuItem divider />);
+            }
+          });
+          return (
+
+            <DropdownButton
+              pullRight
+              bsStyle="info"
+              title="Previous Args"
+              id={`${formElement.name}-input-dropdown-options`}
+            >
+              {menuItems}
+            </DropdownButton>
+          );
+        }
+      }
 
       let extraHelp;
 
@@ -284,16 +327,21 @@ export default class FormModal extends React.Component {
 
         case FormModal.INPUT_TYPES.MULTIINPUT:
           return (
-            <FormModal.FormItem element={formElement} formState={this.state.formState} key={formElement.name}>
-              <label style={{display: 'block', width: '100%'}}>
-                {formElement.label}
-                <MultiInput
-                  id={`${formElement.name}-input`}
-                  value={this.state.formState[formElement.name] || []}
-                  onChange={(values) => this.handleFormChange(formElement.name, values)}
-                />
-              </label>
-            </FormModal.FormItem>
+            <div>
+              <FormModal.FormItem element={formElement} formState={this.state.formState} key={formElement.name}>
+                <label style={{display: 'block', width: '100%'}}>
+                  {formElement.label}
+                  <span className="pull-right">
+                    {selectOptions()}
+                  </span>
+                  <MultiInput
+                    id={`${formElement.name}-input`}
+                    value={this.state.formState[formElement.name] || []}
+                    onChange={(values) => this.handleFormChange(formElement.name, values)}
+                  />
+                </label>
+              </FormModal.FormItem>
+            </div>
           );
 
         case FormModal.INPUT_TYPES.NUMBER:

--- a/SingularityUI/app/components/common/modal/FormModal.jsx
+++ b/SingularityUI/app/components/common/modal/FormModal.jsx
@@ -228,6 +228,9 @@ export default class FormModal extends React.Component {
           const menuItems = []
           _.each(formElement.valueOptions, (optionValue, index) => {
             if (index < 5) {
+              if (index != 0) {
+                menuItems.push(<MenuItem divider />);
+              }
               menuItems.push(
                 <MenuItem
                   eventKey={index}
@@ -236,7 +239,6 @@ export default class FormModal extends React.Component {
                   {this.renderFormattedOptions(optionValue)}
                 </MenuItem>
               );
-              menuItems.push(<MenuItem divider />);
             }
           });
           return (
@@ -244,6 +246,7 @@ export default class FormModal extends React.Component {
             <DropdownButton
               pullRight
               bsStyle="info"
+              bsSize="small"
               title="Previous Args"
               id={`${formElement.name}-input-dropdown-options`}
             >

--- a/SingularityUI/app/components/common/modalButtons/RunNowButton.jsx
+++ b/SingularityUI/app/components/common/modalButtons/RunNowButton.jsx
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import { withRouter } from 'react-router';
 import { connect } from 'react-redux';
-import { FetchTaskHistory, FetchTaskHistoryForRequest } from '../../../actions/api/history';
+import { FetchTaskHistory, FetchTaskHistoryForRequest, FetchRequestArgHistory } from '../../../actions/api/history';
 
 import { Glyphicon } from 'react-bootstrap';
 import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
@@ -22,11 +22,13 @@ class RunNowButton extends Component {
     requestId: PropTypes.string.isRequired,
     fetchTaskHistory: PropTypes.func.isRequired,
     fetchLastRunTask: PropTypes.func.isRequired,
+    fetchRequestArgHistory: PropTypes.func.isRequired,
     taskHistory: PropTypes.arrayOf(PropTypes.shape({
       taskId: PropTypes.shape({
         id: PropTypes.string.isRequired
       }).isRequired
     })),
+    requestArgHistory: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)).isRequired,
     children: PropTypes.node,
     router: PropTypes.object,
     taskId: PropTypes.string,
@@ -51,15 +53,15 @@ class RunNowButton extends Component {
 
   doBeforeOpeningModal() {
     if (this.props.taskId) {
-      return this.props.fetchTaskHistory(this.props.taskId);
+      return this.props.fetchRequestArgHistory(this.props.requestId).then(this.props.fetchTaskHistory(this.props.taskId));
     }
     if (!_.isEmpty(this.props.taskHistory)) {
-      return this.props.fetchTaskHistory(this.props.taskHistory[0].taskId.id);
+      return this.props.fetchRequestArgHistory(this.props.requestId).then(this.props.fetchTaskHistory(this.props.taskHistory[0].taskId.id));
     }
     return this.props.fetchLastRunTask(this.props.requestId).then((response) => {
       const taskId = Utils.maybe(response, ['data', '0', 'taskId', 'id']);
       if (taskId) {
-        return this.props.fetchTaskHistory(taskId);
+        return this.props.fetchRequestArgHistory(this.props.requestId).then(this.props.fetchTaskHistory(taskId));
       }
       return Promise.resolve();
     });
@@ -76,6 +78,7 @@ class RunNowButton extends Component {
           rerun={!!this.props.taskId}
           router={this.props.router}
           then={this.props.then}
+          requestArgHistory={this.props.requestArgHistory}
         />
       </span>
     );
@@ -87,13 +90,15 @@ const mapStateToProps = (state, ownProps) => {
   const taskId = ownProps.taskId || taskHistory[0] && taskHistory[0].taskId.id;
   return {
     taskHistory,
-    task: Utils.maybe(state.api.task[taskId], ['data', 'task'])
+    task: Utils.maybe(state.api.task[taskId], ['data', 'task']),
+    requestArgHistory: Utils.maybe(state.api.requestArgHistory, [ownProps.requestId, 'data'], [])
   };
 };
 
 const mapDispatchToProps = (dispatch) => ({
   fetchLastRunTask: (requestId) => dispatch(FetchTaskHistoryForRequest.trigger(requestId, 1, 1)),
-  fetchTaskHistory: (taskId) => dispatch(FetchTaskHistory.trigger(taskId))
+  fetchTaskHistory: (taskId) => dispatch(FetchTaskHistory.trigger(taskId), false, [404]),
+  fetchRequestArgHistory: (requestId) => dispatch(FetchRequestArgHistory.trigger(requestId))
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(withRouter(RunNowButton));

--- a/SingularityUI/app/components/common/modalButtons/RunNowModal.jsx
+++ b/SingularityUI/app/components/common/modalButtons/RunNowModal.jsx
@@ -21,7 +21,8 @@ class RunNowModal extends Component {
     router: PropTypes.object.isRequired,
     rerun: PropTypes.bool,
     task: PropTypes.object,
-    then: PropTypes.func
+    then: PropTypes.func,
+    requestArgHistory: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)).isRequired
   };
 
   static AFTER_TRIGGER = {
@@ -88,7 +89,8 @@ class RunNowModal extends Component {
               name: 'commandLineArgs',
               type: FormModal.INPUT_TYPES.MULTIINPUT,
               label: 'Additional command line arguments: (optional)',
-              defaultValue: this.defaultCommandLineArgs()
+              defaultValue: this.defaultCommandLineArgs(),
+              valueOptions: this.props.requestArgHistory
             },
             {
               name: 'message',

--- a/SingularityUI/app/reducers/api/index.es6
+++ b/SingularityUI/app/reducers/api/index.es6
@@ -17,7 +17,8 @@ import {
   FetchDeployForRequest,
   FetchDeploysForRequest,
   FetchTaskSearchParams,
-  FetchRequestHistory
+  FetchRequestHistory,
+  FetchRequestArgHistory
 } from '../../actions/api/history';
 
 import { FetchTaskS3Logs } from '../../actions/api/logs';
@@ -95,6 +96,7 @@ const saveRequest = buildApiActionReducer(SaveRequest);
 const requests = buildApiActionReducer(FetchRequests, []);
 const requestsInState = buildApiActionReducer(FetchRequestsInState, []);
 const requestHistory = buildKeyedApiActionReducer(FetchRequestHistory, []);
+const requestArgHistory = buildKeyedApiActionReducer(FetchRequestArgHistory, []);
 const removeRequest = buildKeyedApiActionReducer(RemoveRequest, []);
 const pauseRequest = buildKeyedApiActionReducer(PauseRequest, []);
 const unpauseRequest = buildKeyedApiActionReducer(UnpauseRequest, []);
@@ -146,6 +148,7 @@ export default combineReducers({
   requests,
   requestsInState,
   requestHistory,
+  requestArgHistory,
   status,
   deploy,
   deploys,


### PR DESCRIPTION
Still need to clean up the styling, but the backend of it works. Now in the run-now dialog, you will get a dropdown menu of up to 5 sets of different previous command line args. Choosing any of these from the dropdown fills the MultiInput with those args.

<img width="586" alt="screen shot 2016-10-28 at 4 23 48 pm" src="https://cloud.githubusercontent.com/assets/6034439/19821158/efd6c564-9d2a-11e6-8e19-04a3bd415367.png">

/cc @tpetr @darcatron 
