### PR TITLE
Don't allow multiple bounces for the same request

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
@@ -61,6 +61,7 @@ public class RequestManager extends CuratorAsyncManager {
   private static final String CLEANUP_PATH_ROOT = REQUEST_ROOT + "/cleanup";
   private static final String HISTORY_PATH_ROOT = REQUEST_ROOT + "/history";
   private static final String LB_CLEANUP_PATH_ROOT = REQUEST_ROOT + "/lbCleanup";
+  private static final String BOUNCING_ROOT = REQUEST_ROOT + "/bouncing";
   private static final String EXPIRING_ACTION_PATH_ROOT = REQUEST_ROOT + "/expiring";
   private static final String EXPIRING_BOUNCE_PATH_ROOT = EXPIRING_ACTION_PATH_ROOT + "/bounce";
   private static final String EXPIRING_PAUSE_PATH_ROOT = EXPIRING_ACTION_PATH_ROOT + "/pause";
@@ -408,4 +409,15 @@ public class RequestManager extends CuratorAsyncManager {
     return getExpiringObject(SingularityExpiringSkipHealthchecks.class, requestId);
   }
 
+  public String getIsBouncingPath(String requestId) {
+    return ZKPaths.makePath(BOUNCING_ROOT, requestId);
+  }
+
+  public SingularityCreateResult markAsBouncing(String requestId) {
+    return create(getIsBouncingPath(requestId));
+  }
+
+  public SingularityDeleteResult markBounceComplete(String requestId) {
+    return delete(getIsBouncingPath(requestId));
+  }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -196,11 +196,11 @@ public class RequestResource extends AbstractRequestResource {
 
     final String deployId = getAndCheckDeployId(requestId);
 
-    SingularityCreateResult createResult = requestManager.createCleanupRequest(
+    checkConflict(!(requestManager.markAsBouncing(requestId) == SingularityCreateResult.EXISTED), "%s is already bouncing", requestId);
+
+    requestManager.createCleanupRequest(
         new SingularityRequestCleanup(JavaUtils.getUserEmail(user), isIncrementalBounce ? RequestCleanupType.INCREMENTAL_BOUNCE : RequestCleanupType.BOUNCE,
             System.currentTimeMillis(), Optional.<Boolean> absent(), requestId, Optional.of(deployId), skipHealthchecks, message, actionId, runBeforeKill));
-
-    checkConflict(createResult != SingularityCreateResult.EXISTED, "%s is already bouncing", requestId);
 
     requestManager.bounce(requestWithState.getRequest(), System.currentTimeMillis(), JavaUtils.getUserEmail(user), message);
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
@@ -605,6 +605,7 @@ public class SingularityCleaner {
 
         requestManager.deleteExpiringObject(SingularityExpiringBounce.class, bounceSucceeded.getRequestId());
       }
+      requestManager.markBounceComplete(bounceSucceeded.getRequestId());
     }
 
     LOG.info("Killed {} tasks in {}", killedTasks, JavaUtils.duration(start));


### PR DESCRIPTION
Normally we have validation that catches attempting to enqueue a bounce when 1 is already running. Not sure if something got removed over time here, but it no longer does that. Incremental bounce partially relies on the number of tasks in an INCREMENTAL_BOUNCE cleanup state. So, if a second bounce is enqueued, more tasks than expected are in this state, and things can be wrongly removed form the loadBalancer.

This adds a marker for when a request is bouncing so that multiple cannot be enqueued at once.