### PR TITLE
Properly roll back from an overdue incremental deploy

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityDeployChecker.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityDeployChecker.java
@@ -258,7 +258,7 @@ public class SingularityDeployChecker {
 
     deployManager.saveDeployResult(pendingDeploy.getDeployMarker(), deploy, deployResult);
 
-    if (request.isDeployable() && (deployResult.getDeployState() == DeployState.CANCELED || deployResult.getDeployState() == DeployState.FAILED)) {
+    if (request.isDeployable() && (deployResult.getDeployState() == DeployState.CANCELED || deployResult.getDeployState() == DeployState.FAILED || deployResult.getDeployState() == DeployState.OVERDUE)) {
       Optional<SingularityRequestDeployState> maybeRequestDeployState = deployManager.getRequestDeployState(request.getId());
       if (maybeRequestDeployState.isPresent()
         && maybeRequestDeployState.get().getActiveDeploy().isPresent()


### PR DESCRIPTION
After most failed or cancelled incremental deploys, we re-enqueue a pending request to be sure that all instances from the previous deploy are present. In the overdue case we weren't previously hitting this code block, so these would not always roll back to the correct instance count if we were part way through an incremental deploy when the deploy became overdue.

/cc @darcatron 