### PR TITLE
Clean up some logging

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/mesos/MesosUtils.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/MesosUtils.java
@@ -385,7 +385,7 @@ public final class MesosUtils {
         } else if (resource.hasRanges()) {
           resourceBuilder.setRanges(subtractRanges(resource.getRanges(), matched.get().getRanges()));
         } else {
-          throw new IllegalStateException(String.format("Can't subtract non-scalar or range resources %s", MesosUtils.formatForLogging(resource)));
+          throw new IllegalStateException(String.format("Can't subtract non-scalar or range resources %s", formatForLogging(resource)));
         }
 
         remaining.add(resourceBuilder.build());

--- a/SingularityBase/src/main/java/com/hubspot/mesos/MesosUtils.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/MesosUtils.java
@@ -11,7 +11,6 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 
-import com.google.common.collect.Sets;
 import org.apache.mesos.Protos.MasterInfo;
 import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.Resource;
@@ -25,6 +24,7 @@ import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.google.common.net.InetAddresses;
 import com.google.common.primitives.Longs;
 
@@ -156,7 +156,7 @@ public final class MesosUtils {
     List<Long> requestedPorts = new ArrayList<>(otherRequestedPorts);
     Ranges ranges = getRanges(resources, PORTS);
 
-    Preconditions.checkState(ranges.getRangeCount() > 0, "Ports %s should have existed in resources %s", PORTS, resources);
+    Preconditions.checkState(ranges.getRangeCount() > 0, "Ports %s should have existed in resources %s", PORTS, formatForLogging(resources));
 
     Ranges.Builder rangesBldr = Ranges.newBuilder();
 
@@ -385,7 +385,7 @@ public final class MesosUtils {
         } else if (resource.hasRanges()) {
           resourceBuilder.setRanges(subtractRanges(resource.getRanges(), matched.get().getRanges()));
         } else {
-          throw new IllegalStateException(String.format("Can't subtract non-scalar or range resources %s", resource));
+          throw new IllegalStateException(String.format("Can't subtract non-scalar or range resources %s", MesosUtils.formatForLogging(resource)));
         }
 
         remaining.add(resourceBuilder.build());
@@ -405,5 +405,9 @@ public final class MesosUtils {
 
   public static String getSafeTaskIdForDirectory(String taskId) {
     return taskId.replace(":", "_");
+  }
+
+  public static String formatForLogging(Object object) {
+    return object.toString().replace("\n", "").replaceAll("( )+", " ");
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityContainerInfo.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityContainerInfo.java
@@ -2,8 +2,6 @@ package com.hubspot.mesos;
 
 import java.util.List;
 
-import org.apache.mesos.Protos.ContainerInfo.Type;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
@@ -41,7 +39,11 @@ public class SingularityContainerInfo {
 
   @Override
   public String toString() {
-    return String.format("ContainerInfo [type=%s, volumes=%s, docker=%s]", type, volumes, docker);
+    return "SingularityContainerInfo{" +
+        "type=" + type +
+        ", volumes=" + volumes +
+        ", docker=" + docker +
+        '}';
   }
 
   @Override

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityVolume.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityVolume.java
@@ -48,7 +48,11 @@ public class SingularityVolume {
 
   @Override
   public String toString() {
-    return String.format("Volume [containerPath=%s, hostPath=%s, mode=%s]", containerPath, hostPath, mode);
+    return "SingularityVolume{" +
+        "containerPath='" + containerPath + '\'' +
+        ", hostPath=" + hostPath +
+        ", mode=" + mode +
+        '}';
   }
 
   @Override

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTask.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTask.java
@@ -3,9 +3,7 @@ package com.hubspot.singularity;
 import java.util.List;
 
 import org.apache.mesos.Protos.Offer;
-import org.apache.mesos.Protos.Resource;
 import org.apache.mesos.Protos.TaskInfo;
-import org.apache.mesos.Protos.Value.Range;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -61,7 +59,11 @@ public class SingularityTask extends SingularityTaskIdHolder {
 
   @Override
   public String toString() {
-    return "SingularityTask [taskRequest=" + taskRequest + ", offer=" + offer + ", mesosTask=" + mesosTask + ", rackId=" + rackId + "]";
+    return "SingularityTask{" +
+        "taskRequest=" + taskRequest +
+        ", offer=" + MesosUtils.formatForLogging(offer) +
+        ", mesosTask=" + MesosUtils.formatForLogging(mesosTask) +
+        ", rackId=" + rackId +
+        '}';
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskStatusHolder.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskStatusHolder.java
@@ -5,6 +5,7 @@ import org.apache.mesos.Protos.TaskStatus;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
+import com.hubspot.mesos.MesosUtils;
 
 public class SingularityTaskStatusHolder {
 
@@ -45,7 +46,7 @@ public class SingularityTaskStatusHolder {
 
   @Override
   public String toString() {
-    return "SingularityTaskStatusHolder [taskStatus=" + taskStatus + ", taskId=" + taskId + ", serverTimestamp=" + serverTimestamp + ", serverId=" + serverId + ", slaveId=" + slaveId + "]";
+    return "SingularityTaskStatusHolder [taskStatus=" + MesosUtils.formatForLogging(taskStatus) + ", taskId=" + taskId + ", serverTimestamp=" + serverTimestamp + ", serverId=" + serverId + ", slaveId=" + slaveId + "]";
   }
 
 }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutor.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutor.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
+import com.hubspot.mesos.MesosUtils;
 import com.hubspot.singularity.executor.SingularityExecutorMonitor.KillState;
 import com.hubspot.singularity.executor.SingularityExecutorMonitor.SubmitState;
 import com.hubspot.singularity.executor.config.SingularityExecutorTaskBuilder;
@@ -41,7 +42,8 @@ public class SingularityExecutor implements Executor {
    */
   @Override
   public void registered(ExecutorDriver executorDriver, Protos.ExecutorInfo executorInfo, Protos.FrameworkInfo frameworkInfo, Protos.SlaveInfo slaveInfo) {
-    LOG.info("Registered {} with Mesos slave {} for framework {}", executorInfo, slaveInfo, frameworkInfo);
+    LOG.debug("Registered {} with Mesos slave {} for framework {}", executorInfo.getExecutorId().getValue(), slaveInfo.getId().getValue(), frameworkInfo.getId().getValue());
+    LOG.trace("Registered {} with Mesos slave {} for framework {}", MesosUtils.formatForLogging(executorInfo), MesosUtils.formatForLogging(slaveInfo), MesosUtils.formatForLogging(frameworkInfo));
   }
 
   /**
@@ -49,7 +51,8 @@ public class SingularityExecutor implements Executor {
    */
   @Override
   public void reregistered(ExecutorDriver executorDriver, Protos.SlaveInfo slaveInfo) {
-    LOG.info("Re-registered with Mesos slave {}", slaveInfo);
+    LOG.debug("Re-registered with Mesos slave {}", slaveInfo.getId().getValue());
+    LOG.info("Re-registered with Mesos slave {}", MesosUtils.formatForLogging(slaveInfo));
   }
 
   /**

--- a/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/config/SingularityRunnerBaseLogging.java
+++ b/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/config/SingularityRunnerBaseLogging.java
@@ -72,7 +72,7 @@ public class SingularityRunnerBaseLogging {
       try {
         final Configuration annotation = configuration.getClass().getAnnotation(Configuration.class);
         final String filename = consolidatedConfigFilename.or(annotation == null ? "(unknown)" : annotation.filename());
-        LOG.info(String.format("Loaded %s from %s:%n%s", configuration.getClass().getSimpleName(), filename, yamlMapper.writeValueAsString(configuration)));
+        LOG.trace(String.format("Loaded %s from %s:%n%s", configuration.getClass().getSimpleName(), filename, yamlMapper.writeValueAsString(configuration)));
       } catch (Exception e) {
         LOG.warn(String.format("Exception while attempting to print %s!", configuration.getClass().getName()), e);
       }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
@@ -251,6 +251,7 @@ public class SingularityMesosScheduler implements Scheduler {
       }
 
       Optional<String> requiredRole = taskRequest.getRequest().getRequiredRole();
+      LOG.debug("Attempting to match task {} against offer {}", taskRequest.getPendingTask().getPendingTaskId(), offerHolder.getOffer().getId());
       LOG.trace("Attempting to match task {} resources {} with required role '{}' ({} for task + {} for executor) with remaining offer resources {}", taskRequest.getPendingTask().getPendingTaskId(), totalResources, requiredRole.or("*"),taskResources, executorResources, offerHolder.getCurrentResources());
 
       final boolean matchesResources = MesosUtils.doesOfferMatchResources(requiredRole, totalResources, offerHolder.getCurrentResources(), requestedPorts);
@@ -261,6 +262,7 @@ public class SingularityMesosScheduler implements Scheduler {
 
         final SingularityTask zkTask = taskSizeOptimizer.getSizeOptimizedTask(task);
 
+        LOG.debug("Built task {}", zkTask.getTaskId());
         LOG.trace("Accepted and built task {}", zkTask);
 
         LOG.info("Launching task {} slot on slave {} ({})", task.getTaskId(), offerHolder.getOffer().getSlaveId().getValue(), offerHolder.getOffer().getHostname());

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityOfferHolder.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityOfferHolder.java
@@ -49,7 +49,8 @@ public class SingularityOfferHolder {
     for (SingularityTask task : acceptedTasks) {
       taskIds.add(task.getTaskId());
       toLaunch.add(task.getMesosTask());
-      LOG.trace("Launching {} mesos task: {}", task.getTaskId(), task.getMesosTask());
+      LOG.debug("Launching {} with offer {}", task.getTaskId(), offer.getId());
+      LOG.trace("Launching {} mesos task: {}", task.getTaskId(), MesosUtils.formatForLogging(task.getMesosTask()));
     }
 
     Status initialStatus = driver.launchTasks(ImmutableList.of(offer.getId()), toLaunch);


### PR DESCRIPTION
- Strip the new lines and repeated spaces out of the toString for the mesos protos objects
- Add shorter but helpful debug messages where we are now logging entire task objects

@wsorenson wasn't a quick-and-easy way to write a template to not log absent optionals in all the toString methods. But this should still clean things up a good bit. Will add to it a bit more tomorrow.