### PR TITLE
Shade com.google.thirdparty

### DIFF
--- a/SingularityClient/pom.xml
+++ b/SingularityClient/pom.xml
@@ -119,6 +119,10 @@
                   <exclude>com.google.common.base.Optional</exclude>
                 </excludes>
               </relocation>
+              <relocation>
+                <pattern>com.google.thirdparty</pattern>
+                <shadedPattern>com.hubspot.singularity.shaded.com.google.thirdparty</shadedPattern>
+              </relocation>
             </relocations>
           </configuration>
         </plugin>


### PR DESCRIPTION
Guava 16 introduced packages starting with `com.google.thirdparty` which need to be shaded as well. I am augmenting all current shadings of Guava regardless of version to prevent future issues.

@ssalinas @jhaber 