### PR TITLE
Interchange argument order in rootComponent

### DIFF
--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -543,4 +543,4 @@ function onLoad(props) {
   props.fechS3Logs(props.params.taskId);
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(rootComponent(withRouter(TaskDetail), (props) => props.params.taskId, refresh, onLoad));
+export default connect(mapStateToProps, mapDispatchToProps)(rootComponent(withRouter(TaskDetail), (props) => props.params.taskId, refresh, true, true, null, onLoad));

--- a/SingularityUI/app/rootComponent.jsx
+++ b/SingularityUI/app/rootComponent.jsx
@@ -2,7 +2,7 @@ import React, { PropTypes, Component } from 'react';
 import classNames from 'classnames';
 import { NotFoundNoRoot } from 'components/common/NotFound';
 
-const rootComponent = (Wrapped, title, refresh = _.noop, onLoad = _.noop, refreshInterval = true, pageMargin = true, initialize) => class extends Component {
+const rootComponent = (Wrapped, title, refresh = _.noop, refreshInterval = true, pageMargin = true, initialize, onLoad = _.noop) => class extends Component {
 
   static propTypes = {
     notFound: PropTypes.bool,


### PR DESCRIPTION
Somehow, in the muddle of branches that is Git, this slipped through
onto `master`. Interchanges the order of arguments to `rootComponent` so
that `onLoad` is at the end, and fix the only caller that uses `onLoad`
to have it in the correct position.