### PR TITLE
Updated mysql index on startedAt

### DIFF
--- a/mysql/migrations.sql
+++ b/mysql/migrations.sql
@@ -119,3 +119,8 @@ ALTER TABLE `requestHistory` MODIFY `createdAt` TIMESTAMP(3) NOT NULL DEFAULT '1
 ALTER TABLE `taskHistory`
   ADD COLUMN `purged` BOOLEAN NOT NULL DEFAULT false,
   ADD KEY `purged` (`requestId`, `purged`, `updatedAt`);
+
+--changeset ssalinas:16 dbms:mysql
+ALTER TABLE `taskHistory`
+  DROP KEY `startedAt2`,
+  ADD KEY `startedAt3` (`startedAt`)


### PR DESCRIPTION
Our db was often using the wrong index when querying the taskHistory table for recent tasks, using the `startedAt2` index instead of the `startedAt` one. `startedAt2` is not actually necessary based on the queries we make, however we could still benefit from an index only on `startedAt`.