### PR TITLE
Pass job user as environment variable to task

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilder.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilder.java
@@ -184,6 +184,8 @@ class SingularityMesosTaskBuilder {
     setEnv(envBldr, "TASK_ID", taskId.getId());
     setEnv(envBldr, "ESTIMATED_INSTANCE_COUNT", task.getRequest().getInstancesSafe());
 
+    setEnv(envBldr, "JOB_USER", task.getPendingTask().getUser().or(""));
+
     for (Entry<String, String> envEntry : task.getDeploy().getEnv().or(Collections.<String, String>emptyMap()).entrySet()) {
       setEnv(envBldr, envEntry.getKey(), fillInTaskIdValues(envEntry.getValue(), offer, taskId));
     }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilder.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilder.java
@@ -184,7 +184,9 @@ class SingularityMesosTaskBuilder {
     setEnv(envBldr, "TASK_ID", taskId.getId());
     setEnv(envBldr, "ESTIMATED_INSTANCE_COUNT", task.getRequest().getInstancesSafe());
 
-    setEnv(envBldr, "JOB_USER", task.getPendingTask().getUser().or(""));
+    if (task.getPendingTask().getUser().isPresent()) {
+      setEnv(envBldr, "STARTED_BY_USER", task.getPendingTask().getUser().get());
+    }
 
     for (Entry<String, String> envEntry : task.getDeploy().getEnv().or(Collections.<String, String>emptyMap()).entrySet()) {
       setEnv(envBldr, envEntry.getKey(), fillInTaskIdValues(envEntry.getValue(), offer, taskId));

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilderTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilderTest.java
@@ -125,7 +125,7 @@ public class SingularityMesosTaskBuilderTest {
       success = success || (environmentVariable.getName().equals("STARTED_BY_USER") && environmentVariable.getValue().equals(user));
     }
 
-    assertTrue("Expected env variable JOB_USER to be set to " + user, success);
+    assertTrue("Expected env variable STARTED_BY_USER to be set to " + user, success);
   }
 
   @Test

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilderTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilderTest.java
@@ -122,7 +122,7 @@ public class SingularityMesosTaskBuilderTest {
 
     boolean success = false;
     for (Variable environmentVariable : environmentVariables) {
-      success = success || (environmentVariable.getName().equals("JOB_USER") && environmentVariable.getValue().equals(user));
+      success = success || (environmentVariable.getName().equals("STARTED_BY_USER") && environmentVariable.getValue().equals(user));
     }
 
     assertTrue("Expected env variable JOB_USER to be set to " + user, success);

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilderTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilderTest.java
@@ -3,7 +3,8 @@ package com.hubspot.singularity.mesos;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.Collections;


### PR DESCRIPTION
Pass the user who clicks the "Run Now" button as the value of the
environment variable `STARTED_BY_USER` in the task environment.  Can provide
more granular, task-level permissions or auditability.