### PR TITLE
fix duplicate exit checker, add longer initial task wait

### DIFF
--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutor.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutor.java
@@ -7,7 +7,6 @@ import org.apache.mesos.Protos.TaskState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.hubspot.singularity.executor.SingularityExecutorMonitor.KillState;
 import com.hubspot.singularity.executor.SingularityExecutorMonitor.SubmitState;
@@ -91,6 +90,7 @@ public class SingularityExecutor implements Executor {
           task.getLog().info("Launched task {} with data {}", taskId, task.getExecutorData());
           break;
       }
+
     } catch (Throwable t) {
       LOG.error("Unexpected exception starting task {}", taskId, t);
 
@@ -146,7 +146,7 @@ public class SingularityExecutor implements Executor {
   public void shutdown(ExecutorDriver executorDriver) {
     LOG.info("Asked to shutdown executor...");
 
-    monitor.shutdown(Optional.of(executorDriver));
+    monitor.shutdown(executorDriver);
   }
 
   /**

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorProcessKiller.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorProcessKiller.java
@@ -14,7 +14,6 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.hubspot.mesos.JavaUtils;
-import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.executor.config.SingularityExecutorConfiguration;
 import com.hubspot.singularity.executor.task.SingularityExecutorTaskProcessCallable;
 

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorRunner.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorRunner.java
@@ -2,6 +2,7 @@ package com.hubspot.singularity.executor;
 
 import org.apache.mesos.MesosExecutorDriver;
 import org.apache.mesos.Protos;
+import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,6 +19,8 @@ import com.hubspot.singularity.runner.base.config.SingularityRunnerBaseModule;
 import com.hubspot.singularity.runner.base.configuration.BaseRunnerConfiguration;
 import com.hubspot.singularity.s3.base.config.SingularityS3Configuration;
 
+import ch.qos.logback.classic.LoggerContext;
+
 public class SingularityExecutorRunner {
 
   private static final Logger LOG = LoggerFactory.getLogger(SingularityExecutorRunner.class);
@@ -33,10 +36,23 @@ public class SingularityExecutorRunner {
 
       LOG.info("Executor finished after {} with status: {}", JavaUtils.duration(start), driverStatus);
 
+      stopLog();
+
       System.exit(driverStatus == Protos.Status.DRIVER_STOPPED ? 0 : 1);
     } catch (Throwable t) {
       LOG.error("Finished after {} with error", JavaUtils.duration(start), t);
+
+      stopLog();
+
       System.exit(1);
+    }
+  }
+
+  private static void stopLog() {
+   ILoggerFactory loggerFactory = LoggerFactory.getILoggerFactory();
+    if (loggerFactory instanceof LoggerContext) {
+      LoggerContext context = (LoggerContext) loggerFactory;
+      context.stop();
     }
   }
 

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorRunner.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorRunner.java
@@ -1,12 +1,10 @@
 package com.hubspot.singularity.executor;
 
-import org.apache.mesos.ExecutorDriver;
 import org.apache.mesos.MesosExecutorDriver;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
@@ -57,13 +55,14 @@ public class SingularityExecutorRunner {
     LOG.info("{} starting MesosExecutorDriver...", name);
 
     final MesosExecutorDriver driver = new MesosExecutorDriver(singularityExecutor);
+    monitor.start(driver);
 
     Runtime.getRuntime().addShutdownHook(new Thread("SingularityExecutorRunnerGracefulShutdown") {
 
       @Override
       public void run() {
         LOG.info("Executor is shutting down, ensuring shutdown via shutdown hook");
-        monitor.shutdown(Optional.of((ExecutorDriver) driver));
+        monitor.shutdown(driver);
       }
 
     });

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
@@ -47,6 +47,10 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
 
   @Min(0)
   @JsonProperty
+  private long initialIdleExecutorShutdownWaitMillis = TimeUnit.MINUTES.toMillis(1);
+
+  @Min(0)
+  @JsonProperty
   private long idleExecutorShutdownWaitMillis = TimeUnit.SECONDS.toMillis(10);
 
   @Min(0)
@@ -634,6 +638,14 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
 
   public void setLogrotateCompressionSettings(LogrotateCompressionSettings logrotateCompressionSettings) {
     this.logrotateCompressionSettings = logrotateCompressionSettings;
+  }
+
+  public long getInitialIdleExecutorShutdownWaitMillis() {
+    return initialIdleExecutorShutdownWaitMillis;
+  }
+
+  public void setInitialIdleExecutorShutdownWaitMillis(long initialIdleExecutorShutdownWaitMillis) {
+    this.initialIdleExecutorShutdownWaitMillis = initialIdleExecutorShutdownWaitMillis;
   }
 
   @Override

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskCleanup.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskCleanup.java
@@ -5,7 +5,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 
 import org.slf4j.Logger;
 


### PR DESCRIPTION
Prevents an extra exit checker enrollment which will fail (and prevent normal shutdown)

Adds a new initial task wait that is longer than task wait.

Note that the executor already did the right thing WRT to locks/concurrency when the task is submitted after a shutdown has started, it was the extra exit checker enrollment which could cause a failure to propagate the TASK_LOST.