### PR TITLE
Add spacing line at the bottom of logs

### DIFF
--- a/SingularityUI/app/styles/scss/new-tailer.scss
+++ b/SingularityUI/app/styles/scss/new-tailer.scss
@@ -31,6 +31,7 @@
       flex-flow: column;
       width: 100%;
       height: 100%;
+      padding-bottom: 10px;
 
       overflow: scroll;
       // will repaint on scroll if you don't put this in!!!

--- a/SingularityUI/app/styles/scss/new-tailer.scss
+++ b/SingularityUI/app/styles/scss/new-tailer.scss
@@ -31,7 +31,7 @@
       flex-flow: column;
       width: 100%;
       height: 100%;
-      padding-bottom: 10px;
+      padding-bottom: 15px;
 
       overflow: scroll;
       // will repaint on scroll if you don't put this in!!!


### PR DESCRIPTION
Add a small amount of padding at the bottom of the logging container.
Now if you scroll all the way to the bottom of log tailer, there should
be a small space between the last log line and the bottom of the screen,
so that the scrollbar (on MacOS) won't overlap the last line of the
text.