### PR TITLE
Add exec so shell commands read correct pid

### DIFF
--- a/SingularityExecutor/src/main/resources/runner.sh.hbs
+++ b/SingularityExecutor/src/main/resources/runner.sh.hbs
@@ -67,7 +67,7 @@ fi
 # execute command
 {{#if shouldChangeUser}}
 echo "Executing: {{{ switchUserCommand }}} {{#if maxOpenFiles}}/bin/bash -c 'ulimit -Sn {{{maxOpenFiles}}} && {{/if}}{{{ cmd }}}{{#if maxOpenFiles}}'{{/if}} >> {{{ logFilePath }}} 2>&1"
-exec {{{ switchUserCommand }}} {{#if maxOpenFiles}}/bin/bash -c 'ulimit -Sn {{{maxOpenFiles}}} && {{/if}}{{{ cmd }}}{{#if maxOpenFiles}}'{{/if}} >> {{{ logFilePath }}} 2>&1
+exec {{{ switchUserCommand }}} {{#if maxOpenFiles}}/bin/bash -c 'ulimit -Sn {{{maxOpenFiles}}} && exec {{/if}}{{{ cmd }}}{{#if maxOpenFiles}}'{{/if}} >> {{{ logFilePath }}} 2>&1
 {{else}}
 echo "Executing: {{{ cmd }}} >> {{{ logFilePath }}} 2>&1"
 {{#if maxOpenFiles}}ulimit -Sn {{{maxOpenFiles}}}{{/if}}


### PR DESCRIPTION
Previously, when using `maxOpenFiles` the actual runnign process would end up being a child pid of the /bin/bash cmd. So any shell commands that rely on the pid were getting the parent pid, not the pid of the process.

The additional exec will fix this.

/cc @tpetr 