### PR TITLE
Fix when bounce alert banner is shown

### DIFF
--- a/SingularityUI/app/components/requestDetail/header/RequestAlerts.jsx
+++ b/SingularityUI/app/components/requestDetail/header/RequestAlerts.jsx
@@ -26,7 +26,7 @@ const RequestAlerts = ({requestId, requestAPI, bounces, activeTasksForRequest, d
   let maybeBouncing;
 
   const requestParent = requestAPI.data;
-  if (bounces.length > 0 && requestParent.request) {
+  if (bounces.length > 0 && requestParent.request && Utils.isIn(requestParent.request.requestType, Utils.request.LONG_RUNNING_TYPES)) {
     maybeBouncing = (
       <Alert bsStyle="warning">
         <b>Request is bouncing:</b> Attempting to start <b>{requestParent.request.instances}</b> replacement tasks.

--- a/SingularityUI/app/selectors/tasks.es6
+++ b/SingularityUI/app/selectors/tasks.es6
@@ -12,7 +12,7 @@ export const getBouncesForRequest = (requestId) => createSelector(
   [getTaskCleanups],
   (taskCleanups) => (
   taskCleanups.data || []).filter((cleanup) => (
-    cleanup.cleanupType === 'BOUNCING' || cleanup.cleanupType === 'INCREMENTAL_BOUNCE' && cleanup.taskId.requestId === requestId
+    (cleanup.cleanupType === 'BOUNCING' || cleanup.cleanupType === 'INCREMENTAL_BOUNCE') && cleanup.taskId.requestId === requestId
   ))
 );
 


### PR DESCRIPTION
- Don't show for non-long-running no matter what
- parens are important in if statements...

In it's previous form, the logic was displaying the banner on the request detail page when _any_ task cleanups of type bounce or incremental bounce were present