### PR TITLE
Defer loading log files till after page load

### DIFF
--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -132,8 +132,6 @@ class TaskDetail extends Component {
     if (this.props.task.isStillRunning) {
       this.props.fetchTaskStatistics(this.props.params.taskId);
     }
-
-    this.props.fechS3Logs(this.props.taskId);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -537,6 +535,9 @@ function refresh(props) {
   promises.push(taskPromise);
   promises.push(props.fetchTaskCleanups());
   promises.push(props.fetchPendingDeploys());
+
+  props.fechS3Logs(props.taskId);
+
   return Promise.all(promises);
 }
 

--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -536,9 +536,9 @@ function refresh(props) {
   promises.push(props.fetchTaskCleanups());
   promises.push(props.fetchPendingDeploys());
 
-  props.fechS3Logs(props.taskId);
-
-  return Promise.all(promises);
+  return Promise.all(promises).then(() => {
+    props.fechS3Logs(props.taskId))
+  });
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(rootComponent(withRouter(TaskDetail), (props) => props.params.taskId, refresh));

--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -536,9 +536,11 @@ function refresh(props) {
   promises.push(props.fetchTaskCleanups());
   promises.push(props.fetchPendingDeploys());
 
-  return Promise.all(promises).then(() => {
-    props.fechS3Logs(props.taskId))
-  });
+  return Promise.all(promises);
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(rootComponent(withRouter(TaskDetail), (props) => props.params.taskId, refresh));
+function onLoad(props) {
+  props.fechS3Logs(props.params.taskId);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(rootComponent(withRouter(TaskDetail), (props) => props.params.taskId, refresh, onLoad));

--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -132,6 +132,8 @@ class TaskDetail extends Component {
     if (this.props.task.isStillRunning) {
       this.props.fetchTaskStatistics(this.props.params.taskId);
     }
+
+    this.props.fechS3Logs(this.props.taskId);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -535,7 +537,6 @@ function refresh(props) {
   promises.push(taskPromise);
   promises.push(props.fetchTaskCleanups());
   promises.push(props.fetchPendingDeploys());
-  promises.push(props.fechS3Logs(props.params.taskId));
   return Promise.all(promises);
 }
 

--- a/SingularityUI/app/rootComponent.jsx
+++ b/SingularityUI/app/rootComponent.jsx
@@ -2,7 +2,7 @@ import React, { PropTypes, Component } from 'react';
 import classNames from 'classnames';
 import { NotFoundNoRoot } from 'components/common/NotFound';
 
-const rootComponent = (Wrapped, title, refresh = _.noop, refreshInterval = true, pageMargin = true, initialize) => class extends Component {
+const rootComponent = (Wrapped, title, refresh = _.noop, onLoad = _.noop, refreshInterval = true, pageMargin = true, initialize) => class extends Component {
 
   static propTypes = {
     notFound: PropTypes.bool,
@@ -52,6 +52,10 @@ const rootComponent = (Wrapped, title, refresh = _.noop, refreshInterval = true,
     }
   }
 
+  componentDidMount() {
+    onLoad(this.props);
+  }
+
   componentWillUnmount() {
     this.unmounted = true;
     if (refreshInterval) {
@@ -76,8 +80,12 @@ const rootComponent = (Wrapped, title, refresh = _.noop, refreshInterval = true,
   startRefreshInterval() {
     this.refreshInterval = setInterval(() => {
       const promise = refresh(this.props);
+      const onLoadPromise = onLoad(this.props);
       if (promise) {
         promise.catch((reason) => setTimeout(() => { throw new Error(reason); }));
+      }
+      if (onLoadPromise) {
+        onLoadPromise.catch((reason) => setTimeout(() => { throw new Error(reason); }));
       }
     }, config.globalRefreshInterval);
   }

--- a/SingularityUI/app/rootComponent.jsx
+++ b/SingularityUI/app/rootComponent.jsx
@@ -53,7 +53,10 @@ const rootComponent = (Wrapped, title, refresh = _.noop, onLoad = _.noop, refres
   }
 
   componentDidMount() {
-    onLoad(this.props);
+    const onLoadPromise = onLoad(this.props);
+    if (onLoadPromise) {
+      onLoadPromise.catch((reason) => setTimeout(() => { throw new Error(reason); }));
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Move the action of loading the log files from S3 from `refresh`, where
the `rootComponent` blocks page load until the Promise resolves, to
`componentDidMount`, where it doesn't block page load. This is intended
as a temporary fix, rather than a best-practice course of action.

/cc @ssalinas 