### PR TITLE
jets3t -> aws sdk

### DIFF
--- a/SingularityS3Base/pom.xml
+++ b/SingularityS3Base/pom.xml
@@ -31,11 +31,21 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
 
-    <!-- for jade and jets3t -->
+    <!-- for jade -->
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
       <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-s3</artifactId>
     </dependency>
 
     <dependency>
@@ -47,11 +57,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>net.java.dev.jets3t</groupId>
-      <artifactId>jets3t</artifactId>
     </dependency>
 
     <dependency>

--- a/SingularityS3Base/src/main/java/com/hubspot/singularity/s3/base/S3ArtifactDownloader.java
+++ b/SingularityS3Base/src/main/java/com/hubspot/singularity/s3/base/S3ArtifactDownloader.java
@@ -68,7 +68,7 @@ public class S3ArtifactDownloader {
     log.info("Downloading {}", s3Artifact);
 
     ClientConfiguration clientConfiguration = new ClientConfiguration()
-        .withSocketTimeout(configuration.getS3ChunkDownloadTimeoutMillis().intValue());
+        .withSocketTimeout(configuration.getS3ChunkDownloadTimeoutMillis());
     final AmazonS3 s3Client = new AmazonS3Client(getCredentialsForBucket(s3Artifact.getS3Bucket()), clientConfiguration);
 
     long length = 0;

--- a/SingularityS3Base/src/main/java/com/hubspot/singularity/s3/base/S3ArtifactDownloader.java
+++ b/SingularityS3Base/src/main/java/com/hubspot/singularity/s3/base/S3ArtifactDownloader.java
@@ -13,14 +13,13 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import org.jets3t.service.Constants;
-import org.jets3t.service.Jets3tProperties;
-import org.jets3t.service.S3Service;
-import org.jets3t.service.impl.rest.httpclient.RestS3Service;
-import org.jets3t.service.model.StorageObject;
-import org.jets3t.service.security.AWSCredentials;
 import org.slf4j.Logger;
 
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.S3Object;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
@@ -57,32 +56,31 @@ public class S3ArtifactDownloader {
     }
   }
 
-  private AWSCredentials getCredentialsForBucket(String bucketName) {
+  private BasicAWSCredentials getCredentialsForBucket(String bucketName) {
     if (configuration.getS3BucketCredentials().containsKey(bucketName)) {
       return configuration.getS3BucketCredentials().get(bucketName).toAWSCredentials();
     }
 
-    return new AWSCredentials(configuration.getS3AccessKey().get(), configuration.getS3SecretKey().get());
+    return new BasicAWSCredentials(configuration.getS3AccessKey().get(), configuration.getS3SecretKey().get());
   }
 
   private void downloadThrows(final S3Artifact s3Artifact, final Path downloadTo) throws Exception {
     log.info("Downloading {}", s3Artifact);
 
-    Jets3tProperties jets3tProperties = Jets3tProperties.getInstance(Constants.JETS3T_PROPERTIES_FILENAME);
-    jets3tProperties.setProperty("httpclient.socket-timeout-ms", Long.toString(configuration.getS3ChunkDownloadTimeoutMillis()));
-
-    final S3Service s3 = new RestS3Service(getCredentialsForBucket(s3Artifact.getS3Bucket()), null, null, jets3tProperties);
+    ClientConfiguration clientConfiguration = new ClientConfiguration()
+        .withSocketTimeout(configuration.getS3ChunkDownloadTimeoutMillis().intValue());
+    final AmazonS3 s3Client = new AmazonS3Client(getCredentialsForBucket(s3Artifact.getS3Bucket()), clientConfiguration);
 
     long length = 0;
 
     if (s3Artifact.getFilesize().isPresent()) {
       length = s3Artifact.getFilesize().get();
     } else {
-      StorageObject details = s3.getObjectDetails(s3Artifact.getS3Bucket(), s3Artifact.getS3ObjectKey());
+      S3Object details = s3Client.getObject(s3Artifact.getS3Bucket(), s3Artifact.getS3ObjectKey());
 
       Preconditions.checkNotNull(details, "Couldn't find object at %s/%s", s3Artifact.getS3Bucket(), s3Artifact.getS3ObjectKey());
 
-      length = details.getContentLength();
+      length = details.getObjectMetadata().getContentLength();
     }
 
     int numChunks = (int) (length / configuration.getS3ChunkSize());
@@ -99,7 +97,7 @@ public class S3ArtifactDownloader {
     final List<Future<Path>> futures = Lists.newArrayListWithCapacity(numChunks);
 
     for (int chunk = 0; chunk < numChunks; chunk++) {
-      futures.add(chunkExecutorService.submit(new S3ArtifactChunkDownloader(configuration, log, s3, s3Artifact, downloadTo, chunk, chunkSize, length, exceptionNotifier)));
+      futures.add(chunkExecutorService.submit(new S3ArtifactChunkDownloader(configuration, log, s3Client, s3Artifact, downloadTo, chunk, chunkSize, length, exceptionNotifier)));
     }
 
     long remainingMillis = configuration.getS3DownloadTimeoutMillis();

--- a/SingularityS3Base/src/main/java/com/hubspot/singularity/s3/base/config/SingularityS3Configuration.java
+++ b/SingularityS3Base/src/main/java/com/hubspot/singularity/s3/base/config/SingularityS3Configuration.java
@@ -45,7 +45,7 @@ public class SingularityS3Configuration extends BaseRunnerConfiguration {
 
   @Min(1)
   @JsonProperty
-  private long s3ChunkDownloadTimeoutMillis = TimeUnit.SECONDS.toMillis(30);
+  private int s3ChunkDownloadTimeoutMillis = (int) TimeUnit.SECONDS.toMillis(30);
 
   @Min(1)
   @JsonProperty
@@ -131,11 +131,11 @@ public class SingularityS3Configuration extends BaseRunnerConfiguration {
     this.localDownloadPath = localDownloadPath;
   }
 
-  public Long getS3ChunkDownloadTimeoutMillis() {
+  public int getS3ChunkDownloadTimeoutMillis() {
     return s3ChunkDownloadTimeoutMillis;
   }
 
-  public void setS3ChunkDownloadTimeoutMillis(long s3ChunkDownloadTimeoutMillis) {
+  public void setS3ChunkDownloadTimeoutMillis(int s3ChunkDownloadTimeoutMillis) {
     this.s3ChunkDownloadTimeoutMillis = s3ChunkDownloadTimeoutMillis;
   }
 

--- a/SingularityS3Base/src/main/java/com/hubspot/singularity/s3/base/config/SingularityS3Configuration.java
+++ b/SingularityS3Base/src/main/java/com/hubspot/singularity/s3/base/config/SingularityS3Configuration.java
@@ -131,7 +131,7 @@ public class SingularityS3Configuration extends BaseRunnerConfiguration {
     this.localDownloadPath = localDownloadPath;
   }
 
-  public long getS3ChunkDownloadTimeoutMillis() {
+  public Long getS3ChunkDownloadTimeoutMillis() {
     return s3ChunkDownloadTimeoutMillis;
   }
 

--- a/SingularityS3Base/src/main/java/com/hubspot/singularity/s3/base/config/SingularityS3Credentials.java
+++ b/SingularityS3Base/src/main/java/com/hubspot/singularity/s3/base/config/SingularityS3Credentials.java
@@ -4,8 +4,7 @@ import static com.hubspot.mesos.JavaUtils.obfuscateValue;
 
 import java.util.Objects;
 
-import org.jets3t.service.security.AWSCredentials;
-
+import com.amazonaws.auth.BasicAWSCredentials;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -59,7 +58,7 @@ public class SingularityS3Credentials {
   }
 
   @JsonIgnore
-  public AWSCredentials toAWSCredentials() {
-    return new AWSCredentials(accessKey, secretKey);
+  public BasicAWSCredentials toAWSCredentials() {
+    return new BasicAWSCredentials(accessKey, secretKey);
   }
 }

--- a/SingularityS3Uploader/pom.xml
+++ b/SingularityS3Uploader/pom.xml
@@ -50,7 +50,17 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
 
-    <!-- for jade and jets3t -->
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-s3</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-core</artifactId>
+    </dependency>
+
+    <!-- for jade -->
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
@@ -66,11 +76,6 @@
     <dependency>
       <groupId>com.codahale.metrics</groupId>
       <artifactId>metrics-core</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>net.java.dev.jets3t</groupId>
-      <artifactId>jets3t</artifactId>
     </dependency>
 
     <dependency>

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3Uploader.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3Uploader.java
@@ -1,6 +1,6 @@
 package com.hubspot.singularity.s3uploader;
 
-import java.io.Closeable;
+import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
@@ -11,25 +11,29 @@ import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.nio.file.attribute.UserDefinedFileAttributeView;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
-import org.jets3t.service.S3Service;
-import org.jets3t.service.S3ServiceException;
-import org.jets3t.service.ServiceException;
-import org.jets3t.service.impl.rest.httpclient.RestS3Service;
-import org.jets3t.service.model.S3Bucket;
-import org.jets3t.service.model.S3Object;
-import org.jets3t.service.model.StorageObject;
-import org.jets3t.service.security.AWSCredentials;
-import org.jets3t.service.utils.MultipartUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.AbortMultipartUploadRequest;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PartETag;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.StorageClass;
+import com.amazonaws.services.s3.model.UploadPartRequest;
 import com.codahale.metrics.Timer.Context;
 import com.github.rholder.retry.RetryException;
 import com.github.rholder.retry.Retryer;
@@ -44,15 +48,15 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.hubspot.mesos.JavaUtils;
-import com.hubspot.singularity.SingularityS3Log;
 import com.hubspot.singularity.SingularityS3FormatHelper;
+import com.hubspot.singularity.SingularityS3Log;
 import com.hubspot.singularity.runner.base.sentry.SingularityRunnerExceptionNotifier;
 import com.hubspot.singularity.runner.base.shared.S3UploadMetadata;
 import com.hubspot.singularity.runner.base.shared.SimpleProcessManager;
 import com.hubspot.singularity.s3uploader.config.SingularityS3UploaderConfiguration;
 import com.hubspot.singularity.s3uploader.config.SingularityS3UploaderContentHeaders;
 
-public class SingularityS3Uploader implements Closeable {
+public class SingularityS3Uploader {
 
   private static final Logger LOG = LoggerFactory.getLogger(SingularityS3Uploader.class);
   private static final String LOG_START_TIME_ATTR = "logstart";
@@ -63,8 +67,8 @@ public class SingularityS3Uploader implements Closeable {
   private final PathMatcher pathMatcher;
   private final Optional<PathMatcher> finishedPathMatcher;
   private final String fileDirectory;
-  private final S3Service s3Service;
-  private final S3Bucket s3Bucket;
+  private final AmazonS3 s3Client;
+  private final String s3BucketName;
   private final Path metadataPath;
   private final SingularityS3UploaderMetrics metrics;
   private final String logIdentifier;
@@ -72,20 +76,15 @@ public class SingularityS3Uploader implements Closeable {
   private final SingularityS3UploaderConfiguration configuration;
   private final SingularityRunnerExceptionNotifier exceptionNotifier;
 
-  public SingularityS3Uploader(AWSCredentials defaultCredentials, S3UploadMetadata uploadMetadata, FileSystem fileSystem, SingularityS3UploaderMetrics metrics, Path metadataPath,
-      SingularityS3UploaderConfiguration configuration, String hostname, SingularityRunnerExceptionNotifier exceptionNotifier) {
-    AWSCredentials credentials = defaultCredentials;
+  public SingularityS3Uploader(BasicAWSCredentials defaultCredentials, S3UploadMetadata uploadMetadata, FileSystem fileSystem, SingularityS3UploaderMetrics metrics, Path metadataPath,
+                               SingularityS3UploaderConfiguration configuration, String hostname, SingularityRunnerExceptionNotifier exceptionNotifier) {
+    BasicAWSCredentials credentials = defaultCredentials;
 
     if (uploadMetadata.getS3SecretKey().isPresent() && uploadMetadata.getS3AccessKey().isPresent()) {
-      credentials = new AWSCredentials(uploadMetadata.getS3AccessKey().get(), uploadMetadata.getS3SecretKey().get());
+      credentials = new BasicAWSCredentials(uploadMetadata.getS3AccessKey().get(), uploadMetadata.getS3SecretKey().get());
     }
 
-    try {
-      this.s3Service = new RestS3Service(credentials);
-    } catch (S3ServiceException e) {
-      throw Throwables.propagate(e);
-    }
-
+    this.s3Client = new AmazonS3Client(credentials);
     this.metrics = metrics;
     this.uploadMetadata = uploadMetadata;
     this.fileDirectory = uploadMetadata.getDirectory();
@@ -98,7 +97,7 @@ public class SingularityS3Uploader implements Closeable {
     }
 
     this.hostname = hostname;
-    this.s3Bucket = new S3Bucket(uploadMetadata.getS3Bucket());
+    this.s3BucketName = uploadMetadata.getS3Bucket();
     this.metadataPath = metadataPath;
     this.logIdentifier = String.format("[%s]", metadataPath.getFileName());
     this.configuration = configuration;
@@ -111,15 +110,6 @@ public class SingularityS3Uploader implements Closeable {
 
   public S3UploadMetadata getUploadMetadata() {
     return uploadMetadata;
-  }
-
-  @Override
-  public void close() throws IOException {
-    try {
-      s3Service.shutdown();
-    } catch (ServiceException e) {
-      throw new IOException(e);
-    }
   }
 
   @Override
@@ -186,10 +176,10 @@ public class SingularityS3Uploader implements Closeable {
           metrics.upload();
           success++;
           Files.delete(file);
-        } catch (S3ServiceException se) {
+        } catch (AmazonS3Exception se) {
           metrics.error();
-          LOG.warn("{} Couldn't upload {} due to {} ({}) - {}", logIdentifier, file, se.getErrorCode(), se.getResponseCode(), se.getErrorMessage(), se);
-          exceptionNotifier.notify(String.format("S3ServiceException during upload (%s)", se.getMessage()), se, ImmutableMap.of("logIdentifier", logIdentifier, "file", file.toString(), "errorCode", se.getErrorCode(), "responseCode", Integer.toString(se.getResponseCode()), "errorMessage", se.getErrorMessage()));
+          LOG.warn("{} Couldn't upload {} due to {} - {}", logIdentifier, file, se.getErrorCode(), se.getErrorMessage(), se);
+          exceptionNotifier.notify(String.format("S3ServiceException during upload (%s)", se.getMessage()), se, ImmutableMap.of("logIdentifier", logIdentifier, "file", file.toString(), "errorCode", se.getErrorCode(), "errorMessage", se.getErrorMessage()));
         } catch (RetryException re) {
           metrics.error();
           LOG.warn("{} Couldn't upload or delete {}", logIdentifier, file, re);
@@ -213,7 +203,7 @@ public class SingularityS3Uploader implements Closeable {
     Callable<Boolean> uploader = new Uploader(sequence, file);
 
     Retryer<Boolean> retryer = RetryerBuilder.<Boolean>newBuilder()
-      .retryIfExceptionOfType(S3ServiceException.class)
+      .retryIfExceptionOfType(AmazonS3Exception.class)
       .retryIfRuntimeException()
       .withWaitStrategy(WaitStrategies.fixedWait(configuration.getRetryWaitMs(), TimeUnit.MILLISECONDS))
       .withStopStrategy(StopStrategies.stopAfterAttempt(configuration.getRetryCount()))
@@ -249,11 +239,10 @@ public class SingularityS3Uploader implements Closeable {
       final String key = SingularityS3FormatHelper.getKey(uploadMetadata.getS3KeyFormat(), sequence, Files.getLastModifiedTime(file).toMillis(), Objects.toString(file.getFileName()), hostname);
 
       long fileSizeBytes = Files.size(file);
-      LOG.info("{} Uploading {} to {}/{} (size {})", logIdentifier, file, s3Bucket.getName(), key, fileSizeBytes);
+      LOG.info("{} Uploading {} to {}/{} (size {})", logIdentifier, file, s3BucketName, key, fileSizeBytes);
 
       try {
-        S3Object object = new S3Object(s3Bucket, file.toFile());
-        object.setKey(key);
+        ObjectMetadata objectMetadata = new ObjectMetadata();
 
         Set<String> supportedViews = FileSystems.getDefault().supportedFileAttributeViews();
         LOG.trace("Supported attribute views are {}", supportedViews);
@@ -264,12 +253,12 @@ public class SingularityS3Uploader implements Closeable {
             LOG.debug("Found file attributes {} for file {}", attributes, file);
             Optional<Long> maybeStartTime = readFileAttributeAsLong(LOG_START_TIME_ATTR, view, attributes);
             if (maybeStartTime.isPresent()) {
-              object.addMetadata(SingularityS3Log.LOG_START_S3_ATTR, maybeStartTime.get().toString());
+              objectMetadata.addUserMetadata(SingularityS3Log.LOG_START_S3_ATTR, maybeStartTime.get().toString());
               LOG.debug("Added extra metadata for object ({}:{})", SingularityS3Log.LOG_START_S3_ATTR, maybeStartTime.get());
             }
             Optional<Long> maybeEndTime = readFileAttributeAsLong(LOG_END_TIME_ATTR, view, attributes);
             if (maybeEndTime.isPresent()) {
-              object.addMetadata(SingularityS3Log.LOG_END_S3_ATTR, maybeEndTime.get().toString());
+              objectMetadata.addUserMetadata(SingularityS3Log.LOG_END_S3_ATTR, maybeEndTime.get().toString());
               LOG.debug("Added extra metadata for object ({}:{})", SingularityS3Log.LOG_END_S3_ATTR, maybeEndTime.get());
             }
           } catch (Exception e) {
@@ -281,26 +270,32 @@ public class SingularityS3Uploader implements Closeable {
           if (file.toString().endsWith(contentHeaders.getFilenameEndsWith())) {
             LOG.debug("{} Using content headers {} for file {}", logIdentifier, contentHeaders, file);
             if (contentHeaders.getContentType().isPresent()) {
-              object.setContentType(contentHeaders.getContentType().get());
+              objectMetadata.setContentType(contentHeaders.getContentType().get());
             }
             if (contentHeaders.getContentEncoding().isPresent()) {
-              object.setContentEncoding(contentHeaders.getContentEncoding().get());
+              objectMetadata.setContentEncoding(contentHeaders.getContentEncoding().get());
             }
             break;
           }
         }
 
+        Optional<StorageClass> maybeStorageClass = Optional.absent();
+
         if (shouldApplyStorageClass(fileSizeBytes)) {
           LOG.debug("{} adding storage class {} to {}", logIdentifier, uploadMetadata.getS3StorageClass().get(), file);
-          object.addMetadata("x-amz-storage-class", uploadMetadata.getS3StorageClass().get());
+          maybeStorageClass = Optional.of(StorageClass.fromValue(uploadMetadata.getS3StorageClass().get()));
         }
 
-        LOG.debug("Uploading object with metadata {}", object.getMetadataMap());
+        LOG.debug("Uploading object with metadata {}", objectMetadata);
 
         if (fileSizeBytes > configuration.getMaxSingleUploadSizeBytes()) {
-          multipartUpload(object);
+          multipartUpload(key, file.toFile(), objectMetadata, maybeStorageClass);
         } else {
-          s3Service.putObject(s3Bucket, object);
+          PutObjectRequest putObjectRequest = new PutObjectRequest(s3BucketName, key, file.toFile());
+          if (maybeStorageClass.isPresent()) {
+            putObjectRequest.setStorageClass(maybeStorageClass.get());
+          }
+          s3Client.putObject(putObjectRequest);
         }
       } catch (Exception e) {
         LOG.warn("Exception uploading {}", file, e);
@@ -352,12 +347,37 @@ public class SingularityS3Uploader implements Closeable {
     return false;
   }
 
-  private void multipartUpload(S3Object object) throws Exception {
+  private void multipartUpload(String key, File file, ObjectMetadata objectMetadata, Optional<StorageClass> maybeStorageClass) throws Exception {
+    List<PartETag> partETags = new ArrayList<>();
+    InitiateMultipartUploadRequest initRequest = new InitiateMultipartUploadRequest(s3BucketName, key, objectMetadata);
+    if (maybeStorageClass.isPresent()) {
+      initRequest.setStorageClass(maybeStorageClass.get());
+    }
+    InitiateMultipartUploadResult initResponse = s3Client.initiateMultipartUpload(initRequest);
 
-    List<StorageObject> objectsToUploadAsMultipart = Arrays.<StorageObject>asList(object);
+    long contentLength = file.length();
+    long partSize = configuration.getUploadPartSize();
 
-    MultipartUtils mpUtils = new MultipartUtils(configuration.getUploadPartSize());
-    mpUtils.uploadObjects(s3Bucket.getName(), s3Service, objectsToUploadAsMultipart, null);
+    try {
+      long filePosition = 0;
+      for (int i = 1; filePosition < contentLength; i++) {
+        partSize = Math.min(partSize, (contentLength - filePosition));
+        UploadPartRequest uploadRequest = new UploadPartRequest()
+            .withBucketName(s3BucketName)
+            .withUploadId(initResponse.getUploadId())
+            .withPartNumber(i)
+            .withFileOffset(filePosition)
+            .withPartSize(partSize);
+        partETags.add(s3Client.uploadPart(uploadRequest).getPartETag());
+        filePosition += partSize;
+      }
+
+      CompleteMultipartUploadRequest completeRequest = new CompleteMultipartUploadRequest(s3BucketName, key, initResponse.getUploadId(), partETags);
+      s3Client.completeMultipartUpload(completeRequest);
+    } catch (Exception e) {
+      s3Client.abortMultipartUpload(new AbortMultipartUploadRequest(s3BucketName, key, initResponse.getUploadId()));
+      Throwables.propagate(e);
+    }
   }
 
 }

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3UploaderDriver.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3UploaderDriver.java
@@ -24,10 +24,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import org.jets3t.service.security.AWSCredentials;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.amazonaws.auth.BasicAWSCredentials;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.base.Throwables;
@@ -36,7 +36,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.google.common.io.Closeables;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
@@ -271,8 +270,6 @@ public class SingularityS3UploaderDriver extends WatchServiceHelper implements S
       expiring.remove(expiredUploader);
 
       try {
-        Closeables.close(expiredUploader, true);
-
         LOG.debug("Deleting expired uploader {}", expiredUploader.getMetadataPath());
         Files.delete(expiredUploader.getMetadataPath());
       } catch (NoSuchFileException nfe) {
@@ -358,13 +355,13 @@ public class SingularityS3UploaderDriver extends WatchServiceHelper implements S
     try {
       metrics.getUploaderCounter().inc();
 
-      Optional<AWSCredentials> bucketCreds = Optional.absent();
+      Optional<BasicAWSCredentials> bucketCreds = Optional.absent();
 
       if (configuration.getS3BucketCredentials().containsKey(metadata.getS3Bucket())) {
         bucketCreds = Optional.of(configuration.getS3BucketCredentials().get(metadata.getS3Bucket()).toAWSCredentials());
       }
 
-      final AWSCredentials defaultCredentials = new AWSCredentials(configuration.getS3AccessKey().or(s3Configuration.getS3AccessKey()).get(), configuration.getS3SecretKey().or(s3Configuration.getS3SecretKey()).get());
+      final BasicAWSCredentials defaultCredentials = new BasicAWSCredentials(configuration.getS3AccessKey().or(s3Configuration.getS3AccessKey()).get(), configuration.getS3SecretKey().or(s3Configuration.getS3SecretKey()).get());
 
       SingularityS3Uploader uploader = new SingularityS3Uploader(bucketCreds.or(defaultCredentials), metadata, fileSystem, metrics, filename, configuration, hostname, exceptionNotifier);
 

--- a/SingularityService/pom.xml
+++ b/SingularityService/pom.xml
@@ -102,7 +102,7 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
 
-    <!-- for jade and jets3t -->
+    <!-- for jade -->
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
@@ -328,8 +328,13 @@
     </dependency>
 
     <dependency>
-      <groupId>net.java.dev.jets3t</groupId>
-      <artifactId>jets3t</artifactId>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-s3</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-core</artifactId>
     </dependency>
 
     <dependency>

--- a/SingularityService/src/main/java/com/hubspot/singularity/helpers/SingularityS3Service.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/helpers/SingularityS3Service.java
@@ -1,16 +1,16 @@
 package com.hubspot.singularity.helpers;
 
-import org.jets3t.service.S3Service;
+import com.amazonaws.services.s3.AmazonS3;
 
 public class SingularityS3Service {
   private final String group;
   private final String bucket;
-  private final S3Service s3Service;
+  private final AmazonS3 s3Client;
 
-  public SingularityS3Service(String group, String bucket, S3Service s3Service) {
+  public SingularityS3Service(String group, String bucket, AmazonS3 s3Client) {
     this.group = group;
     this.bucket = bucket;
-    this.s3Service = s3Service;
+    this.s3Client = s3Client;
   }
 
   public String getGroup() {
@@ -21,8 +21,8 @@ public class SingularityS3Service {
     return bucket;
   }
 
-  public S3Service getS3Service() {
-    return s3Service;
+  public AmazonS3 getS3Client() {
+    return s3Client;
   }
 
   @Override
@@ -30,7 +30,7 @@ public class SingularityS3Service {
     return "SingularityS3Service{" +
         "group='" + group + '\'' +
         ", bucket='" + bucket + '\'' +
-        ", s3Service=" + s3Service +
+        ", s3Client=" + s3Client +
         '}';
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/helpers/SingularityS3Services.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/helpers/SingularityS3Services.java
@@ -3,7 +3,7 @@ package com.hubspot.singularity.helpers;
 import java.util.Collections;
 import java.util.List;
 
-import org.jets3t.service.S3Service;
+import com.amazonaws.services.s3.AmazonS3;
 
 public class SingularityS3Services {
   private final boolean s3ConfigPresent;
@@ -34,12 +34,12 @@ public class SingularityS3Services {
     return defaultS3Service;
   }
 
-  public S3Service getServiceByGroupAndBucketOrDefault(String group, String bucket) {
+  public AmazonS3 getServiceByGroupAndBucketOrDefault(String group, String bucket) {
     for (SingularityS3Service s3Service : s3Services) {
       if (s3Service.getGroup().equals(group) && s3Service.getBucket().equals(bucket)) {
-        return s3Service.getS3Service();
+        return s3Service.getS3Client();
       }
     }
-    return defaultS3Service.getS3Service();
+    return defaultS3Service.getS3Client();
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
     <mesos.docker.tag>0.28.1-2.0.20.ubuntu1404</mesos.docker.tag>
     <mesos.version>0.28.2</mesos.version>
     <singularitybase.image.revision>2</singularitybase.image.revision>
+    <aws.sdk.version>1.10.77</aws.sdk.version>
   </properties>
 
   <modules>
@@ -243,6 +244,22 @@
         <groupId>org.dmfs</groupId>
         <artifactId>rfc5545-datetime</artifactId>
         <version>0.2.2</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.amazonaws</groupId>
+        <artifactId>aws-java-sdk-s3</artifactId>
+        <version>${aws.sdk.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Moving us to the aws sdk. This is partly just to keep up to date, but also so that we can use the new `GetObjectV2` to do pagination when listing buckets in the future.

`aws.sdk.version` is bumped to `1.10.77` for now. `1.10.x` is the first to have the new v2 request (basepom has `1.9.x`). Going all the way to `1.11.x` created too many dependency issues.

PRing this into the other S3 rework  branch.

/cc @tpetr 