### PR TITLE
Make task destroy work from the ui

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -416,10 +416,10 @@ public class TaskManager extends CuratorAsyncManager {
   }
 
   @Timed
-  public SingularityCreateResult saveTaskHistoryUpdate(SingularityTaskHistoryUpdate taskHistoryUpdate, boolean overwrite) {
+  public SingularityCreateResult saveTaskHistoryUpdate(SingularityTaskHistoryUpdate taskHistoryUpdate, boolean overwriteExisting) {
     singularityEventListener.taskHistoryUpdateEvent(taskHistoryUpdate);
 
-    if (overwrite) {
+    if (overwriteExisting) {
       return save(getUpdatePath(taskHistoryUpdate.getTaskId(), taskHistoryUpdate.getTaskState()), taskHistoryUpdate, taskHistoryUpdateTranscoder);
     } else {
       return create(getUpdatePath(taskHistoryUpdate.getTaskId(), taskHistoryUpdate.getTaskState()), taskHistoryUpdate, taskHistoryUpdateTranscoder);

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -411,11 +411,19 @@ public class TaskManager extends CuratorAsyncManager {
     return Maps.uniqueIndex(healthcheckResults, SingularityTaskIdHolder.getTaskIdFunction());
   }
 
-  @Timed
   public SingularityCreateResult saveTaskHistoryUpdate(SingularityTaskHistoryUpdate taskHistoryUpdate) {
+    return saveTaskHistoryUpdate(taskHistoryUpdate, false);
+  }
+
+  @Timed
+  public SingularityCreateResult saveTaskHistoryUpdate(SingularityTaskHistoryUpdate taskHistoryUpdate, boolean overwrite) {
     singularityEventListener.taskHistoryUpdateEvent(taskHistoryUpdate);
 
-    return create(getUpdatePath(taskHistoryUpdate.getTaskId(), taskHistoryUpdate.getTaskState()), taskHistoryUpdate, taskHistoryUpdateTranscoder);
+    if (overwrite) {
+      return save(getUpdatePath(taskHistoryUpdate.getTaskId(), taskHistoryUpdate.getTaskState()), taskHistoryUpdate, taskHistoryUpdateTranscoder);
+    } else {
+      return create(getUpdatePath(taskHistoryUpdate.getTaskId(), taskHistoryUpdate.getTaskState()), taskHistoryUpdate, taskHistoryUpdateTranscoder);
+    }
   }
 
   public SingularityDeleteResult deleteTaskHistoryUpdate(SingularityTaskId taskId, ExtendedTaskState state, Optional<SingularityTaskHistoryUpdate> previousStateUpdate) {
@@ -778,7 +786,7 @@ public class TaskManager extends CuratorAsyncManager {
       msg.append(cleanup.getMessage().get());
     }
 
-    saveTaskHistoryUpdate(new SingularityTaskHistoryUpdate(cleanup.getTaskId(), cleanup.getTimestamp(), ExtendedTaskState.TASK_CLEANING, Optional.of(msg.toString()), Optional.<String>absent()));
+    saveTaskHistoryUpdate(new SingularityTaskHistoryUpdate(cleanup.getTaskId(), cleanup.getTimestamp(), ExtendedTaskState.TASK_CLEANING, Optional.of(msg.toString()), Optional.<String>absent()), true);
   }
 
   public SingularityCreateResult createTaskCleanup(SingularityTaskCleanup cleanup) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
@@ -19,6 +19,9 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -72,6 +75,7 @@ import com.wordnik.swagger.annotations.ApiResponses;
 @Api(description="Manages Singularity tasks.", value=TaskResource.PATH)
 public class TaskResource {
   public static final String PATH = SingularityService.API_BASE_PATH + "/tasks";
+  private static final Logger LOG = LoggerFactory.getLogger(TaskResource.class);
 
   private final TaskManager taskManager;
   private final RequestManager requestManager;
@@ -300,7 +304,8 @@ public class TaskResource {
 
     final SingularityTaskCleanup taskCleanup;
 
-    if (override.isPresent() && override.get().booleanValue()) {
+    if (override.isPresent() && override.get()) {
+      LOG.debug("Requested destroy of {}", taskId);
       cleanupType = TaskCleanupType.USER_REQUESTED_DESTROY;
       taskCleanup = new SingularityTaskCleanup(JavaUtils.getUserEmail(user), cleanupType, now,
         task.getTaskId(), message, actionId, runBeforeKillId);

--- a/SingularityUI/app/components/common/modalButtons/KillTaskButton.jsx
+++ b/SingularityUI/app/components/common/modalButtons/KillTaskButton.jsx
@@ -19,7 +19,8 @@ export default class KillTaskButton extends Component {
     taskId: PropTypes.string.isRequired,
     shouldShowWaitForReplacementTask: PropTypes.bool,
     children: PropTypes.node,
-    name: PropTypes.string
+    name: PropTypes.string,
+    destroy: PropTypes.bool
   };
 
   static defaultProps = {
@@ -38,6 +39,7 @@ export default class KillTaskButton extends Component {
         {getClickComponent(this)}
         <KillTaskModal
           name={this.props.name}
+          destroy={this.props.destroy}
           ref="modal"
           taskId={this.props.taskId}
           shouldShowWaitForReplacementTask={this.props.shouldShowWaitForReplacementTask}

--- a/SingularityUI/app/components/common/modalButtons/KillTaskButton.jsx
+++ b/SingularityUI/app/components/common/modalButtons/KillTaskButton.jsx
@@ -20,7 +20,8 @@ export default class KillTaskButton extends Component {
     shouldShowWaitForReplacementTask: PropTypes.bool,
     children: PropTypes.node,
     name: PropTypes.string,
-    destroy: PropTypes.bool
+    destroy: PropTypes.bool,
+    then: PropTypes.func
   };
 
   static defaultProps = {
@@ -40,6 +41,7 @@ export default class KillTaskButton extends Component {
         <KillTaskModal
           name={this.props.name}
           destroy={this.props.destroy}
+          then={this.props.then}
           ref="modal"
           taskId={this.props.taskId}
           shouldShowWaitForReplacementTask={this.props.shouldShowWaitForReplacementTask}

--- a/SingularityUI/app/components/common/modalButtons/KillTaskModal.jsx
+++ b/SingularityUI/app/components/common/modalButtons/KillTaskModal.jsx
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 
-import { KillTask, FetchTaskCleanups } from '../../../actions/api/tasks';
+import { KillTask } from '../../../actions/api/tasks';
 
 import FormModal from '../modal/FormModal';
 
@@ -11,7 +11,8 @@ class KillTaskModal extends Component {
     shouldShowWaitForReplacementTask: PropTypes.bool,
     killTask: PropTypes.func.isRequired,
     destroy: PropTypes.bool,
-    name: PropTypes.string
+    name: PropTypes.string,
+    then: PropTypes.func
   };
 
   constructor() {
@@ -79,7 +80,7 @@ class KillTaskModal extends Component {
           if (this.props.destroy) {
             data.override = true;
           }
-          this.props.killTask(data)
+          this.props.killTask(data);
         }}
         buttonStyle="danger"
         formElements={formElements}>
@@ -99,7 +100,7 @@ class KillTaskModal extends Component {
 }
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
-  killTask: (data) => dispatch(KillTask.trigger(ownProps.taskId, data)).then(dispatch(FetchTaskCleanups.trigger()))
+  killTask: (data) => dispatch(KillTask.trigger(ownProps.taskId, data)).then(() => ownProps.then && ownProps.then())
 });
 
 export default connect(

--- a/SingularityUI/app/components/common/modalButtons/KillTaskModal.jsx
+++ b/SingularityUI/app/components/common/modalButtons/KillTaskModal.jsx
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 
-import { KillTask } from '../../../actions/api/tasks';
+import { KillTask, FetchTaskCleanups } from '../../../actions/api/tasks';
 
 import FormModal from '../modal/FormModal';
 
@@ -10,6 +10,7 @@ class KillTaskModal extends Component {
     taskId: PropTypes.string.isRequired,
     shouldShowWaitForReplacementTask: PropTypes.bool,
     killTask: PropTypes.func.isRequired,
+    destroy: PropTypes.bool,
     name: PropTypes.string
   };
 
@@ -75,13 +76,15 @@ class KillTaskModal extends Component {
           } else {
             delete data.runShellCommandBeforeKill;
           }
-          console.log(data);
+          if (this.props.destroy) {
+            data.override = true;
+          }
           this.props.killTask(data)
         }}
         buttonStyle="danger"
         formElements={formElements}>
         <span>
-          <p>Are you sure you want to kill this task?</p>
+          <p>Are you sure you want to kill {this.props.destroy ? '-9' : ''} this task?</p>
           <pre>{this.props.taskId}</pre>
           <p>
               Long running process will be started again instantly, scheduled
@@ -96,7 +99,7 @@ class KillTaskModal extends Component {
 }
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
-  killTask: (data) => dispatch(KillTask.trigger(ownProps.taskId, data))
+  killTask: (data) => dispatch(KillTask.trigger(ownProps.taskId, data)).then(dispatch(FetchTaskCleanups.trigger()))
 });
 
 export default connect(

--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -205,11 +205,22 @@ class TaskDetail extends Component {
   }
 
   renderHeader(cleanup) {
+    const cleaningUpdate = _.find(Utils.maybe(this.props.task, ['taskUpdates'], []), (taskUpdate) => {
+      return taskUpdate.taskState == "TASK_CLEANING";
+    });
+
+    let cleanupType;
+    if (cleaningUpdate) {
+      cleanupType = cleaningUpdate.statusMessage.split(/\s+/)[0];
+    } else if (cleanup) {
+      cleanupType = cleanup.cleanupType;
+    }
+
     const taskState = this.props.task.taskUpdates && (
       <div className="col-xs-6 task-state-header">
         <h1>
           <span className={`label label-${Utils.getLabelClassFromTaskState(_.last(this.props.task.taskUpdates).taskState)} task-state-header-label`}>
-            {Utils.humanizeText(_.last(this.props.task.taskUpdates).taskState)} {cleanup && `(${Utils.humanizeText(cleanup.cleanupType)})`}
+            {Utils.humanizeText(_.last(this.props.task.taskUpdates).taskState)} {cleanupType && `(${Utils.humanizeText(cleanupType)})`}
           </span>
         </h1>
       </div>
@@ -217,8 +228,8 @@ class TaskDetail extends Component {
 
     let destroy = false;
     let removeText = 'Kill Task';
-    if (cleanup) {
-      if (Utils.isImmediateCleanup(cleanup, Utils.request.isLongRunning(this.props.task.task.taskRequest))) {
+    if (cleanupType) {
+      if (Utils.isImmediateCleanup(cleanupType, Utils.request.isLongRunning(this.props.task.task.taskRequest))) {
         removeText = 'Destroy task';
         destroy = true;
       } else {
@@ -246,7 +257,7 @@ class TaskDetail extends Component {
         </a>
       </KillTaskButton>
     );
-    const terminationAlert = this.props.task.isStillRunning && !cleanup && this.props.task.isCleaning && (
+    const terminationAlert = this.props.task.isStillRunning && this.props.task.isCleaning && destroy && (
       <Alert bsStyle="warning">
           <strong>Task is terminating:</strong> To issue a non-graceful termination (kill -term), click Destroy Task.
       </Alert>

--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -215,17 +215,23 @@ class TaskDetail extends Component {
       </div>
     );
 
-    let removeText;
+    let destroy = false;
+    let removeText = 'Kill Task';
     if (cleanup) {
-      removeText = cleanup.isImmediate ? 'Destroy task' : 'Override cleanup';
-    } else {
-      removeText = this.props.task.isCleaning ? 'Destroy task' : 'Kill Task';
+      if (Utils.isImmediateCleanup(cleanup, Utils.request.isLongRunning(this.props.task.task.taskRequest))) {
+        removeText = 'Destroy task';
+        destroy = true;
+      } else {
+        removeText = 'Override cleanup';
+      }
     }
+
     const removeBtn = this.props.task.isStillRunning && (
       <KillTaskButton
         name={removeText}
         taskId={this.props.params.taskId}
-        shouldShowWaitForReplacementTask={Utils.isIn(this.props.task.task.taskRequest.request.requestType, ['SERVICE', 'WORKER'])}
+        destroy={destroy}
+        shouldShowWaitForReplacementTask={Utils.isIn(this.props.task.task.taskRequest.request.requestType, ['SERVICE', 'WORKER']) && !destroy}
       >
         <a className="btn btn-danger">
           {removeText}

--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -226,11 +226,19 @@ class TaskDetail extends Component {
       }
     }
 
+    const refreshHistoryAndCleanups = () => {
+      const promises = [];
+      promises.push(this.props.fetchTaskCleanups());
+      promises.push(this.props.fetchTaskHistory(this.props.params.taskId));
+      return Promise.all(promises);
+    }
+
     const removeBtn = this.props.task.isStillRunning && (
       <KillTaskButton
         name={removeText}
         taskId={this.props.params.taskId}
         destroy={destroy}
+        then={refreshHistoryAndCleanups}
         shouldShowWaitForReplacementTask={Utils.isIn(this.props.task.task.taskRequest.request.requestType, ['SERVICE', 'WORKER']) && !destroy}
       >
         <a className="btn btn-danger">

--- a/SingularityUI/app/utils.es6
+++ b/SingularityUI/app/utils.es6
@@ -345,11 +345,11 @@ const Utils = {
 
 
 
-  isImmediateCleanup: (cleanup, longRunning) => {
+  isImmediateCleanup: (cleanupType, longRunning) => {
     if (longRunning) {
-      return _.contains(Utils.LONG_RUNNING_IMMEDIATE_CLEANUPS, cleanup.cleanupType)
+      return _.contains(Utils.LONG_RUNNING_IMMEDIATE_CLEANUPS, cleanupType)
     } else {
-      return _.contains(Utils.NON_LONG_RUNNING_IMMEDIATE_CLEANUPS, cleanup.cleanupType)
+      return _.contains(Utils.NON_LONG_RUNNING_IMMEDIATE_CLEANUPS, cleanupType)
     }
   },
 

--- a/SingularityUI/app/utils.es6
+++ b/SingularityUI/app/utils.es6
@@ -7,6 +7,10 @@ const Utils = {
 
   GLOB_CHARS: ['*', '!', '?', '[', ']'],
 
+  LONG_RUNNING_IMMEDIATE_CLEANUPS: ['USER_REQUESTED', 'SCALING_DOWN', 'DEPLOY_FAILED', 'NEW_DEPLOY_SUCCEEDED', 'DEPLOY_STEP_FINISHED', 'DEPLOY_CANCELED' , 'TASK_EXCEEDED_TIME_LIMIT', 'UNHEALTHY_NEW_TASK', 'OVERDUE_NEW_TASK', 'USER_REQUESTED_DESTROY', 'PRIORITY_KILL', 'PAUSE'],
+
+  NON_LONG_RUNNING_IMMEDIATE_CLEANUPS: ['USER_REQUESTED', 'DEPLOY_FAILED', 'DEPLOY_CANCELED', 'TASK_EXCEEDED_TIME_LIMIT', 'UNHEALTHY_NEW_TASK', 'OVERDUE_NEW_TASK', 'USER_REQUESTED_DESTROY', 'INCREMENTAL_DEPLOY_FAILED', 'INCREMENTAL_DEPLOY_CANCELLED', 'PRIORITY_KILL', 'PAUSE'],
+
   isIn(needle, haystack) {
     return !_.isEmpty(haystack) && haystack.indexOf(needle) >= 0;
   },
@@ -336,6 +340,16 @@ const Utils = {
       return expiringBounce
         ? (expiringBounce.startMillis + expiringBounce.expiringAPIRequestObject.durationMillis) > new Date().getTime()
         : false;
+    },
+  },
+
+
+
+  isImmediateCleanup: (cleanup, longRunning) => {
+    if (longRunning) {
+      return _.contains(Utils.LONG_RUNNING_IMMEDIATE_CLEANUPS, cleanup.cleanupType)
+    } else {
+      return _.contains(Utils.NON_LONG_RUNNING_IMMEDIATE_CLEANUPS, cleanup.cleanupType)
     }
   },
 


### PR DESCRIPTION
Seems this got lost in the rewrite. 
- Updates the ui to make sure task destroys work correctly to trigger the destroy task framework messages.
- Hides the wait for replacement when clicking destroy task. If you are on the destroy modal, you are likely looking for instant and the wait for replacement being checked can confuse the user as to why nothing is happening.
- Refresh the task history and cleanups immediately after triggering kill

/cc @tpetr @darcatron 
