### PR TITLE
Add maxTasksPerOffer at request level

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
@@ -57,6 +57,7 @@ public class SingularityRequest {
   private final Optional<Boolean> taskLogErrorRegexCaseSensitive;
 
   private final Optional<Double> taskPriorityLevel;
+  private final Optional<Integer> maxTasksPerOffer;
 
   @JsonCreator
   public SingularityRequest(@JsonProperty("id") String id, @JsonProperty("requestType") RequestType requestType, @JsonProperty("owners") Optional<List<String>> owners,
@@ -73,7 +74,7 @@ public class SingularityRequest {
       @JsonProperty("emailConfigurationOverrides") Optional<Map<SingularityEmailType, List<SingularityEmailDestination>>> emailConfigurationOverrides,
       @JsonProperty("daemon") @Deprecated Optional<Boolean> daemon, @JsonProperty("hideEvenNumberAcrossRacks") Optional<Boolean> hideEvenNumberAcrossRacksHint,
       @JsonProperty("taskLogErrorRegex") Optional<String> taskLogErrorRegex, @JsonProperty("taskLogErrorRegexCaseSensitive") Optional<Boolean> taskLogErrorRegexCaseSensitive,
-      @JsonProperty("taskPriorityLevel") Optional<Double> taskPriorityLevel) {
+      @JsonProperty("taskPriorityLevel") Optional<Double> taskPriorityLevel, @JsonProperty("maxTasksPerOffer") Optional<Integer> maxTasksPerOffer) {
     this.id = checkNotNull(id, "id cannot be null");
     this.owners = owners;
     this.numRetriesOnFailure = numRetriesOnFailure;
@@ -102,6 +103,7 @@ public class SingularityRequest {
     this.taskLogErrorRegex = taskLogErrorRegex;
     this.taskLogErrorRegexCaseSensitive = taskLogErrorRegexCaseSensitive;
     this.taskPriorityLevel = taskPriorityLevel;
+    this.maxTasksPerOffer = maxTasksPerOffer;
     if (requestType == null) {
       this.requestType = RequestType.fromDaemonAndScheduleAndLoadBalanced(schedule, daemon, loadBalanced);
     } else {
@@ -137,7 +139,8 @@ public class SingularityRequest {
     .setHideEvenNumberAcrossRacksHint(hideEvenNumberAcrossRacksHint)
     .setTaskLogErrorRegex(taskLogErrorRegex)
     .setTaskLogErrorRegexCaseSensitive(taskLogErrorRegexCaseSensitive)
-    .setTaskPriorityLevel(taskPriorityLevel);
+    .setTaskPriorityLevel(taskPriorityLevel)
+    .setMaxTasksPerOffer(maxTasksPerOffer);
   }
 
   @ApiModelProperty(required=true, value="A unique id for the request")
@@ -228,6 +231,11 @@ public class SingularityRequest {
   @ApiModelProperty(required=false, value="Allow tasks to run on slaves with these attributes, but do not restrict them to only these slaves")
   public Optional<Map<String, String>> getAllowedSlaveAttributes() {
     return allowedSlaveAttributes;
+  }
+
+  @ApiModelProperty(required=false, value="Do not schedule more than this many tasks using a single offer from a single mesos slave")
+  public Optional<Integer> getMaxTasksPerOffer() {
+    return maxTasksPerOffer;
   }
 
   @JsonIgnore
@@ -364,6 +372,7 @@ public class SingularityRequest {
       .add("taskLogErrorRegex", taskLogErrorRegex)
       .add("taskLogErrorRegexCaseSensitive", taskLogErrorRegexCaseSensitive)
       .add("taskPriorityLevel", taskPriorityLevel)
+      .add("maxTasksPerOffer", maxTasksPerOffer)
       .toString();
   }
 
@@ -403,11 +412,12 @@ public class SingularityRequest {
             Objects.equals(hideEvenNumberAcrossRacksHint, request.hideEvenNumberAcrossRacksHint) &&
             Objects.equals(taskLogErrorRegex, request.taskLogErrorRegex) &&
             Objects.equals(taskLogErrorRegexCaseSensitive, request.taskLogErrorRegexCaseSensitive) &&
-            Objects.equals(taskPriorityLevel, request.taskPriorityLevel);
+            Objects.equals(taskPriorityLevel, request.taskPriorityLevel) &&
+            Objects.equals(maxTasksPerOffer, request.maxTasksPerOffer);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, requestType, owners, numRetriesOnFailure, schedule, quartzSchedule, scheduleTimeZone, scheduleType, killOldNonLongRunningTasksAfterMillis, taskExecutionTimeLimitMillis, scheduledExpectedRuntimeMillis, waitAtLeastMillisAfterTaskFinishesForReschedule, instances, rackSensitive, rackAffinity, slavePlacement, requiredSlaveAttributes, allowedSlaveAttributes, loadBalanced, group, readWriteGroups, readOnlyGroups, bounceAfterScale, emailConfigurationOverrides, hideEvenNumberAcrossRacksHint, taskLogErrorRegex, taskLogErrorRegexCaseSensitive, taskPriorityLevel);
+    return Objects.hash(id, requestType, owners, numRetriesOnFailure, schedule, quartzSchedule, scheduleTimeZone, scheduleType, killOldNonLongRunningTasksAfterMillis, taskExecutionTimeLimitMillis, scheduledExpectedRuntimeMillis, waitAtLeastMillisAfterTaskFinishesForReschedule, instances, rackSensitive, rackAffinity, slavePlacement, requiredSlaveAttributes, allowedSlaveAttributes, loadBalanced, group, readWriteGroups, readOnlyGroups, bounceAfterScale, emailConfigurationOverrides, hideEvenNumberAcrossRacksHint, taskLogErrorRegex, taskLogErrorRegexCaseSensitive, taskPriorityLevel, maxTasksPerOffer);
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestBuilder.java
@@ -48,6 +48,7 @@ public class SingularityRequestBuilder {
   private Optional<String> taskLogErrorRegex;
   private Optional<Boolean> taskLogErrorRegexCaseSensitive;
   private Optional<Double> taskPriorityLevel;
+  private Optional<Integer> maxTasksPerOffer;
 
   public SingularityRequestBuilder(String id, RequestType requestType) {
     this.id = checkNotNull(id, "id cannot be null");
@@ -79,12 +80,13 @@ public class SingularityRequestBuilder {
     this.taskLogErrorRegex = Optional.absent();
     this.taskLogErrorRegexCaseSensitive = Optional.absent();
     this.taskPriorityLevel = Optional.absent();
+    this.maxTasksPerOffer = Optional.absent();
   }
 
   public SingularityRequest build() {
     return new SingularityRequest(id, requestType, owners, numRetriesOnFailure, schedule, instances, rackSensitive, loadBalanced, killOldNonLongRunningTasksAfterMillis, taskExecutionTimeLimitMillis, scheduleType, quartzSchedule, scheduleTimeZone,
         rackAffinity, slavePlacement, requiredSlaveAttributes, allowedSlaveAttributes, scheduledExpectedRuntimeMillis, waitAtLeastMillisAfterTaskFinishesForReschedule, group, readWriteGroups, readOnlyGroups,
-        bounceAfterScale, skipHealthchecks, emailConfigurationOverrides, Optional.<Boolean>absent(), hideEvenNumberAcrossRacksHint, taskLogErrorRegex, taskLogErrorRegexCaseSensitive, taskPriorityLevel);
+        bounceAfterScale, skipHealthchecks, emailConfigurationOverrides, Optional.<Boolean>absent(), hideEvenNumberAcrossRacksHint, taskLogErrorRegex, taskLogErrorRegexCaseSensitive, taskPriorityLevel, maxTasksPerOffer);
   }
 
   public Optional<Boolean> getSkipHealthchecks() {
@@ -325,6 +327,15 @@ public class SingularityRequestBuilder {
     return this;
   }
 
+  public Optional<Integer> getMaxTasksPerOffer() {
+    return maxTasksPerOffer;
+  }
+
+  public SingularityRequestBuilder setMaxTasksPerOffer(Optional<Integer> maxTasksPerOffer) {
+    this.maxTasksPerOffer = maxTasksPerOffer;
+    return this;
+  }
+
   @Override
   public String toString() {
     return "SingularityRequestBuilder[" +
@@ -357,6 +368,7 @@ public class SingularityRequestBuilder {
             ", taskLogErrorRegex=" + taskLogErrorRegex +
             ", taskLogErrorRegexCaseSensitive=" + taskLogErrorRegexCaseSensitive +
             ", taskPriorityLevel=" + taskPriorityLevel +
+            ", maxTasksPerOffer=" + maxTasksPerOffer +
             ']';
   }
 
@@ -397,7 +409,8 @@ public class SingularityRequestBuilder {
             Objects.equals(hideEvenNumberAcrossRacksHint, that.hideEvenNumberAcrossRacksHint) &&
             Objects.equals(taskLogErrorRegex, that.taskLogErrorRegex) &&
             Objects.equals(taskLogErrorRegexCaseSensitive, that.taskLogErrorRegexCaseSensitive) &&
-            Objects.equals(taskPriorityLevel, that.taskPriorityLevel);
+            Objects.equals(taskPriorityLevel, that.taskPriorityLevel) &&
+            Objects.equals(maxTasksPerOffer, that.maxTasksPerOffer);
   }
 
   @Override
@@ -405,7 +418,7 @@ public class SingularityRequestBuilder {
     return Objects.hash(id, requestType, owners, numRetriesOnFailure, schedule, quartzSchedule, scheduleTimeZone, scheduleType, killOldNonLongRunningTasksAfterMillis,
         taskExecutionTimeLimitMillis, scheduledExpectedRuntimeMillis, waitAtLeastMillisAfterTaskFinishesForReschedule, instances, rackSensitive, rackAffinity, slavePlacement,
         requiredSlaveAttributes, allowedSlaveAttributes, loadBalanced, group, readOnlyGroups, readWriteGroups, bounceAfterScale, skipHealthchecks, emailConfigurationOverrides,
-        hideEvenNumberAcrossRacksHint, taskLogErrorRegex, taskLogErrorRegexCaseSensitive, taskPriorityLevel);
+        hideEvenNumberAcrossRacksHint, taskLogErrorRegex, taskLogErrorRegexCaseSensitive, taskPriorityLevel, maxTasksPerOffer);
   }
 
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -169,6 +169,8 @@ public class SingularityConfiguration extends Configuration {
 
   private int maxTasksPerOffer = 0;
 
+  private int maxTasksPerOfferPerRequest = 0;
+
   private int maxRequestIdSize = 100;
 
   private int maxUserIdSize = 100;
@@ -576,6 +578,10 @@ public class SingularityConfiguration extends Configuration {
     return maxTasksPerOffer;
   }
 
+  public int getMaxTasksPerOfferPerRequest() {
+    return maxTasksPerOfferPerRequest;
+  }
+
   public MesosConfiguration getMesosConfiguration() {
     return mesosConfiguration;
   }
@@ -915,6 +921,10 @@ public class SingularityConfiguration extends Configuration {
 
   public void setMaxTasksPerOffer(int maxTasksPerOffer) {
     this.maxTasksPerOffer = maxTasksPerOffer;
+  }
+
+  public void setMaxTasksPerOfferPerRequest(int maxTasksPerOfferPerRequest) {
+    this.maxTasksPerOfferPerRequest = maxTasksPerOfferPerRequest;
   }
 
   public void setMesosConfiguration(MesosConfiguration mesosConfiguration) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
@@ -225,6 +225,10 @@ public class SingularityValidator {
       checkBadRequest(!request.getInstances().isPresent(), "one-off requests can not define a # of instances");
     }
 
+    if (request.getMaxTasksPerOffer().isPresent()) {
+      checkBadRequest(request.getMaxTasksPerOffer().get() > 0, "maxTasksPerOffer must be positive");
+    }
+
     return request.toBuilder().setQuartzSchedule(Optional.fromNullable(quartzSchedule)).build();
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
@@ -294,16 +294,18 @@ public class SingularityMesosScheduler implements Scheduler {
   }
 
   private boolean tooManyTasksPerOfferForRequest(Map<String, Map<String, Integer>> tasksPerOfferPerRequest, String offerId, SingularityTaskRequest taskRequest) {
-    if (!taskRequest.getRequest().getMaxTasksPerOffer().isPresent()) {
-      return false;
-    }
     if (!tasksPerOfferPerRequest.containsKey(offerId)) {
       return false;
     }
     if (!tasksPerOfferPerRequest.get(offerId).containsKey(taskRequest.getRequest().getId())) {
       return false;
     }
-    return tasksPerOfferPerRequest.get(offerId).get(taskRequest.getRequest().getId()) > taskRequest.getRequest().getMaxTasksPerOffer().get();
+
+    int maxPerOfferPerRequest = taskRequest.getRequest().getMaxTasksPerOffer().or(configuration.getMaxTasksPerOfferPerRequest());
+    if (!(maxPerOfferPerRequest > 0)) {
+      return false;
+    }
+    return tasksPerOfferPerRequest.get(offerId).get(taskRequest.getRequest().getId()) > maxPerOfferPerRequest;
   }
 
   @Override

--- a/SingularityUI/app/components/requestForm/RequestForm.jsx
+++ b/SingularityUI/app/components/requestForm/RequestForm.jsx
@@ -517,6 +517,17 @@ const RequestForm = (props) => {
     />
   );
 
+  const maxTasksPerOffer = (
+    <TextFormGroup
+      id="max-per-offer"
+      onChange={event => updateField('maxTasksPerOffer', event.target.value)}
+      value={getValue('maxTasksPerOffer')}
+      label="Schedule at most this many tasks using a single offer form a single slave"
+      required={INDEXED_FIELDS.maxTasksPerOffer.required}
+      feedback={feedback('maxTasksPerOffer')}
+    />
+  );
+
   const taskLogErrorRegex = (
     <TextFormGroup
       id="task-log-error-regex"
@@ -651,6 +662,7 @@ const RequestForm = (props) => {
                   { shouldRenderField('group') && group }
                   { shouldRenderField('readOnlyGroups') && readOnlyGroups }
                   { shouldRenderField('readWriteGroups') && readWriteGroups }
+                  { shouldRenderField('maxTasksPerOffer') && maxTasksPerOffer }
                   { shouldRenderField('taskLogErrorRegex') && taskLogErrorRegex }
                   { shouldRenderField('taskLogErrorRegexCaseSensitive') && taskLogErrorRegexCaseSensitive }
                   { shouldRenderField('emailConfigurationOverrides') && emailConfigurationOverrides }

--- a/SingularityUI/app/components/requestForm/fields.es6
+++ b/SingularityUI/app/components/requestForm/fields.es6
@@ -44,6 +44,7 @@ export const FIELDS_BY_REQUEST_TYPE = {
       }
     },
     {id: 'group', type: 'string'},
+    {id: 'maxTasksPerOffer', type: 'number'},
     {id: 'taskLogErrorRegex', type: 'string'},
     {id: 'taskLogErrorRegexCaseSensitive', type: 'bool'},
     {


### PR DESCRIPTION
Allow a request to override the max tasks per offer so we can avoid scheduling a large stack of tasks on a single host
/cc @tpetr 