### PR TITLE
No retry for scheduled tasks run on-demand through UI

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -585,12 +585,14 @@ public class SingularityScheduler {
   private void updateDeployStatistics(SingularityDeployStatistics deployStatistics, SingularityTaskId taskId, long timestamp, ExtendedTaskState state, Optional<PendingType> scheduleResult) {
     SingularityDeployStatisticsBuilder bldr = deployStatistics.toBuilder();
 
-    if (bldr.getAverageRuntimeMillis().isPresent() && !state.isFailed()) {
-      long newAvgRuntimeMillis = (bldr.getAverageRuntimeMillis().get() * bldr.getNumTasks() + (timestamp - taskId.getStartedAt())) / (bldr.getNumTasks() + 1);
+    if (!state.isFailed()) {
+      if (bldr.getAverageRuntimeMillis().isPresent()) {
+        long newAvgRuntimeMillis = (bldr.getAverageRuntimeMillis().get() * bldr.getNumTasks() + (timestamp - taskId.getStartedAt())) / (bldr.getNumTasks() + 1);
 
-      bldr.setAverageRuntimeMillis(Optional.of(newAvgRuntimeMillis));
-    } else {
-      bldr.setAverageRuntimeMillis(Optional.of(timestamp - taskId.getStartedAt()));
+        bldr.setAverageRuntimeMillis(Optional.of(newAvgRuntimeMillis));
+      } else {
+        bldr.setAverageRuntimeMillis(Optional.of(timestamp - taskId.getStartedAt()));
+      }
     }
 
     bldr.setNumTasks(bldr.getNumTasks() + 1);
@@ -614,6 +616,7 @@ public class SingularityScheduler {
           sequentialFailureTimestamps.set(0, timestamp);
         }
 
+        bldr.setNumFailures(bldr.getNumFailures() + 1);
         Collections.sort(sequentialFailureTimestamps);
       }
     } else {

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -585,7 +585,7 @@ public class SingularityScheduler {
   private void updateDeployStatistics(SingularityDeployStatistics deployStatistics, SingularityTaskId taskId, long timestamp, ExtendedTaskState state, Optional<PendingType> scheduleResult) {
     SingularityDeployStatisticsBuilder bldr = deployStatistics.toBuilder();
 
-    if (bldr.getAverageRuntimeMillis().isPresent()) {
+    if (bldr.getAverageRuntimeMillis().isPresent() && !state.isFailed()) {
       long newAvgRuntimeMillis = (bldr.getAverageRuntimeMillis().get() * bldr.getNumTasks() + (timestamp - taskId.getStartedAt())) / (bldr.getNumTasks() + 1);
 
       bldr.setAverageRuntimeMillis(Optional.of(newAvgRuntimeMillis));
@@ -642,7 +642,7 @@ public class SingularityScheduler {
     if (task.isPresent() && task.get().getTaskRequest().getPendingTask().getPendingTaskId().getPendingType() == PendingType.IMMEDIATE) {
       return false; // don't retry UI initiated run now
     }
-q
+
     final int numRetriesInARow = deployStatistics.getNumSequentialRetries();
 
     if (numRetriesInARow >= request.getNumRetriesOnFailure().get()) {

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -1238,21 +1238,26 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
   }
 
   @Test
-  public void testScheduledJobRetryKeepsArgs() {
-    Optional<List<String>> cmdLinArgs = Optional.of(Arrays.asList("arg1", "arg2"));
+  public void testRunNowScheduledJobDoesNotRetry() {
     initScheduledRequest();
     SingularityRequest request = requestResource.getRequest(requestId).getRequest();
     SingularityRequest newRequest = request.toBuilder().setNumRetriesOnFailure(Optional.of(2)).build();
     requestResource.postRequest(newRequest);
     initFirstDeploy();
 
-    requestResource.scheduleImmediately(requestId, Optional.of(new SingularityRunNowRequest(Optional.<String>absent(), Optional.<Boolean>absent(), Optional.<String>absent(), cmdLinArgs, Optional.<Resources>absent())));
+    requestResource.scheduleImmediately(requestId, Optional.of(new SingularityRunNowRequest(Optional.<String>absent(), Optional.<Boolean>absent(), Optional.<String>absent(), Optional.<List<String>>absent(), Optional.<Resources>absent())));
     resourceOffers();
 
     SingularityTask task = taskManager.getActiveTasks().get(0);
     statusUpdate(task, TaskState.TASK_FAILED);
 
-    Assert.assertEquals(cmdLinArgs, taskManager.getPendingTasks().get(0).getCmdLineArgsList());
+    SingularityDeployStatistics deployStatistics = deployManager.getDeployStatistics(task.getTaskId().getRequestId(), task.getTaskId().getDeployId()).get();
+
+    Assert.assertEquals(TaskState.TASK_FAILED, deployStatistics.getLastTaskState().get().toTaskState().get());
+    Assert.assertEquals(PendingType.TASK_DONE, taskManager.getPendingTaskIds().get(0).getPendingType());
+    Assert.assertEquals(1, deployStatistics.getNumFailures());
+    Assert.assertEquals(0, deployStatistics.getNumSequentialRetries());
+    Assert.assertEquals(Optional.<Long>absent(), deployStatistics.getAverageRuntimeMillis());
   }
 
   @Test


### PR DESCRIPTION
Changes:
- UI initiated 'run now' won't retry
- Failed tasks aren't included in average task runtime


@tpetr