### PR TITLE
Fix tailer when reloading file

### DIFF
--- a/SingularityUI/SingularityTailer/package.json
+++ b/SingularityUI/SingularityTailer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "singularityui-tailer",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "A robust log tailer",
   "author": "Danny Wolf <dwolf@hubspot.com>",
   "contributors": [

--- a/SingularityUI/SingularityTailer/src/components/Log.js
+++ b/SingularityUI/SingularityTailer/src/components/Log.js
@@ -51,6 +51,8 @@ class Log extends Component {
   componentDidMount() {
     if (!this.props.isLoaded) {
       this.props.initializeFile(this.props.goToOffset);
+    } else {
+      this.tailLog();
     }
 
     this.rafRequestId = window.requestAnimationFrame(this.pollScroll);

--- a/SingularityUI/package.json
+++ b/SingularityUI/package.json
@@ -64,7 +64,7 @@
     "redux-thunk": "^2.0.1",
     "reselect": "^2.5.1",
     "select2": "~3.5.1",
-    "singularityui-tailer": "0.3.5",
+    "singularityui-tailer": "0.3.6",
     "typeahead.js": "~0.10.4",
     "underscore": "~1.8.0",
     "uuid": "^3.0.0",


### PR DESCRIPTION
Previously if you started tailing a file, navigated away, then came back to the file, it would never load. The `initializeFile` call in `componentDidMount` also triggered the start of tailing. But, we sipped that in the case that we had already loaded the log before. Now, in the case where we already loaded the log we'll still start tailing again.

/cc @tpetr 