### PR TITLE
Replace existing global search with search from requests page

### DIFF
--- a/SingularityUI/app/components/globalSearch/GlobalSearch.jsx
+++ b/SingularityUI/app/components/globalSearch/GlobalSearch.jsx
@@ -8,6 +8,7 @@ import { SetVisibility } from '../../actions/ui/globalSearch';
 import { Typeahead } from 'react-typeahead';
 import fuzzy from 'fuzzy';
 import key from 'keymaster';
+import filterSelector from '../../selectors/requests/filterSelector';
 
 class GlobalSearch extends React.Component {
 
@@ -69,19 +70,26 @@ class GlobalSearch extends React.Component {
   }
 
   searchOptions(inputValue, options) {
-    // fuzzy lazily just appends a string before and after a matching char
-    // we have to later use a simple shift-in shift-out state machine to convert
-    const fuzzyOptions = {
-      returnMatchInfo: true
-    };
-
-    const searched = fuzzy.filter(inputValue, options, fuzzyOptions);
+    const searched = filterSelector({
+      requestsInState: options,
+      filter: {
+        state: 'all',
+        searchFilter: inputValue,
+        subFilter: [
+          'SERVICE',
+          'WORKER',
+          'SCHEDULED',
+          'ON_DEMAND',
+          'RUN_ONCE'
+        ]
+      }
+    });
 
     return searched;
   }
 
   getValueFromOption(option) {
-    return option.original;
+    return option.id;
   }
 
   optionSelected(requestIdObject) {
@@ -92,19 +100,15 @@ class GlobalSearch extends React.Component {
   }
 
   renderOption(option, index) {
-    // transform fuzzy string into react component
-    const bolded = option.string.map((matchInfo) => {
-      if (matchInfo.match) {
-        return <strong>{matchInfo.char}</strong>;
-      }
-      return matchInfo.char;
-    });
-
-    return <span key={index}>{bolded}</span>;
+    return <span key={index}>{option.id}</span>;
   }
 
   render() {
-    const options = _.map(this.props.requests, (requestParent) => requestParent.request.id);
+    const options = _.map(this.props.requests, (requestParent) => ({
+      request: requestParent.request,
+      id: requestParent.request.id,
+      requestDeployState: requestParent.requestDeployState
+    }));
 
     const globalSearchClasses = classNames('global-search', {
       'global-search-active': this.props.visible


### PR DESCRIPTION
Change from directly using the fuzzy search API provided by `fuzzy` to
the existing custom one used in the search bar on the Requests page.
This did preserve using the existing `react-typeahead` element, rather
than switching to the `react-select` element. This should make the 
global search a little less helter-skelter in what it matches.

One thing that we lost in this switchover: highlighting of matched
characters. The search on the requests page doesn't use or emit that
data, so it no longer comes into the global search. We also aren't as
yet using the full potential of the global search - for example, you
can't search by the deploy user, and you can't toggle searching by
status.

/cc @ssalinas 