### PR TITLE
Destroy task

### DIFF
--- a/SingularityUI/app/components/common/modal/FormModal.jsx
+++ b/SingularityUI/app/components/common/modal/FormModal.jsx
@@ -84,7 +84,7 @@ export default class FormModal extends React.Component {
     this.setState({ formState });
   }
 
-  validateForm() {
+  isValidForm() {
     // Check required values
     const errors = {};
     this.props.formElements.forEach((formElement) => {
@@ -141,11 +141,11 @@ export default class FormModal extends React.Component {
     if (event) {
       event.preventDefault();
     }
-    if (this.validateForm()) {
+    if (this.isValidForm()) {
       let formState = this.parseFormState(this.state.formState);
       this.props.onConfirm(formState);
       if (!this.props.keepCurrentFormState) {
-        const formState = {};
+        formState = {};
         this.props.formElements.forEach((formElement) => {
           formState[formElement.name] = formElement.defaultValue;
         });

--- a/SingularityUI/app/components/common/modal/FormModal.jsx
+++ b/SingularityUI/app/components/common/modal/FormModal.jsx
@@ -114,9 +114,7 @@ export default class FormModal extends React.Component {
     const parsed = {};
     _.mapObject(state, (val, key) => {
       const element = _.find(this.props.formElements, (formElement) => formElement.name === key);
-      if (element === undefined) {
-        delete this.state.formState[key];
-      } else {
+      if (element !== undefined) {
         switch (element.type) {
           case FormModal.INPUT_TYPES.BOOLEAN:
             parsed[key] = Boolean(val);

--- a/SingularityUI/app/components/common/modal/FormModal.jsx
+++ b/SingularityUI/app/components/common/modal/FormModal.jsx
@@ -84,11 +84,6 @@ export default class FormModal extends React.Component {
     this.setState({ formState });
   }
 
-  clearForm() {
-    const formState = {}
-    this.setState({ formState })
-  }
-
   validateForm() {
     // Check required values
     const errors = {};
@@ -119,20 +114,24 @@ export default class FormModal extends React.Component {
     const parsed = {};
     _.mapObject(state, (val, key) => {
       const element = _.find(this.props.formElements, (formElement) => formElement.name === key);
-      switch (element.type) {
-        case FormModal.INPUT_TYPES.BOOLEAN:
-          parsed[key] = Boolean(val);
-          break;
-        case FormModal.INPUT_TYPES.NUMBER:
-          parsed[key] = Number.parseFloat(val);
-          break;
-        case FormModal.INPUT_TYPES.DURATION:
-          if (val) {
-            parsed[key] = juration.parse(val) * 1000;
-          }
-          break;
-        default:
-          parsed[key] = val;
+      if (element === undefined) {
+        delete this.state.formState[key];
+      } else {
+        switch (element.type) {
+          case FormModal.INPUT_TYPES.BOOLEAN:
+            parsed[key] = Boolean(val);
+            break;
+          case FormModal.INPUT_TYPES.NUMBER:
+            parsed[key] = Number.parseFloat(val);
+            break;
+          case FormModal.INPUT_TYPES.DURATION:
+            if (val) {
+              parsed[key] = juration.parse(val) * 1000;
+            }
+            break;
+          default:
+            parsed[key] = val;
+        }
       }
     });
     return parsed;
@@ -235,10 +234,10 @@ export default class FormModal extends React.Component {
 
       const selectOptions = () => {
         if (formElement.valueOptions && formElement.valueOptions.length > 0) {
-          const menuItems = []
+          const menuItems = [];
           _.each(formElement.valueOptions, (optionValue, index) => {
             if (index < 5) {
-              if (index != 0) {
+              if (index !== 0) {
                 menuItems.push(<MenuItem divider />);
               }
               menuItems.push(
@@ -264,7 +263,7 @@ export default class FormModal extends React.Component {
             </DropdownButton>
           );
         }
-      }
+      };
 
       let extraHelp;
 

--- a/SingularityUI/app/components/common/modalButtons/KillTaskModal.jsx
+++ b/SingularityUI/app/components/common/modalButtons/KillTaskModal.jsx
@@ -43,10 +43,10 @@ class KillTaskModal extends Component {
     if (config.shellCommands.length > 0) {
       formElements.push(
         {
-        name: 'runShellCommand',
-        type: FormModal.INPUT_TYPES.BOOLEAN,
-        label: 'Run shell command before killing tasks',
-        defaultValue: false
+          name: 'runShellCommand',
+          type: FormModal.INPUT_TYPES.BOOLEAN,
+          label: 'Run shell command before killing tasks',
+          defaultValue: false
         },
         {
           name: 'runShellCommandBeforeKill',

--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -48,6 +48,7 @@ class TaskDetail extends Component {
       task: PropTypes.shape({
         taskId: PropTypes.shape({
           id: PropTypes.string.isRequired,
+          startedAt: PropTypes.number.isRequired,
           requestId: PropTypes.string.isRequired,
           deployId: PropTypes.string.isRequired,
           instanceNo: PropTypes.number.isRequired
@@ -111,6 +112,7 @@ class TaskDetail extends Component {
     taskId: PropTypes.string.isRequired,
     params: PropTypes.object,
     fetchTaskHistory: PropTypes.func.isRequired,
+    fetchTaskCleanups: PropTypes.func.isRequired,
     fetchTaskStatistics: PropTypes.func.isRequired,
     fetchTaskFiles: PropTypes.func.isRequired,
     runCommandOnTask: PropTypes.func.isRequired,
@@ -206,7 +208,7 @@ class TaskDetail extends Component {
 
   renderHeader(cleanup) {
     const cleaningUpdate = _.find(Utils.maybe(this.props.task, ['taskUpdates'], []), (taskUpdate) => {
-      return taskUpdate.taskState == "TASK_CLEANING";
+      return taskUpdate.taskState === 'TASK_CLEANING';
     });
 
     let cleanupType;
@@ -230,7 +232,7 @@ class TaskDetail extends Component {
     let removeText = 'Kill Task';
     if (cleanupType) {
       if (Utils.isImmediateCleanup(cleanupType, Utils.request.isLongRunning(this.props.task.task.taskRequest))) {
-        removeText = 'Destroy task';
+        removeText = 'Destroy Task';
         destroy = true;
       } else {
         removeText = 'Override cleanup';
@@ -242,7 +244,7 @@ class TaskDetail extends Component {
       promises.push(this.props.fetchTaskCleanups());
       promises.push(this.props.fetchTaskHistory(this.props.params.taskId));
       return Promise.all(promises);
-    }
+    };
 
     const removeBtn = this.props.task.isStillRunning && (
       <KillTaskButton


### PR DESCRIPTION
This fixes an issue with how the form elements were mapped. If a prior form field isn't used in an updated form, it would throw an undefined error when it tried to access the non-existent field. I tried finding a good way to remove the field without disrupting the rest of the uses of the FormModal component, but I could not find one. Right now it just removes as unused fields from the mapping. If you see a better method, I could def use it

@ssalinas  