### PR TITLE
Clarifications on S3ArtifactSignature

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/deploy/S3ArtifactSignature.java
+++ b/SingularityBase/src/main/java/com/hubspot/deploy/S3ArtifactSignature.java
@@ -5,7 +5,9 @@ import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
+import com.wordnik.swagger.annotations.ApiModel;
 
+@ApiModel(description="A file with name `filename` containing the signature (e.g. gpg signature) for an artifact with the specified `artifactFilename`. Used to verify the validity of the artifact being downloaded")
 public class S3ArtifactSignature extends S3Artifact {
 
   private final String artifactFilename;

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorArtifactVerifier.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorArtifactVerifier.java
@@ -29,7 +29,7 @@ public class SingularityExecutorArtifactVerifier {
 
   public void checkSignatures() {
     if (!taskDefinition.getExecutorData().getS3ArtifactSignatures().isPresent() || taskDefinition.getExecutorData().getS3ArtifactSignatures().get().isEmpty()) {
-      log.info("No s3 artifact signatures, skipping verification.");
+      log.info("No files containing artifact signatures specified, skipping verification.");
       return;
     }
 
@@ -66,13 +66,13 @@ public class SingularityExecutorArtifactVerifier {
       p.waitFor();  // TODO: add some sort of timeout?
 
       if (p.exitValue() != 0) {
-        log.error("Failed to validate signature {} for artifact {}", s3ArtifactSignature.getFilename(), s3ArtifactSignature.getArtifactFilename());
+        log.error("Failed to validate signature in file {} for artifact file {}", s3ArtifactSignature.getFilename(), s3ArtifactSignature.getArtifactFilename());
 
         if (executorConfiguration.isFailTaskOnInvalidArtifactSignature()) {
           throw new RuntimeException(String.format("Failed to validate signature for artifact %s", artifactPath));
         }
       } else {
-        log.info("Signature {} for artifact {} is valid!", s3ArtifactSignature.getFilename(), s3ArtifactSignature.getArtifactFilename());
+        log.info("Signature in {} for artifact {} is valid!", s3ArtifactSignature.getFilename(), s3ArtifactSignature.getArtifactFilename());
       }
     } catch (InterruptedException | IOException e) {
       throw Throwables.propagate(e);


### PR DESCRIPTION
We've mentioned that it was unclear exactly what this class was used for. In terms of field and method naming, things are accurate, when explained in context. I've added an `ApiModel` annotation giving a brief description of the class' purpose as well as slightly tweaking log statements to indicate that this is a file _containing_ the signature for a _separate_ artifact.

/cc @tpetr 