### PR TITLE
Add support for Role / Mesos Reserved Resources

### DIFF
--- a/Docs/reference/configuration.md
+++ b/Docs/reference/configuration.md
@@ -163,6 +163,7 @@ These settings should live under the "mesos" field inside the root configuration
 | frameworkName | null | | string |
 | frameworkId | null | | string |
 | frameworkFailoverTimeout | 0.0 | | double |
+| frameworkRole | null | Specify framework's desired role when Singularity registers with the master | String |
 | checkpoint | true | | boolean |
 | credentialPrincipal | | Enable framework auth by setting both this and credentialSecret | String |
 | credentialSecret | | Enable framework auth by setting both this and credentialPrincipal | String |

--- a/SingularityBase/src/main/java/com/hubspot/mesos/MesosUtils.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/MesosUtils.java
@@ -9,7 +9,10 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
+import java.util.Iterator;
 
+import com.google.common.collect.Sets;
 import org.apache.mesos.Protos.MasterInfo;
 import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.Resource;
@@ -39,15 +42,42 @@ public final class MesosUtils {
     return r.getScalar().getValue();
   }
 
-  private static double getScalar(List<Resource> resources, String name) {
+  private static double getScalar(List<Resource> resources, String name, Optional<String> requiredRole) {
     for (Resource r : resources) {
 
-      if (r.hasName() && r.getName().equals(name) && r.hasScalar()) {
+      if (r.hasName() && r.getName().equals(name) && r.hasScalar() && isRequiredRole(r, requiredRole)) {
         return getScalar(r);
       }
     }
 
     return 0;
+  }
+
+  private static Boolean hasRole(Resource r) {
+    return r.hasRole() && !r.getRole().equals("*");
+  }
+
+  private static Boolean isRequiredRole(Resource r, Optional<String> requiredRole) {
+
+    if (requiredRole.isPresent() && hasRole(r)) {
+      // required role with a resource with role
+      return requiredRole.get().equals(r.getRole());
+
+    } else if (requiredRole.isPresent() && !hasRole(r)) {
+      // required role with a resource for any role
+      return false;
+
+    } else if (!requiredRole.isPresent() && hasRole(r)) {
+      // no required role but resource with role
+      return false;
+
+    } else if (!requiredRole.isPresent() && !hasRole(r)) {
+      // no required role and resource for any role
+      return true;
+    } else {
+      return false;
+    }
+
   }
 
   private static Ranges getRanges(List<Resource> resources, String name) {
@@ -70,15 +100,17 @@ public final class MesosUtils {
     return totalRanges;
   }
 
-  public static Resource getCpuResource(double cpus) {
-    return newScalar(CPUS, cpus);
+  public static Resource getCpuResource(double cpus, Optional<String> role) {
+    return newScalar(CPUS, cpus, role);
   }
 
-  public static Resource getMemoryResource(double memory) {
-    return newScalar(MEMORY, memory);
+  public static Resource getMemoryResource(double memory, Optional<String> role) {
+    return newScalar(MEMORY, memory, role);
   }
 
-  public static Resource getDiskResource(double disk) { return newScalar(DISK, disk); }
+  public static Resource getDiskResource(double disk, Optional<String> role) {
+    return newScalar(DISK, disk, role);
+  }
 
   public static long[] getPorts(Resource portsResource, int numPorts) {
     long[] ports = new long[numPorts];
@@ -183,33 +215,65 @@ public final class MesosUtils {
         .build();
   }
 
-  private static Resource newScalar(String name, double value) {
-    return Resource.newBuilder().setName(name).setType(Value.Type.SCALAR).setScalar(Value.Scalar.newBuilder().setValue(value).build()).build();
+  private static Resource newScalar(String name, double value, Optional<String> role) {
+    Resource.Builder builder = Resource.newBuilder().setName(name).setType(Value.Type.SCALAR).setScalar(Value.Scalar.newBuilder().setValue(value).build());
+    if (role.isPresent()) {
+      builder.setRole(role.get());
+    }
+
+    return builder.build();
   }
 
   private static Resource newRange(String name, long begin, long end) {
     return Resource.newBuilder().setName(name).setType(Type.RANGES).setRanges(Ranges.newBuilder().addRange(Range.newBuilder().setBegin(begin).setEnd(end).build()).build()).build();
   }
 
+  public static String getRolesInfo(Offer offer) {
+    StringBuilder info = new StringBuilder();
+    info.append("[");
+    for (Iterator<String> itr = getRoles(offer).iterator(); itr.hasNext(); ) {
+      info.append(itr.next());
+      if (itr.hasNext()) {
+        info.append(", ");
+      }
+    }
+    info.append("]");
+    return info.toString();
+  }
+
+  private static Set<String> getRoles(Offer offer) {
+    Set<String> roles = Sets.newHashSet();
+
+    for (Resource r : offer.getResourcesList()) {
+      roles.add(r.getRole());
+    }
+
+    return roles;
+  }
+
   public static double getNumCpus(Offer offer) {
-    return getNumCpus(offer.getResourcesList());
+    return getNumCpus(offer.getResourcesList(), Optional.<String>absent());
   }
 
   public static double getMemory(Offer offer) {
-    return getMemory(offer.getResourcesList());
+    return getMemory(offer.getResourcesList(), Optional.<String>absent());
   }
 
-  public static double getDisk(Offer offer) { return getDisk(offer.getResourcesList()); }
-
-  public static double getNumCpus(List<Resource> resources) {
-    return getScalar(resources, CPUS);
+  public static double getDisk(Offer offer) {
+    return getDisk(offer.getResourcesList(), Optional.<String>absent());
   }
 
-  public static double getMemory(List<Resource> resources) {
-    return getScalar(resources, MEMORY);
+  public static double getNumCpus(List<Resource> resources, Optional<String> requiredRole) {
+    return getScalar(resources, CPUS, requiredRole);
   }
 
-  public static double getDisk(List<Resource> resources) { return getScalar(resources, DISK); }
+  public static double getMemory(List<Resource> resources, Optional<String> requiredRole) {
+    return getScalar(resources, MEMORY, requiredRole);
+  }
+
+  public static double getDisk(List<Resource> resources, Optional<String> requiredRole) {
+    return getScalar(resources, DISK, requiredRole);
+  }
 
   public static int getNumPorts(List<Resource> resources) {
     return getNumRanges(resources, PORTS);
@@ -219,20 +283,20 @@ public final class MesosUtils {
     return getNumPorts(offer.getResourcesList());
   }
 
-  public static boolean doesOfferMatchResources(Resources resources, List<Resource> offerResources, List<Long> otherRequestedPorts) {
-    double numCpus = getNumCpus(offerResources);
+  public static boolean doesOfferMatchResources(Optional<String> requiredRole, Resources resources, List<Resource> offerResources, List<Long> otherRequestedPorts) {
+    double numCpus = getNumCpus(offerResources, requiredRole);
 
     if (numCpus < resources.getCpus()) {
       return false;
     }
 
-    double memory = getMemory(offerResources);
+    double memory = getMemory(offerResources, requiredRole);
 
     if (memory < resources.getMemoryMb()) {
       return false;
     }
 
-    double disk = getDisk(offerResources);
+    double disk = getDisk(offerResources, requiredRole);
 
     if (disk < resources.getDiskMb()) {
       return false;
@@ -347,7 +411,7 @@ public final class MesosUtils {
   }
 
   public static Resources buildResourcesFromMesosResourceList(List<Resource> resources) {
-    return new Resources(getNumCpus(resources), getMemory(resources), getNumPorts(resources), getDisk(resources));
+    return new Resources(getNumCpus(resources, Optional.<String>absent()), getMemory(resources, Optional.<String>absent()), getNumPorts(resources), getDisk(resources, Optional.<String>absent()));
   }
 
   public static Path getTaskDirectoryPath(String taskId) {

--- a/SingularityBase/src/main/java/com/hubspot/mesos/MesosUtils.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/MesosUtils.java
@@ -10,7 +10,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
-import java.util.Iterator;
 
 import com.google.common.collect.Sets;
 import org.apache.mesos.Protos.MasterInfo;
@@ -44,8 +43,7 @@ public final class MesosUtils {
 
   private static double getScalar(List<Resource> resources, String name, Optional<String> requiredRole) {
     for (Resource r : resources) {
-
-      if (r.hasName() && r.getName().equals(name) && r.hasScalar() && isRequiredRole(r, requiredRole)) {
+      if (r.hasName() && r.getName().equals(name) && r.hasScalar() && hasRequiredRole(r, requiredRole)) {
         return getScalar(r);
       }
     }
@@ -53,11 +51,11 @@ public final class MesosUtils {
     return 0;
   }
 
-  private static Boolean hasRole(Resource r) {
+  private static boolean hasRole(Resource r) {
     return r.hasRole() && !r.getRole().equals("*");
   }
 
-  private static Boolean isRequiredRole(Resource r, Optional<String> requiredRole) {
+  private static boolean hasRequiredRole(Resource r, Optional<String> requiredRole) {
 
     if (requiredRole.isPresent() && hasRole(r)) {
       // required role with a resource with role
@@ -228,20 +226,7 @@ public final class MesosUtils {
     return Resource.newBuilder().setName(name).setType(Type.RANGES).setRanges(Ranges.newBuilder().addRange(Range.newBuilder().setBegin(begin).setEnd(end).build()).build()).build();
   }
 
-  public static String getRolesInfo(Offer offer) {
-    StringBuilder info = new StringBuilder();
-    info.append("[");
-    for (Iterator<String> itr = getRoles(offer).iterator(); itr.hasNext(); ) {
-      info.append(itr.next());
-      if (itr.hasNext()) {
-        info.append(", ");
-      }
-    }
-    info.append("]");
-    return info.toString();
-  }
-
-  private static Set<String> getRoles(Offer offer) {
+  public static Set<String> getRoles(Offer offer) {
     Set<String> roles = Sets.newHashSet();
 
     for (Resource r : offer.getResourcesList()) {

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
@@ -45,6 +45,7 @@ public class SingularityRequest {
   private final Optional<Boolean> loadBalanced;
 
   private final Optional<String> group;
+  private final Optional<String> requiredRole;
   private final Optional<Set<String>> readWriteGroups;
   private final Optional<Set<String>> readOnlyGroups;
   private final Optional<Boolean> bounceAfterScale;
@@ -76,7 +77,7 @@ public class SingularityRequest {
       @JsonProperty("emailConfigurationOverrides") Optional<Map<SingularityEmailType, List<SingularityEmailDestination>>> emailConfigurationOverrides,
       @JsonProperty("daemon") @Deprecated Optional<Boolean> daemon, @JsonProperty("hideEvenNumberAcrossRacks") Optional<Boolean> hideEvenNumberAcrossRacksHint,
       @JsonProperty("taskLogErrorRegex") Optional<String> taskLogErrorRegex, @JsonProperty("taskLogErrorRegexCaseSensitive") Optional<Boolean> taskLogErrorRegexCaseSensitive,
-      @JsonProperty("taskPriorityLevel") Optional<Double> taskPriorityLevel, @JsonProperty("maxTasksPerOffer") Optional<Integer> maxTasksPerOffer, @JsonProperty("allowBounceToSameHost") Optional<Boolean> allowBounceToSameHost) {
+      @JsonProperty("taskPriorityLevel") Optional<Double> taskPriorityLevel, @JsonProperty("maxTasksPerOffer") Optional<Integer> maxTasksPerOffer, @JsonProperty("allowBounceToSameHost") Optional<Boolean> allowBounceToSameHost, @JsonProperty("requiredRole") Optional<String> requiredRole) {
     this.id = checkNotNull(id, "id cannot be null");
     this.owners = owners;
     this.numRetriesOnFailure = numRetriesOnFailure;
@@ -96,6 +97,7 @@ public class SingularityRequest {
     this.scheduledExpectedRuntimeMillis = scheduledExpectedRuntimeMillis;
     this.waitAtLeastMillisAfterTaskFinishesForReschedule = waitAtLeastMillisAfterTaskFinishesForReschedule;
     this.group = group;
+    this.requiredRole = requiredRole;
     this.readWriteGroups = readWriteGroups;
     this.readOnlyGroups = readOnlyGroups;
     this.bounceAfterScale = bounceAfterScale;
@@ -133,6 +135,7 @@ public class SingularityRequest {
     .setRequiredSlaveAttributes(requiredSlaveAttributes)
     .setAllowedSlaveAttributes(allowedSlaveAttributes)
     .setScheduledExpectedRuntimeMillis(scheduledExpectedRuntimeMillis)
+    .setRequiredRole(requiredRole)
     .setGroup(group)
     .setReadWriteGroups(readWriteGroups)
     .setReadOnlyGroups(readOnlyGroups)
@@ -309,6 +312,11 @@ public class SingularityRequest {
   @ApiModelProperty(required=false, value="Auth group associated with this request. Users in this group are allowed read/write access to this request")
   public Optional<String> getGroup() {
     return group;
+  }
+
+  @ApiModelProperty(required=false, value="Mesos Role required for this request. Only offers with the required role will be accepted to execute the tasks associated with the request")
+  public Optional<String> getRequiredRole() {
+    return requiredRole;
   }
 
   @ApiModelProperty(required=false, value="Users in these groups are allowed read/write access to this request")

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestBuilder.java
@@ -38,6 +38,7 @@ public class SingularityRequestBuilder {
   private Optional<Map<String, String>> requiredSlaveAttributes;
   private Optional<Map<String, String>> allowedSlaveAttributes;
   private Optional<Boolean> loadBalanced;
+  private Optional<String> requiredRole;
 
   private Optional<String> group;
   private Optional<Set<String>> readWriteGroups;
@@ -83,12 +84,13 @@ public class SingularityRequestBuilder {
     this.taskPriorityLevel = Optional.absent();
     this.maxTasksPerOffer = Optional.absent();
     this.allowBounceToSameHost = Optional.absent();
+    this.requiredRole = Optional.absent();
   }
 
   public SingularityRequest build() {
     return new SingularityRequest(id, requestType, owners, numRetriesOnFailure, schedule, instances, rackSensitive, loadBalanced, killOldNonLongRunningTasksAfterMillis, taskExecutionTimeLimitMillis, scheduleType, quartzSchedule, scheduleTimeZone,
         rackAffinity, slavePlacement, requiredSlaveAttributes, allowedSlaveAttributes, scheduledExpectedRuntimeMillis, waitAtLeastMillisAfterTaskFinishesForReschedule, group, readWriteGroups, readOnlyGroups,
-        bounceAfterScale, skipHealthchecks, emailConfigurationOverrides, Optional.<Boolean>absent(), hideEvenNumberAcrossRacksHint, taskLogErrorRegex, taskLogErrorRegexCaseSensitive, taskPriorityLevel, maxTasksPerOffer, allowBounceToSameHost);
+        bounceAfterScale, skipHealthchecks, emailConfigurationOverrides, Optional.<Boolean>absent(), hideEvenNumberAcrossRacksHint, taskLogErrorRegex, taskLogErrorRegexCaseSensitive, taskPriorityLevel, maxTasksPerOffer, allowBounceToSameHost, requiredRole);
   }
 
   public Optional<Boolean> getSkipHealthchecks() {
@@ -146,6 +148,11 @@ public class SingularityRequestBuilder {
 
   public SingularityRequestBuilder setInstances(Optional<Integer> instances) {
     this.instances = instances;
+    return this;
+  }
+
+  public SingularityRequestBuilder setRequiredRole(Optional<String> requiredRole) {
+    this.requiredRole = requiredRole;
     return this;
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/MesosConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/MesosConfiguration.java
@@ -26,6 +26,9 @@ public class MesosConfiguration {
   private boolean checkpoint = true;
 
   @NotNull
+  private Optional<String> frameworkRole = Optional.absent();
+
+  @NotNull
   private String rackIdAttributeKey = "rackid";
 
   @NotNull
@@ -126,6 +129,14 @@ public class MesosConfiguration {
 
   public void setFrameworkFailoverTimeout(double frameworkFailoverTimeout) {
     this.frameworkFailoverTimeout = frameworkFailoverTimeout;
+  }
+
+  public Optional<String> getFrameworkRole() {
+    return frameworkRole;
+  }
+
+  public void setFrameworkRole(Optional<String> frameworkRole) {
+    this.frameworkRole = frameworkRole;
   }
 
   public void setMaster(String master) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityDriver.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityDriver.java
@@ -61,6 +61,10 @@ public class SingularityDriver {
       }
     }
 
+    if (configuration.getFrameworkRole().isPresent()) {
+      frameworkInfoBuilder.setRole(configuration.getFrameworkRole().get());
+    }
+
     this.frameworkInfo = frameworkInfoBuilder.build();
 
     this.scheduler = scheduler;

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
@@ -120,7 +120,7 @@ public class SingularityMesosScheduler implements Scheduler {
     LOG.info("Received {} offer(s)", offers.size());
 
     for (Offer offer : offers) {
-      String rolesInfo = MesosUtils.getRolesInfo(offer);
+      String rolesInfo = MesosUtils.getRoles(offer).toString();
       LOG.debug("Received offer ID {} with roles {} from {} ({}) for {} cpu(s), {} memory, {} ports, and {} disk", offer.getId().getValue(), rolesInfo, offer.getHostname(), offer.getSlaveId().getValue(), MesosUtils.getNumCpus(offer), MesosUtils.getMemory(offer),
           MesosUtils.getNumPorts(offer), MesosUtils.getDisk(offer));
     }
@@ -273,9 +273,9 @@ public class SingularityMesosScheduler implements Scheduler {
 
         return Optional.of(task);
       } else {
-        String rolesInfo = MesosUtils.getRolesInfo(offerHolder.getOffer());
+        String rolesInfo = MesosUtils.getRoles(offerHolder.getOffer()).toString();
         LOG.trace("Ignoring offer {} with roles {} on {} for task {}; matched resources: {}, slave match state: {}", offerHolder.getOffer().getId(), rolesInfo, offerHolder.getOffer().getHostname(), taskRequest
-            .getPendingTask().getPendingTaskId(), matchesResources, slaveMatchState);
+                .getPendingTask().getPendingTaskId(), matchesResources, slaveMatchState);
       }
     }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
@@ -250,9 +250,9 @@ public class SingularityMesosScheduler implements Scheduler {
         requestedPorts.addAll(taskRequest.getDeploy().getContainerInfo().get().getDocker().get().getLiteralHostPorts());
       }
 
-      LOG.trace("Attempting to match task {} resources {} ({} for task + {} for executor) with remaining offer resources {}", taskRequest.getPendingTask().getPendingTaskId(), totalResources, taskResources, executorResources, offerHolder.getCurrentResources());
-
       Optional<String> requiredRole = taskRequest.getRequest().getRequiredRole();
+      LOG.trace("Attempting to match task {} resources {} with required role '{}' ({} for task + {} for executor) with remaining offer resources {}", taskRequest.getPendingTask().getPendingTaskId(), totalResources, requiredRole.or("*"),taskResources, executorResources, offerHolder.getCurrentResources());
+
       final boolean matchesResources = MesosUtils.doesOfferMatchResources(requiredRole, totalResources, offerHolder.getCurrentResources(), requestedPorts);
       final SlaveMatchState slaveMatchState = slaveAndRackManager.doesOfferMatch(offerHolder.getOffer(), taskRequest, stateCache);
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -477,7 +477,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     sms.resourceOffers(driver, Arrays.asList(createOffer(5, 5, "slave1", "host1", Optional.of("rack1"))));
 
     SingularityTask task = taskManager.getActiveTasks().get(0);
-    Assert.assertEquals(MesosUtils.getNumCpus(task.getMesosTask().getResourcesList()), 2.0, 0.0);
+    Assert.assertEquals(MesosUtils.getNumCpus(task.getMesosTask().getResourcesList(), Optional.<String>absent()), 2.0, 0.0);
   }
 
   @Test
@@ -1731,5 +1731,53 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
 
     scheduler.drainPendingQueue(stateCacheProvider.get());
     Assert.assertEquals(5, taskManager.getPendingTaskIds().size());
+  }
+
+  public void testAcceptOffersWithRoleForRequestWithRole() {
+    SingularityRequestBuilder bldr = new SingularityRequestBuilder(requestId, RequestType.ON_DEMAND);
+    bldr.setRequiredRole(Optional.of("test-role"));
+    requestResource.postRequest(bldr.build());
+    deploy("d2");
+
+    SingularityRunNowRequest runNowRequest = new SingularityRunNowRequest(Optional.<String>absent(), Optional.<Boolean>absent(), Optional.<String>absent(), Optional.<List<String>>absent(), Optional.of(new Resources(2, 2, 0)));
+    requestResource.scheduleImmediately(requestId, Optional.of(runNowRequest));
+
+    scheduler.drainPendingQueue(stateCacheProvider.get());
+
+    SingularityPendingTask pendingTaskWithResources = taskManager.getPendingTasks().get(0);
+    Assert.assertTrue(pendingTaskWithResources.getResources().isPresent());
+    Assert.assertEquals(pendingTaskWithResources.getResources().get().getCpus(), 2, 0.0);
+
+    sms.resourceOffers(driver, Arrays.asList(createOffer(5, 5)));
+
+    pendingTaskWithResources = taskManager.getPendingTasks().get(0);
+    Assert.assertTrue(pendingTaskWithResources.getResources().isPresent());
+    Assert.assertEquals(pendingTaskWithResources.getResources().get().getCpus(), 2, 0.0);
+
+    sms.resourceOffers(driver, Arrays.asList(createOffer(5, 5, Optional.of("test-role"))));
+    SingularityTask task = taskManager.getActiveTasks().get(0);
+    Assert.assertEquals(MesosUtils.getNumCpus(task.getMesosTask().getResourcesList(), Optional.of("test-role")), 2.0, 0.0);
+  }
+
+  @Test
+  public void testNotAcceptOfferWithRoleForRequestWithoutRole() {
+    SingularityRequestBuilder bldr = new SingularityRequestBuilder(requestId, RequestType.ON_DEMAND);
+    requestResource.postRequest(bldr.build());
+    deploy("d2");
+
+    SingularityRunNowRequest runNowRequest = new SingularityRunNowRequest(Optional.<String>absent(), Optional.<Boolean>absent(), Optional.<String>absent(), Optional.<List<String>>absent(), Optional.of(new Resources(2, 2, 0)));
+    requestResource.scheduleImmediately(requestId, Optional.of(runNowRequest));
+
+    scheduler.drainPendingQueue(stateCacheProvider.get());
+
+    SingularityPendingTask pendingTaskWithResources = taskManager.getPendingTasks().get(0);
+    Assert.assertTrue(pendingTaskWithResources.getResources().isPresent());
+    Assert.assertEquals(pendingTaskWithResources.getResources().get().getCpus(), 2, 0.0);
+
+    sms.resourceOffers(driver, Arrays.asList(createOffer(5, 5, Optional.of("test-role"))));
+
+    pendingTaskWithResources = taskManager.getPendingTasks().get(0);
+    Assert.assertTrue(pendingTaskWithResources.getResources().isPresent());
+    Assert.assertEquals(pendingTaskWithResources.getResources().get().getCpus(), 2, 0.0);
   }
 }


### PR DESCRIPTION
This PR aims at adding support for Mesos Reserved Resources to Singularity. Related with #1359 

The main change is in `MesosUtils.doesOfferMatchResources` that now takes into account  Singularity `Request.requiredRole` and Mesos Offer `Resources.Role`

The UI is still missing, and I'm not sure if this approach is the right one, but hopefully this PR can help us to discuss it.

We need to think about the semantic of "required role" for a Request.  The current implementation will not accept offers with `*` for a Request with `requiredRole`, but we may want to support other use cases here.

sidekick @ssalinas @relistan