### PR TITLE
Ability to override docker workdir

### DIFF
--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/models/EnvironmentContext.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/models/EnvironmentContext.java
@@ -1,10 +1,14 @@
 package com.hubspot.singularity.executor.models;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.Environment.Variable;
+import org.apache.mesos.Protos.Parameter;
 import org.apache.mesos.Protos.TaskInfo;
+
+import com.google.common.base.Strings;
 
 public class EnvironmentContext {
 
@@ -22,12 +26,41 @@ public class EnvironmentContext {
     return taskInfo.getContainer().getDocker();
   }
 
-  public List<Protos.Parameter> getDockerParameters() {
-    return taskInfo.getContainer().getDocker().getParametersList();
+  public List<String> getDockerParameters() {
+    List<String> args = new ArrayList<>();
+    for (Parameter parameter : taskInfo.getContainer().getDocker().getParametersList()) {
+      args.add(toCmdLineArg(parameter));
+    }
+    return args;
+  }
+
+  public boolean isDockerWorkdirOverriden() {
+    for (Parameter parameter : taskInfo.getContainer().getDocker().getParametersList()) {
+      if (parameter.hasKey() && (parameter.getKey().equals("w") || parameter.getKey().equals("workdir"))) {
+        return true;
+      }
+    }
+    return false;
   }
 
   public List<Protos.Volume> getContainerVolumes() {
     return taskInfo.getContainer().getVolumesList();
+  }
+
+  private String toCmdLineArg(Parameter parameter) {
+    if (parameter.hasKey() && parameter.getKey().length() > 1) {
+      if (parameter.hasValue() && !Strings.isNullOrEmpty(parameter.getValue())) {
+        return String.format("--%s=%s", parameter.getKey(), parameter.getValue());
+      } else {
+        return String.format("--%s", parameter.getKey());
+      }
+    } else {
+      if (parameter.hasValue() && !Strings.isNullOrEmpty(parameter.getValue())) {
+        return String.format("-%s=%s", parameter.getKey(), parameter.getValue());
+      } else {
+        return String.format("-%s", parameter.getKey());
+      }
+    }
   }
 
   @Override

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskProcessBuilder.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskProcessBuilder.java
@@ -8,6 +8,7 @@ import org.apache.mesos.Protos.TaskInfo;
 import org.apache.mesos.Protos.TaskState;
 
 import com.google.common.base.Optional;
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.hubspot.deploy.ExecutorData;
 import com.hubspot.singularity.executor.TemplateManager;
@@ -94,7 +95,7 @@ public class SingularityExecutorTaskProcessBuilder implements Callable<ProcessBu
   }
 
   private String getCommand(ExecutorData executorData) {
-    final StringBuilder bldr = new StringBuilder(executorData.getCmd());
+    final StringBuilder bldr = new StringBuilder(Strings.isNullOrEmpty(executorData.getCmd()) ? "" : executorData.getCmd());
     for (String extraCmdLineArg : executorData.getExtraCmdLineArgs()) {
       bldr.append(" ");
       bldr.append(extraCmdLineArg);

--- a/SingularityExecutor/src/main/resources/docker.sh.hbs
+++ b/SingularityExecutor/src/main/resources/docker.sh.hbs
@@ -131,18 +131,20 @@ DOCKER_NETWORK="--net=${raw_network,,}"
 DOCKER_NETWORK="--net=host"
 {{/if}}
 
-DOCKER_WORKDIR="/mnt/mesos/sandbox/{{{ runContext.taskAppDirectory }}}"
-
 PARENT_CGROUP=$(get_deepest_cgroup)
 
-DOCKER_OPTIONS="--name=$CONTAINER_NAME --cgroup-parent=$PARENT_CGROUP -w $DOCKER_WORKDIR $DOCKER_NETWORK --env-file=docker.env ${DOCKER_VOLUMES[@]} ${DOCKER_PORTS[@]}"
+DOCKER_OPTIONS="--name=$CONTAINER_NAME --cgroup-parent=$PARENT_CGROUP $DOCKER_NETWORK --env-file=docker.env ${DOCKER_VOLUMES[@]} ${DOCKER_PORTS[@]}"
+
+{{#unless envContext.dockerWorkdirOverriden }}
+DOCKER_OPTIONS="$DOCKER_OPTIONS -w /mnt/mesos/sandbox/{{{ runContext.taskAppDirectory }}}"
+{{/unless}}
 
 {{#if privileged}}
 DOCKER_OPTIONS="$DOCKER_OPTIONS --privileged"
 {{/if}}
 
 {{#each envContext.dockerParameters}}
-DOCKER_OPTIONS="$DOCKER_OPTIONS --{{{this.key}}}={{{this.value}}}"
+DOCKER_OPTIONS="$DOCKER_OPTIONS {{this}}"
 {{/each}}
 
 echo "Ensuring {{{ runContext.taskAppDirectory }}} is owned by {{{ runContext.user }}}"


### PR DESCRIPTION
Previously the custom executor was always setting the workdir as the task app directory. This will allow the docker parameters to override that setting. It also cleans up the parameters rendering so that an arg like `e` gets written as `-e` not `--e`