### PR TITLE
Guava 21: remove use of removed objects class for MoreObjects instead.

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/deploy/ExecutorData.java
+++ b/SingularityBase/src/main/java/com/hubspot/deploy/ExecutorData.java
@@ -6,7 +6,7 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 import com.hubspot.mesos.JavaUtils;
 import com.hubspot.singularity.executor.SingularityExecutorLogrotateFrequency;
@@ -152,7 +152,7 @@ public class ExecutorData {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("cmd", cmd)
       .add("embeddedArtifacts", embeddedArtifacts)
       .add("externalArtifacts", externalArtifacts)

--- a/SingularityBase/src/main/java/com/hubspot/deploy/HealthcheckOptions.java
+++ b/SingularityBase/src/main/java/com/hubspot/deploy/HealthcheckOptions.java
@@ -1,6 +1,5 @@
 package com.hubspot.deploy;
 
-import java.util.Collections;
 import java.util.List;
 
 import javax.validation.constraints.NotNull;
@@ -8,6 +7,7 @@ import javax.validation.constraints.NotNull;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.hubspot.singularity.HealthcheckProtocol;
@@ -143,7 +143,7 @@ public class HealthcheckOptions {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("uri", uri)
       .add("portIndex", portIndex)
       .add("portNumber", portNumber)

--- a/SingularityBase/src/main/java/com/hubspot/deploy/HealthcheckOptionsBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/deploy/HealthcheckOptionsBuilder.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import javax.validation.constraints.NotNull;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.hubspot.singularity.HealthcheckProtocol;
@@ -167,7 +168,7 @@ public class HealthcheckOptionsBuilder {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("uri", uri)
       .add("portIndex", portIndex)
       .add("portNumber", portNumber)

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityDockerInfo.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityDockerInfo.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.wordnik.swagger.annotations.ApiModelProperty;
@@ -134,7 +135,7 @@ public class SingularityDockerInfo {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("image", image)
       .add("privileged", privileged)
       .add("network", network)

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityDockerPortMapping.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityDockerPortMapping.java
@@ -2,7 +2,7 @@ package com.hubspot.mesos;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 import com.wordnik.swagger.annotations.ApiModelProperty;
 
@@ -56,7 +56,7 @@ public class SingularityDockerPortMapping {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("containerPortType", containerPortType)
       .add("hostPortType", hostPortType)
       .add("containerPort", containerPort)

--- a/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosExecutorObject.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosExecutorObject.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 public class MesosExecutorObject {
 
@@ -57,7 +57,7 @@ public class MesosExecutorObject {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("directory", directory)
       .add("id", id)
       .add("container", container)

--- a/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosResourcesObject.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosResourcesObject.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
@@ -84,7 +85,7 @@ public class MesosResourcesObject {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("properties", properties)
       .toString();
   }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosTaskObject.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosTaskObject.java
@@ -1,11 +1,8 @@
 package com.hubspot.mesos.json;
 
-import java.util.List;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
-import com.hubspot.mesos.SingularityMesosTaskLabel;
+import com.google.common.base.MoreObjects;
 
 public class MesosTaskObject {
 
@@ -59,7 +56,7 @@ public class MesosTaskObject {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("resources", resources)
       .add("state", state)
       .add("id", id)

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeploy.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeploy.java
@@ -1,8 +1,8 @@
 package com.hubspot.singularity;
 
 import static com.hubspot.singularity.JsonHelpers.copyOfList;
-import static com.hubspot.singularity.JsonHelpers.copyOfSet;
 import static com.hubspot.singularity.JsonHelpers.copyOfMap;
+import static com.hubspot.singularity.JsonHelpers.copyOfSet;
 
 import java.util.HashMap;
 import java.util.List;
@@ -11,7 +11,7 @@ import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 import com.hubspot.deploy.ExecutorData;
 import com.hubspot.deploy.HealthcheckOptions;
@@ -531,7 +531,7 @@ public class SingularityDeploy {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("requestId", requestId)
       .add("id", id)
       .add("version", version)

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeployBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeployBuilder.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 import com.hubspot.deploy.ExecutorData;
 import com.hubspot.deploy.HealthcheckOptions;
@@ -585,7 +585,7 @@ public class SingularityDeployBuilder {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("requestId", requestId)
       .add("id", id)
       .add("version", version)

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeployResult.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeployResult.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 
 public class SingularityDeployResult {
@@ -39,7 +39,7 @@ public class SingularityDeployResult {
     this.deployState = deployState;
     this.lbUpdate = lbUpdate;
     this.message = message;
-    this.deployFailures = Objects.firstNonNull(deployFailures, Collections.<SingularityDeployFailure> emptyList());
+    this.deployFailures = MoreObjects.firstNonNull(deployFailures, Collections.<SingularityDeployFailure> emptyList());
     this.timestamp = timestamp;
   }
 

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDisabledAction.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDisabledAction.java
@@ -2,6 +2,7 @@ package com.hubspot.singularity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 
@@ -65,7 +66,7 @@ public class SingularityDisabledAction {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("type", type)
       .add("message", message)
       .add("user", user)

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDisaster.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDisaster.java
@@ -2,6 +2,7 @@ package com.hubspot.singularity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 public class SingularityDisaster {
@@ -42,7 +43,7 @@ public class SingularityDisaster {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("type", type)
       .add("active", active)
       .toString();

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDisasterDataPoint.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDisasterDataPoint.java
@@ -2,6 +2,7 @@ package com.hubspot.singularity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.primitives.Longs;
 
@@ -92,7 +93,7 @@ public class SingularityDisasterDataPoint implements Comparable<SingularityDisas
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("timestamp", timestamp)
       .add("numActiveTasks", numActiveTasks)
       .add("numPendingTasks", numPendingTasks)

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDisasterDataPoints.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDisasterDataPoints.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 public class SingularityDisasterDataPoints {
@@ -42,7 +43,7 @@ public class SingularityDisasterDataPoints {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("dataPoints", dataPoints)
       .toString();
   }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDisastersData.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDisastersData.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 public class SingularityDisastersData {
@@ -53,7 +54,7 @@ public class SingularityDisastersData {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("stats", stats)
       .add("disasters", disasters)
       .add("automatedActionDisabled", automatedActionDisabled)

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityPaginatedResponse.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityPaginatedResponse.java
@@ -1,9 +1,9 @@
 package com.hubspot.singularity;
 
-import com.google.common.base.Objects;
-import com.google.common.base.Optional;
-
 import java.util.List;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Optional;
 
 public class SingularityPaginatedResponse<Q> {
 
@@ -37,7 +37,7 @@ public class SingularityPaginatedResponse<Q> {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("dataCount", dataCount)
       .add("pageCount", pageCount)
       .add("page", page)

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 import com.wordnik.swagger.annotations.ApiModelProperty;
 
@@ -359,7 +360,7 @@ public class SingularityRequest {
 
   @Override
   public String toString() {
-    return com.google.common.base.Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("id", id)
       .add("requestType", requestType)
       .add("owners", owners)

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularitySlave.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularitySlave.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 import com.hubspot.mesos.json.MesosResourcesObject;
 import com.wordnik.swagger.annotations.ApiModel;
@@ -80,7 +80,7 @@ public class SingularitySlave extends SingularityMachineAbstraction<SingularityS
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("host", host)
       .add("rackId", rackId)
       .add("attributes", attributes)

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskCleanup.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskCleanup.java
@@ -2,7 +2,7 @@ package com.hubspot.singularity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 
 public class SingularityTaskCleanup {
@@ -58,7 +58,7 @@ public class SingularityTaskCleanup {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("user", user)
       .add("cleanupType", cleanupType)
       .add("timestamp", timestamp)

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskDestroyFrameworkMessage.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskDestroyFrameworkMessage.java
@@ -2,6 +2,7 @@ package com.hubspot.singularity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 
@@ -15,6 +16,7 @@ public class SingularityTaskDestroyFrameworkMessage extends SingularityFramework
     this.user = user;
   }
 
+  @Override
   public SingularityTaskId getTaskId() {
     return taskId;
   }
@@ -43,7 +45,7 @@ public class SingularityTaskDestroyFrameworkMessage extends SingularityFramework
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("taskId", taskId)
       .add("user", user)
       .toString();

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskHealthcheckResult.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskHealthcheckResult.java
@@ -3,6 +3,7 @@ package com.hubspot.singularity;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.collect.ComparisonChain;
@@ -91,7 +92,7 @@ public class SingularityTaskHealthcheckResult extends SingularityTaskIdHolder im
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("statusCode", statusCode)
       .add("durationMillis", durationMillis)
       .add("responseBody", responseBody)

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskHistory.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskHistory.java
@@ -5,7 +5,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 import com.hubspot.mesos.JavaUtils;
 
@@ -75,7 +75,7 @@ public class SingularityTaskHistory {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("taskUpdates", taskUpdates)
       .add("directory", directory)
       .add("containerId", containerId)

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskId.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskId.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Function;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
@@ -100,7 +100,7 @@ public class SingularityTaskId extends SingularityId implements SingularityHisto
   public SingularityTaskId(@JsonProperty("requestId") String requestId, @JsonProperty("deployId") String deployId, @JsonProperty("nextRunAt") Long nextRunAt, @JsonProperty("startedAt") Long startedAt,
       @JsonProperty("instanceNo") int instanceNo, @JsonProperty("host") String host, @JsonProperty("sanitizedHost") String sanitizedHost,
       @JsonProperty("sanitizedRackId") String sanitizedRackId, @JsonProperty("rackId") String rackId) {
-    this(requestId, deployId, Objects.firstNonNull(startedAt, nextRunAt), instanceNo, Objects.firstNonNull(sanitizedHost, host), Objects.firstNonNull(sanitizedRackId, rackId));
+    this(requestId, deployId, MoreObjects.firstNonNull(startedAt, nextRunAt), instanceNo, MoreObjects.firstNonNull(sanitizedHost, host), MoreObjects.firstNonNull(sanitizedRackId, rackId));
   }
 
   /**

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityUserSettings.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityUserSettings.java
@@ -5,6 +5,7 @@ import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 public class SingularityUserSettings {
@@ -13,7 +14,7 @@ public class SingularityUserSettings {
   @JsonCreator
   public SingularityUserSettings(
       @JsonProperty("starredRequestIds") Set<String> starredRequestIds) {
-    this.starredRequestIds = Objects.firstNonNull(starredRequestIds, Collections.<String>emptySet());
+    this.starredRequestIds = MoreObjects.firstNonNull(starredRequestIds, Collections.<String>emptySet());
   }
 
   public static SingularityUserSettings empty() {
@@ -53,7 +54,7 @@ public class SingularityUserSettings {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("starredRequestIds", starredRequestIds)
       .toString();
   }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityWebhookSummary.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityWebhookSummary.java
@@ -2,6 +2,7 @@ package com.hubspot.singularity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 public class SingularityWebhookSummary {
@@ -43,7 +44,7 @@ public class SingularityWebhookSummary {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("webhook", webhook)
       .add("queueSize", queueSize)
       .toString();

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityBounceRequestBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityBounceRequestBuilder.java
@@ -1,6 +1,6 @@
 package com.hubspot.singularity.api;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 import com.hubspot.singularity.SingularityShellCommand;
 
@@ -84,7 +84,7 @@ public class SingularityBounceRequestBuilder {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("incremental", incremental)
       .add("skipHealthchecks", skipHealthchecks)
       .add("runShellCommandBeforeKill", runShellCommandBeforeKill)

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityDisabledActionRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityDisabledActionRequest.java
@@ -2,6 +2,7 @@ package com.hubspot.singularity.api;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.hubspot.singularity.SingularityAction;
@@ -47,7 +48,7 @@ public class SingularityDisabledActionRequest {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("type", type)
       .add("message", message)
       .toString();

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityMachineChangeRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityMachineChangeRequest.java
@@ -2,7 +2,7 @@ package com.hubspot.singularity.api;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 import com.hubspot.singularity.MachineState;
 import com.wordnik.swagger.annotations.ApiModelProperty;
@@ -40,7 +40,7 @@ public class SingularityMachineChangeRequest extends SingularityExpiringRequestP
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("durationMillis", getDurationMillis())
       .add("actionId", getActionId())
       .add("message", getMessage())

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityS3SearchRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityS3SearchRequest.java
@@ -6,7 +6,7 @@ import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 import com.wordnik.swagger.annotations.ApiModelProperty;
 
@@ -30,14 +30,14 @@ public class SingularityS3SearchRequest {
                                     @JsonProperty("listOnly") boolean listOnly,
                                     @JsonProperty("maxPerPage") Optional<Integer> maxPerPage,
                                     @JsonProperty("continuationTokens") Map<String, ContinuationToken> continuationTokens) {
-    this.requestsAndDeploys = Objects.firstNonNull(requestsAndDeploys, Collections.<String, List<String>>emptyMap());
-    this.taskIds = Objects.firstNonNull(taskIds, Collections.<String>emptyList());
+    this.requestsAndDeploys = MoreObjects.firstNonNull(requestsAndDeploys, Collections.<String, List<String>>emptyMap());
+    this.taskIds = MoreObjects.firstNonNull(taskIds, Collections.<String>emptyList());
     this.start = start;
     this.end = end;
     this.excludeMetadata = excludeMetadata;
     this.listOnly = listOnly;
     this.maxPerPage = maxPerPage;
-    this.continuationTokens = Objects.firstNonNull(continuationTokens, Collections.<String, ContinuationToken>emptyMap());
+    this.continuationTokens = MoreObjects.firstNonNull(continuationTokens, Collections.<String, ContinuationToken>emptyMap());
   }
 
   @ApiModelProperty(required=false, value="A map of request IDs to a list of deploy ids to search")

--- a/SingularityBase/src/main/java/com/hubspot/singularity/expiring/SingularityExpiringMachineState.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/expiring/SingularityExpiringMachineState.java
@@ -2,7 +2,7 @@ package com.hubspot.singularity.expiring;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 import com.hubspot.singularity.MachineState;
 import com.hubspot.singularity.api.SingularityMachineChangeRequest;
@@ -41,7 +41,7 @@ public class SingularityExpiringMachineState extends SingularityExpiringParent<S
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("user", getUser())
       .add("startMillis", getStartMillis())
       .add("actionId", getActionId())

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/LogrotateCompressionSettings.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/LogrotateCompressionSettings.java
@@ -2,7 +2,7 @@ package com.hubspot.singularity.executor.config;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 
 public class LogrotateCompressionSettings {
@@ -60,7 +60,7 @@ public class LogrotateCompressionSettings {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("compressCmd", compressCmd)
       .add("uncompressCmd", uncompressCmd)
       .add("compressOptions", compressOptions)

--- a/SingularityService/src/main/java/com/hubspot/singularity/views/IndexView.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/views/IndexView.java
@@ -5,7 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import com.hubspot.singularity.SingularityService;
@@ -236,7 +236,7 @@ public class IndexView extends View {
   }
 
   @Override public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("appRoot", appRoot)
       .add("apiDocs", apiDocs)
       .add("staticRoot", staticRoot)

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
     <mesos.version>0.28.2</mesos.version>
     <singularitybase.image.revision>2</singularitybase.image.revision>
     <aws.sdk.version>1.10.77</aws.sdk.version>
+    <dep.guava.version>20.0</dep.guava.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
These methods got removed.  If you try to link SingularityClient with someone who uses Guava 21, it fails due to NoSuchMethodErrors on removed `Objects.firstNonNull` and friends.