### PR TITLE
Display previous overridden cleanups

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/mesos/JavaUtils.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/JavaUtils.java
@@ -20,6 +20,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.lang3.time.DateFormatUtils;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -118,6 +119,10 @@ public final class JavaUtils {
 
   public static String durationFromMillis(final long millis) {
     return DurationFormatUtils.formatDuration(Math.max(millis, 0), DURATION_FORMAT);
+  }
+
+  public static String formatTimestamp(final long millis) {
+    return DateFormatUtils.ISO_DATETIME_TIME_ZONE_FORMAT.format(millis);
   }
 
   public static Thread awaitTerminationWithLatch(final CountDownLatch latch, final String threadNameSuffix, final ExecutorService service, final long millis) {

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskHistoryUpdate.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskHistoryUpdate.java
@@ -84,9 +84,9 @@ public class SingularityTaskHistoryUpdate extends SingularityTaskIdHolder implem
 
   private Set<SingularityTaskHistoryUpdate> getFlattenedPreviousUpdates(SingularityTaskHistoryUpdate update) {
     Set<SingularityTaskHistoryUpdate> previousUpdates = new HashSet<>();
-    for (SingularityTaskHistoryUpdate preivousUpdate : update.getPrevious()) {
-      previousUpdates.add(preivousUpdate.withoutPrevious());
-      previousUpdates.addAll(getFlattenedPreviousUpdates(preivousUpdate));
+    for (SingularityTaskHistoryUpdate previousUpdate : update.getPrevious()) {
+      previousUpdates.add(previousUpdate.withoutPrevious());
+      previousUpdates.addAll(getFlattenedPreviousUpdates(previousUpdate));
     }
     return previousUpdates;
   }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskHistoryUpdate.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskHistoryUpdate.java
@@ -1,5 +1,9 @@
 package com.hubspot.singularity;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import javax.annotation.Nonnull;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -16,6 +20,7 @@ public class SingularityTaskHistoryUpdate extends SingularityTaskIdHolder implem
   private final ExtendedTaskState taskState;
   private final Optional<String> statusMessage;
   private final Optional<String> statusReason;
+  private final List<SingularityTaskHistoryUpdate> previous;
 
   public enum SimplifiedTaskState {
     UNKNOWN, WAITING, RUNNING, DONE
@@ -50,14 +55,38 @@ public class SingularityTaskHistoryUpdate extends SingularityTaskIdHolder implem
     return state;
   }
 
+  public SingularityTaskHistoryUpdate(SingularityTaskId taskId, long timestamp, ExtendedTaskState taskState, Optional<String> statusMessage, Optional<String> statusReason) {
+    this(taskId, timestamp, taskState, statusMessage, statusReason, Collections.<SingularityTaskHistoryUpdate>emptyList());
+  }
+
   @JsonCreator
-  public SingularityTaskHistoryUpdate(@JsonProperty("taskId") SingularityTaskId taskId, @JsonProperty("timestamp") long timestamp, @JsonProperty("taskState") ExtendedTaskState taskState, @JsonProperty("statusMessage") Optional<String> statusMessage, @JsonProperty("statusReason") Optional<String> statusReason) {
+  public SingularityTaskHistoryUpdate(@JsonProperty("taskId") SingularityTaskId taskId,
+                                      @JsonProperty("timestamp") long timestamp,
+                                      @JsonProperty("taskState") ExtendedTaskState taskState,
+                                      @JsonProperty("statusMessage") Optional<String> statusMessage,
+                                      @JsonProperty("statusReason") Optional<String> statusReason,
+                                      @JsonProperty("previous") List<SingularityTaskHistoryUpdate> previous) {
     super(taskId);
 
     this.timestamp = timestamp;
     this.taskState = taskState;
     this.statusMessage = statusMessage;
     this.statusReason = statusReason;
+    this.previous = previous != null ? previous : Collections.<SingularityTaskHistoryUpdate>emptyList();
+  }
+
+  public SingularityTaskHistoryUpdate withPrevious(SingularityTaskHistoryUpdate previousUpdate) {
+    List<SingularityTaskHistoryUpdate> newPreviousUpdates = getFlattenedPreviousUpdates(this);
+    newPreviousUpdates.addAll(getFlattenedPreviousUpdates(previousUpdate));
+    return new SingularityTaskHistoryUpdate(getTaskId(), timestamp, taskState, statusMessage, statusReason, newPreviousUpdates);
+  }
+
+  private List<SingularityTaskHistoryUpdate> getFlattenedPreviousUpdates(SingularityTaskHistoryUpdate update) {
+    List<SingularityTaskHistoryUpdate> previousUpdates = new ArrayList<>();
+    for (SingularityTaskHistoryUpdate preivousUpdate : update.getPrevious()) {
+      previousUpdates.addAll(getFlattenedPreviousUpdates(preivousUpdate));
+    }
+    return previousUpdates;
   }
 
   @Override
@@ -108,12 +137,17 @@ public class SingularityTaskHistoryUpdate extends SingularityTaskIdHolder implem
     return statusReason;
   }
 
+  public List<SingularityTaskHistoryUpdate> getPrevious() {
+    return previous;
+  }
+
   @Override public String toString() {
     return "SingularityTaskHistoryUpdate[" +
         "timestamp=" + timestamp +
         ", taskState=" + taskState +
         ", statusMessage=" + statusMessage +
         ", statusReason=" + statusReason +
+        ", previous=" + previous +
         ']';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskHistoryUpdate.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskHistoryUpdate.java
@@ -77,17 +77,22 @@ public class SingularityTaskHistoryUpdate extends SingularityTaskIdHolder implem
 
   public SingularityTaskHistoryUpdate withPrevious(SingularityTaskHistoryUpdate previousUpdate) {
     Set<SingularityTaskHistoryUpdate> newPreviousUpdates = getFlattenedPreviousUpdates(this);
-    newPreviousUpdates.add(previousUpdate);
+    newPreviousUpdates.add(previousUpdate.withoutPrevious());
     newPreviousUpdates.addAll(getFlattenedPreviousUpdates(previousUpdate));
     return new SingularityTaskHistoryUpdate(getTaskId(), timestamp, taskState, statusMessage, statusReason, newPreviousUpdates);
   }
 
   private Set<SingularityTaskHistoryUpdate> getFlattenedPreviousUpdates(SingularityTaskHistoryUpdate update) {
-    Set<SingularityTaskHistoryUpdate> previousUpdates = new HashSet<>(update.getPrevious());
+    Set<SingularityTaskHistoryUpdate> previousUpdates = new HashSet<>();
     for (SingularityTaskHistoryUpdate preivousUpdate : update.getPrevious()) {
+      previousUpdates.add(preivousUpdate.withoutPrevious());
       previousUpdates.addAll(getFlattenedPreviousUpdates(preivousUpdate));
     }
     return previousUpdates;
+  }
+
+  public SingularityTaskHistoryUpdate withoutPrevious() {
+    return new SingularityTaskHistoryUpdate(getTaskId(), timestamp, taskState, statusMessage, statusReason, Collections.<SingularityTaskHistoryUpdate>emptySet());
   }
 
   @Override

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -481,6 +481,8 @@ public class TaskManager extends CuratorAsyncManager {
       SingularityTaskHistoryUpdate updateWithPrevious;
       if (maybeExisting.isPresent()) {
         updateWithPrevious = taskHistoryUpdate.withPrevious(maybeExisting.get());
+        LOG.info("Will save new update {}", updateWithPrevious);
+
       } else {
         updateWithPrevious = taskHistoryUpdate;
       }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -477,20 +477,15 @@ public class TaskManager extends CuratorAsyncManager {
 
     if (overwriteExisting) {
       Optional<SingularityTaskHistoryUpdate> maybeExisting = getTaskHistoryUpdate(taskHistoryUpdate.getTaskId(), taskHistoryUpdate.getTaskState());
-      SingularityTaskHistoryUpdate updateWithMessage;
-      if (maybeExisting.isPresent() && maybeExisting.get().getStatusMessage().isPresent() && taskHistoryUpdate.getStatusMessage().isPresent()) {
-        updateWithMessage = new SingularityTaskHistoryUpdate(
-            taskHistoryUpdate.getTaskId(),
-            taskHistoryUpdate.getTimestamp(),
-            taskHistoryUpdate.getTaskState(),
-            Optional.of(String.format("%s\n  Previously: %s (At %s)", taskHistoryUpdate.getStatusMessage().get(), maybeExisting.get().getStatusMessage().get(), JavaUtils.formatTimestamp(maybeExisting.get().getTimestamp()))),
-            taskHistoryUpdate.getStatusReason()
-        );
+      LOG.info("Found existing history {}", maybeExisting);
+      SingularityTaskHistoryUpdate updateWithPrevious;
+      if (maybeExisting.isPresent()) {
+        updateWithPrevious = taskHistoryUpdate.withPrevious(maybeExisting.get());
       } else {
-        updateWithMessage = taskHistoryUpdate;
+        updateWithPrevious = taskHistoryUpdate;
       }
 
-      return save(getUpdatePath(taskHistoryUpdate.getTaskId(), taskHistoryUpdate.getTaskState()), updateWithMessage, taskHistoryUpdateTranscoder);
+      return save(getUpdatePath(taskHistoryUpdate.getTaskId(), taskHistoryUpdate.getTaskState()), updateWithPrevious, taskHistoryUpdateTranscoder);
     } else {
       return create(getUpdatePath(taskHistoryUpdate.getTaskId(), taskHistoryUpdate.getTaskState()), taskHistoryUpdate, taskHistoryUpdateTranscoder);
     }

--- a/SingularityUI/app/components/taskDetail/TaskHistory.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskHistory.jsx
@@ -16,7 +16,7 @@ function TaskHistory (props) {
         data={_.sortBy(props.taskUpdates.concat(previousHistories), 'timestamp').reverse()}
         keyGetter={(taskUpdate) => taskUpdate.timestamp}
         rowChunkSize={5}
-        paginated={true}
+        paginated={false}
         rowClassName={(rowData, index) => classNames({'medium-weight': index === 0})}
       >
         <Column

--- a/SingularityUI/app/components/taskDetail/TaskHistory.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskHistory.jsx
@@ -6,11 +6,13 @@ import Column from '../common/table/Column';
 import classNames from 'classnames';
 
 function TaskHistory (props) {
+  const previousHistories = _.flatten(_.pluck(_.filter(props.taskUpdates, (update) => {return update.preivous}), 'previous'));
+
   return (
     <Section title="History">
       <UITable
         emptyTableMessage="This task has no history yet"
-        data={props.taskUpdates.concat().reverse()}
+        data={_.sortBy(props.taskUpdates.concat(previousHistories), 'timestamp').reverse()}
         keyGetter={(taskUpdate) => taskUpdate.timestamp}
         rowChunkSize={5}
         paginated={true}

--- a/SingularityUI/app/components/taskDetail/TaskHistory.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskHistory.jsx
@@ -6,7 +6,8 @@ import Column from '../common/table/Column';
 import classNames from 'classnames';
 
 function TaskHistory (props) {
-  const previousHistories = _.flatten(_.pluck(_.filter(props.taskUpdates, (update) => {return update.preivous}), 'previous'));
+  console.log(_.pluck(_.filter(props.taskUpdates, (update) => {return update.previous.length > 0}), 'previous'));
+  const previousHistories = _.flatten(_.pluck(_.filter(props.taskUpdates, (update) => {return update.previous.length > 0}), 'previous'));
 
   return (
     <Section title="History">


### PR DESCRIPTION
Right now, when a cleanup type changes we override the previous entry to change the type. It is useful to still be able to see the history of what happened. This saves previous entries in a filed on the cleanup and displays them in the ui table. They are added on a field in the entry because it would be a much larger change to try and update the zk node structure to accommodate multiple of the same type of update

/cc @darcatron 