### PR TITLE
Sanitize file data before parsing with Jackson

### DIFF
--- a/SingularityExecutor/pom.xml
+++ b/SingularityExecutor/pom.xml
@@ -123,6 +123,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/SingularityService/pom.xml
+++ b/SingularityService/pom.xml
@@ -360,6 +360,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-test</artifactId>
       <scope>test</scope>

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SandboxManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SandboxManager.java
@@ -124,7 +124,9 @@ public class SandboxManager {
   @VisibleForTesting
   MesosFileChunkObject parseResponseBody(Response response) throws IOException {
     // not thread-safe, need to make a new one each time;
-    CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder().onMalformedInput(CodingErrorAction.REPLACE);
+    CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder()
+        .onMalformedInput(CodingErrorAction.REPLACE)
+        .replaceWith(REPLACEMENT_CHARACTER);
 
     ByteBuffer responseBuffer = response.getResponseBodyAsByteBuffer();
     Reader sanitizedReader = CharSource.wrap(decoder.decode(responseBuffer)).openStream();

--- a/SingularityService/src/test/java/com/hubspot/singularity/data/SandboxManagerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/data/SandboxManagerTest.java
@@ -4,8 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.Test;
 
@@ -13,9 +15,11 @@ import com.google.inject.Inject;
 import com.hubspot.mesos.json.MesosFileChunkObject;
 import com.hubspot.singularity.SingularityTestBaseNoDb;
 import com.ning.http.client.Response;
-import com.ning.http.util.Base64;
 
 public class SandboxManagerTest extends SingularityTestBaseNoDb {
+  private static final byte[] SNOWMAN_BYTES = "☃".getBytes(StandardCharsets.UTF_8);
+  private static final byte FIRST_SNOWMAN_BYTE = SNOWMAN_BYTES[0];
+  private static final byte SECOND_SNOWMAN_BYTE = SNOWMAN_BYTES[1];
 
   @Inject
   private SandboxManager sandboxManager;
@@ -23,38 +27,52 @@ public class SandboxManagerTest extends SingularityTestBaseNoDb {
   @Test
   public void testInvalidUtf8WithOneByteOfThreeByteCharacter() throws IOException {
     // data contains a ☃ character and the first byte of another ☃ character
-    String base64 = "eyJkYXRhIjoi4piD4iIsIm9mZnNldCI6MjkwfQ==";
+    byte[] bytes = toBytes("{\"data\":\"", SNOWMAN_BYTES, FIRST_SNOWMAN_BYTE, "\",\"offset\":123}");
 
-    MesosFileChunkObject chunk = sandboxManager.parseResponseBody(response(base64));
+    MesosFileChunkObject chunk = sandboxManager.parseResponseBody(response(bytes));
     // the partial ☃ should be dropped
     assertThat(chunk.getData()).isEqualTo("☃");
-    assertThat(chunk.getOffset()).isEqualTo(290);
+    assertThat(chunk.getOffset()).isEqualTo(123);
   }
 
   @Test
   public void testInvalidUtf8WithTwoBytesOfThreeByteCharacter() throws IOException {
     // data contains a ☃ character and the first two bytes of another ☃ character
-    String base64 = "eyJkYXRhIjoi4piD4pgiLCJvZmZzZXQiOjI5MH0=";
+    byte[] bytes = toBytes("{\"data\":\"", SNOWMAN_BYTES, FIRST_SNOWMAN_BYTE, SECOND_SNOWMAN_BYTE, "\",\"offset\":123}");
 
-    MesosFileChunkObject chunk = sandboxManager.parseResponseBody(response(base64));
+    MesosFileChunkObject chunk = sandboxManager.parseResponseBody(response(bytes));
     // the partial ☃ should be dropped
     assertThat(chunk.getData()).isEqualTo("☃");
-    assertThat(chunk.getOffset()).isEqualTo(290);
+    assertThat(chunk.getOffset()).isEqualTo(123);
   }
 
   @Test
   public void testValidUtf8WithThreeByteCharacters() throws IOException {
     // data contains two ☃ characters
-    String base64 = "eyJkYXRhIjoi4piD4piDIiwib2Zmc2V0IjoyOTB9";
+    byte[] bytes = toBytes("{\"data\":\"", SNOWMAN_BYTES, SNOWMAN_BYTES, "\",\"offset\":123}");
 
-    MesosFileChunkObject chunk = sandboxManager.parseResponseBody(response(base64));
+    MesosFileChunkObject chunk = sandboxManager.parseResponseBody(response(bytes));
     assertThat(chunk.getData()).isEqualTo("☃☃");
-    assertThat(chunk.getOffset()).isEqualTo(290);
+    assertThat(chunk.getOffset()).isEqualTo(123);
   }
 
-  private static Response response(String base64) throws IOException {
+  private static byte[] toBytes(Object... objects) throws IOException {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    for (Object o : objects) {
+      if (o instanceof String) {
+        output.write(((String) o).getBytes(StandardCharsets.UTF_8));
+      } else if (o instanceof byte[]) {
+        output.write((byte[]) o);
+      } else if (o instanceof Byte) {
+        output.write((Byte) o);
+      }
+    }
+
+    return output.toByteArray();
+  }
+
+  private static Response response(byte[] bytes) throws IOException {
     Response response = mock(Response.class);
-    byte[] bytes = Base64.decode(base64);
     when(response.getResponseBodyAsByteBuffer()).thenReturn(ByteBuffer.wrap(bytes));
     return response;
   }

--- a/SingularityService/src/test/java/com/hubspot/singularity/data/SandboxManagerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/data/SandboxManagerTest.java
@@ -1,0 +1,61 @@
+package com.hubspot.singularity.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import org.junit.Test;
+
+import com.google.inject.Inject;
+import com.hubspot.mesos.json.MesosFileChunkObject;
+import com.hubspot.singularity.SingularityTestBaseNoDb;
+import com.ning.http.client.Response;
+import com.ning.http.util.Base64;
+
+public class SandboxManagerTest extends SingularityTestBaseNoDb {
+
+  @Inject
+  private SandboxManager sandboxManager;
+
+  @Test
+  public void testInvalidUtf8WithOneByteOfThreeByteCharacter() throws IOException {
+    // data contains a ☃ character and the first byte of another ☃ character
+    String base64 = "eyJkYXRhIjoi4piD4iIsIm9mZnNldCI6MjkwfQ==";
+
+    MesosFileChunkObject chunk = sandboxManager.parseResponseBody(response(base64));
+    // the partial ☃ should be dropped
+    assertThat(chunk.getData()).isEqualTo("☃");
+    assertThat(chunk.getOffset()).isEqualTo(290);
+  }
+
+  @Test
+  public void testInvalidUtf8WithTwoBytesOfThreeByteCharacter() throws IOException {
+    // data contains a ☃ character and the first two bytes of another ☃ character
+    String base64 = "eyJkYXRhIjoi4piD4pgiLCJvZmZzZXQiOjI5MH0=";
+
+    MesosFileChunkObject chunk = sandboxManager.parseResponseBody(response(base64));
+    // the partial ☃ should be dropped
+    assertThat(chunk.getData()).isEqualTo("☃");
+    assertThat(chunk.getOffset()).isEqualTo(290);
+  }
+
+  @Test
+  public void testValidUtf8WithThreeByteCharacters() throws IOException {
+    // data contains two ☃ characters
+    String base64 = "eyJkYXRhIjoi4piD4piDIiwib2Zmc2V0IjoyOTB9";
+
+    MesosFileChunkObject chunk = sandboxManager.parseResponseBody(response(base64));
+    assertThat(chunk.getData()).isEqualTo("☃☃");
+    assertThat(chunk.getOffset()).isEqualTo(290);
+  }
+
+  private static Response response(String base64) throws IOException {
+    Response response = mock(Response.class);
+    byte[] bytes = Base64.decode(base64);
+    when(response.getResponseBodyAsByteBuffer()).thenReturn(ByteBuffer.wrap(bytes));
+    return response;
+  }
+}


### PR DESCRIPTION
This takes the raw response from Mesos and decodes it with a UTF8 decoder that ignores invalid characters before passing the sanitized data to Jackson for parsing (which should now always succeed). Since these responses can be non-trivial in size I tried to avoid extra allocations as much as possible (the `Response` class exposes the data as a `ByteBuffer` which gets converted to a `CharBuffer` which backs the `Reader` passed to Jackson). 

@tpetr @ssalinas 