### PR TITLE
Remove expiring scale on deploy finish

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityDeployChecker.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityDeployChecker.java
@@ -55,6 +55,7 @@ import com.hubspot.singularity.data.DeployManager;
 import com.hubspot.singularity.data.RequestManager;
 import com.hubspot.singularity.data.TaskManager;
 import com.hubspot.singularity.expiring.SingularityExpiringPause;
+import com.hubspot.singularity.expiring.SingularityExpiringScale;
 import com.hubspot.singularity.hooks.LoadBalancerClient;
 import com.hubspot.singularity.scheduler.SingularityDeployHealthHelper.DeployHealth;
 
@@ -292,6 +293,7 @@ public class SingularityDeployChecker {
 
     if (pendingDeploy.getUpdatedRequest().isPresent() && deployResult.getDeployState() == DeployState.SUCCEEDED) {
       requestManager.update(pendingDeploy.getUpdatedRequest().get(), System.currentTimeMillis(), pendingDeploy.getDeployMarker().getUser(), Optional.<String>absent());
+      requestManager.deleteExpiringObject(SingularityExpiringScale.class, request.getId());
     }
 
     removePendingDeploy(pendingDeploy);


### PR DESCRIPTION
In the case where a deploy with a new scale has completed, we should remove any expiring scale requests for that request id and maintain the scale from the new deploy.