### PR TITLE
Fixes for Immediate Uploaders

### DIFF
--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3UploaderMetrics.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3UploaderMetrics.java
@@ -19,6 +19,7 @@ public class SingularityS3UploaderMetrics {
   private final MetricRegistry registry;
   private final Counter uploaderCounter;
   private final Counter uploadCounter;
+  private final Counter immediateUploaderCounter;
   private final Counter errorCounter;
   private final Timer uploadTimer;
   private final Meter filesystemEventsMeter;
@@ -33,6 +34,7 @@ public class SingularityS3UploaderMetrics {
   public SingularityS3UploaderMetrics(MetricRegistry registry) {
     this.registry = registry;
     this.uploaderCounter = registry.counter(name("uploaders", "total"));
+    this.immediateUploaderCounter = registry.counter(name("uploaders", "total"));
     this.uploadCounter = registry.counter(name("uploads", "success"));
     this.errorCounter = registry.counter(name("uploads", "errors"));
     this.uploadTimer = registry.timer(name("uploads", "timer"));
@@ -123,6 +125,10 @@ public class SingularityS3UploaderMetrics {
 
   public Counter getUploaderCounter() {
     return uploaderCounter;
+  }
+
+  public Counter getImmediateUploaderCounter() {
+    return immediateUploaderCounter;
   }
 
   public Timer getUploadTimer() {


### PR DESCRIPTION
@PtrTeixeira after looking at the code for this for a while I realized a few things:
- It's quite messy to deal with the single uploader metric counter when the immediate vs regular uploaders are treated so differently
- We weren't actually able to guarantee that the files eventually got uploaded in the exception case. i.e. if there is an exception from S3, we probably need to retry that still.

So, I updated this to have a map to keep track of the immediate uploaders and have a separate metric counter for them as well. We submit the callables to the executor service immediately, but rather than working with the callbacks, we check the results on our regular polling interval, restarting them if there are exceptions (only retrying for exception, not for no files found right now)

This probably still needs a few tweaks, can you take it from here on this one?