### PR TITLE
Fix another js TypeError on task detail page

### DIFF
--- a/SingularityUI/app/components/deployDetail/DeployDetail.jsx
+++ b/SingularityUI/app/components/deployDetail/DeployDetail.jsx
@@ -224,7 +224,7 @@ class DeployDetail extends React.Component {
     if (deploy.deploy.executorData && deploy.deploy.executorData.cmd) {
       stats.push(<InfoBox key="cmd" copyableClassName="info-copyable" name="Command" value={deploy.deploy.executorData.cmd} />);
     }
-    if (deploy.deploy.resources.cpus) {
+    if (deploy.deploy.resources && deploy.deploy.resources.cpus) {
       let value = `CPUs: ${deploy.deploy.resources.cpus} | Memory (Mb): ${deploy.deploy.resources.memoryMb} | Ports: ${deploy.deploy.resources.numPorts}`;
       stats.push(<InfoBox key="cpus" copyableClassName="info-copyable" name="Resources" value={value} />);
     }


### PR DESCRIPTION
Submitting a deploy with no "resources" constraint would result in another js error on the task detail page

```
TypeError: undefined is not an object (evaluating 't.deploy.resources.cpus')
```
