### PR TITLE
Standardize on toString/hash/equals formats

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/deploy/Artifact.java
+++ b/SingularityBase/src/main/java/com/hubspot/deploy/Artifact.java
@@ -70,7 +70,11 @@ public abstract class Artifact {
 
   @Override
   public String toString() {
-    return "Artifact [name=" + name + ", filename=" + filename + ", md5sum=" + md5sum + ", targetFolderRelativeToTask=" + targetFolderRelativeToTask + "]";
+    return "Artifact{" +
+        "name='" + name + '\'' +
+        ", filename='" + filename + '\'' +
+        ", md5sum=" + md5sum +
+        ", targetFolderRelativeToTask=" + targetFolderRelativeToTask +
+        '}';
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/deploy/EmbeddedArtifact.java
+++ b/SingularityBase/src/main/java/com/hubspot/deploy/EmbeddedArtifact.java
@@ -29,11 +29,6 @@ public class EmbeddedArtifact extends Artifact {
   }
 
   @Override
-  public int hashCode() {
-    return Objects.hash(super.hashCode(), content);
-  }
-
-  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;
@@ -44,14 +39,19 @@ public class EmbeddedArtifact extends Artifact {
     if (!super.equals(o)) {
       return false;
     }
-
     EmbeddedArtifact that = (EmbeddedArtifact) o;
     return Arrays.equals(content, that.content);
   }
 
   @Override
-  public String toString() {
-    return "EmbeddedArtifact [parent=" + super.toString() + "]";
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), content);
   }
 
+  @Override
+  public String toString() {
+    return "EmbeddedArtifact{" +
+        "content=" + Arrays.toString(content) +
+        "} " + super.toString();
+  }
 }

--- a/SingularityBase/src/main/java/com/hubspot/deploy/ExecutorData.java
+++ b/SingularityBase/src/main/java/com/hubspot/deploy/ExecutorData.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.hubspot.mesos.JavaUtils;
 import com.hubspot.singularity.executor.SingularityExecutorLogrotateFrequency;
@@ -152,25 +151,24 @@ public class ExecutorData {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("cmd", cmd)
-      .add("embeddedArtifacts", embeddedArtifacts)
-      .add("externalArtifacts", externalArtifacts)
-      .add("s3Artifacts", s3Artifacts)
-      .add("successfulExitCodes", successfulExitCodes)
-      .add("runningSentinel", runningSentinel)
-      .add("user", user)
-      .add("extraCmdLineArgs", extraCmdLineArgs)
-      .add("loggingTag", loggingTag)
-      .add("loggingExtraFields", loggingExtraFields)
-      .add("sigKillProcessesAfterMillis", sigKillProcessesAfterMillis)
-      .add("maxTaskThreads", maxTaskThreads)
-      .add("preserveTaskSandboxAfterFinish", preserveTaskSandboxAfterFinish)
-      .add("maxOpenFiles", maxOpenFiles)
-      .add("skipLogrotateAndCompress", skipLogrotateAndCompress)
-      .add("s3ArtifactSignatures", s3ArtifactSignatures)
-      .add("logrotateFrequency", logrotateFrequency)
-      .add("builder", toBuilder())
-      .toString();
+    return "ExecutorData{" +
+        "cmd='" + cmd + '\'' +
+        ", embeddedArtifacts=" + embeddedArtifacts +
+        ", externalArtifacts=" + externalArtifacts +
+        ", s3Artifacts=" + s3Artifacts +
+        ", successfulExitCodes=" + successfulExitCodes +
+        ", runningSentinel=" + runningSentinel +
+        ", user=" + user +
+        ", extraCmdLineArgs=" + extraCmdLineArgs +
+        ", loggingTag=" + loggingTag +
+        ", loggingExtraFields=" + loggingExtraFields +
+        ", sigKillProcessesAfterMillis=" + sigKillProcessesAfterMillis +
+        ", maxTaskThreads=" + maxTaskThreads +
+        ", preserveTaskSandboxAfterFinish=" + preserveTaskSandboxAfterFinish +
+        ", maxOpenFiles=" + maxOpenFiles +
+        ", skipLogrotateAndCompress=" + skipLogrotateAndCompress +
+        ", s3ArtifactSignatures=" + s3ArtifactSignatures +
+        ", logrotateFrequency=" + logrotateFrequency +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/deploy/ExecutorDataBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/deploy/ExecutorDataBuilder.java
@@ -213,24 +213,24 @@ public class ExecutorDataBuilder {
 
   @Override
   public String toString() {
-    return "ExecutorDataBuilder[" +
-            "cmd='" + cmd + '\'' +
-            ", embeddedArtifacts=" + embeddedArtifacts +
-            ", externalArtifacts=" + externalArtifacts +
-            ", s3Artifacts=" + s3Artifacts +
-            ", successfulExitCodes=" + successfulExitCodes +
-            ", runningSentinel=" + runningSentinel +
-            ", user=" + user +
-            ", extraCmdLineArgs=" + extraCmdLineArgs +
-            ", loggingTag=" + loggingTag +
-            ", loggingExtraFields=" + loggingExtraFields +
-            ", sigKillProcessesAfterMillis=" + sigKillProcessesAfterMillis +
-            ", maxTaskThreads=" + maxTaskThreads +
-            ", preserveTaskSandboxAfterFinish=" + preserveTaskSandboxAfterFinish +
-            ", maxOpenFiles=" + maxOpenFiles +
-            ", skipLogrotateAndCompress=" + skipLogrotateAndCompress +
-            ", s3ArtifactSignatures=" + s3ArtifactSignatures +
-            ", logrotateFrequency=" + logrotateFrequency +
-            ']';
+    return "ExecutorDataBuilder{" +
+        "cmd='" + cmd + '\'' +
+        ", embeddedArtifacts=" + embeddedArtifacts +
+        ", externalArtifacts=" + externalArtifacts +
+        ", s3Artifacts=" + s3Artifacts +
+        ", successfulExitCodes=" + successfulExitCodes +
+        ", runningSentinel=" + runningSentinel +
+        ", user=" + user +
+        ", extraCmdLineArgs=" + extraCmdLineArgs +
+        ", loggingTag=" + loggingTag +
+        ", loggingExtraFields=" + loggingExtraFields +
+        ", sigKillProcessesAfterMillis=" + sigKillProcessesAfterMillis +
+        ", maxTaskThreads=" + maxTaskThreads +
+        ", preserveTaskSandboxAfterFinish=" + preserveTaskSandboxAfterFinish +
+        ", maxOpenFiles=" + maxOpenFiles +
+        ", skipLogrotateAndCompress=" + skipLogrotateAndCompress +
+        ", s3ArtifactSignatures=" + s3ArtifactSignatures +
+        ", logrotateFrequency=" + logrotateFrequency +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/deploy/ExternalArtifact.java
+++ b/SingularityBase/src/main/java/com/hubspot/deploy/ExternalArtifact.java
@@ -44,7 +44,8 @@ public class ExternalArtifact extends RemoteArtifact {
 
   @Override
   public String toString() {
-    return "ExternalArtifact [url=" + url + ", parent=" + super.toString() + "]";
+    return "ExternalArtifact{" +
+        "url='" + url + '\'' +
+        "} " + super.toString();
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/deploy/HealthcheckOptions.java
+++ b/SingularityBase/src/main/java/com/hubspot/deploy/HealthcheckOptions.java
@@ -1,14 +1,13 @@
 package com.hubspot.deploy;
 
-import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.hubspot.singularity.HealthcheckProtocol;
 import com.wordnik.swagger.annotations.ApiModelProperty;
@@ -123,37 +122,39 @@ public class HealthcheckOptions {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    HealthcheckOptions options = (HealthcheckOptions) o;
-    return Objects.equal(uri, options.uri) &&
-      Objects.equal(portIndex, options.portIndex) &&
-      Objects.equal(portNumber, options.portNumber) &&
-      Objects.equal(protocol, options.protocol) &&
-      Objects.equal(startupTimeoutSeconds, options.startupTimeoutSeconds) &&
-      Objects.equal(startupDelaySeconds, options.startupDelaySeconds) &&
-      Objects.equal(startupIntervalSeconds, options.startupIntervalSeconds) &&
-      Objects.equal(intervalSeconds, options.intervalSeconds) &&
-      Objects.equal(responseTimeoutSeconds, options.responseTimeoutSeconds) &&
-      Objects.equal(maxRetries, options.maxRetries);
+    HealthcheckOptions that = (HealthcheckOptions) o;
+    return Objects.equals(uri, that.uri) &&
+        Objects.equals(portIndex, that.portIndex) &&
+        Objects.equals(portNumber, that.portNumber) &&
+        Objects.equals(protocol, that.protocol) &&
+        Objects.equals(startupTimeoutSeconds, that.startupTimeoutSeconds) &&
+        Objects.equals(startupDelaySeconds, that.startupDelaySeconds) &&
+        Objects.equals(startupIntervalSeconds, that.startupIntervalSeconds) &&
+        Objects.equals(intervalSeconds, that.intervalSeconds) &&
+        Objects.equals(responseTimeoutSeconds, that.responseTimeoutSeconds) &&
+        Objects.equals(maxRetries, that.maxRetries) &&
+        Objects.equals(failureStatusCodes, that.failureStatusCodes);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(uri, portIndex, portNumber, protocol, startupTimeoutSeconds, startupDelaySeconds, startupIntervalSeconds, intervalSeconds, responseTimeoutSeconds, maxRetries);
+    return Objects.hash(uri, portIndex, portNumber, protocol, startupTimeoutSeconds, startupDelaySeconds, startupIntervalSeconds, intervalSeconds, responseTimeoutSeconds, maxRetries, failureStatusCodes);
   }
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("uri", uri)
-      .add("portIndex", portIndex)
-      .add("portNumber", portNumber)
-      .add("protocol", protocol)
-      .add("startupTimeoutSeconds", startupTimeoutSeconds)
-      .add("startupDelaySeconds", startupDelaySeconds)
-      .add("startupIntervalSeconds", startupIntervalSeconds)
-      .add("intervalSeconds", intervalSeconds)
-      .add("responseTimeoutSeconds", responseTimeoutSeconds)
-      .add("maxRetries", maxRetries)
-      .toString();
+    return "HealthcheckOptions{" +
+        "uri='" + uri + '\'' +
+        ", portIndex=" + portIndex +
+        ", portNumber=" + portNumber +
+        ", protocol=" + protocol +
+        ", startupTimeoutSeconds=" + startupTimeoutSeconds +
+        ", startupDelaySeconds=" + startupDelaySeconds +
+        ", startupIntervalSeconds=" + startupIntervalSeconds +
+        ", intervalSeconds=" + intervalSeconds +
+        ", responseTimeoutSeconds=" + responseTimeoutSeconds +
+        ", maxRetries=" + maxRetries +
+        ", failureStatusCodes=" + failureStatusCodes +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/deploy/HealthcheckOptionsBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/deploy/HealthcheckOptionsBuilder.java
@@ -1,10 +1,10 @@
 package com.hubspot.deploy;
 
 import java.util.List;
+import java.util.Objects;
 
 import javax.validation.constraints.NotNull;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.hubspot.singularity.HealthcheckProtocol;
 
@@ -147,37 +147,39 @@ public class HealthcheckOptionsBuilder {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    HealthcheckOptionsBuilder options = (HealthcheckOptionsBuilder) o;
-    return Objects.equal(uri, options.uri) &&
-      Objects.equal(portIndex, options.portIndex) &&
-      Objects.equal(portNumber, options.portNumber) &&
-      Objects.equal(protocol, options.protocol) &&
-      Objects.equal(startupTimeoutSeconds, options.startupTimeoutSeconds) &&
-      Objects.equal(startupDelaySeconds, options.startupDelaySeconds) &&
-      Objects.equal(startupIntervalSeconds, options.startupIntervalSeconds) &&
-      Objects.equal(intervalSeconds, options.intervalSeconds) &&
-      Objects.equal(responseTimeoutSeconds, options.responseTimeoutSeconds) &&
-      Objects.equal(maxRetries, options.maxRetries);
+    HealthcheckOptionsBuilder that = (HealthcheckOptionsBuilder) o;
+    return Objects.equals(uri, that.uri) &&
+        Objects.equals(portIndex, that.portIndex) &&
+        Objects.equals(portNumber, that.portNumber) &&
+        Objects.equals(protocol, that.protocol) &&
+        Objects.equals(startupTimeoutSeconds, that.startupTimeoutSeconds) &&
+        Objects.equals(startupDelaySeconds, that.startupDelaySeconds) &&
+        Objects.equals(startupIntervalSeconds, that.startupIntervalSeconds) &&
+        Objects.equals(intervalSeconds, that.intervalSeconds) &&
+        Objects.equals(responseTimeoutSeconds, that.responseTimeoutSeconds) &&
+        Objects.equals(maxRetries, that.maxRetries) &&
+        Objects.equals(failureStatusCodes, that.failureStatusCodes);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(uri, portIndex, portNumber, protocol, startupTimeoutSeconds, startupDelaySeconds, startupIntervalSeconds, intervalSeconds, responseTimeoutSeconds, maxRetries);
+    return Objects.hash(uri, portIndex, portNumber, protocol, startupTimeoutSeconds, startupDelaySeconds, startupIntervalSeconds, intervalSeconds, responseTimeoutSeconds, maxRetries, failureStatusCodes);
   }
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("uri", uri)
-      .add("portIndex", portIndex)
-      .add("portNumber", portNumber)
-      .add("protocol", protocol)
-      .add("startupTimeoutSeconds", startupTimeoutSeconds)
-      .add("startupDelaySeconds", startupDelaySeconds)
-      .add("startupIntervalSeconds", startupIntervalSeconds)
-      .add("intervalSeconds", intervalSeconds)
-      .add("responseTimeoutSeconds", responseTimeoutSeconds)
-      .add("maxRetries", maxRetries)
-      .toString();
+    return "HealthcheckOptionsBuilder{" +
+        "uri='" + uri + '\'' +
+        ", portIndex=" + portIndex +
+        ", portNumber=" + portNumber +
+        ", protocol=" + protocol +
+        ", startupTimeoutSeconds=" + startupTimeoutSeconds +
+        ", startupDelaySeconds=" + startupDelaySeconds +
+        ", startupIntervalSeconds=" + startupIntervalSeconds +
+        ", intervalSeconds=" + intervalSeconds +
+        ", responseTimeoutSeconds=" + responseTimeoutSeconds +
+        ", maxRetries=" + maxRetries +
+        ", failureStatusCodes=" + failureStatusCodes +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/deploy/RemoteArtifact.java
+++ b/SingularityBase/src/main/java/com/hubspot/deploy/RemoteArtifact.java
@@ -39,7 +39,8 @@ public abstract class RemoteArtifact extends Artifact {
 
   @Override
   public String toString() {
-    return "RemoteArtifact [filesize=" + filesize + ", parent=" + super.toString() + "]";
+    return "RemoteArtifact{" +
+        "filesize=" + filesize +
+        "} " + super.toString();
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/deploy/S3Artifact.java
+++ b/SingularityBase/src/main/java/com/hubspot/deploy/S3Artifact.java
@@ -51,7 +51,9 @@ public class S3Artifact extends RemoteArtifact {
 
   @Override
   public String toString() {
-    return "S3Artifact [s3Bucket=" + s3Bucket + ", s3ObjectKey=" + s3ObjectKey + ", parent=" + super.toString() + "]";
+    return "S3Artifact{" +
+        "s3Bucket='" + s3Bucket + '\'' +
+        ", s3ObjectKey='" + s3ObjectKey + '\'' +
+        "} " + super.toString();
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/deploy/S3ArtifactSignature.java
+++ b/SingularityBase/src/main/java/com/hubspot/deploy/S3ArtifactSignature.java
@@ -47,7 +47,8 @@ public class S3ArtifactSignature extends S3Artifact {
 
   @Override
   public String toString() {
-    return "S3ArtifactSignature [artifactFilename=" + artifactFilename + ", parent=" + super.toString() + "]";
+    return "S3ArtifactSignature{" +
+        "artifactFilename='" + artifactFilename + '\'' +
+        "} " + super.toString();
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/CounterMap.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/CounterMap.java
@@ -105,7 +105,8 @@ public class CounterMap<K> {
 
   @Override
   public String toString() {
-    return "CounterMap [map=" + map + "]";
+    return "CounterMap{" +
+        "map=" + map +
+        '}';
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/Resources.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/Resources.java
@@ -51,16 +51,6 @@ public class Resources {
   }
 
   @Override
-  public String toString() {
-    return "Resources[" +
-        "cpus=" + cpus +
-        ", memoryMb=" + memoryMb +
-        ", numPorts=" + numPorts +
-        ", diskMb=" + diskMb +
-        ']';
-  }
-
-  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;
@@ -78,5 +68,15 @@ public class Resources {
   @Override
   public int hashCode() {
     return Objects.hash(cpus, memoryMb, numPorts, diskMb);
+  }
+
+  @Override
+  public String toString() {
+    return "Resources{" +
+        "cpus=" + cpus +
+        ", memoryMb=" + memoryMb +
+        ", numPorts=" + numPorts +
+        ", diskMb=" + diskMb +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityContainerInfo.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityContainerInfo.java
@@ -1,6 +1,7 @@
 package com.hubspot.mesos;
 
 import java.util.List;
+import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -38,15 +39,6 @@ public class SingularityContainerInfo {
   }
 
   @Override
-  public String toString() {
-    return "SingularityContainerInfo{" +
-        "type=" + type +
-        ", volumes=" + volumes +
-        ", docker=" + docker +
-        '}';
-  }
-
-  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;
@@ -54,26 +46,23 @@ public class SingularityContainerInfo {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-
     SingularityContainerInfo that = (SingularityContainerInfo) o;
-
-    if (!type.equals(that.type)) {
-      return false;
-    }
-    if (!volumes.equals(that.volumes)) {
-      return false;
-    }
-    if (!docker.equals(that.docker)) {
-      return false;
-    }
-    return true;
+    return type == that.type &&
+        Objects.equals(volumes, that.volumes) &&
+        Objects.equals(docker, that.docker);
   }
 
   @Override
   public int hashCode() {
-    int result = type.hashCode();
-    result = 31 * result + volumes.hashCode();
-    result = 31 *result + docker.hashCode();
-    return result;
+    return Objects.hash(type, volumes, docker);
+  }
+
+  @Override
+  public String toString() {
+    return "SingularityContainerInfo{" +
+        "type=" + type +
+        ", volumes=" + volumes +
+        ", docker=" + docker +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityDockerInfo.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityDockerInfo.java
@@ -4,11 +4,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.wordnik.swagger.annotations.ApiModelProperty;
 
@@ -109,6 +109,7 @@ public class SingularityDockerInfo {
     return dockerParameters;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -119,29 +120,29 @@ public class SingularityDockerInfo {
     }
     SingularityDockerInfo that = (SingularityDockerInfo) o;
     return privileged == that.privileged &&
-      forcePullImage == that.forcePullImage &&
-      Objects.equal(image, that.image) &&
-      Objects.equal(network, that.network) &&
-      Objects.equal(portMappings, that.portMappings) &&
-      Objects.equal(parameters, that.parameters) &&
-      Objects.equal(dockerParameters, that.dockerParameters);
+        forcePullImage == that.forcePullImage &&
+        Objects.equals(image, that.image) &&
+        Objects.equals(network, that.network) &&
+        Objects.equals(portMappings, that.portMappings) &&
+        Objects.equals(parameters, that.parameters) &&
+        Objects.equals(dockerParameters, that.dockerParameters);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(image, privileged, network, portMappings, forcePullImage, parameters, dockerParameters);
+    return Objects.hash(image, privileged, network, portMappings, forcePullImage, parameters, dockerParameters);
   }
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("image", image)
-      .add("privileged", privileged)
-      .add("network", network)
-      .add("portMappings", portMappings)
-      .add("forcePullImage", forcePullImage)
-      .add("parameters", parameters)
-      .add("dockerParameters", dockerParameters)
-      .toString();
+    return "SingularityDockerInfo{" +
+        "image='" + image + '\'' +
+        ", privileged=" + privileged +
+        ", network=" + network +
+        ", portMappings=" + portMappings +
+        ", forcePullImage=" + forcePullImage +
+        ", parameters=" + parameters +
+        ", dockerParameters=" + dockerParameters +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityDockerParameter.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityDockerParameter.java
@@ -7,7 +7,6 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Optional;
 
 public class SingularityDockerParameter {
   private final String key;
@@ -32,12 +31,12 @@ public class SingularityDockerParameter {
     return value;
   }
 
-  @Override
-  public String toString() {
-    return "SingularityDockerParameter{" +
-      "key='" + key + '\'' +
-      ", value=" + value +
-      '}';
+  public static List<SingularityDockerParameter> parametersFromMap(Map<String, String> parametersMap) {
+    List<SingularityDockerParameter> parameters = new ArrayList<>();
+    for (Map.Entry<String, String> entry : parametersMap.entrySet()) {
+      parameters.add(new SingularityDockerParameter(entry.getKey(), entry.getValue()));
+    }
+    return parameters;
   }
 
   @Override
@@ -50,7 +49,7 @@ public class SingularityDockerParameter {
     }
     SingularityDockerParameter that = (SingularityDockerParameter) o;
     return Objects.equals(key, that.key) &&
-      Objects.equals(value, that.value);
+        Objects.equals(value, that.value);
   }
 
   @Override
@@ -58,11 +57,11 @@ public class SingularityDockerParameter {
     return Objects.hash(key, value);
   }
 
-  public static List<SingularityDockerParameter> parametersFromMap(Map<String, String> parametersMap) {
-    List<SingularityDockerParameter> parameters = new ArrayList<>();
-    for (Map.Entry<String, String> entry : parametersMap.entrySet()) {
-      parameters.add(new SingularityDockerParameter(entry.getKey(), entry.getValue()));
-    }
-    return parameters;
+  @Override
+  public String toString() {
+    return "SingularityDockerParameter{" +
+        "key='" + key + '\'' +
+        ", value='" + value + '\'' +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityDockerPortMapping.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityDockerPortMapping.java
@@ -1,8 +1,9 @@
 package com.hubspot.mesos;
 
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.wordnik.swagger.annotations.ApiModelProperty;
 
@@ -55,17 +56,6 @@ public class SingularityDockerPortMapping {
   }
 
   @Override
-  public String toString() {
-    return Objects.toStringHelper(this)
-      .add("containerPortType", containerPortType)
-      .add("hostPortType", hostPortType)
-      .add("containerPort", containerPort)
-      .add("hostPort", hostPort)
-      .add("protocol", protocol)
-      .toString();
-  }
-
-  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;
@@ -73,31 +63,27 @@ public class SingularityDockerPortMapping {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-
     SingularityDockerPortMapping that = (SingularityDockerPortMapping) o;
-
-    if (!containerPortType.equals(that.containerPortType)) {
-      return false;
-    }
-    if (containerPort != that.containerPort) {
-      return false;
-    }
-    if (!hostPortType.equals(that.hostPortType)) {
-      return false;
-    }
-    if (!protocol.equals(that.protocol)) {
-      return false;
-    }
-    return true;
+    return containerPort == that.containerPort &&
+        hostPort == that.hostPort &&
+        containerPortType == that.containerPortType &&
+        hostPortType == that.hostPortType &&
+        Objects.equals(protocol, that.protocol);
   }
 
   @Override
   public int hashCode() {
-    int result = containerPortType.hashCode();
-    result = 31 * result + hostPortType.hashCode();
-    result = 31 * result + containerPort;
-    result = 31 * result + hostPort;
-    result = 31 * result + protocol.hashCode();
-    return result;
+    return Objects.hash(containerPortType, hostPortType, containerPort, hostPort, protocol);
+  }
+
+  @Override
+  public String toString() {
+    return "SingularityDockerPortMapping{" +
+        "containerPortType=" + containerPortType +
+        ", hostPortType=" + hostPortType +
+        ", containerPort=" + containerPort +
+        ", hostPort=" + hostPort +
+        ", protocol='" + protocol + '\'' +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityMesosArtifact.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityMesosArtifact.java
@@ -1,5 +1,7 @@
 package com.hubspot.mesos;
 
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -49,28 +51,16 @@ public class SingularityMesosArtifact {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-
     SingularityMesosArtifact that = (SingularityMesosArtifact) o;
-
-    if (cache != that.cache) {
-      return false;
-    }
-    if (executable != that.executable) {
-      return false;
-    }
-    if (extract != that.extract) {
-      return false;
-    }
-    return uri != null ? uri.equals(that.uri) : that.uri == null;
+    return cache == that.cache &&
+        executable == that.executable &&
+        extract == that.extract &&
+        Objects.equals(uri, that.uri);
   }
 
   @Override
   public int hashCode() {
-    int result = uri != null ? uri.hashCode() : 0;
-    result = 31 * result + (cache ? 1 : 0);
-    result = 31 * result + (executable ? 1 : 0);
-    result = 31 * result + (extract ? 1 : 0);
-    return result;
+    return Objects.hash(uri, cache, executable, extract);
   }
 
   @Override

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityMesosTaskLabel.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityMesosTaskLabel.java
@@ -32,12 +32,12 @@ public class SingularityMesosTaskLabel {
     return value;
   }
 
-  @Override
-  public String toString() {
-    return "SingularityLabel{" +
-      "key='" + key + '\'' +
-      ", value=" + value +
-      '}';
+  public static List<SingularityMesosTaskLabel> labelsFromMap(Map<String, String> parametersMap) {
+    List<SingularityMesosTaskLabel> labels = new ArrayList<>();
+    for (Map.Entry<String, String> entry : parametersMap.entrySet()) {
+      labels.add(new SingularityMesosTaskLabel(entry.getKey(), Optional.of(entry.getValue())));
+    }
+    return labels;
   }
 
   @Override
@@ -50,7 +50,7 @@ public class SingularityMesosTaskLabel {
     }
     SingularityMesosTaskLabel that = (SingularityMesosTaskLabel) o;
     return Objects.equals(key, that.key) &&
-      Objects.equals(value, that.value);
+        Objects.equals(value, that.value);
   }
 
   @Override
@@ -58,11 +58,11 @@ public class SingularityMesosTaskLabel {
     return Objects.hash(key, value);
   }
 
-  public static List<SingularityMesosTaskLabel> labelsFromMap(Map<String, String> parametersMap) {
-    List<SingularityMesosTaskLabel> labels = new ArrayList<>();
-    for (Map.Entry<String, String> entry : parametersMap.entrySet()) {
-      labels.add(new SingularityMesosTaskLabel(entry.getKey(), Optional.of(entry.getValue())));
-    }
-    return labels;
+  @Override
+  public String toString() {
+    return "SingularityMesosTaskLabel{" +
+        "key='" + key + '\'' +
+        ", value=" + value +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityVolume.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityVolume.java
@@ -1,5 +1,7 @@
 package com.hubspot.mesos;
 
+import java.util.Objects;
+
 import org.apache.mesos.Protos;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -47,15 +49,6 @@ public class SingularityVolume {
   }
 
   @Override
-  public String toString() {
-    return "SingularityVolume{" +
-        "containerPath='" + containerPath + '\'' +
-        ", hostPath=" + hostPath +
-        ", mode=" + mode +
-        '}';
-  }
-
-  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;
@@ -63,26 +56,23 @@ public class SingularityVolume {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-
     SingularityVolume that = (SingularityVolume) o;
-
-    if (!containerPath.equals(that.containerPath)) {
-      return false;
-    }
-    if (!hostPath.equals(that.hostPath)) {
-      return false;
-    }
-    if (!mode.equals(that.mode)) {
-      return false;
-    }
-    return true;
+    return Objects.equals(containerPath, that.containerPath) &&
+        Objects.equals(hostPath, that.hostPath) &&
+        Objects.equals(mode, that.mode);
   }
 
   @Override
   public int hashCode() {
-    int result = containerPath.hashCode();
-    result = 31 * result + hostPath.hashCode();
-    result = 31 * result + mode.hashCode();
-    return result;
+    return Objects.hash(containerPath, hostPath, mode);
+  }
+
+  @Override
+  public String toString() {
+    return "SingularityVolume{" +
+        "containerPath='" + containerPath + '\'' +
+        ", hostPath=" + hostPath +
+        ", mode=" + mode +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosExecutorObject.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosExecutorObject.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 
 public class MesosExecutorObject {
 
@@ -57,14 +56,14 @@ public class MesosExecutorObject {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("directory", directory)
-      .add("id", id)
-      .add("container", container)
-      .add("name", name)
-      .add("resources", resources)
-      .add("tasks", tasks)
-      .add("completedTasks", completedTasks)
-      .toString();
+    return "MesosExecutorObject{" +
+        "directory='" + directory + '\'' +
+        ", id='" + id + '\'' +
+        ", container='" + container + '\'' +
+        ", name='" + name + '\'' +
+        ", resources=" + resources +
+        ", tasks=" + tasks +
+        ", completedTasks=" + completedTasks +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosFileChunkObject.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosFileChunkObject.java
@@ -31,15 +31,6 @@ public class MesosFileChunkObject {
   }
 
   @Override
-  public String toString() {
-    return "MesosFileChunkObject[" +
-            "data='" + data + '\'' +
-            ", offset=" + offset +
-            ", nextOffset=" + nextOffset +
-            ']';
-  }
-
-  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;
@@ -48,13 +39,22 @@ public class MesosFileChunkObject {
       return false;
     }
     MesosFileChunkObject that = (MesosFileChunkObject) o;
-    return Objects.equals(offset, that.offset) &&
-            Objects.equals(data, that.data) &&
-            Objects.equals(nextOffset, that.nextOffset);
+    return offset == that.offset &&
+        Objects.equals(data, that.data) &&
+        Objects.equals(nextOffset, that.nextOffset);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(data, offset, nextOffset);
+  }
+
+  @Override
+  public String toString() {
+    return "MesosFileChunkObject{" +
+        "data='" + data + '\'' +
+        ", offset=" + offset +
+        ", nextOffset=" + nextOffset +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosFileObject.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosFileObject.java
@@ -1,5 +1,7 @@
 package com.hubspot.mesos.json;
 
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -52,5 +54,41 @@ public class MesosFileObject {
 
   public String getUid() {
     return uid;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    MesosFileObject that = (MesosFileObject) o;
+    return mtime == that.mtime &&
+        nlink == that.nlink &&
+        size == that.size &&
+        Objects.equals(gid, that.gid) &&
+        Objects.equals(mode, that.mode) &&
+        Objects.equals(path, that.path) &&
+        Objects.equals(uid, that.uid);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(gid, mode, mtime, nlink, path, size, uid);
+  }
+
+  @Override
+  public String toString() {
+    return "MesosFileObject{" +
+        "gid='" + gid + '\'' +
+        ", mode='" + mode + '\'' +
+        ", mtime=" + mtime +
+        ", nlink=" + nlink +
+        ", path='" + path + '\'' +
+        ", size=" + size +
+        ", uid='" + uid + '\'' +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosFrameworkObject.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosFrameworkObject.java
@@ -1,9 +1,9 @@
 package com.hubspot.mesos.json;
 
 import java.util.List;
+import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class MesosFrameworkObject {
@@ -110,5 +110,59 @@ public class MesosFrameworkObject {
 
   public List<MesosTaskObject> getTasks() {
     return tasks;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    MesosFrameworkObject that = (MesosFrameworkObject) o;
+    return registeredTime == that.registeredTime &&
+        unregisteredTime == that.unregisteredTime &&
+        reregisteredTime == that.reregisteredTime &&
+        active == that.active &&
+        checkpoint == that.checkpoint &&
+        Objects.equals(name, that.name) &&
+        Objects.equals(id, that.id) &&
+        Objects.equals(pid, that.pid) &&
+        Objects.equals(hostname, that.hostname) &&
+        Objects.equals(webuiUrl, that.webuiUrl) &&
+        Objects.equals(user, that.user) &&
+        Objects.equals(role, that.role) &&
+        Objects.equals(resources, that.resources) &&
+        Objects.equals(usedResources, that.usedResources) &&
+        Objects.equals(offeredResources, that.offeredResources) &&
+        Objects.equals(tasks, that.tasks);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, id, pid, hostname, webuiUrl, user, role, registeredTime, unregisteredTime, reregisteredTime, active, checkpoint, resources, usedResources, offeredResources, tasks);
+  }
+
+  @Override
+  public String toString() {
+    return "MesosFrameworkObject{" +
+        "name='" + name + '\'' +
+        ", id='" + id + '\'' +
+        ", pid='" + pid + '\'' +
+        ", hostname='" + hostname + '\'' +
+        ", webuiUrl='" + webuiUrl + '\'' +
+        ", user='" + user + '\'' +
+        ", role='" + role + '\'' +
+        ", registeredTime=" + registeredTime +
+        ", unregisteredTime=" + unregisteredTime +
+        ", reregisteredTime=" + reregisteredTime +
+        ", active=" + active +
+        ", checkpoint=" + checkpoint +
+        ", resources=" + resources +
+        ", usedResources=" + usedResources +
+        ", offeredResources=" + offeredResources +
+        ", tasks=" + tasks +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosMasterSlaveObject.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosMasterSlaveObject.java
@@ -1,6 +1,7 @@
 package com.hubspot.mesos.json;
 
 import java.util.Map;
+import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -85,5 +86,51 @@ public class MesosMasterSlaveObject {
 
   public boolean isActive() {
     return active;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    MesosMasterSlaveObject that = (MesosMasterSlaveObject) o;
+    return registeredTime == that.registeredTime &&
+        active == that.active &&
+        Objects.equals(id, that.id) &&
+        Objects.equals(pid, that.pid) &&
+        Objects.equals(hostname, that.hostname) &&
+        Objects.equals(attributes, that.attributes) &&
+        Objects.equals(resources, that.resources) &&
+        Objects.equals(usedResources, that.usedResources) &&
+        Objects.equals(offeredResources, that.offeredResources) &&
+        Objects.equals(reservedResources, that.reservedResources) &&
+        Objects.equals(unreservedResources, that.unreservedResources) &&
+        Objects.equals(version, that.version);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, pid, hostname, attributes, registeredTime, resources, usedResources, offeredResources, reservedResources, unreservedResources, version, active);
+  }
+
+  @Override
+  public String toString() {
+    return "MesosMasterSlaveObject{" +
+        "id='" + id + '\'' +
+        ", pid='" + pid + '\'' +
+        ", hostname='" + hostname + '\'' +
+        ", attributes=" + attributes +
+        ", registeredTime=" + registeredTime +
+        ", resources=" + resources +
+        ", usedResources=" + usedResources +
+        ", offeredResources=" + offeredResources +
+        ", reservedResources=" + reservedResources +
+        ", unreservedResources=" + unreservedResources +
+        ", version='" + version + '\'' +
+        ", active=" + active +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosMasterStateObject.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosMasterStateObject.java
@@ -2,6 +2,7 @@ package com.hubspot.mesos.json;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -129,5 +130,65 @@ public class MesosMasterStateObject {
 
   public List<MesosFrameworkObject> getFrameworks() {
     return frameworks;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    MesosMasterStateObject that = (MesosMasterStateObject) o;
+    return buildTime == that.buildTime &&
+        Double.compare(that.startTime, startTime) == 0 &&
+        Double.compare(that.electedTime, electedTime) == 0 &&
+        activatedSlaves == that.activatedSlaves &&
+        deactivatedSlaves == that.deactivatedSlaves &&
+        Objects.equals(version, that.version) &&
+        Objects.equals(gitSha, that.gitSha) &&
+        Objects.equals(gitTag, that.gitTag) &&
+        Objects.equals(buildDate, that.buildDate) &&
+        Objects.equals(buildUser, that.buildUser) &&
+        Objects.equals(id, that.id) &&
+        Objects.equals(pid, that.pid) &&
+        Objects.equals(hostname, that.hostname) &&
+        Objects.equals(cluster, that.cluster) &&
+        Objects.equals(leader, that.leader) &&
+        Objects.equals(logDir, that.logDir) &&
+        Objects.equals(flags, that.flags) &&
+        Objects.equals(slaves, that.slaves) &&
+        Objects.equals(frameworks, that.frameworks);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(version, gitSha, gitTag, buildDate, buildTime, buildUser, startTime, electedTime, id, pid, hostname, activatedSlaves, deactivatedSlaves, cluster, leader, logDir, flags, slaves, frameworks);
+  }
+
+  @Override
+  public String toString() {
+    return "MesosMasterStateObject{" +
+        "version='" + version + '\'' +
+        ", gitSha='" + gitSha + '\'' +
+        ", gitTag='" + gitTag + '\'' +
+        ", buildDate='" + buildDate + '\'' +
+        ", buildTime=" + buildTime +
+        ", buildUser='" + buildUser + '\'' +
+        ", startTime=" + startTime +
+        ", electedTime=" + electedTime +
+        ", id='" + id + '\'' +
+        ", pid='" + pid + '\'' +
+        ", hostname='" + hostname + '\'' +
+        ", activatedSlaves=" + activatedSlaves +
+        ", deactivatedSlaves=" + deactivatedSlaves +
+        ", cluster='" + cluster + '\'' +
+        ", leader='" + leader + '\'' +
+        ", logDir='" + logDir + '\'' +
+        ", flags=" + flags +
+        ", slaves=" + slaves +
+        ", frameworks=" + frameworks +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosResourcesObject.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosResourcesObject.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 
@@ -74,18 +73,18 @@ public class MesosResourcesObject {
       return false;
     }
     MesosResourcesObject that = (MesosResourcesObject) o;
-    return Objects.equal(properties, that.properties);
+    return java.util.Objects.equals(properties, that.properties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(properties);
+    return java.util.Objects.hash(properties);
   }
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("properties", properties)
-      .toString();
+    return "MesosResourcesObject{" +
+        "properties=" + properties +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosSlaveFrameworkObject.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosSlaveFrameworkObject.java
@@ -1,6 +1,7 @@
 package com.hubspot.mesos.json;
 
 import java.util.List;
+import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -30,4 +31,31 @@ public class MesosSlaveFrameworkObject {
     return executors;
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    MesosSlaveFrameworkObject that = (MesosSlaveFrameworkObject) o;
+    return Objects.equals(executors, that.executors) &&
+        Objects.equals(completedExecutors, that.completedExecutors) &&
+        Objects.equals(id, that.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(executors, completedExecutors, id);
+  }
+
+  @Override
+  public String toString() {
+    return "MesosSlaveFrameworkObject{" +
+        "executors=" + executors +
+        ", completedExecutors=" + completedExecutors +
+        ", id='" + id + '\'' +
+        '}';
+  }
 }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosSlaveStateObject.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosSlaveStateObject.java
@@ -1,6 +1,7 @@
 package com.hubspot.mesos.json;
 
 import java.util.List;
+import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -96,5 +97,51 @@ public class MesosSlaveStateObject {
 
   public int getStagedTasks() {
     return stagedTasks;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    MesosSlaveStateObject that = (MesosSlaveStateObject) o;
+    return startTime == that.startTime &&
+        finishedTasks == that.finishedTasks &&
+        lostTasks == that.lostTasks &&
+        startedTasks == that.startedTasks &&
+        failedTasks == that.failedTasks &&
+        killedTasks == that.killedTasks &&
+        stagedTasks == that.stagedTasks &&
+        Objects.equals(id, that.id) &&
+        Objects.equals(pid, that.pid) &&
+        Objects.equals(hostname, that.hostname) &&
+        Objects.equals(resources, that.resources) &&
+        Objects.equals(frameworks, that.frameworks);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, pid, hostname, startTime, resources, frameworks, finishedTasks, lostTasks, startedTasks, failedTasks, killedTasks, stagedTasks);
+  }
+
+  @Override
+  public String toString() {
+    return "MesosSlaveStateObject{" +
+        "id='" + id + '\'' +
+        ", pid='" + pid + '\'' +
+        ", hostname='" + hostname + '\'' +
+        ", startTime=" + startTime +
+        ", resources=" + resources +
+        ", frameworks=" + frameworks +
+        ", finishedTasks=" + finishedTasks +
+        ", lostTasks=" + lostTasks +
+        ", startedTasks=" + startedTasks +
+        ", failedTasks=" + failedTasks +
+        ", killedTasks=" + killedTasks +
+        ", stagedTasks=" + stagedTasks +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosTaskMonitorObject.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosTaskMonitorObject.java
@@ -45,7 +45,12 @@ public class MesosTaskMonitorObject {
 
   @Override
   public String toString() {
-    return "MesosTaskMonitorObject [executorId=" + executorId + ", executorName=" + executorName + ", frameworkId=" + frameworkId + ", source=" + source + ", statistics=" + statistics + "]";
+    return "MesosTaskMonitorObject{" +
+        "executorId='" + executorId + '\'' +
+        ", executorName='" + executorName + '\'' +
+        ", frameworkId='" + frameworkId + '\'' +
+        ", source='" + source + '\'' +
+        ", statistics=" + statistics +
+        '}';
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosTaskObject.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosTaskObject.java
@@ -1,11 +1,9 @@
 package com.hubspot.mesos.json;
 
-import java.util.List;
+import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
-import com.hubspot.mesos.SingularityMesosTaskLabel;
 
 public class MesosTaskObject {
 
@@ -58,15 +56,38 @@ public class MesosTaskObject {
   }
 
   @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    MesosTaskObject that = (MesosTaskObject) o;
+    return Objects.equals(resources, that.resources) &&
+        Objects.equals(state, that.state) &&
+        Objects.equals(id, that.id) &&
+        Objects.equals(name, that.name) &&
+        Objects.equals(slaveId, that.slaveId) &&
+        Objects.equals(frameworkId, that.frameworkId) &&
+        Objects.equals(executorId, that.executorId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(resources, state, id, name, slaveId, frameworkId, executorId);
+  }
+
+  @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("resources", resources)
-      .add("state", state)
-      .add("id", id)
-      .add("name", name)
-      .add("slaveId", slaveId)
-      .add("frameworkId", frameworkId)
-      .add("executorId", executorId)
-      .toString();
+    return "MesosTaskObject{" +
+        "resources=" + resources +
+        ", state='" + state + '\'' +
+        ", id='" + id + '\'' +
+        ", name='" + name + '\'' +
+        ", slaveId='" + slaveId + '\'' +
+        ", frameworkId='" + frameworkId + '\'' +
+        ", executorId='" + executorId + '\'' +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosTaskStatisticsObject.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosTaskStatisticsObject.java
@@ -94,7 +94,7 @@ public class MesosTaskStatisticsObject {
 
   @Override
   public String toString() {
-    return "MesosTaskStatisticsObject [" +
+    return "MesosTaskStatisticsObject{" +
         "cpusLimit=" + cpusLimit +
         ", cpusNrPeriods=" + cpusNrPeriods +
         ", cpusNrThrottled=" + cpusNrThrottled +
@@ -107,6 +107,6 @@ public class MesosTaskStatisticsObject {
         ", memMappedFileBytes=" + memMappedFileBytes +
         ", memRssBytes=" + memRssBytes +
         ", timestamp=" + timestamp +
-        ']';
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityClientCredentials.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityClientCredentials.java
@@ -4,7 +4,6 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.hubspot.mesos.JavaUtils;
 
 public class SingularityClientCredentials {
   private final String headerName;
@@ -25,14 +24,6 @@ public class SingularityClientCredentials {
   }
 
   @Override
-  public String toString() {
-    return "SingularityClientCredentials[" +
-            "headerName='" + headerName + '\'' +
-            ", token='" + JavaUtils.obfuscateValue(token) + '\'' +
-            ']';
-  }
-
-  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;
@@ -42,11 +33,19 @@ public class SingularityClientCredentials {
     }
     SingularityClientCredentials that = (SingularityClientCredentials) o;
     return Objects.equals(headerName, that.headerName) &&
-            Objects.equals(token, that.token);
+        Objects.equals(token, that.token);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(headerName, token);
+  }
+
+  @Override
+  public String toString() {
+    return "SingularityClientCredentials{" +
+        "headerName='" + headerName + '\'' +
+        ", token='" + token + '\'' +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeploy.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeploy.java
@@ -11,7 +11,6 @@ import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.hubspot.deploy.ExecutorData;
 import com.hubspot.deploy.HealthcheckOptions;
@@ -532,54 +531,54 @@ public class SingularityDeploy {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("requestId", requestId)
-      .add("id", id)
-      .add("version", version)
-      .add("timestamp", timestamp)
-      .add("metadata", metadata)
-      .add("containerInfo", containerInfo)
-      .add("customExecutorCmd", customExecutorCmd)
-      .add("customExecutorId", customExecutorId)
-      .add("customExecutorSource", customExecutorSource)
-      .add("customExecutorResources", customExecutorResources)
-      .add("resources", resources)
-      .add("command", command)
-      .add("arguments", arguments)
-      .add("env", env)
-      .add("uris", uris)
-      .add("executorData", executorData)
-      .add("labels", labels)
-      .add("mesosLabels", mesosLabels)
-      .add("taskLabels", taskLabels)
-      .add("mesosTaskLabels", mesosTaskLabels)
-      .add("taskEnv", taskEnv)
-      .add("healthcheckUri", healthcheckUri)
-      .add("healthcheckIntervalSeconds", healthcheckIntervalSeconds)
-      .add("healthcheckTimeoutSeconds", healthcheckTimeoutSeconds)
-      .add("healthcheckPortIndex", healthcheckPortIndex)
-      .add("healthcheckProtocol", healthcheckProtocol)
-      .add("healthcheckMaxRetries", healthcheckMaxRetries)
-      .add("healthcheckMaxTotalTimeoutSeconds", healthcheckMaxTotalTimeoutSeconds)
-      .add("healthcheck", healthcheck)
-      .add("skipHealthchecksOnDeploy", skipHealthchecksOnDeploy)
-      .add("deployHealthTimeoutSeconds", deployHealthTimeoutSeconds)
-      .add("considerHealthyAfterRunningForSeconds", considerHealthyAfterRunningForSeconds)
-      .add("serviceBasePath", serviceBasePath)
-      .add("loadBalancerGroups", loadBalancerGroups)
-      .add("loadBalancerPortIndex", loadBalancerPortIndex)
-      .add("loadBalancerOptions", loadBalancerOptions)
-      .add("loadBalancerDomains", loadBalancerDomains)
-      .add("loadBalancerAdditionalRoutes", loadBalancerAdditionalRoutes)
-      .add("loadBalancerTemplate", loadBalancerTemplate)
-      .add("loadBalancerServiceIdOverride", loadBalancerServiceIdOverride)
-      .add("loadBalancerUpstreamGroup", loadBalancerUpstreamGroup)
-      .add("deployInstanceCountPerStep", deployInstanceCountPerStep)
-      .add("deployStepWaitTimeMs", deployStepWaitTimeMs)
-      .add("autoAdvanceDeploySteps", autoAdvanceDeploySteps)
-      .add("maxTaskRetries", maxTaskRetries)
-      .add("shell", shell)
-      .add("user", user)
-      .toString();
+    return "SingularityDeploy{" +
+        "requestId='" + requestId + '\'' +
+        ", id='" + id + '\'' +
+        ", version=" + version +
+        ", timestamp=" + timestamp +
+        ", metadata=" + metadata +
+        ", containerInfo=" + containerInfo +
+        ", customExecutorCmd=" + customExecutorCmd +
+        ", customExecutorId=" + customExecutorId +
+        ", customExecutorSource=" + customExecutorSource +
+        ", customExecutorResources=" + customExecutorResources +
+        ", resources=" + resources +
+        ", command=" + command +
+        ", arguments=" + arguments +
+        ", env=" + env +
+        ", uris=" + uris +
+        ", executorData=" + executorData +
+        ", labels=" + labels +
+        ", mesosLabels=" + mesosLabels +
+        ", taskLabels=" + taskLabels +
+        ", mesosTaskLabels=" + mesosTaskLabels +
+        ", taskEnv=" + taskEnv +
+        ", healthcheckUri=" + healthcheckUri +
+        ", healthcheckIntervalSeconds=" + healthcheckIntervalSeconds +
+        ", healthcheckTimeoutSeconds=" + healthcheckTimeoutSeconds +
+        ", healthcheckPortIndex=" + healthcheckPortIndex +
+        ", healthcheckProtocol=" + healthcheckProtocol +
+        ", healthcheckMaxRetries=" + healthcheckMaxRetries +
+        ", healthcheckMaxTotalTimeoutSeconds=" + healthcheckMaxTotalTimeoutSeconds +
+        ", healthcheck=" + healthcheck +
+        ", skipHealthchecksOnDeploy=" + skipHealthchecksOnDeploy +
+        ", deployHealthTimeoutSeconds=" + deployHealthTimeoutSeconds +
+        ", considerHealthyAfterRunningForSeconds=" + considerHealthyAfterRunningForSeconds +
+        ", serviceBasePath=" + serviceBasePath +
+        ", loadBalancerGroups=" + loadBalancerGroups +
+        ", loadBalancerPortIndex=" + loadBalancerPortIndex +
+        ", loadBalancerOptions=" + loadBalancerOptions +
+        ", loadBalancerDomains=" + loadBalancerDomains +
+        ", loadBalancerAdditionalRoutes=" + loadBalancerAdditionalRoutes +
+        ", loadBalancerTemplate=" + loadBalancerTemplate +
+        ", loadBalancerServiceIdOverride=" + loadBalancerServiceIdOverride +
+        ", loadBalancerUpstreamGroup=" + loadBalancerUpstreamGroup +
+        ", deployInstanceCountPerStep=" + deployInstanceCountPerStep +
+        ", deployStepWaitTimeMs=" + deployStepWaitTimeMs +
+        ", autoAdvanceDeploySteps=" + autoAdvanceDeploySteps +
+        ", maxTaskRetries=" + maxTaskRetries +
+        ", shell=" + shell +
+        ", user=" + user +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeployBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeployBuilder.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.hubspot.deploy.ExecutorData;
 import com.hubspot.deploy.HealthcheckOptions;
@@ -583,57 +582,56 @@ public class SingularityDeployBuilder {
     return this;
   }
 
-
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("requestId", requestId)
-      .add("id", id)
-      .add("version", version)
-      .add("timestamp", timestamp)
-      .add("metadata", metadata)
-      .add("containerInfo", containerInfo)
-      .add("customExecutorCmd", customExecutorCmd)
-      .add("customExecutorId", customExecutorId)
-      .add("customExecutorSource", customExecutorSource)
-      .add("customExecutorResources", customExecutorResources)
-      .add("resources", resources)
-      .add("command", command)
-      .add("arguments", arguments)
-      .add("env", env)
-      .add("taskEnv", taskEnv)
-      .add("uris", uris)
-      .add("executorData", executorData)
-      .add("labels", labels)
-      .add("mesosLabels", mesosLabels)
-      .add("taskLabels", taskLabels)
-      .add("mesosTaskLabels", mesosTaskLabels)
-      .add("healthcheckUri", healthcheckUri)
-      .add("healthcheckIntervalSeconds", healthcheckIntervalSeconds)
-      .add("healthcheckTimeoutSeconds", healthcheckTimeoutSeconds)
-      .add("healthcheckPortIndex", healthcheckPortIndex)
-      .add("healthcheckProtocol", healthcheckProtocol)
-      .add("healthcheckMaxRetries", healthcheckMaxRetries)
-      .add("healthcheckMaxTotalTimeoutSeconds", healthcheckMaxTotalTimeoutSeconds)
-      .add("skipHealthchecksOnDeploy", skipHealthchecksOnDeploy)
-      .add("healthcheck", healthcheck)
-      .add("deployHealthTimeoutSeconds", deployHealthTimeoutSeconds)
-      .add("considerHealthyAfterRunningForSeconds", considerHealthyAfterRunningForSeconds)
-      .add("serviceBasePath", serviceBasePath)
-      .add("loadBalancerGroups", loadBalancerGroups)
-      .add("loadBalancerPortIndex", loadBalancerPortIndex)
-      .add("loadBalancerOptions", loadBalancerOptions)
-      .add("loadBalancerDomains", loadBalancerDomains)
-      .add("loadBalancerAdditionalRoutes", loadBalancerAdditionalRoutes)
-      .add("loadBalancerTemplate", loadBalancerTemplate)
-      .add("loadBalancerServiceIdOverride", loadBalancerServiceIdOverride)
-      .add("loadBalancerUpstreamGroup", loadBalancerUpstreamGroup)
-      .add("deployInstanceCountPerStep", deployInstanceCountPerStep)
-      .add("deployStepWaitTimeMs", deployStepWaitTimeMs)
-      .add("autoAdvanceDeploySteps", autoAdvanceDeploySteps)
-      .add("maxTaskRetries", maxTaskRetries)
-      .add("shell", shell)
-      .add("user", user)
-      .toString();
+    return "SingularityDeployBuilder{" +
+        "requestId='" + requestId + '\'' +
+        ", id='" + id + '\'' +
+        ", version=" + version +
+        ", timestamp=" + timestamp +
+        ", metadata=" + metadata +
+        ", containerInfo=" + containerInfo +
+        ", customExecutorCmd=" + customExecutorCmd +
+        ", customExecutorId=" + customExecutorId +
+        ", customExecutorSource=" + customExecutorSource +
+        ", customExecutorResources=" + customExecutorResources +
+        ", resources=" + resources +
+        ", command=" + command +
+        ", arguments=" + arguments +
+        ", env=" + env +
+        ", taskEnv=" + taskEnv +
+        ", uris=" + uris +
+        ", executorData=" + executorData +
+        ", labels=" + labels +
+        ", mesosLabels=" + mesosLabels +
+        ", taskLabels=" + taskLabels +
+        ", mesosTaskLabels=" + mesosTaskLabels +
+        ", healthcheckUri=" + healthcheckUri +
+        ", healthcheckIntervalSeconds=" + healthcheckIntervalSeconds +
+        ", healthcheckTimeoutSeconds=" + healthcheckTimeoutSeconds +
+        ", healthcheckPortIndex=" + healthcheckPortIndex +
+        ", healthcheckProtocol=" + healthcheckProtocol +
+        ", healthcheckMaxRetries=" + healthcheckMaxRetries +
+        ", healthcheckMaxTotalTimeoutSeconds=" + healthcheckMaxTotalTimeoutSeconds +
+        ", skipHealthchecksOnDeploy=" + skipHealthchecksOnDeploy +
+        ", healthcheck=" + healthcheck +
+        ", deployHealthTimeoutSeconds=" + deployHealthTimeoutSeconds +
+        ", considerHealthyAfterRunningForSeconds=" + considerHealthyAfterRunningForSeconds +
+        ", serviceBasePath=" + serviceBasePath +
+        ", loadBalancerGroups=" + loadBalancerGroups +
+        ", loadBalancerPortIndex=" + loadBalancerPortIndex +
+        ", loadBalancerOptions=" + loadBalancerOptions +
+        ", loadBalancerDomains=" + loadBalancerDomains +
+        ", loadBalancerAdditionalRoutes=" + loadBalancerAdditionalRoutes +
+        ", loadBalancerTemplate=" + loadBalancerTemplate +
+        ", loadBalancerServiceIdOverride=" + loadBalancerServiceIdOverride +
+        ", loadBalancerUpstreamGroup=" + loadBalancerUpstreamGroup +
+        ", deployInstanceCountPerStep=" + deployInstanceCountPerStep +
+        ", deployStepWaitTimeMs=" + deployStepWaitTimeMs +
+        ", autoAdvanceDeploySteps=" + autoAdvanceDeploySteps +
+        ", maxTaskRetries=" + maxTaskRetries +
+        ", shell=" + shell +
+        ", user=" + user +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeployHistory.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeployHistory.java
@@ -1,9 +1,10 @@
 package com.hubspot.singularity;
 
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 
 public class SingularityDeployHistory implements Comparable<SingularityDeployHistory>, SingularityHistoryItem {
@@ -25,27 +26,6 @@ public class SingularityDeployHistory implements Comparable<SingularityDeployHis
   @Override
   public int compareTo(SingularityDeployHistory o) {
     return o.getDeployMarker().compareTo(getDeployMarker());
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hashCode(deployResult, deployMarker, deploy, deployStatistics);
-  }
-
-  @Override
-  public boolean equals(Object other) {
-    if (other == this) {
-      return true;
-    }
-    if (other == null || other.getClass() != this.getClass()) {
-      return false;
-    }
-
-    SingularityDeployHistory that = (SingularityDeployHistory) other;
-    return Objects.equal(this.deployResult, that.deployResult)
-        && Objects.equal(this.deployMarker, that.deployMarker)
-        && Objects.equal(this.deploy, that.deploy)
-        && Objects.equal(this.deployStatistics, that.deployStatistics);
   }
 
   public Optional<SingularityDeployResult> getDeployResult() {
@@ -71,8 +51,32 @@ public class SingularityDeployHistory implements Comparable<SingularityDeployHis
   }
 
   @Override
-  public String toString() {
-    return "SingularityDeployHistory [deployResult=" + deployResult + ", deployMarker=" + deployMarker + ", deploy=" + deploy + ", deployStatistics=" + deployStatistics + "]";
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SingularityDeployHistory that = (SingularityDeployHistory) o;
+    return Objects.equals(deployResult, that.deployResult) &&
+        Objects.equals(deployMarker, that.deployMarker) &&
+        Objects.equals(deploy, that.deploy) &&
+        Objects.equals(deployStatistics, that.deployStatistics);
   }
 
+  @Override
+  public int hashCode() {
+    return Objects.hash(deployResult, deployMarker, deploy, deployStatistics);
+  }
+
+  @Override
+  public String toString() {
+    return "SingularityDeployHistory{" +
+        "deployResult=" + deployResult +
+        ", deployMarker=" + deployMarker +
+        ", deploy=" + deploy +
+        ", deployStatistics=" + deployStatistics +
+        '}';
+  }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeployMarker.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeployMarker.java
@@ -34,37 +34,21 @@ public class SingularityDeployMarker implements Comparable<SingularityDeployMark
   }
 
   @Override
-  public int hashCode() {
-    return Objects.hash(requestId, deployId);
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SingularityDeployMarker that = (SingularityDeployMarker) o;
+    return Objects.equals(requestId, that.requestId) &&
+        Objects.equals(deployId, that.deployId);
   }
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    SingularityDeployMarker other = (SingularityDeployMarker) obj;
-    if (deployId == null) {
-      if (other.deployId != null) {
-        return false;
-      }
-    } else if (!deployId.equals(other.deployId)) {
-      return false;
-    }
-    if (requestId == null) {
-      if (other.requestId != null) {
-        return false;
-      }
-    } else if (!requestId.equals(other.requestId)) {
-      return false;
-    }
-    return true;
+  public int hashCode() {
+    return Objects.hash(requestId, deployId);
   }
 
   public String getRequestId() {
@@ -89,7 +73,12 @@ public class SingularityDeployMarker implements Comparable<SingularityDeployMark
 
   @Override
   public String toString() {
-    return "SingularityDeployMarker [requestId=" + requestId + ", deployId=" + deployId + ", timestamp=" + timestamp + ", user=" + user + ", message=" + message + "]";
+    return "SingularityDeployMarker{" +
+        "requestId='" + requestId + '\'' +
+        ", deployId='" + deployId + '\'' +
+        ", timestamp=" + timestamp +
+        ", user=" + user +
+        ", message=" + message +
+        '}';
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeployResult.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeployResult.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 
 public class SingularityDeployResult {
@@ -39,7 +38,7 @@ public class SingularityDeployResult {
     this.deployState = deployState;
     this.lbUpdate = lbUpdate;
     this.message = message;
-    this.deployFailures = Objects.firstNonNull(deployFailures, Collections.<SingularityDeployFailure> emptyList());
+    this.deployFailures = deployFailures != null ? deployFailures : Collections.<SingularityDeployFailure> emptyList();
     this.timestamp = timestamp;
   }
 
@@ -65,7 +64,12 @@ public class SingularityDeployResult {
 
   @Override
   public String toString() {
-    return "SingularityDeployResult [deployState=" + deployState + ", lbUpdate=" + lbUpdate + ", message=" + message + ", deployFailures=" + deployFailures + ", timestamp=" + timestamp + "]";
+    return "SingularityDeployResult{" +
+        "deployState=" + deployState +
+        ", lbUpdate=" + lbUpdate +
+        ", message=" + message +
+        ", deployFailures=" + deployFailures +
+        ", timestamp=" + timestamp +
+        '}';
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeployStatistics.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeployStatistics.java
@@ -96,9 +96,17 @@ public class SingularityDeployStatistics {
 
   @Override
   public String toString() {
-    return "SingularityDeployStatistics [requestId=" + requestId + ", deployId=" + deployId + ", numTasks=" + numTasks + ", numSuccess=" + numSuccess + ", numFailures=" + numFailures
-        + ", numSequentialRetries=" + numSequentialRetries + ", instanceSequentialFailureTimestamps=" + instanceSequentialFailureTimestamps + ", lastFinishAt=" + lastFinishAt + ", lastTaskState="
-        + lastTaskState + ", averageRuntimeMillis=" + averageRuntimeMillis + "]";
+    return "SingularityDeployStatistics{" +
+        "requestId='" + requestId + '\'' +
+        ", deployId='" + deployId + '\'' +
+        ", numTasks=" + numTasks +
+        ", numSuccess=" + numSuccess +
+        ", numFailures=" + numFailures +
+        ", numSequentialRetries=" + numSequentialRetries +
+        ", instanceSequentialFailureTimestamps=" + instanceSequentialFailureTimestamps +
+        ", lastFinishAt=" + lastFinishAt +
+        ", lastTaskState=" + lastTaskState +
+        ", averageRuntimeMillis=" + averageRuntimeMillis +
+        '}';
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeployStatisticsBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeployStatisticsBuilder.java
@@ -117,11 +117,17 @@ public class SingularityDeployStatisticsBuilder {
 
   @Override
   public String toString() {
-    return "SingularityDeployStatisticsBuilder [requestId=" + requestId + ", deployId=" + deployId + ", numTasks=" + numTasks + ", numSuccess=" + numSuccess + ", numFailures=" + numFailures
-        + ", numSequentialRetries=" + numSequentialRetries + ", instanceSequentialFailureTimestamps=" + instanceSequentialFailureTimestamps + ", lastFinishAt=" + lastFinishAt + ", lastTaskState="
-        + lastTaskState + ", averageRuntimeMillis=" + averageRuntimeMillis + "]";
+    return "SingularityDeployStatisticsBuilder{" +
+        "requestId='" + requestId + '\'' +
+        ", deployId='" + deployId + '\'' +
+        ", numTasks=" + numTasks +
+        ", numSuccess=" + numSuccess +
+        ", numFailures=" + numFailures +
+        ", numSequentialRetries=" + numSequentialRetries +
+        ", instanceSequentialFailureTimestamps=" + instanceSequentialFailureTimestamps +
+        ", lastFinishAt=" + lastFinishAt +
+        ", lastTaskState=" + lastTaskState +
+        ", averageRuntimeMillis=" + averageRuntimeMillis +
+        '}';
   }
-
-
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeployUpdate.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeployUpdate.java
@@ -41,7 +41,11 @@ public class SingularityDeployUpdate {
 
   @Override
   public String toString() {
-    return "SingularityDeployWebhook [deployMarker=" + deployMarker + ", deploy=" + deploy + ", eventType=" + eventType + ", deployResult=" + deployResult + "]";
+    return "SingularityDeployUpdate{" +
+        "deployMarker=" + deployMarker +
+        ", deploy=" + deploy +
+        ", eventType=" + eventType +
+        ", deployResult=" + deployResult +
+        '}';
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDisabledAction.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDisabledAction.java
@@ -1,8 +1,9 @@
 package com.hubspot.singularity;
 
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 
 public class SingularityDisabledAction {
@@ -52,25 +53,25 @@ public class SingularityDisabledAction {
     }
     SingularityDisabledAction that = (SingularityDisabledAction) o;
     return automaticallyClearable == that.automaticallyClearable &&
-      type == that.type &&
-      Objects.equal(message, that.message) &&
-      Objects.equal(user, that.user) &&
-      Objects.equal(expiresAt, that.expiresAt);
+        type == that.type &&
+        Objects.equals(message, that.message) &&
+        Objects.equals(user, that.user) &&
+        Objects.equals(expiresAt, that.expiresAt);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(type, message, user, automaticallyClearable, expiresAt);
+    return Objects.hash(type, message, user, automaticallyClearable, expiresAt);
   }
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("type", type)
-      .add("message", message)
-      .add("user", user)
-      .add("automaticallyClearable", automaticallyClearable)
-      .add("expiresAt", expiresAt)
-      .toString();
+    return "SingularityDisabledAction{" +
+        "type=" + type +
+        ", message='" + message + '\'' +
+        ", user=" + user +
+        ", automaticallyClearable=" + automaticallyClearable +
+        ", expiresAt=" + expiresAt +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDisaster.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDisaster.java
@@ -1,8 +1,9 @@
 package com.hubspot.singularity;
 
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 
 public class SingularityDisaster {
   private final SingularityDisasterType type;
@@ -32,19 +33,19 @@ public class SingularityDisaster {
     }
     SingularityDisaster that = (SingularityDisaster) o;
     return active == that.active &&
-      type == that.type;
+        type == that.type;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(type, active);
+    return Objects.hash(type, active);
   }
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("type", type)
-      .add("active", active)
-      .toString();
+    return "SingularityDisaster{" +
+        "type=" + type +
+        ", active=" + active +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDisasterDataPoint.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDisasterDataPoint.java
@@ -1,8 +1,9 @@
 package com.hubspot.singularity;
 
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 import com.google.common.primitives.Longs;
 
 public class SingularityDisasterDataPoint implements Comparable<SingularityDisasterDataPoint> {
@@ -76,32 +77,32 @@ public class SingularityDisasterDataPoint implements Comparable<SingularityDisas
     }
     SingularityDisasterDataPoint that = (SingularityDisasterDataPoint) o;
     return timestamp == that.timestamp &&
-      numActiveTasks == that.numActiveTasks &&
-      numPendingTasks == that.numPendingTasks &&
-      numLateTasks == that.numLateTasks &&
-      avgTaskLagMillis == that.avgTaskLagMillis &&
-      numLostTasks == that.numLostTasks &&
-      numActiveSlaves == that.numActiveSlaves &&
-      numLostSlaves == that.numLostSlaves;
+        numActiveTasks == that.numActiveTasks &&
+        numPendingTasks == that.numPendingTasks &&
+        numLateTasks == that.numLateTasks &&
+        avgTaskLagMillis == that.avgTaskLagMillis &&
+        numLostTasks == that.numLostTasks &&
+        numActiveSlaves == that.numActiveSlaves &&
+        numLostSlaves == that.numLostSlaves;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(timestamp, numActiveTasks, numPendingTasks, numLateTasks, avgTaskLagMillis, numLostTasks, numActiveSlaves, numLostSlaves);
+    return Objects.hash(timestamp, numActiveTasks, numPendingTasks, numLateTasks, avgTaskLagMillis, numLostTasks, numActiveSlaves, numLostSlaves);
   }
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("timestamp", timestamp)
-      .add("numActiveTasks", numActiveTasks)
-      .add("numPendingTasks", numPendingTasks)
-      .add("numLateTasks", numLateTasks)
-      .add("avgTaskLagMillis", avgTaskLagMillis)
-      .add("numLostTasks", numLostTasks)
-      .add("numActiveSlaves", numActiveSlaves)
-      .add("numLostSlaves", numLostSlaves)
-      .toString();
+    return "SingularityDisasterDataPoint{" +
+        "timestamp=" + timestamp +
+        ", numActiveTasks=" + numActiveTasks +
+        ", numPendingTasks=" + numPendingTasks +
+        ", numLateTasks=" + numLateTasks +
+        ", avgTaskLagMillis=" + avgTaskLagMillis +
+        ", numLostTasks=" + numLostTasks +
+        ", numActiveSlaves=" + numActiveSlaves +
+        ", numLostSlaves=" + numLostSlaves +
+        '}';
   }
 
   @Override

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDisasterDataPoints.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDisasterDataPoints.java
@@ -2,10 +2,10 @@ package com.hubspot.singularity;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 
 public class SingularityDisasterDataPoints {
   private final List<SingularityDisasterDataPoint> dataPoints;
@@ -32,18 +32,18 @@ public class SingularityDisasterDataPoints {
       return false;
     }
     SingularityDisasterDataPoints that = (SingularityDisasterDataPoints) o;
-    return Objects.equal(dataPoints, that.dataPoints);
+    return Objects.equals(dataPoints, that.dataPoints);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(dataPoints);
+    return Objects.hash(dataPoints);
   }
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("dataPoints", dataPoints)
-      .toString();
+    return "SingularityDisasterDataPoints{" +
+        "dataPoints=" + dataPoints +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDisastersData.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDisastersData.java
@@ -1,10 +1,10 @@
 package com.hubspot.singularity;
 
 import java.util.List;
+import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 
 public class SingularityDisastersData {
   private final List<SingularityDisasterDataPoint> stats;
@@ -42,21 +42,21 @@ public class SingularityDisastersData {
     }
     SingularityDisastersData that = (SingularityDisastersData) o;
     return automatedActionDisabled == that.automatedActionDisabled &&
-      Objects.equal(stats, that.stats) &&
-      Objects.equal(disasters, that.disasters);
+        Objects.equals(stats, that.stats) &&
+        Objects.equals(disasters, that.disasters);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(stats, disasters, automatedActionDisabled);
+    return Objects.hash(stats, disasters, automatedActionDisabled);
   }
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("stats", stats)
-      .add("disasters", disasters)
-      .add("automatedActionDisabled", automatedActionDisabled)
-      .toString();
+    return "SingularityDisastersData{" +
+        "stats=" + stats +
+        ", disasters=" + disasters +
+        ", automatedActionDisabled=" + automatedActionDisabled +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityHostState.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityHostState.java
@@ -72,8 +72,15 @@ public class SingularityHostState {
 
   @Override
   public String toString() {
-    return "SingularityHostState [master=" + master + ", uptime=" + uptime + ", driverStatus=" + driverStatus + ", millisSinceLastOffer=" + millisSinceLastOffer + ", hostAddress=" + hostAddress + ", hostname=" + hostname + ", mesosMaster="
-        + mesosMaster + ", mesosConnected=" + mesosConnected + "]";
+    return "SingularityHostState{" +
+        "master=" + master +
+        ", uptime=" + uptime +
+        ", driverStatus='" + driverStatus + '\'' +
+        ", millisSinceLastOffer=" + millisSinceLastOffer +
+        ", hostAddress='" + hostAddress + '\'' +
+        ", hostname='" + hostname + '\'' +
+        ", mesosMaster='" + mesosMaster + '\'' +
+        ", mesosConnected=" + mesosConnected +
+        '}';
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityKilledTaskIdRecord.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityKilledTaskIdRecord.java
@@ -51,8 +51,13 @@ public class SingularityKilledTaskIdRecord {
 
   @Override
   public String toString() {
-    return "SingularityKilledTaskIdRecord [taskId=" + taskId + ", originalTimestamp=" + originalTimestamp + ", timestamp=" + timestamp + ", requestCleanupType=" + requestCleanupType + ", taskCleanupType=" + taskCleanupType + ", retries="
-        + retries + "]";
+    return "SingularityKilledTaskIdRecord{" +
+        "taskId=" + taskId +
+        ", originalTimestamp=" + originalTimestamp +
+        ", timestamp=" + timestamp +
+        ", requestCleanupType=" + requestCleanupType +
+        ", taskCleanupType=" + taskCleanupType +
+        ", retries=" + retries +
+        '}';
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityLoadBalancerUpdate.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityLoadBalancerUpdate.java
@@ -63,8 +63,13 @@ public class SingularityLoadBalancerUpdate {
 
   @Override
   public String toString() {
-    return "SingularityLoadBalancerUpdate [loadBalancerState=" + loadBalancerState + ", message=" + message + ", timestamp=" + timestamp + ", uri=" + uri + ", method=" + method
-      + ", loadBalancerRequestId=" + loadBalancerRequestId + "]";
+    return "SingularityLoadBalancerUpdate{" +
+        "loadBalancerState=" + loadBalancerState +
+        ", message=" + message +
+        ", timestamp=" + timestamp +
+        ", uri=" + uri +
+        ", method=" + method +
+        ", loadBalancerRequestId=" + loadBalancerRequestId +
+        '}';
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityMachineStateHistoryUpdate.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityMachineStateHistoryUpdate.java
@@ -1,5 +1,7 @@
 package com.hubspot.singularity;
 
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
@@ -43,62 +45,34 @@ public class SingularityMachineStateHistoryUpdate {
   }
 
   @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((message == null) ? 0 : message.hashCode());
-    result = prime * result + ((objectId == null) ? 0 : objectId.hashCode());
-    result = prime * result + ((state == null) ? 0 : state.hashCode());
-    result = prime * result + (int) (timestamp ^ (timestamp >>> 32));
-    result = prime * result + ((user == null) ? 0 : user.hashCode());
-    return result;
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SingularityMachineStateHistoryUpdate that = (SingularityMachineStateHistoryUpdate) o;
+    return timestamp == that.timestamp &&
+        Objects.equals(objectId, that.objectId) &&
+        state == that.state &&
+        Objects.equals(user, that.user) &&
+        Objects.equals(message, that.message);
   }
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    SingularityMachineStateHistoryUpdate other = (SingularityMachineStateHistoryUpdate) obj;
-    if (message == null) {
-      if (other.message != null) {
-        return false;
-      }
-    } else if (!message.equals(other.message)) {
-      return false;
-    }
-    if (objectId == null) {
-      if (other.objectId != null) {
-        return false;
-      }
-    } else if (!objectId.equals(other.objectId)) {
-      return false;
-    }
-    if (state != other.state) {
-      return false;
-    }
-    if (timestamp != other.timestamp) {
-      return false;
-    }
-    if (user == null) {
-      if (other.user != null) {
-        return false;
-      }
-    } else if (!user.equals(other.user)) {
-      return false;
-    }
-    return true;
+  public int hashCode() {
+    return Objects.hash(objectId, state, user, message, timestamp);
   }
 
   @Override
   public String toString() {
-    return "SingularityMachineStateHistoryUpdate [objectId=" + objectId + ", state=" + state + ", user=" + user + ", message=" + message + ", timestamp=" + timestamp + "]";
+    return "SingularityMachineStateHistoryUpdate{" +
+        "objectId='" + objectId + '\'' +
+        ", state=" + state +
+        ", user=" + user +
+        ", message=" + message +
+        ", timestamp=" + timestamp +
+        '}';
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityPaginatedResponse.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityPaginatedResponse.java
@@ -1,9 +1,8 @@
 package com.hubspot.singularity;
 
-import com.google.common.base.Objects;
-import com.google.common.base.Optional;
-
 import java.util.List;
+
+import com.google.common.base.Optional;
 
 public class SingularityPaginatedResponse<Q> {
 
@@ -37,11 +36,11 @@ public class SingularityPaginatedResponse<Q> {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("dataCount", dataCount)
-      .add("pageCount", pageCount)
-      .add("page", page)
-      .add("objects", objects)
-      .toString();
+    return "SingularityPaginatedResponse{" +
+        "dataCount=" + dataCount +
+        ", pageCount=" + pageCount +
+        ", page=" + page +
+        ", objects=" + objects +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityPendingDeploy.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityPendingDeploy.java
@@ -44,8 +44,12 @@ public class SingularityPendingDeploy {
 
   @Override
   public String toString() {
-    return "SingularityPendingDeploy [deployMarker=" + deployMarker + ", lastLoadBalancerUpdate=" + lastLoadBalancerUpdate + ", currentDeployState=" + currentDeployState + ", deployProgress=" + deployProgress + ", updatedRequest=" + updatedRequest
-      + "]";
+    return "SingularityPendingDeploy{" +
+        "deployMarker=" + deployMarker +
+        ", lastLoadBalancerUpdate=" + lastLoadBalancerUpdate +
+        ", currentDeployState=" + currentDeployState +
+        ", deployProgress=" + deployProgress +
+        ", updatedRequest=" + updatedRequest +
+        '}';
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityPendingRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityPendingRequest.java
@@ -98,8 +98,18 @@ public class SingularityPendingRequest {
 
   @Override
   public String toString() {
-    return "SingularityPendingRequest [requestId=" + requestId + ", deployId=" + deployId + ", timestamp=" + timestamp + ", pendingType=" + pendingType + ", user=" + user + ", cmdLineArgsList="
-        + cmdLineArgsList + ", runId=" + runId + ", skipHealthchecks=" + skipHealthchecks + ", message=" + message + ", actionId=" + actionId + ", resources=" + resources + "]";
+    return "SingularityPendingRequest{" +
+        "requestId='" + requestId + '\'' +
+        ", deployId='" + deployId + '\'' +
+        ", timestamp=" + timestamp +
+        ", pendingType=" + pendingType +
+        ", user=" + user +
+        ", cmdLineArgsList=" + cmdLineArgsList +
+        ", runId=" + runId +
+        ", skipHealthchecks=" + skipHealthchecks +
+        ", message=" + message +
+        ", actionId=" + actionId +
+        ", resources=" + resources +
+        '}';
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityPendingRequestParent.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityPendingRequestParent.java
@@ -35,8 +35,8 @@ public class SingularityPendingRequestParent extends SingularityRequestParent {
 
   @Override
   public String toString() {
-    return "SingularityRequestParent [request=" + getRequest() + ", state=" + getState() + ", requestDeployState=" + getRequestDeployState() + ", activeDeploy=" + getActiveDeploy() + ", pendingDeploy=" + getPendingDeploy() + ", pendingDeployState="
-            + getPendingDeployState() + ", pendingRequest=" + pendingRequest + "]";
+    return "SingularityPendingRequestParent{" +
+        "pendingRequest=" + pendingRequest +
+        "} " + super.toString();
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityPendingTask.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityPendingTask.java
@@ -59,23 +59,20 @@ public class SingularityPendingTask {
   }
 
   @Override
-  public int hashCode() {
-    return Objects.hashCode(pendingTaskId);
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SingularityPendingTask that = (SingularityPendingTask) o;
+    return Objects.equals(pendingTaskId, that.pendingTaskId);
   }
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    SingularityPendingTask other = (SingularityPendingTask) obj;
-    return Objects.equals(pendingTaskId, other.getPendingTaskId());
+  public int hashCode() {
+    return Objects.hash(pendingTaskId);
   }
 
   public Optional<String> getUser() {
@@ -112,8 +109,15 @@ public class SingularityPendingTask {
 
   @Override
   public String toString() {
-    return "SingularityPendingTask [pendingTaskId=" + pendingTaskId + ", cmdLineArgsList=" + cmdLineArgsList + ", user=" + user + ", runId=" + runId + ", skipHealthchecks=" + skipHealthchecks
-        + ", message=" + message + ", resources=" + resources + ", actionId=" + actionId + "]";
+    return "SingularityPendingTask{" +
+        "pendingTaskId=" + pendingTaskId +
+        ", cmdLineArgsList=" + cmdLineArgsList +
+        ", user=" + user +
+        ", runId=" + runId +
+        ", skipHealthchecks=" + skipHealthchecks +
+        ", message=" + message +
+        ", resources=" + resources +
+        ", actionId=" + actionId +
+        '}';
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRack.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRack.java
@@ -35,7 +35,6 @@ public class SingularityRack extends SingularityMachineAbstraction<SingularityRa
 
   @Override
   public String toString() {
-    return "SingularityRack [getId()=" + getId() + ", getFirstSeenAt()=" + getFirstSeenAt() + ", getCurrentState()=" + getCurrentState() + "]";
+    return "SingularityRack{} " + super.toString();
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
@@ -358,43 +358,6 @@ public class SingularityRequest {
   }
 
   @Override
-  public String toString() {
-    return com.google.common.base.Objects.toStringHelper(this)
-      .add("id", id)
-      .add("requestType", requestType)
-      .add("owners", owners)
-      .add("numRetriesOnFailure", numRetriesOnFailure)
-      .add("schedule", schedule)
-      .add("quartzSchedule", quartzSchedule)
-      .add("scheduleType", scheduleType)
-      .add("scheduleTimeZone", scheduleTimeZone)
-      .add("killOldNonLongRunningTasksAfterMillis", killOldNonLongRunningTasksAfterMillis)
-      .add("taskExecutionTimeLimitMillis", taskExecutionTimeLimitMillis)
-      .add("scheduledExpectedRuntimeMillis", scheduledExpectedRuntimeMillis)
-      .add("waitAtLeastMillisAfterTaskFinishesForReschedule", waitAtLeastMillisAfterTaskFinishesForReschedule)
-      .add("instances", instances)
-      .add("skipHealthchecks", skipHealthchecks)
-      .add("rackSensitive", rackSensitive)
-      .add("rackAffinity", rackAffinity)
-      .add("slavePlacement", slavePlacement)
-      .add("requiredSlaveAttributes", requiredSlaveAttributes)
-      .add("allowedSlaveAttributes", allowedSlaveAttributes)
-      .add("loadBalanced", loadBalanced)
-      .add("group", group)
-      .add("readWriteGroups", readWriteGroups)
-      .add("readOnlyGroups", readOnlyGroups)
-      .add("bounceAfterScale", bounceAfterScale)
-      .add("emailConfigurationOverrides", emailConfigurationOverrides)
-      .add("hideEvenNumberAcrossRacksHint", hideEvenNumberAcrossRacksHint)
-      .add("taskLogErrorRegex", taskLogErrorRegex)
-      .add("taskLogErrorRegexCaseSensitive", taskLogErrorRegexCaseSensitive)
-      .add("taskPriorityLevel", taskPriorityLevel)
-      .add("maxTasksPerOffer", maxTasksPerOffer)
-      .add("allowBounceToSameHost", allowBounceToSameHost)
-      .toString();
-  }
-
-  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;
@@ -402,41 +365,81 @@ public class SingularityRequest {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    SingularityRequest request = (SingularityRequest) o;
-    return Objects.equals(id, request.id) &&
-            Objects.equals(requestType, request.requestType) &&
-            Objects.equals(owners, request.owners) &&
-            Objects.equals(numRetriesOnFailure, request.numRetriesOnFailure) &&
-            Objects.equals(schedule, request.schedule) &&
-            Objects.equals(quartzSchedule, request.quartzSchedule) &&
-            Objects.equals(scheduleTimeZone, request.scheduleTimeZone) &&
-            Objects.equals(scheduleType, request.scheduleType) &&
-            Objects.equals(killOldNonLongRunningTasksAfterMillis, request.killOldNonLongRunningTasksAfterMillis) &&
-            Objects.equals(taskExecutionTimeLimitMillis, request.taskExecutionTimeLimitMillis) &&
-            Objects.equals(scheduledExpectedRuntimeMillis, request.scheduledExpectedRuntimeMillis) &&
-            Objects.equals(waitAtLeastMillisAfterTaskFinishesForReschedule, request.waitAtLeastMillisAfterTaskFinishesForReschedule) &&
-            Objects.equals(instances, request.instances) &&
-            Objects.equals(rackSensitive, request.rackSensitive) &&
-            Objects.equals(rackAffinity, request.rackAffinity) &&
-            Objects.equals(slavePlacement, request.slavePlacement) &&
-            Objects.equals(requiredSlaveAttributes, request.requiredSlaveAttributes) &&
-            Objects.equals(allowedSlaveAttributes, request.allowedSlaveAttributes) &&
-            Objects.equals(loadBalanced, request.loadBalanced) &&
-            Objects.equals(group, request.group) &&
-            Objects.equals(readWriteGroups, request.readWriteGroups) &&
-            Objects.equals(readOnlyGroups, request.readOnlyGroups) &&
-            Objects.equals(bounceAfterScale, request.bounceAfterScale) &&
-            Objects.equals(emailConfigurationOverrides, request.emailConfigurationOverrides) &&
-            Objects.equals(hideEvenNumberAcrossRacksHint, request.hideEvenNumberAcrossRacksHint) &&
-            Objects.equals(taskLogErrorRegex, request.taskLogErrorRegex) &&
-            Objects.equals(taskLogErrorRegexCaseSensitive, request.taskLogErrorRegexCaseSensitive) &&
-            Objects.equals(taskPriorityLevel, request.taskPriorityLevel) &&
-            Objects.equals(maxTasksPerOffer, request.maxTasksPerOffer) &&
-            Objects.equals(allowBounceToSameHost, request.allowBounceToSameHost);
+    SingularityRequest that = (SingularityRequest) o;
+    return Objects.equals(id, that.id) &&
+        requestType == that.requestType &&
+        Objects.equals(owners, that.owners) &&
+        Objects.equals(numRetriesOnFailure, that.numRetriesOnFailure) &&
+        Objects.equals(schedule, that.schedule) &&
+        Objects.equals(quartzSchedule, that.quartzSchedule) &&
+        Objects.equals(scheduleType, that.scheduleType) &&
+        Objects.equals(scheduleTimeZone, that.scheduleTimeZone) &&
+        Objects.equals(killOldNonLongRunningTasksAfterMillis, that.killOldNonLongRunningTasksAfterMillis) &&
+        Objects.equals(taskExecutionTimeLimitMillis, that.taskExecutionTimeLimitMillis) &&
+        Objects.equals(scheduledExpectedRuntimeMillis, that.scheduledExpectedRuntimeMillis) &&
+        Objects.equals(waitAtLeastMillisAfterTaskFinishesForReschedule, that.waitAtLeastMillisAfterTaskFinishesForReschedule) &&
+        Objects.equals(instances, that.instances) &&
+        Objects.equals(skipHealthchecks, that.skipHealthchecks) &&
+        Objects.equals(rackSensitive, that.rackSensitive) &&
+        Objects.equals(rackAffinity, that.rackAffinity) &&
+        Objects.equals(slavePlacement, that.slavePlacement) &&
+        Objects.equals(requiredSlaveAttributes, that.requiredSlaveAttributes) &&
+        Objects.equals(allowedSlaveAttributes, that.allowedSlaveAttributes) &&
+        Objects.equals(loadBalanced, that.loadBalanced) &&
+        Objects.equals(group, that.group) &&
+        Objects.equals(requiredRole, that.requiredRole) &&
+        Objects.equals(readWriteGroups, that.readWriteGroups) &&
+        Objects.equals(readOnlyGroups, that.readOnlyGroups) &&
+        Objects.equals(bounceAfterScale, that.bounceAfterScale) &&
+        Objects.equals(emailConfigurationOverrides, that.emailConfigurationOverrides) &&
+        Objects.equals(hideEvenNumberAcrossRacksHint, that.hideEvenNumberAcrossRacksHint) &&
+        Objects.equals(taskLogErrorRegex, that.taskLogErrorRegex) &&
+        Objects.equals(taskLogErrorRegexCaseSensitive, that.taskLogErrorRegexCaseSensitive) &&
+        Objects.equals(taskPriorityLevel, that.taskPriorityLevel) &&
+        Objects.equals(maxTasksPerOffer, that.maxTasksPerOffer) &&
+        Objects.equals(allowBounceToSameHost, that.allowBounceToSameHost);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, requestType, owners, numRetriesOnFailure, schedule, quartzSchedule, scheduleTimeZone, scheduleType, killOldNonLongRunningTasksAfterMillis, taskExecutionTimeLimitMillis, scheduledExpectedRuntimeMillis, waitAtLeastMillisAfterTaskFinishesForReschedule, instances, rackSensitive, rackAffinity, slavePlacement, requiredSlaveAttributes, allowedSlaveAttributes, loadBalanced, group, readWriteGroups, readOnlyGroups, bounceAfterScale, emailConfigurationOverrides, hideEvenNumberAcrossRacksHint, taskLogErrorRegex, taskLogErrorRegexCaseSensitive, taskPriorityLevel, maxTasksPerOffer, allowBounceToSameHost);
+    return Objects.hash(id, requestType, owners, numRetriesOnFailure, schedule, quartzSchedule, scheduleType, scheduleTimeZone, killOldNonLongRunningTasksAfterMillis, taskExecutionTimeLimitMillis, scheduledExpectedRuntimeMillis, waitAtLeastMillisAfterTaskFinishesForReschedule, instances, skipHealthchecks, rackSensitive, rackAffinity, slavePlacement, requiredSlaveAttributes, allowedSlaveAttributes, loadBalanced, group, requiredRole, readWriteGroups, readOnlyGroups, bounceAfterScale, emailConfigurationOverrides, hideEvenNumberAcrossRacksHint, taskLogErrorRegex, taskLogErrorRegexCaseSensitive, taskPriorityLevel, maxTasksPerOffer, allowBounceToSameHost);
+  }
+
+  @Override
+  public String toString() {
+    return "SingularityRequest{" +
+        "id='" + id + '\'' +
+        ", requestType=" + requestType +
+        ", owners=" + owners +
+        ", numRetriesOnFailure=" + numRetriesOnFailure +
+        ", schedule=" + schedule +
+        ", quartzSchedule=" + quartzSchedule +
+        ", scheduleType=" + scheduleType +
+        ", scheduleTimeZone=" + scheduleTimeZone +
+        ", killOldNonLongRunningTasksAfterMillis=" + killOldNonLongRunningTasksAfterMillis +
+        ", taskExecutionTimeLimitMillis=" + taskExecutionTimeLimitMillis +
+        ", scheduledExpectedRuntimeMillis=" + scheduledExpectedRuntimeMillis +
+        ", waitAtLeastMillisAfterTaskFinishesForReschedule=" + waitAtLeastMillisAfterTaskFinishesForReschedule +
+        ", instances=" + instances +
+        ", skipHealthchecks=" + skipHealthchecks +
+        ", rackSensitive=" + rackSensitive +
+        ", rackAffinity=" + rackAffinity +
+        ", slavePlacement=" + slavePlacement +
+        ", requiredSlaveAttributes=" + requiredSlaveAttributes +
+        ", allowedSlaveAttributes=" + allowedSlaveAttributes +
+        ", loadBalanced=" + loadBalanced +
+        ", group=" + group +
+        ", requiredRole=" + requiredRole +
+        ", readWriteGroups=" + readWriteGroups +
+        ", readOnlyGroups=" + readOnlyGroups +
+        ", bounceAfterScale=" + bounceAfterScale +
+        ", emailConfigurationOverrides=" + emailConfigurationOverrides +
+        ", hideEvenNumberAcrossRacksHint=" + hideEvenNumberAcrossRacksHint +
+        ", taskLogErrorRegex=" + taskLogErrorRegex +
+        ", taskLogErrorRegexCaseSensitive=" + taskLogErrorRegexCaseSensitive +
+        ", taskPriorityLevel=" + taskPriorityLevel +
+        ", maxTasksPerOffer=" + maxTasksPerOffer +
+        ", allowBounceToSameHost=" + allowBounceToSameHost +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestBuilder.java
@@ -355,43 +355,6 @@ public class SingularityRequestBuilder {
   }
 
   @Override
-  public String toString() {
-    return "SingularityRequestBuilder[" +
-            "id='" + id + '\'' +
-            ", requestType=" + requestType +
-            ", owners=" + owners +
-            ", numRetriesOnFailure=" + numRetriesOnFailure +
-            ", schedule=" + schedule +
-            ", quartzSchedule=" + quartzSchedule +
-            ", scheduleTimeZone=" + scheduleTimeZone +
-            ", scheduleType=" + scheduleType +
-            ", killOldNonLongRunningTasksAfterMillis=" + killOldNonLongRunningTasksAfterMillis +
-            ", taskExecutionTimeLimitMillis=" + taskExecutionTimeLimitMillis +
-            ", scheduledExpectedRuntimeMillis=" + scheduledExpectedRuntimeMillis +
-            ", waitAtLeastMillisAfterTaskFinishesForReschedule=" + waitAtLeastMillisAfterTaskFinishesForReschedule +
-            ", instances=" + instances +
-            ", rackSensitive=" + rackSensitive +
-            ", rackAffinity=" + rackAffinity +
-            ", slavePlacement=" + slavePlacement +
-            ", requiredSlaveAttrbiutes=" + requiredSlaveAttributes +
-            ", allowedSlaveAttrbiutes=" + allowedSlaveAttributes +
-            ", loadBalanced=" + loadBalanced +
-            ", group=" + group +
-            ", readOnlyGroups=" + readOnlyGroups +
-            ", readWriteGroups=" + readWriteGroups +
-            ", bounceAfterScale=" + bounceAfterScale +
-            ", emailConfigurationOverrides=" + emailConfigurationOverrides +
-            ", skipHealthchecks=" + skipHealthchecks +
-            ", hideEvenNumberAcrossRacksHint=" + hideEvenNumberAcrossRacksHint +
-            ", taskLogErrorRegex=" + taskLogErrorRegex +
-            ", taskLogErrorRegexCaseSensitive=" + taskLogErrorRegexCaseSensitive +
-            ", taskPriorityLevel=" + taskPriorityLevel +
-            ", maxTasksPerOffer=" + maxTasksPerOffer +
-            ", allowBounceToSameHost=" + allowBounceToSameHost +
-            ']';
-  }
-
-  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;
@@ -401,44 +364,79 @@ public class SingularityRequestBuilder {
     }
     SingularityRequestBuilder that = (SingularityRequestBuilder) o;
     return Objects.equals(id, that.id) &&
-            Objects.equals(requestType, that.requestType) &&
-            Objects.equals(owners, that.owners) &&
-            Objects.equals(numRetriesOnFailure, that.numRetriesOnFailure) &&
-            Objects.equals(schedule, that.schedule) &&
-            Objects.equals(quartzSchedule, that.quartzSchedule) &&
-            Objects.equals(scheduleTimeZone, that.scheduleTimeZone) &&
-            Objects.equals(scheduleType, that.scheduleType) &&
-            Objects.equals(killOldNonLongRunningTasksAfterMillis, that.killOldNonLongRunningTasksAfterMillis) &&
-            Objects.equals(taskExecutionTimeLimitMillis, that.taskExecutionTimeLimitMillis) &&
-            Objects.equals(scheduledExpectedRuntimeMillis, that.scheduledExpectedRuntimeMillis) &&
-            Objects.equals(waitAtLeastMillisAfterTaskFinishesForReschedule, that.waitAtLeastMillisAfterTaskFinishesForReschedule) &&
-            Objects.equals(instances, that.instances) &&
-            Objects.equals(rackSensitive, that.rackSensitive) &&
-            Objects.equals(rackAffinity, that.rackAffinity) &&
-            Objects.equals(slavePlacement, that.slavePlacement) &&
-            Objects.equals(requiredSlaveAttributes, that.requiredSlaveAttributes) &&
-            Objects.equals(allowedSlaveAttributes, that.allowedSlaveAttributes) &&
-            Objects.equals(loadBalanced, that.loadBalanced) &&
-            Objects.equals(group, that.group) &&
-            Objects.equals(readOnlyGroups, that.readOnlyGroups) &&
-            Objects.equals(readWriteGroups, that.readWriteGroups) &&
-            Objects.equals(bounceAfterScale, that.bounceAfterScale) &&
-            Objects.equals(skipHealthchecks, that.skipHealthchecks) &&
-            Objects.equals(emailConfigurationOverrides, that.emailConfigurationOverrides) &&
-            Objects.equals(hideEvenNumberAcrossRacksHint, that.hideEvenNumberAcrossRacksHint) &&
-            Objects.equals(taskLogErrorRegex, that.taskLogErrorRegex) &&
-            Objects.equals(taskLogErrorRegexCaseSensitive, that.taskLogErrorRegexCaseSensitive) &&
-            Objects.equals(taskPriorityLevel, that.taskPriorityLevel) &&
-            Objects.equals(maxTasksPerOffer, that.maxTasksPerOffer) &&
-            Objects.equals(allowBounceToSameHost, that.allowBounceToSameHost);
+        requestType == that.requestType &&
+        Objects.equals(owners, that.owners) &&
+        Objects.equals(numRetriesOnFailure, that.numRetriesOnFailure) &&
+        Objects.equals(schedule, that.schedule) &&
+        Objects.equals(quartzSchedule, that.quartzSchedule) &&
+        Objects.equals(scheduleTimeZone, that.scheduleTimeZone) &&
+        Objects.equals(scheduleType, that.scheduleType) &&
+        Objects.equals(killOldNonLongRunningTasksAfterMillis, that.killOldNonLongRunningTasksAfterMillis) &&
+        Objects.equals(taskExecutionTimeLimitMillis, that.taskExecutionTimeLimitMillis) &&
+        Objects.equals(scheduledExpectedRuntimeMillis, that.scheduledExpectedRuntimeMillis) &&
+        Objects.equals(waitAtLeastMillisAfterTaskFinishesForReschedule, that.waitAtLeastMillisAfterTaskFinishesForReschedule) &&
+        Objects.equals(instances, that.instances) &&
+        Objects.equals(skipHealthchecks, that.skipHealthchecks) &&
+        Objects.equals(rackSensitive, that.rackSensitive) &&
+        Objects.equals(rackAffinity, that.rackAffinity) &&
+        Objects.equals(slavePlacement, that.slavePlacement) &&
+        Objects.equals(requiredSlaveAttributes, that.requiredSlaveAttributes) &&
+        Objects.equals(allowedSlaveAttributes, that.allowedSlaveAttributes) &&
+        Objects.equals(loadBalanced, that.loadBalanced) &&
+        Objects.equals(requiredRole, that.requiredRole) &&
+        Objects.equals(group, that.group) &&
+        Objects.equals(readWriteGroups, that.readWriteGroups) &&
+        Objects.equals(readOnlyGroups, that.readOnlyGroups) &&
+        Objects.equals(bounceAfterScale, that.bounceAfterScale) &&
+        Objects.equals(emailConfigurationOverrides, that.emailConfigurationOverrides) &&
+        Objects.equals(hideEvenNumberAcrossRacksHint, that.hideEvenNumberAcrossRacksHint) &&
+        Objects.equals(taskLogErrorRegex, that.taskLogErrorRegex) &&
+        Objects.equals(taskLogErrorRegexCaseSensitive, that.taskLogErrorRegexCaseSensitive) &&
+        Objects.equals(taskPriorityLevel, that.taskPriorityLevel) &&
+        Objects.equals(maxTasksPerOffer, that.maxTasksPerOffer) &&
+        Objects.equals(allowBounceToSameHost, that.allowBounceToSameHost);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, requestType, owners, numRetriesOnFailure, schedule, quartzSchedule, scheduleTimeZone, scheduleType, killOldNonLongRunningTasksAfterMillis,
-        taskExecutionTimeLimitMillis, scheduledExpectedRuntimeMillis, waitAtLeastMillisAfterTaskFinishesForReschedule, instances, rackSensitive, rackAffinity, slavePlacement,
-        requiredSlaveAttributes, allowedSlaveAttributes, loadBalanced, group, readOnlyGroups, readWriteGroups, bounceAfterScale, skipHealthchecks, emailConfigurationOverrides,
-        hideEvenNumberAcrossRacksHint, taskLogErrorRegex, taskLogErrorRegexCaseSensitive, taskPriorityLevel, maxTasksPerOffer, allowBounceToSameHost);
+    return Objects.hash(id, requestType, owners, numRetriesOnFailure, schedule, quartzSchedule, scheduleTimeZone, scheduleType, killOldNonLongRunningTasksAfterMillis, taskExecutionTimeLimitMillis, scheduledExpectedRuntimeMillis, waitAtLeastMillisAfterTaskFinishesForReschedule, instances, skipHealthchecks, rackSensitive, rackAffinity, slavePlacement, requiredSlaveAttributes, allowedSlaveAttributes, loadBalanced, requiredRole, group, readWriteGroups, readOnlyGroups, bounceAfterScale, emailConfigurationOverrides, hideEvenNumberAcrossRacksHint, taskLogErrorRegex, taskLogErrorRegexCaseSensitive, taskPriorityLevel, maxTasksPerOffer, allowBounceToSameHost);
   }
 
+  @Override
+  public String toString() {
+    return "SingularityRequestBuilder{" +
+        "id='" + id + '\'' +
+        ", requestType=" + requestType +
+        ", owners=" + owners +
+        ", numRetriesOnFailure=" + numRetriesOnFailure +
+        ", schedule=" + schedule +
+        ", quartzSchedule=" + quartzSchedule +
+        ", scheduleTimeZone=" + scheduleTimeZone +
+        ", scheduleType=" + scheduleType +
+        ", killOldNonLongRunningTasksAfterMillis=" + killOldNonLongRunningTasksAfterMillis +
+        ", taskExecutionTimeLimitMillis=" + taskExecutionTimeLimitMillis +
+        ", scheduledExpectedRuntimeMillis=" + scheduledExpectedRuntimeMillis +
+        ", waitAtLeastMillisAfterTaskFinishesForReschedule=" + waitAtLeastMillisAfterTaskFinishesForReschedule +
+        ", instances=" + instances +
+        ", skipHealthchecks=" + skipHealthchecks +
+        ", rackSensitive=" + rackSensitive +
+        ", rackAffinity=" + rackAffinity +
+        ", slavePlacement=" + slavePlacement +
+        ", requiredSlaveAttributes=" + requiredSlaveAttributes +
+        ", allowedSlaveAttributes=" + allowedSlaveAttributes +
+        ", loadBalanced=" + loadBalanced +
+        ", requiredRole=" + requiredRole +
+        ", group=" + group +
+        ", readWriteGroups=" + readWriteGroups +
+        ", readOnlyGroups=" + readOnlyGroups +
+        ", bounceAfterScale=" + bounceAfterScale +
+        ", emailConfigurationOverrides=" + emailConfigurationOverrides +
+        ", hideEvenNumberAcrossRacksHint=" + hideEvenNumberAcrossRacksHint +
+        ", taskLogErrorRegex=" + taskLogErrorRegex +
+        ", taskLogErrorRegexCaseSensitive=" + taskLogErrorRegexCaseSensitive +
+        ", taskPriorityLevel=" + taskPriorityLevel +
+        ", maxTasksPerOffer=" + maxTasksPerOffer +
+        ", allowBounceToSameHost=" + allowBounceToSameHost +
+        '}';
+  }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestCleanup.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestCleanup.java
@@ -76,9 +76,17 @@ public class SingularityRequestCleanup {
 
   @Override
   public String toString() {
-    return "SingularityRequestCleanup [user=" + user + ", cleanupType=" + cleanupType + ", killTasks=" + killTasks + ", skipHealthchecks=" + skipHealthchecks + ", deployId=" + deployId
-        + ", timestamp=" + timestamp + ", requestId=" + requestId + ", message=" + message + ", actionId=" + actionId + ", runShellCommandBeforeKill=" + runShellCommandBeforeKill + "]";
+    return "SingularityRequestCleanup{" +
+        "user=" + user +
+        ", cleanupType=" + cleanupType +
+        ", killTasks=" + killTasks +
+        ", skipHealthchecks=" + skipHealthchecks +
+        ", deployId=" + deployId +
+        ", timestamp=" + timestamp +
+        ", requestId='" + requestId + '\'' +
+        ", message=" + message +
+        ", actionId=" + actionId +
+        ", runShellCommandBeforeKill=" + runShellCommandBeforeKill +
+        '}';
   }
-
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestDeployState.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestDeployState.java
@@ -32,7 +32,10 @@ public class SingularityRequestDeployState {
 
   @Override
   public String toString() {
-    return "SingularityRequestDeployState [requestId=" + requestId + ", activeDeploy=" + activeDeploy + ", pendingDeploy=" + pendingDeploy + "]";
+    return "SingularityRequestDeployState{" +
+        "requestId='" + requestId + '\'' +
+        ", activeDeploy=" + activeDeploy +
+        ", pendingDeploy=" + pendingDeploy +
+        '}';
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestHistory.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestHistory.java
@@ -1,9 +1,10 @@
 package com.hubspot.singularity;
 
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.collect.ComparisonChain;
 
@@ -36,28 +37,6 @@ public class SingularityRequestHistory implements Comparable<SingularityRequestH
         .compare(o.getCreatedAt(), createdAt)
         .compare(request.getId(), o.getRequest().getId())
         .result();
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hashCode(createdAt, user, eventType, request, message);
-  }
-
-  @Override
-  public boolean equals(Object other) {
-    if (this == other) {
-      return true;
-    }
-    if (other == null || other.getClass() != this.getClass()) {
-      return false;
-    }
-
-    SingularityRequestHistory that = (SingularityRequestHistory) other;
-    return Objects.equal(this.createdAt, that.createdAt)
-        && Objects.equal(this.user, that.user)
-        && Objects.equal(this.eventType, that.eventType)
-        && Objects.equal(this.request, that.request)
-        && Objects.equal(this.message, that.message);
   }
 
   public long getCreatedAt() {
@@ -93,8 +72,34 @@ public class SingularityRequestHistory implements Comparable<SingularityRequestH
   }
 
   @Override
-  public String toString() {
-    return "SingularityRequestHistory [createdAt=" + createdAt + ", user=" + user + ", eventType=" + eventType + ", request=" + request + ", message=" + message + "]";
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SingularityRequestHistory that = (SingularityRequestHistory) o;
+    return createdAt == that.createdAt &&
+        Objects.equals(user, that.user) &&
+        eventType == that.eventType &&
+        Objects.equals(request, that.request) &&
+        Objects.equals(message, that.message);
   }
 
+  @Override
+  public int hashCode() {
+    return Objects.hash(createdAt, user, eventType, request, message);
+  }
+
+  @Override
+  public String toString() {
+    return "SingularityRequestHistory{" +
+        "createdAt=" + createdAt +
+        ", user=" + user +
+        ", eventType=" + eventType +
+        ", request=" + request +
+        ", message=" + message +
+        '}';
+  }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestParent.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestParent.java
@@ -93,9 +93,17 @@ public class SingularityRequestParent {
 
   @Override
   public String toString() {
-    return "SingularityRequestParent [request=" + request + ", state=" + state + ", requestDeployState=" + requestDeployState + ", activeDeploy=" + activeDeploy + ", pendingDeploy=" + pendingDeploy
-        + ", pendingDeployState=" + pendingDeployState + ", expiringBounce=" + expiringBounce + ", expiringPause=" + expiringPause + ", expiringScale=" + expiringScale + ", expiringSkipHealthchecks="
-        + expiringSkipHealthchecks + "]";
+    return "SingularityRequestParent{" +
+        "request=" + request +
+        ", state=" + state +
+        ", requestDeployState=" + requestDeployState +
+        ", activeDeploy=" + activeDeploy +
+        ", pendingDeploy=" + pendingDeploy +
+        ", pendingDeployState=" + pendingDeployState +
+        ", expiringBounce=" + expiringBounce +
+        ", expiringPause=" + expiringPause +
+        ", expiringScale=" + expiringScale +
+        ", expiringSkipHealthchecks=" + expiringSkipHealthchecks +
+        '}';
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestWithState.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestWithState.java
@@ -54,7 +54,10 @@ public class SingularityRequestWithState {
 
   @Override
   public String toString() {
-    return "SingularityRequestWithState [request=" + request + ", state=" + state + ", timestamp=" + timestamp + "]";
+    return "SingularityRequestWithState{" +
+        "request=" + request +
+        ", state=" + state +
+        ", timestamp=" + timestamp +
+        '}';
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularitySandbox.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularitySandbox.java
@@ -45,6 +45,11 @@ public class SingularitySandbox {
 
   @Override
   public String toString() {
-    return "SingularitySandbox [files=" + files + ", fullPathToRoot=" + fullPathToRoot + ", currentDirectory=" + currentDirectory + ", slaveHostname=" + slaveHostname + "]";
+    return "SingularitySandbox{" +
+        "files=" + files +
+        ", fullPathToRoot='" + fullPathToRoot + '\'' +
+        ", currentDirectory='" + currentDirectory + '\'' +
+        ", slaveHostname='" + slaveHostname + '\'' +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularitySandboxFile.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularitySandboxFile.java
@@ -43,7 +43,11 @@ public class SingularitySandboxFile {
 
   @Override
   public String toString() {
-    return "SingularitySandboxFile [name=" + name + ", mtime=" + mtime + ", size=" + size + ", mode=" + mode + "]";
+    return "SingularitySandboxFile{" +
+        "name='" + name + '\'' +
+        ", mtime=" + mtime +
+        ", size=" + size +
+        ", mode='" + mode + '\'' +
+        '}';
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularitySlave.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularitySlave.java
@@ -5,7 +5,6 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.hubspot.mesos.json.MesosResourcesObject;
 import com.wordnik.swagger.annotations.ApiModel;
@@ -80,11 +79,11 @@ public class SingularitySlave extends SingularityMachineAbstraction<SingularityS
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("host", host)
-      .add("rackId", rackId)
-      .add("attributes", attributes)
-      .add("resources", resources)
-      .toString();
+    return "SingularitySlave{" +
+        "host='" + host + '\'' +
+        ", rackId='" + rackId + '\'' +
+        ", attributes=" + attributes +
+        ", resources=" + resources +
+        "} " + super.toString();
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityState.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityState.java
@@ -246,13 +246,40 @@ public class SingularityState {
 
   @Override
   public String toString() {
-    return "SingularityState [activeTasks=" + activeTasks + ", launchingTasks=" + launchingTasks + ", pausedRequests=" + pausedRequests + ", activeRequests=" + activeRequests + ", cooldownRequests=" + cooldownRequests + ", scheduledTasks=" + scheduledTasks
-        + ", lateTasks=" + lateTasks + ", futureTasks=" + futureTasks + ", cleaningTasks=" + cleaningTasks + ", lbCleanupTasks=" + lbCleanupTasks + ", lbCleanupRequests=" + lbCleanupRequests
-        + ", maxTaskLag=" + maxTaskLag + ", pendingRequests=" + pendingRequests + ", cleaningRequests=" + cleaningRequests + ", finishedRequests=" + finishedRequests + ", activeSlaves="
-        + activeSlaves + ", deadSlaves=" + deadSlaves + ", decommissioningSlaves=" + decommissioningSlaves + ", unknownSlaves=" + unknownSlaves + ", activeRacks=" + activeRacks + ", deadRacks="
-        + deadRacks + ", decommissioningRacks=" + decommissioningRacks + ", unknownRacks=" + unknownRacks + ", oldestDeploy=" + oldestDeploy + ", numDeploys=" + numDeploys + ", generatedAt="
-        + generatedAt + ", hostStates=" + hostStates + ", overProvisionedRequestIds=" + overProvisionedRequestIds + ", underProvisionedRequestIds=" + underProvisionedRequestIds
-        + ", overProvisionedRequests=" + overProvisionedRequests + ", underProvisionedRequests=" + underProvisionedRequests + ", authDatastoreHealthy=" + authDatastoreHealthy + ", minimumPriorityLevel=" + minimumPriorityLevel + "]";
+    return "SingularityState{" +
+        "activeTasks=" + activeTasks +
+        ", launchingTasks=" + launchingTasks +
+        ", pausedRequests=" + pausedRequests +
+        ", activeRequests=" + activeRequests +
+        ", cooldownRequests=" + cooldownRequests +
+        ", scheduledTasks=" + scheduledTasks +
+        ", lateTasks=" + lateTasks +
+        ", futureTasks=" + futureTasks +
+        ", cleaningTasks=" + cleaningTasks +
+        ", lbCleanupTasks=" + lbCleanupTasks +
+        ", lbCleanupRequests=" + lbCleanupRequests +
+        ", maxTaskLag=" + maxTaskLag +
+        ", pendingRequests=" + pendingRequests +
+        ", cleaningRequests=" + cleaningRequests +
+        ", finishedRequests=" + finishedRequests +
+        ", activeSlaves=" + activeSlaves +
+        ", deadSlaves=" + deadSlaves +
+        ", decommissioningSlaves=" + decommissioningSlaves +
+        ", unknownSlaves=" + unknownSlaves +
+        ", activeRacks=" + activeRacks +
+        ", deadRacks=" + deadRacks +
+        ", decommissioningRacks=" + decommissioningRacks +
+        ", unknownRacks=" + unknownRacks +
+        ", oldestDeploy=" + oldestDeploy +
+        ", numDeploys=" + numDeploys +
+        ", generatedAt=" + generatedAt +
+        ", hostStates=" + hostStates +
+        ", overProvisionedRequestIds=" + overProvisionedRequestIds +
+        ", underProvisionedRequestIds=" + underProvisionedRequestIds +
+        ", overProvisionedRequests=" + overProvisionedRequests +
+        ", underProvisionedRequests=" + underProvisionedRequests +
+        ", authDatastoreHealthy=" + authDatastoreHealthy +
+        ", minimumPriorityLevel=" + minimumPriorityLevel +
+        '}';
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskCleanup.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskCleanup.java
@@ -2,7 +2,6 @@ package com.hubspot.singularity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 
 public class SingularityTaskCleanup {
@@ -58,14 +57,14 @@ public class SingularityTaskCleanup {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("user", user)
-      .add("cleanupType", cleanupType)
-      .add("timestamp", timestamp)
-      .add("taskId", taskId)
-      .add("message", message)
-      .add("actionId", actionId)
-      .add("runBeforeKillId", runBeforeKillId)
-      .toString();
+    return "SingularityTaskCleanup{" +
+        "user=" + user +
+        ", cleanupType=" + cleanupType +
+        ", timestamp=" + timestamp +
+        ", taskId=" + taskId +
+        ", message=" + message +
+        ", actionId=" + actionId +
+        ", runBeforeKillId=" + runBeforeKillId +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskCleanupResult.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskCleanupResult.java
@@ -24,6 +24,9 @@ public class SingularityTaskCleanupResult {
 
   @Override
   public String toString() {
-    return "SingularityTaskCleanupResult [result=" + result + ", taskId=" + task.getTaskId() + "]";
+    return "SingularityTaskCleanupResult{" +
+        "result=" + result +
+        ", task=" + task +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskDestroyFrameworkMessage.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskDestroyFrameworkMessage.java
@@ -1,8 +1,9 @@
 package com.hubspot.singularity;
 
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 
 public class SingularityTaskDestroyFrameworkMessage extends SingularityFrameworkMessage {
@@ -32,20 +33,20 @@ public class SingularityTaskDestroyFrameworkMessage extends SingularityFramework
       return false;
     }
     SingularityTaskDestroyFrameworkMessage that = (SingularityTaskDestroyFrameworkMessage) o;
-    return Objects.equal(taskId, that.taskId) &&
-      Objects.equal(user, that.user);
+    return Objects.equals(taskId, that.taskId) &&
+        Objects.equals(user, that.user);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(taskId, user);
+    return Objects.hash(taskId, user);
   }
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("taskId", taskId)
-      .add("user", user)
-      .toString();
+    return "SingularityTaskDestroyFrameworkMessage{" +
+        "taskId=" + taskId +
+        ", user=" + user +
+        "} " + super.toString();
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskHealthcheckResult.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskHealthcheckResult.java
@@ -1,9 +1,10 @@
 package com.hubspot.singularity;
 
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.collect.ComparisonChain;
 import com.hubspot.mesos.JavaUtils;
@@ -48,16 +49,16 @@ public class SingularityTaskHealthcheckResult extends SingularityTaskIdHolder im
     }
     SingularityTaskHealthcheckResult that = (SingularityTaskHealthcheckResult) o;
     return startup == that.startup &&
-      timestamp == that.timestamp &&
-      Objects.equal(statusCode, that.statusCode) &&
-      Objects.equal(durationMillis, that.durationMillis) &&
-      Objects.equal(responseBody, that.responseBody) &&
-      Objects.equal(errorMessage, that.errorMessage);
+        timestamp == that.timestamp &&
+        Objects.equals(statusCode, that.statusCode) &&
+        Objects.equals(durationMillis, that.durationMillis) &&
+        Objects.equals(responseBody, that.responseBody) &&
+        Objects.equals(errorMessage, that.errorMessage);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(statusCode, durationMillis, responseBody, errorMessage, startup, timestamp);
+    return Objects.hash(statusCode, durationMillis, responseBody, errorMessage, startup, timestamp);
   }
 
   public Optional<Integer> getStatusCode() {
@@ -91,13 +92,13 @@ public class SingularityTaskHealthcheckResult extends SingularityTaskIdHolder im
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("statusCode", statusCode)
-      .add("durationMillis", durationMillis)
-      .add("responseBody", responseBody)
-      .add("errorMessage", errorMessage)
-      .add("startup", startup)
-      .add("timestamp", timestamp)
-      .toString();
+    return "SingularityTaskHealthcheckResult{" +
+        "statusCode=" + statusCode +
+        ", durationMillis=" + durationMillis +
+        ", responseBody=" + responseBody +
+        ", errorMessage=" + errorMessage +
+        ", startup=" + startup +
+        ", timestamp=" + timestamp +
+        "} " + super.toString();
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskHistory.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskHistory.java
@@ -5,7 +5,6 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.hubspot.mesos.JavaUtils;
 
@@ -75,16 +74,15 @@ public class SingularityTaskHistory {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("taskUpdates", taskUpdates)
-      .add("directory", directory)
-      .add("containerId", containerId)
-      .add("task", task)
-      .add("healthcheckResults", healthcheckResults)
-      .add("loadBalancerUpdates", loadBalancerUpdates)
-      .add("shellCommandHistory", shellCommandHistory)
-      .add("taskMetadata", taskMetadata)
-      .add("lastTaskUpdate", getLastTaskUpdate())
-      .toString();
+    return "SingularityTaskHistory{" +
+        "taskUpdates=" + taskUpdates +
+        ", directory=" + directory +
+        ", containerId=" + containerId +
+        ", task=" + task +
+        ", healthcheckResults=" + healthcheckResults +
+        ", loadBalancerUpdates=" + loadBalancerUpdates +
+        ", shellCommandHistory=" + shellCommandHistory +
+        ", taskMetadata=" + taskMetadata +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskHistoryQuery.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskHistoryQuery.java
@@ -156,9 +156,17 @@ public class SingularityTaskHistoryQuery {
 
   @Override
   public String toString() {
-    return "SingularityTaskHistoryQuery [requestId=" + requestId + ", deployId=" + deployId + ", runId=" + runId + ", host=" + host + ", lastTaskStatus=" + lastTaskStatus + ", startedBefore=" + startedBefore
-        + ", startedAfter=" + startedAfter + ", orderDirection=" + orderDirection + "]";
+    return "SingularityTaskHistoryQuery{" +
+        "requestId=" + requestId +
+        ", deployId=" + deployId +
+        ", runId=" + runId +
+        ", host=" + host +
+        ", lastTaskStatus=" + lastTaskStatus +
+        ", startedBefore=" + startedBefore +
+        ", startedAfter=" + startedAfter +
+        ", updatedBefore=" + updatedBefore +
+        ", updatedAfter=" + updatedAfter +
+        ", orderDirection=" + orderDirection +
+        '}';
   }
-
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskHistoryUpdate.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskHistoryUpdate.java
@@ -1,10 +1,11 @@
 package com.hubspot.singularity;
 
+import java.util.Objects;
+
 import javax.annotation.Nonnull;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ComparisonChain;
@@ -70,26 +71,23 @@ public class SingularityTaskHistoryUpdate extends SingularityTaskIdHolder implem
   }
 
   @Override
-  public int hashCode() {
-    return Objects.hashCode(getTaskId(), timestamp, taskState, statusMessage, statusReason);
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SingularityTaskHistoryUpdate that = (SingularityTaskHistoryUpdate) o;
+    return timestamp == that.timestamp &&
+        taskState == that.taskState &&
+        Objects.equals(statusMessage, that.statusMessage) &&
+        Objects.equals(statusReason, that.statusReason);
   }
 
   @Override
-  public boolean equals(Object other) {
-    if (this == other) {
-      return true;
-    }
-    if ((other == null) || (other.getClass() != this.getClass())) {
-      return false;
-    }
-
-    SingularityTaskHistoryUpdate that = (SingularityTaskHistoryUpdate) other;
-
-    return Objects.equal(this.getTaskId(), that.getTaskId())
-        && Objects.equal(this.timestamp, that.timestamp)
-        && Objects.equal(this.taskState, that.taskState)
-        && Objects.equal(this.statusMessage, that.statusMessage)
-        && Objects.equal(this.statusReason, that.statusReason);
+  public int hashCode() {
+    return Objects.hash(timestamp, taskState, statusMessage, statusReason);
   }
 
   public long getTimestamp() {

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskId.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskId.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Function;
-import com.google.common.base.Objects;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
@@ -100,7 +99,7 @@ public class SingularityTaskId extends SingularityId implements SingularityHisto
   public SingularityTaskId(@JsonProperty("requestId") String requestId, @JsonProperty("deployId") String deployId, @JsonProperty("nextRunAt") Long nextRunAt, @JsonProperty("startedAt") Long startedAt,
       @JsonProperty("instanceNo") int instanceNo, @JsonProperty("host") String host, @JsonProperty("sanitizedHost") String sanitizedHost,
       @JsonProperty("sanitizedRackId") String sanitizedRackId, @JsonProperty("rackId") String rackId) {
-    this(requestId, deployId, Objects.firstNonNull(startedAt, nextRunAt), instanceNo, Objects.firstNonNull(sanitizedHost, host), Objects.firstNonNull(sanitizedRackId, rackId));
+    this(requestId, deployId, startedAt != null ? startedAt : nextRunAt, instanceNo, sanitizedHost != null ? sanitizedHost : host, sanitizedRackId != null ? sanitizedRackId : rackId);
   }
 
   /**

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskIdHistory.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskIdHistory.java
@@ -1,12 +1,11 @@
 package com.hubspot.singularity;
 
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.collect.ComparisonChain;
 
@@ -47,27 +46,6 @@ public class SingularityTaskIdHistory implements Comparable<SingularityTaskIdHis
       .result();
   }
 
-  @Override
-  public int hashCode() {
-    return Objects.hashCode(taskId, updatedAt, lastTaskState, runId);
-  }
-
-  @Override
-  public boolean equals(Object other) {
-      if (other == this) {
-          return true;
-      }
-      if (other == null || other.getClass() != this.getClass()) {
-          return false;
-      }
-
-      SingularityTaskIdHistory that = (SingularityTaskIdHistory) other;
-      return Objects.equal(this.taskId , that.taskId)
-              && Objects.equal(this.updatedAt , that.updatedAt)
-              && Objects.equal(this.lastTaskState , that.lastTaskState)
-              && Objects.equal(this.runId, that.runId);
-  }
-
   public SingularityTaskId getTaskId() {
     return taskId;
   }
@@ -85,8 +63,32 @@ public class SingularityTaskIdHistory implements Comparable<SingularityTaskIdHis
   }
 
   @Override
-  public String toString() {
-    return "SingularityTaskIdHistory [taskId=" + taskId + ", updatedAt=" + updatedAt + ", lastTaskState=" + lastTaskState + ", runId=" + runId + "]";
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SingularityTaskIdHistory that = (SingularityTaskIdHistory) o;
+    return updatedAt == that.updatedAt &&
+        Objects.equals(taskId, that.taskId) &&
+        Objects.equals(lastTaskState, that.lastTaskState) &&
+        Objects.equals(runId, that.runId);
   }
 
+  @Override
+  public int hashCode() {
+    return Objects.hash(taskId, updatedAt, lastTaskState, runId);
+  }
+
+  @Override
+  public String toString() {
+    return "SingularityTaskIdHistory{" +
+        "taskId=" + taskId +
+        ", updatedAt=" + updatedAt +
+        ", lastTaskState=" + lastTaskState +
+        ", runId=" + runId +
+        '}';
+  }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskMetadata.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskMetadata.java
@@ -1,8 +1,9 @@
 package com.hubspot.singularity;
 
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ComparisonChain;
@@ -64,33 +65,36 @@ public class SingularityTaskMetadata extends SingularityTaskIdHolder implements 
   }
 
   @Override
-  public int hashCode() {
-    return Objects.hashCode(user, type, title, message, timestamp, getTaskId());
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SingularityTaskMetadata that = (SingularityTaskMetadata) o;
+    return timestamp == that.timestamp &&
+        Objects.equals(type, that.type) &&
+        Objects.equals(title, that.title) &&
+        level == that.level &&
+        Objects.equals(message, that.message) &&
+        Objects.equals(user, that.user);
   }
 
   @Override
-  public boolean equals(Object other) {
-    if (this == other) {
-        return true;
-    }
-    if (other == null || other.getClass() != this.getClass()) {
-        return false;
-    }
-
-    SingularityTaskMetadata that = (SingularityTaskMetadata) other;
-
-    return Objects.equal(this.user, that.user)
-            && Objects.equal(this.type, that.type)
-            && Objects.equal(this.title, that.title)
-            && Objects.equal(this.message, that.message)
-            && Objects.equal(this.timestamp, that.timestamp)
-            && Objects.equal(this.getTaskId(), that.getTaskId())
-            && Objects.equal(this.level, that.level);
+  public int hashCode() {
+    return Objects.hash(timestamp, type, title, level, message, user);
   }
 
   @Override
   public String toString() {
-    return "SingularityTaskMetadata [timestamp=" + timestamp + ", type=" + type + ", title=" + title + ", message=" + message + ", user=" + user + ", taskId=" + getTaskId() + ", level=" + getLevel() + "]";
+    return "SingularityTaskMetadata{" +
+        "timestamp=" + timestamp +
+        ", type='" + type + '\'' +
+        ", title='" + title + '\'' +
+        ", level=" + level +
+        ", message=" + message +
+        ", user=" + user +
+        "} " + super.toString();
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskRequest.java
@@ -64,7 +64,10 @@ public class SingularityTaskRequest implements Comparable<SingularityTaskRequest
 
   @Override
   public String toString() {
-    return "SingularityTaskRequest [request=" + request + ", deploy=" + deploy + ", pendingTask=" + pendingTask + "]";
+    return "SingularityTaskRequest{" +
+        "request=" + request +
+        ", deploy=" + deploy +
+        ", pendingTask=" + pendingTask +
+        '}';
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskShellCommandHistory.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskShellCommandHistory.java
@@ -28,7 +28,9 @@ public class SingularityTaskShellCommandHistory {
 
   @Override
   public String toString() {
-    return "SingularityTaskShellCommandHistory [shellRequest=" + shellRequest + ", shellUpdates=" + shellUpdates + "]";
+    return "SingularityTaskShellCommandHistory{" +
+        "shellRequest=" + shellRequest +
+        ", shellUpdates=" + shellUpdates +
+        '}';
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskShellCommandRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskShellCommandRequest.java
@@ -1,5 +1,7 @@
 package com.hubspot.singularity;
 
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -35,33 +37,20 @@ public class SingularityTaskShellCommandRequest extends SingularityFrameworkMess
   }
 
   @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((id == null) ? 0 : id.hashCode());
-    return result;
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SingularityTaskShellCommandRequest that = (SingularityTaskShellCommandRequest) o;
+    return Objects.equals(id, that.id);
   }
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    SingularityTaskShellCommandRequest other = (SingularityTaskShellCommandRequest) obj;
-    if (id == null) {
-      if (other.id != null) {
-        return false;
-      }
-    } else if (!id.equals(other.id)) {
-      return false;
-    }
-    return true;
+  public int hashCode() {
+    return Objects.hash(id);
   }
 
   public SingularityTaskId getTaskId() {
@@ -82,7 +71,12 @@ public class SingularityTaskShellCommandRequest extends SingularityFrameworkMess
 
   @Override
   public String toString() {
-    return "SingularityTaskShellCommandRequest [taskId=" + taskId + ", user=" + user + ", shellCommand=" + shellCommand + ", timestamp=" + timestamp + "]";
+    return "SingularityTaskShellCommandRequest{" +
+        "taskId=" + taskId +
+        ", user=" + user +
+        ", shellCommand=" + shellCommand +
+        ", timestamp=" + timestamp +
+        ", id=" + id +
+        "} " + super.toString();
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskShellCommandRequestId.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskShellCommandRequestId.java
@@ -44,7 +44,11 @@ public class SingularityTaskShellCommandRequestId extends SingularityId {
 
   @Override
   public String toString() {
-    return "SingularityTaskShellCommandRequestId [taskId=" + taskId + ", name=" + name + ", timestamp=" + timestamp + "]";
+    return "SingularityTaskShellCommandRequestId{" +
+        "taskId=" + taskId +
+        ", name='" + name + '\'' +
+        ", safeName='" + safeName + '\'' +
+        ", timestamp=" + timestamp +
+        "} " + super.toString();
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskShellCommandUpdate.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskShellCommandUpdate.java
@@ -58,12 +58,12 @@ public class SingularityTaskShellCommandUpdate {
 
   @Override
   public String toString() {
-    return "SingularityTaskShellCommandUpdate[" +
-            "shellRequestId=" + shellRequestId +
-            ", timestamp=" + timestamp +
-            ", message=" + message +
-            ", outputFilename=" + outputFilename +
-            ", updateType=" + updateType +
-            ']';
+    return "SingularityTaskShellCommandUpdate{" +
+        "shellRequestId=" + shellRequestId +
+        ", timestamp=" + timestamp +
+        ", message=" + message +
+        ", outputFilename=" + outputFilename +
+        ", updateType=" + updateType +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskStatusHolder.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskStatusHolder.java
@@ -46,7 +46,12 @@ public class SingularityTaskStatusHolder {
 
   @Override
   public String toString() {
-    return "SingularityTaskStatusHolder [taskStatus=" + MesosUtils.formatForLogging(taskStatus) + ", taskId=" + taskId + ", serverTimestamp=" + serverTimestamp + ", serverId=" + serverId + ", slaveId=" + slaveId + "]";
+    return "SingularityTaskStatusHolder{" +
+        "taskStatus=" + MesosUtils.formatForLogging(taskStatus) +
+        ", taskId=" + taskId +
+        ", serverTimestamp=" + serverTimestamp +
+        ", serverId='" + serverId + '\'' +
+        ", slaveId=" + slaveId +
+        '}';
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskWebhook.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskWebhook.java
@@ -24,7 +24,9 @@ public class SingularityTaskWebhook {
 
   @Override
   public String toString() {
-    return "SingularityTaskWebhook [task=" + task + ", taskUpdate=" + taskUpdate + "]";
+    return "SingularityTaskWebhook{" +
+        "task=" + task +
+        ", taskUpdate=" + taskUpdate +
+        '}';
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityUser.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityUser.java
@@ -41,12 +41,12 @@ public class SingularityUser {
 
   @Override
   public String toString() {
-    return "SingularityUser[" +
-            "id='" + id + '\'' +
-            ", name=" + name +
-            ", email=" + email +
-            ", groups=" + groups +
-            ']';
+    return "SingularityUser{" +
+        "id='" + id + '\'' +
+        ", name=" + name +
+        ", email=" + email +
+        ", groups=" + groups +
+        '}';
   }
 
   @Override

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityUserSettings.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityUserSettings.java
@@ -1,11 +1,11 @@
 package com.hubspot.singularity;
 
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 
 public class SingularityUserSettings {
   private final Set<String> starredRequestIds;
@@ -13,7 +13,7 @@ public class SingularityUserSettings {
   @JsonCreator
   public SingularityUserSettings(
       @JsonProperty("starredRequestIds") Set<String> starredRequestIds) {
-    this.starredRequestIds = Objects.firstNonNull(starredRequestIds, Collections.<String>emptySet());
+    this.starredRequestIds = starredRequestIds != null ? starredRequestIds : Collections.<String>emptySet();
   }
 
   public static SingularityUserSettings empty() {
@@ -43,18 +43,18 @@ public class SingularityUserSettings {
       return false;
     }
     SingularityUserSettings that = (SingularityUserSettings) o;
-    return Objects.equal(starredRequestIds, that.starredRequestIds);
+    return Objects.equals(starredRequestIds, that.starredRequestIds);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(starredRequestIds);
+    return Objects.hash(starredRequestIds);
   }
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("starredRequestIds", starredRequestIds)
-      .toString();
+    return "SingularityUserSettings{" +
+        "starredRequestIds=" + starredRequestIds +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityWebhook.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityWebhook.java
@@ -52,6 +52,12 @@ public class SingularityWebhook {
 
   @Override
   public String toString() {
-    return "SingularityWebhook [uri=" + uri + ", timestamp=" + timestamp + ", id=" + id + ", user=" + user + ", type=" + type + "]";
+    return "SingularityWebhook{" +
+        "uri='" + uri + '\'' +
+        ", type=" + type +
+        ", user=" + user +
+        ", timestamp=" + timestamp +
+        ", id='" + id + '\'' +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityWebhookSummary.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityWebhookSummary.java
@@ -1,8 +1,9 @@
 package com.hubspot.singularity;
 
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 
 public class SingularityWebhookSummary {
   private final SingularityWebhook webhook;
@@ -33,19 +34,19 @@ public class SingularityWebhookSummary {
     }
     SingularityWebhookSummary that = (SingularityWebhookSummary) o;
     return queueSize == that.queueSize &&
-      Objects.equal(webhook, that.webhook);
+        Objects.equals(webhook, that.webhook);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(webhook, queueSize);
+    return Objects.hash(webhook, queueSize);
   }
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("webhook", webhook)
-      .add("queueSize", queueSize)
-      .toString();
+    return "SingularityWebhookSummary{" +
+        "webhook=" + webhook +
+        ", queueSize=" + queueSize +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/ContinuationToken.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/ContinuationToken.java
@@ -1,5 +1,7 @@
 package com.hubspot.singularity.api;
 
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.wordnik.swagger.annotations.ApiModelProperty;
@@ -32,20 +34,14 @@ public class ContinuationToken {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-
-    ContinuationToken token = (ContinuationToken) o;
-
-    if (lastPage != token.lastPage) {
-      return false;
-    }
-    return value != null ? value.equals(token.value) : token.value == null;
+    ContinuationToken that = (ContinuationToken) o;
+    return lastPage == that.lastPage &&
+        Objects.equals(value, that.value);
   }
 
   @Override
   public int hashCode() {
-    int result = value != null ? value.hashCode() : 0;
-    result = 31 * result + (lastPage ? 1 : 0);
-    return result;
+    return Objects.hash(value, lastPage);
   }
 
   @Override

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityBounceRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityBounceRequest.java
@@ -55,7 +55,10 @@ public class SingularityBounceRequest extends SingularityExpiringRequestParent {
 
   @Override
   public String toString() {
-    return "SingularityBounceRequest [incremental=" + incremental + ", skipHealthchecks=" + skipHealthchecks + ", runShellCommandBeforeKill=" + runShellCommandBeforeKill + ", toString()=" + super.toString() + "]";
+    return "SingularityBounceRequest{" +
+        "incremental=" + incremental +
+        ", skipHealthchecks=" + skipHealthchecks +
+        ", runShellCommandBeforeKill=" + runShellCommandBeforeKill +
+        "} " + super.toString();
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityBounceRequestBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityBounceRequestBuilder.java
@@ -1,6 +1,5 @@
 package com.hubspot.singularity.api;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.hubspot.singularity.SingularityShellCommand;
 
@@ -84,13 +83,13 @@ public class SingularityBounceRequestBuilder {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("incremental", incremental)
-      .add("skipHealthchecks", skipHealthchecks)
-      .add("runShellCommandBeforeKill", runShellCommandBeforeKill)
-      .add("durationMillis", durationMillis)
-      .add("actionId", actionId)
-      .add("message", message)
-      .toString();
+    return "SingularityBounceRequestBuilder{" +
+        "incremental=" + incremental +
+        ", skipHealthchecks=" + skipHealthchecks +
+        ", runShellCommandBeforeKill=" + runShellCommandBeforeKill +
+        ", durationMillis=" + durationMillis +
+        ", actionId=" + actionId +
+        ", message=" + message +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityDeleteRequestRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityDeleteRequestRequest.java
@@ -29,7 +29,9 @@ public class SingularityDeleteRequestRequest {
 
   @Override
   public String toString() {
-    return "SingularityDeleteRequestRequest [message=" + message + ", actionId=" + actionId + "]";
+    return "SingularityDeleteRequestRequest{" +
+        "message=" + message +
+        ", actionId=" + actionId +
+        '}';
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityDeployRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityDeployRequest.java
@@ -58,7 +58,11 @@ public class SingularityDeployRequest {
 
   @Override
   public String toString() {
-    return "SingularityDeployRequest [unpauseOnSuccessfulDeploy=" + unpauseOnSuccessfulDeploy + ", deploy=" + deploy + ", message=" + message + ", updatedRequest=" + updatedRequest + "]";
+    return "SingularityDeployRequest{" +
+        "unpauseOnSuccessfulDeploy=" + unpauseOnSuccessfulDeploy +
+        ", deploy=" + deploy +
+        ", message=" + message +
+        ", updatedRequest=" + updatedRequest +
+        '}';
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityDisabledActionRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityDisabledActionRequest.java
@@ -1,8 +1,9 @@
 package com.hubspot.singularity.api;
 
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.hubspot.singularity.SingularityAction;
 import com.wordnik.swagger.annotations.ApiModelProperty;
@@ -37,19 +38,19 @@ public class SingularityDisabledActionRequest {
     }
     SingularityDisabledActionRequest that = (SingularityDisabledActionRequest) o;
     return type == that.type &&
-      Objects.equal(message, that.message);
+        Objects.equals(message, that.message);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(type, message);
+    return Objects.hash(type, message);
   }
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("type", type)
-      .add("message", message)
-      .toString();
+    return "SingularityDisabledActionRequest{" +
+        "type=" + type +
+        ", message=" + message +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityExitCooldownRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityExitCooldownRequest.java
@@ -36,7 +36,10 @@ public class SingularityExitCooldownRequest {
 
   @Override
   public String toString() {
-    return "SingularityExitCooldownRequest [message=" + message + ", actionId=" + actionId + ", skipHealthchecks=" + skipHealthchecks + "]";
+    return "SingularityExitCooldownRequest{" +
+        "message=" + message +
+        ", actionId=" + actionId +
+        ", skipHealthchecks=" + skipHealthchecks +
+        '}';
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityExpiringRequestParent.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityExpiringRequestParent.java
@@ -32,7 +32,10 @@ public abstract class SingularityExpiringRequestParent {
 
   @Override
   public String toString() {
-    return "SingularityExpiringRequestParent [durationMillis=" + durationMillis + ", actionId=" + actionId + ", message=" + message + "]";
+    return "SingularityExpiringRequestParent{" +
+        "durationMillis=" + durationMillis +
+        ", actionId=" + actionId +
+        ", message=" + message +
+        '}';
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityKillTaskRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityKillTaskRequest.java
@@ -52,8 +52,12 @@ public class SingularityKillTaskRequest {
 
   @Override
   public String toString() {
-    return "SingularityKillTaskRequest [message=" + message + ", override=" + override + ", actionId=" + actionId + ", waitForReplacementTask=" + waitForReplacementTask + ", runShellCommandBeforeKill=" + runShellCommandBeforeKill
-      + "]";
+    return "SingularityKillTaskRequest{" +
+        "message=" + message +
+        ", override=" + override +
+        ", actionId=" + actionId +
+        ", waitForReplacementTask=" + waitForReplacementTask +
+        ", runShellCommandBeforeKill=" + runShellCommandBeforeKill +
+        '}';
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityMachineChangeRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityMachineChangeRequest.java
@@ -2,7 +2,6 @@ package com.hubspot.singularity.api;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.hubspot.singularity.MachineState;
 import com.wordnik.swagger.annotations.ApiModelProperty;
@@ -40,12 +39,9 @@ public class SingularityMachineChangeRequest extends SingularityExpiringRequestP
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("durationMillis", getDurationMillis())
-      .add("actionId", getActionId())
-      .add("message", getMessage())
-      .add("revertToState", revertToState)
-      .add("killTasksOnDecommissionTimeout", killTasksOnDecommissionTimeout)
-      .toString();
+    return "SingularityMachineChangeRequest{" +
+        "revertToState=" + revertToState +
+        ", killTasksOnDecommissionTimeout=" + killTasksOnDecommissionTimeout +
+        "} " + super.toString();
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityPauseRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityPauseRequest.java
@@ -33,7 +33,9 @@ public class SingularityPauseRequest extends SingularityExpiringRequestParent {
 
   @Override
   public String toString() {
-    return "SingularityPauseRequest [killTasks=" + killTasks + ", toString()=" + super.toString() + "]";
+    return "SingularityPauseRequest{" +
+        "killTasks=" + killTasks +
+        ", runShellCommandBeforeKill=" + runShellCommandBeforeKill +
+        "} " + super.toString();
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityPriorityFreeze.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityPriorityFreeze.java
@@ -51,23 +51,23 @@ public class SingularityPriorityFreeze {
     }
     SingularityPriorityFreeze that = (SingularityPriorityFreeze) o;
     return Double.compare(that.minimumPriorityLevel, minimumPriorityLevel) == 0 &&
-      Objects.equals(killTasks, that.killTasks) &&
-      Objects.equals(message, that.message) &&
-      Objects.equals(actionId, that.actionId);
+        killTasks == that.killTasks &&
+        Objects.equals(message, that.message) &&
+        Objects.equals(actionId, that.actionId);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(minimumPriorityLevel, message, actionId);
+    return Objects.hash(minimumPriorityLevel, killTasks, message, actionId);
   }
 
   @Override
   public String toString() {
-    return "SingularityPriorityFreeze[" +
-      "minimumPriorityLevel=" + minimumPriorityLevel +
-      ", killTasks=" + killTasks +
-      ", message=" + message +
-      ", actionId=" + actionId +
-      ']';
+    return "SingularityPriorityFreeze{" +
+        "minimumPriorityLevel=" + minimumPriorityLevel +
+        ", killTasks=" + killTasks +
+        ", message=" + message +
+        ", actionId=" + actionId +
+        '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityRunNowRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityRunNowRequest.java
@@ -53,7 +53,12 @@ public class SingularityRunNowRequest {
 
   @Override
   public String toString() {
-    return "SingularityRunNowRequest [message=" + message + ", runId=" + runId + ", commandLineArgs=" + commandLineArgs + ", skipHealthchecks=" + skipHealthchecks + ", resources=" + resources + "]";
+    return "SingularityRunNowRequest{" +
+        "message=" + message +
+        ", runId=" + runId +
+        ", commandLineArgs=" + commandLineArgs +
+        ", skipHealthchecks=" + skipHealthchecks +
+        ", resources=" + resources +
+        '}';
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityS3SearchRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityS3SearchRequest.java
@@ -6,7 +6,6 @@ import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.wordnik.swagger.annotations.ApiModelProperty;
 
@@ -30,14 +29,14 @@ public class SingularityS3SearchRequest {
                                     @JsonProperty("listOnly") boolean listOnly,
                                     @JsonProperty("maxPerPage") Optional<Integer> maxPerPage,
                                     @JsonProperty("continuationTokens") Map<String, ContinuationToken> continuationTokens) {
-    this.requestsAndDeploys = Objects.firstNonNull(requestsAndDeploys, Collections.<String, List<String>>emptyMap());
-    this.taskIds = Objects.firstNonNull(taskIds, Collections.<String>emptyList());
+    this.requestsAndDeploys = requestsAndDeploys != null ? requestsAndDeploys : Collections.<String, List<String>>emptyMap();
+    this.taskIds = taskIds != null ? taskIds : Collections.<String>emptyList();
     this.start = start;
     this.end = end;
     this.excludeMetadata = excludeMetadata;
     this.listOnly = listOnly;
     this.maxPerPage = maxPerPage;
-    this.continuationTokens = Objects.firstNonNull(continuationTokens, Collections.<String, ContinuationToken>emptyMap());
+    this.continuationTokens = continuationTokens != null ? continuationTokens : Collections.<String, ContinuationToken>emptyMap();
   }
 
   @ApiModelProperty(required=false, value="A map of request IDs to a list of deploy ids to search")

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityScaleRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityScaleRequest.java
@@ -45,7 +45,11 @@ public class SingularityScaleRequest extends SingularityExpiringRequestParent {
 
   @Override
   public String toString() {
-    return "SingularityScaleRequest [instances=" + instances + ", skipHealthchecks=" + skipHealthchecks + ", bounce=" + bounce + ", incremental=" + incremental + ", toString()=" + super.toString() + "]";
+    return "SingularityScaleRequest{" +
+        "instances=" + instances +
+        ", skipHealthchecks=" + skipHealthchecks +
+        ", bounce=" + bounce +
+        ", incremental=" + incremental +
+        "} " + super.toString();
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularitySkipHealthchecksRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularitySkipHealthchecksRequest.java
@@ -23,7 +23,8 @@ public class SingularitySkipHealthchecksRequest extends SingularityExpiringReque
 
   @Override
   public String toString() {
-    return "SingularitySkipHealthchecksRequest [skipHealthchecks=" + skipHealthchecks + ", toString()=" + super.toString() + "]";
+    return "SingularitySkipHealthchecksRequest{" +
+        "skipHealthchecks=" + skipHealthchecks +
+        "} " + super.toString();
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityTaskMetadataRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityTaskMetadataRequest.java
@@ -44,7 +44,11 @@ public class SingularityTaskMetadataRequest {
 
   @Override
   public String toString() {
-    return "SingularityTaskMetadataRequest [type=" + type + ", title=" + title + ", message=" + message + ", level=" + level + "]";
+    return "SingularityTaskMetadataRequest{" +
+        "type='" + type + '\'' +
+        ", title='" + title + '\'' +
+        ", message=" + message +
+        ", level=" + level +
+        '}';
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityUnpauseRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityUnpauseRequest.java
@@ -36,7 +36,10 @@ public class SingularityUnpauseRequest {
 
   @Override
   public String toString() {
-    return "SingularityExitCooldownRequest [message=" + message + ", actionId=" + actionId + ", skipHealthchecks=" + skipHealthchecks + "]";
+    return "SingularityUnpauseRequest{" +
+        "message=" + message +
+        ", actionId=" + actionId +
+        ", skipHealthchecks=" + skipHealthchecks +
+        '}';
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/expiring/SingularityExpiringBounce.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/expiring/SingularityExpiringBounce.java
@@ -22,7 +22,8 @@ public class SingularityExpiringBounce extends SingularityExpiringRequestActionP
 
   @Override
   public String toString() {
-    return "SingularityExpiringBounce [toString()=" + super.toString() + "]";
+    return "SingularityExpiringBounce{" +
+        "deployId='" + deployId + '\'' +
+        "} " + super.toString();
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/expiring/SingularityExpiringMachineState.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/expiring/SingularityExpiringMachineState.java
@@ -2,7 +2,6 @@ package com.hubspot.singularity.expiring;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.hubspot.singularity.MachineState;
 import com.hubspot.singularity.api.SingularityMachineChangeRequest;
@@ -41,13 +40,10 @@ public class SingularityExpiringMachineState extends SingularityExpiringParent<S
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("user", getUser())
-      .add("startMillis", getStartMillis())
-      .add("actionId", getActionId())
-      .add("expiringAPIRequestObject", getExpiringAPIRequestObject())
-      .add("revertToState", revertToState)
-      .add("killTasksOnDecommissionTimeout", killTasksOnDecommissionTimeout)
-      .toString();
+    return "SingularityExpiringMachineState{" +
+        "machineId='" + machineId + '\'' +
+        ", revertToState=" + revertToState +
+        ", killTasksOnDecommissionTimeout=" + killTasksOnDecommissionTimeout +
+        "} " + super.toString();
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/expiring/SingularityExpiringParent.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/expiring/SingularityExpiringParent.java
@@ -35,7 +35,11 @@ public abstract class SingularityExpiringParent<T extends SingularityExpiringReq
 
   @Override
   public String toString() {
-    return "SingularityExpiringParent [user=" + user + ", startMillis=" + startMillis + ", actionId=" + actionId + ", expiringAPIRequestObject=" + expiringAPIRequestObject + "]";
+    return "SingularityExpiringParent{" +
+        "user=" + user +
+        ", startMillis=" + startMillis +
+        ", actionId='" + actionId + '\'' +
+        ", expiringAPIRequestObject=" + expiringAPIRequestObject +
+        '}';
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/expiring/SingularityExpiringPause.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/expiring/SingularityExpiringPause.java
@@ -13,7 +13,6 @@ public class SingularityExpiringPause extends SingularityExpiringRequestActionPa
 
   @Override
   public String toString() {
-    return "SingularityExpiringPause [toString()=" + super.toString() + "]";
+    return "SingularityExpiringPause{} " + super.toString();
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/expiring/SingularityExpiringRequestActionParent.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/expiring/SingularityExpiringRequestActionParent.java
@@ -18,7 +18,8 @@ public abstract class SingularityExpiringRequestActionParent<T extends Singulari
 
   @Override
   public String toString() {
-    return "SingularityExpiringParent [requestId=" + requestId + ", user=" + getUser() + ", startMillis=" + getStartMillis() + ", actionId=" + getActionId() + ", expiringAPIRequestObject=" + getExpiringAPIRequestObject() + "]";
+    return "SingularityExpiringRequestActionParent{" +
+        "requestId='" + requestId + '\'' +
+        "} " + super.toString();
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/expiring/SingularityExpiringScale.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/expiring/SingularityExpiringScale.java
@@ -28,7 +28,9 @@ public class SingularityExpiringScale extends SingularityExpiringRequestActionPa
 
   @Override
   public String toString() {
-    return "SingularityExpiringScale [revertToInstances=" + revertToInstances + ", bounce=" + bounce + "]";
+    return "SingularityExpiringScale{" +
+        "revertToInstances=" + revertToInstances +
+        ", bounce=" + bounce +
+        "} " + super.toString();
   }
-
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/expiring/SingularityExpiringSkipHealthchecks.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/expiring/SingularityExpiringSkipHealthchecks.java
@@ -22,7 +22,8 @@ public class SingularityExpiringSkipHealthchecks extends SingularityExpiringRequ
 
   @Override
   public String toString() {
-    return "SingularityExpiringSkipHealthchecks [revertToSkipHealthchecks=" + revertToSkipHealthchecks + ", toString()=" + super.toString() + "]";
+    return "SingularityExpiringSkipHealthchecks{" +
+        "revertToSkipHealthchecks=" + revertToSkipHealthchecks +
+        "} " + super.toString();
   }
-
 }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/LogrotateCompressionSettings.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/LogrotateCompressionSettings.java
@@ -2,7 +2,6 @@ package com.hubspot.singularity.executor.config;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 
 public class LogrotateCompressionSettings {
@@ -60,11 +59,11 @@ public class LogrotateCompressionSettings {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("compressCmd", compressCmd)
-      .add("uncompressCmd", uncompressCmd)
-      .add("compressOptions", compressOptions)
-      .add("compressExt", compressExt)
-      .toString();
+    return "LogrotateCompressionSettings{" +
+        "compressCmd=" + compressCmd +
+        ", uncompressCmd=" + uncompressCmd +
+        ", compressOptions=" + compressOptions +
+        ", compressExt=" + compressExt +
+        '}';
   }
 }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/models/DockerContext.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/models/DockerContext.java
@@ -37,13 +37,12 @@ public class DockerContext {
 
   @Override
   public String toString() {
-    return "DockerContext [" +
-      "envContext=" + envContext +
-      "runContext=" + runContext +
-      "prefix=" + prefix +
-      "stopTimeout=" + stopTimeout +
-      "privileged=" + privileged +
-      "]";
-
+    return "DockerContext{" +
+        "envContext=" + envContext +
+        ", runContext=" + runContext +
+        ", prefix='" + prefix + '\'' +
+        ", stopTimeout=" + stopTimeout +
+        ", privileged=" + privileged +
+        '}';
   }
 }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/models/EnvironmentContext.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/models/EnvironmentContext.java
@@ -65,7 +65,8 @@ public class EnvironmentContext {
 
   @Override
   public String toString() {
-    return "EnvironmentContext [taskInfo=" + taskInfo + "]";
+    return "EnvironmentContext{" +
+        "taskInfo=" + taskInfo +
+        '}';
   }
-
 }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/models/LogrotateAdditionalFile.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/models/LogrotateAdditionalFile.java
@@ -25,10 +25,10 @@ public class LogrotateAdditionalFile {
 
     @Override
     public String toString() {
-        return "LogrotateAdditionalFile[" +
+        return "LogrotateAdditionalFile{" +
             "filename='" + filename + '\'' +
             ", extension='" + extension + '\'' +
             ", dateformat='" + dateformat + '\'' +
-            ']';
+            '}';
     }
 }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/models/LogrotateTemplateContext.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/models/LogrotateTemplateContext.java
@@ -131,8 +131,9 @@ public class LogrotateTemplateContext {
 
   @Override
   public String toString() {
-    return "LogrotateTemplateContext [taskId=" + taskDefinition.getTaskId() + "]";
+    return "LogrotateTemplateContext{" +
+        "taskDefinition=" + taskDefinition +
+        ", configuration=" + configuration +
+        '}';
   }
-
-
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/views/IndexView.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/views/IndexView.java
@@ -5,7 +5,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.google.common.base.Objects;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import com.hubspot.singularity.SingularityService;
@@ -235,37 +234,38 @@ public class IndexView extends View {
     return redirectOnUnauthorizedUrl;
   }
 
-  @Override public String toString() {
-    return Objects.toStringHelper(this)
-      .add("appRoot", appRoot)
-      .add("apiDocs", apiDocs)
-      .add("staticRoot", staticRoot)
-      .add("apiRoot", apiRoot)
-      .add("navColor", navColor)
-      .add("defaultMemory", defaultMemory)
-      .add("defaultCpus", defaultCpus)
-      .add("hideNewDeployButton", hideNewDeployButton)
-      .add("hideNewRequestButton", hideNewRequestButton)
-      .add("loadBalancingEnabled", loadBalancingEnabled)
-      .add("title", title)
-      .add("slaveHttpPort", slaveHttpPort)
-      .add("slaveHttpsPort", slaveHttpsPort)
-      .add("defaultBounceExpirationMinutes", defaultBounceExpirationMinutes)
-      .add("defaultHealthcheckIntervalSeconds", defaultHealthcheckIntervalSeconds)
-      .add("defaultHealthcheckTimeoutSeconds", defaultHealthcheckTimeoutSeconds)
-      .add("defaultHealthcheckMaxRetries", defaultHealthcheckMaxRetries)
-      .add("defaultStartupTimeoutSeconds", defaultStartupTimeoutSeconds)
-      .add("runningTaskLogPath", runningTaskLogPath)
-      .add("finishedTaskLogPath", finishedTaskLogPath)
-      .add("commonHostnameSuffixToOmit", commonHostnameSuffixToOmit)
-      .add("taskS3LogOmitPrefix", taskS3LogOmitPrefix)
-      .add("warnIfScheduledJobIsRunningPastNextRunPct", warnIfScheduledJobIsRunningPastNextRunPct)
-      .add("shellCommands", shellCommands)
-      .add("timestampFormat", timestampFormat)
-      .add("showTaskDiskResource", showTaskDiskResource)
-      .add("timestampWithSecondsFormat", timestampWithSecondsFormat)
-      .add("redirectOnUnauthorizedUrl", redirectOnUnauthorizedUrl)
-      .add("extraScript", extraScript)
-      .toString();
+  @Override
+  public String toString() {
+    return "IndexView{" +
+        "appRoot='" + appRoot + '\'' +
+        ", apiDocs='" + apiDocs + '\'' +
+        ", staticRoot='" + staticRoot + '\'' +
+        ", apiRoot='" + apiRoot + '\'' +
+        ", navColor='" + navColor + '\'' +
+        ", defaultMemory=" + defaultMemory +
+        ", defaultCpus=" + defaultCpus +
+        ", hideNewDeployButton=" + hideNewDeployButton +
+        ", hideNewRequestButton=" + hideNewRequestButton +
+        ", loadBalancingEnabled=" + loadBalancingEnabled +
+        ", title='" + title + '\'' +
+        ", slaveHttpPort=" + slaveHttpPort +
+        ", slaveHttpsPort=" + slaveHttpsPort +
+        ", defaultBounceExpirationMinutes=" + defaultBounceExpirationMinutes +
+        ", defaultHealthcheckIntervalSeconds=" + defaultHealthcheckIntervalSeconds +
+        ", defaultHealthcheckTimeoutSeconds=" + defaultHealthcheckTimeoutSeconds +
+        ", defaultHealthcheckMaxRetries=" + defaultHealthcheckMaxRetries +
+        ", defaultStartupTimeoutSeconds=" + defaultStartupTimeoutSeconds +
+        ", runningTaskLogPath='" + runningTaskLogPath + '\'' +
+        ", finishedTaskLogPath='" + finishedTaskLogPath + '\'' +
+        ", commonHostnameSuffixToOmit='" + commonHostnameSuffixToOmit + '\'' +
+        ", taskS3LogOmitPrefix='" + taskS3LogOmitPrefix + '\'' +
+        ", warnIfScheduledJobIsRunningPastNextRunPct=" + warnIfScheduledJobIsRunningPastNextRunPct +
+        ", shellCommands='" + shellCommands + '\'' +
+        ", timestampFormat='" + timestampFormat + '\'' +
+        ", showTaskDiskResource=" + showTaskDiskResource +
+        ", timestampWithSecondsFormat='" + timestampWithSecondsFormat + '\'' +
+        ", redirectOnUnauthorizedUrl='" + redirectOnUnauthorizedUrl + '\'' +
+        ", extraScript='" + extraScript + '\'' +
+        "} " + super.toString();
   }
 }


### PR DESCRIPTION
Probably long overdue, but there is a mix of guava, java.util, string concat, etc in our override methods. This changes all of them to java.util.Objects for equals/hashCode and plain string concat for toString. This way there won't be any conflicts when guava changes class/method names etc.

replaces #1425 
/cc @stevenschlansker 