### PR TITLE
Prevent building duplicate immediate uploaders

### DIFF
--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3UploaderDriver.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3UploaderDriver.java
@@ -534,19 +534,19 @@ public class SingularityS3UploaderDriver extends WatchServiceHelper implements S
     try {
       if (lock.tryLock(400, TimeUnit.MILLISECONDS)) {
         if (this.immediateUploadMetadata.contains(metadata)) {
-          LOG.debug("Stopped from creating a duplicate immediate uploader.");
+          LOG.debug("Already have an immediate uploader for metadata {}.", metadata);
           return false;
         } else {
-          LOG.debug("Preparing to create new immediate uploader.");
+          LOG.debug("Preparing to create new immediate uploader for metadata {}.", metadata);
           this.immediateUploadMetadata.add(metadata);
           return true;
         }
       } else {
-        LOG.debug("Could not acquire a lock to create an immediate uploader.");
+        LOG.debug("Could not acquire lock to create an immediate uploader for metadata {}.", metadata);
         return false;
       }
     } catch (InterruptedException exn) {
-      LOG.debug("Interrupted while waiting on a lock to create an immediate uploader.");
+      LOG.debug("Interrupted while waiting on a lock to create an immediate uploader for metadata {}.", metadata);
       return false;
     } finally {
       lock.unlock();


### PR DESCRIPTION
There _appears_ to be a threading issue where if the file system poller
happens to run at the same time as an immediate uploaders is running, a
second immediate uploader can be created for the same metadata.
Typically this would be prevented by the metadata-to-uploader map, but
immediate uploaders are removed from or never added to the map, so it
was never checked if there was an existing uploader for a given metadata
file.

This polls the list of immediate uploaders to check their metadata, and
will refuse to create another uploader of there is an existing uploader
with the same metadata file.