### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/SingularityUI/app/components/common/modalButtons/RunNowModal.jsx
+++ b/SingularityUI/app/components/common/modalButtons/RunNowModal.jsx
@@ -9,7 +9,7 @@ import FormModal from '../modal/FormModal';
 
 import Messenger from 'messenger';
 import Utils from '../../../utils';
-import uuid from 'node-uuid';
+import uuid from 'uuid';
 
 const LOCAL_STORAGE_AFTER_TRIGGER_VALUE = 'afterRunNowTrigger';
 const LOCAL_STORAGE_TAIL_AFTER_TRIGGER_FILENAME = 'taskRunRedirectFilename';

--- a/SingularityUI/package.json
+++ b/SingularityUI/package.json
@@ -35,7 +35,6 @@
     "messenger": "git://github.com/HubSpot/messenger.git#set-main-field",
     "micromatch": "^2.3.8",
     "moment": "^2.13.0",
-    "node-uuid": "^1.4.7",
     "parseurl": "^1.3.1",
     "promise-polyfill": "^5.2.0",
     "q": "^1.4.1",
@@ -61,6 +60,7 @@
     "select2": "~3.5.1",
     "typeahead.js": "~0.10.4",
     "underscore": "~1.8.0",
+    "uuid": "^3.0.0",
     "vex-js": "git://github.com/HubSpot/vex.git#v2.3.0-plus-beforeClose-hook"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.