### PR TITLE
Transition onLoad to an action dispatcher

### DIFF
--- a/SingularityUI/app/rootComponent.jsx
+++ b/SingularityUI/app/rootComponent.jsx
@@ -76,7 +76,7 @@ const rootComponent = (Wrapped, refresh = null, refreshInterval = true, pageMarg
   }
 
   componentDidMount() {
-    const onLoadPromise = onLoad(this.props);
+    const onLoadPromise = this.dispatchOnLoad();
     if (onLoadPromise) {
       onLoadPromise.catch((reason) => setTimeout(() => { throw new Error(reason); }));
     }


### PR DESCRIPTION
One of the changes that was blocked on the tailer was making `onLoad`
behave like an action dispatcher, rather than a function. So each of the
components treats it as an object (or, at least, the base case is `null`
rather than `_.noop`).  This means that it was misbehaving when it
wasn't explicitly set because pre-tailer it was expected to be a
function.

More specifically, some pages were permanently stuck with the page loaded, but a visible loading spinner still present