### PR TITLE
Rename metric for immediate uploaders

### DIFF
--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3UploaderMetrics.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3UploaderMetrics.java
@@ -34,7 +34,7 @@ public class SingularityS3UploaderMetrics {
   public SingularityS3UploaderMetrics(MetricRegistry registry) {
     this.registry = registry;
     this.uploaderCounter = registry.counter(name("uploaders", "total"));
-    this.immediateUploaderCounter = registry.counter(name("uploaders", "total"));
+    this.immediateUploaderCounter = registry.counter(name("uploaders", "immediate"));
     this.uploadCounter = registry.counter(name("uploads", "success"));
     this.errorCounter = registry.counter(name("uploads", "errors"));
     this.uploadTimer = registry.timer(name("uploads", "timer"));


### PR DESCRIPTION
Rename the metric for immediate uploaders. I _think_ that if you ask the `MetricsRegistry` for another counter with the same name, it will just give you back a reference to the original counter.