### PR TITLE
Ensure quotes and new lines are escaped in echo

### DIFF
--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorModule.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorModule.java
@@ -11,7 +11,7 @@ import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import com.hubspot.singularity.executor.handlebars.BashEscapedHelper;
-import com.hubspot.singularity.executor.handlebars.EscapedNewLinesHelper;
+import com.hubspot.singularity.executor.handlebars.EscapeNewLinesAndQuotesHelper;
 import com.hubspot.singularity.executor.handlebars.IfHasNewLinesHelper;
 import com.hubspot.singularity.executor.handlebars.IfPresentHelper;
 import com.hubspot.singularity.runner.base.config.SingularityRunnerBaseLogging;
@@ -93,7 +93,7 @@ public class SingularityExecutorModule extends AbstractModule {
     handlebars.registerHelper(BashEscapedHelper.NAME, new BashEscapedHelper());
     handlebars.registerHelper(IfPresentHelper.NAME, new IfPresentHelper());
     handlebars.registerHelper(IfHasNewLinesHelper.NAME, new IfHasNewLinesHelper());
-    handlebars.registerHelper(EscapedNewLinesHelper.NAME, new EscapedNewLinesHelper());
+    handlebars.registerHelper(EscapeNewLinesAndQuotesHelper.NAME, new EscapeNewLinesAndQuotesHelper());
 
     return handlebars;
   }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/handlebars/EscapeNewLinesAndQuotesHelper.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/handlebars/EscapeNewLinesAndQuotesHelper.java
@@ -5,9 +5,9 @@ import java.io.IOException;
 import com.github.jknack.handlebars.Helper;
 import com.github.jknack.handlebars.Options;
 
-public class EscapedNewLinesHelper implements Helper<Object> {
+public class EscapeNewLinesAndQuotesHelper implements Helper<Object> {
 
-  public static final String NAME = "escapedNewLines";
+  public static final String NAME = "escapeNewLinesAndQuotes";
 
   @Override
   public CharSequence apply(Object context, Options options) throws IOException {
@@ -23,6 +23,9 @@ public class EscapedNewLinesHelper implements Helper<Object> {
       if (c == '\n') {
         sb.append('\\');
         sb.append('n');
+      } else if (c == '"') {
+        sb.append('\\');
+        sb.append('"');
       } else {
         sb.append(c);
       }

--- a/SingularityExecutor/src/main/resources/docker.sh.hbs
+++ b/SingularityExecutor/src/main/resources/docker.sh.hbs
@@ -150,8 +150,8 @@ mkdir -p {{{ runContext.taskAppDirectory }}}
 sudo chown -R {{{ runContext.user }}} {{{ runContext.taskAppDirectory }}}
 
 # Start up the container
-echo "Creating continer with: sudo -E -H -u {{{ runContext.user }}} docker create $DOCKER_OPTIONS {{#each envContext.env}}{{#ifHasNewLines value}}-e {{{name}}}={{#escapedNewLines value}}{{/escapedNewLines}}{{/ifHasNewLines}}{{/each}} $DOCKER_IMAGE {{{ runContext.cmd }}}"
-cid=`sudo -E -H -u {{{ runContext.user }}} docker create $DOCKER_OPTIONS {{#each envContext.env}}{{#ifHasNewLines value}}-e {{{name}}}={{#escapedNewLines value}}{{/escapedNewLines}}{{/ifHasNewLines}}{{/each}} $DOCKER_IMAGE {{{runContext.cmd }}}`
+echo -e "Creating continer with: sudo -E -H -u {{{ runContext.user }}} docker create $DOCKER_OPTIONS {{#each envContext.env}}{{#ifHasNewLines value}}-e {{{name}}}={{#escapeNewLinesAndQuotes value}}{{/escapeNewLinesAndQuotes}}{{/ifHasNewLines}}{{/each}} $DOCKER_IMAGE {{{ runContext.cmd }}}"
+cid=`sudo -E -H -u {{{ runContext.user }}} docker create $DOCKER_OPTIONS {{#each envContext.env}}{{#ifHasNewLines value}}-e {{{name}}}={{#escapeNewLinesAndQuotes value}}{{/escapeNewLinesAndQuotes}}{{/ifHasNewLines}}{{/each}} $DOCKER_IMAGE {{{runContext.cmd }}}`
 sudo -E -H -u {{{ runContext.user }}} docker start -a $cid >> {{{ runContext.logFile }}} 2>&1 &
 running=1
 


### PR DESCRIPTION
So, we had previously made this a bit more resilient to weird new lines in environment variables not being loaded properly in docker by adding them to command line args instead. But, with the right order or quotes/newlines/etc, we can still run into issues at the `echo` statement before the actual command is executed. This adds escaping for the double quotes as well as calling `echo -e` so that the escaped characters are expanded properly when printed.