### PR TITLE
Better zk cleanup for removed requests

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/config/HistoryPurgingConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/HistoryPurgingConfiguration.java
@@ -21,6 +21,8 @@ public class HistoryPurgingConfiguration {
 
   private int purgeLimitPerQuery = 25000;
 
+  private int purgeStaleRequestIdsAfterDays = 7;
+
   private Map<String, HistoryPurgeRequestSettings> requestOverrides = Collections.emptyMap();
 
   private Optional<Integer> absentIfNotOverOne(int value) {
@@ -92,5 +94,13 @@ public class HistoryPurgingConfiguration {
 
   public void setPurgeLimitPerQuery(int purgeLimitPerQuery) {
     this.purgeLimitPerQuery = purgeLimitPerQuery;
+  }
+
+  public int getPurgeStaleRequestIdsAfterDays() {
+    return purgeStaleRequestIdsAfterDays;
+  }
+
+  public void setPurgeStaleRequestIdsAfterDays(int purgeStaleRequestIdsAfterDays) {
+    this.purgeStaleRequestIdsAfterDays = purgeStaleRequestIdsAfterDays;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/CuratorManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/CuratorManager.java
@@ -292,5 +292,4 @@ public abstract class CuratorManager {
   protected Optional<String> getStringData(String path) {
     return getData(path, Optional.<Stat> absent(), StringTranscoder.INSTANCE, Optional.<ZkCache<String>> absent(), Optional.<Boolean> absent());
   }
-
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
@@ -52,7 +52,6 @@ import com.hubspot.singularity.SingularityTaskShellCommandUpdate;
 import com.hubspot.singularity.TaskCleanupType;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.DeployManager;
-import com.hubspot.singularity.data.MetadataManager;
 import com.hubspot.singularity.data.RequestManager;
 import com.hubspot.singularity.data.TaskManager;
 import com.hubspot.singularity.data.history.RequestHistoryHelper;
@@ -90,7 +89,6 @@ public class SingularityCleaner {
     this.driverManager = driverManager;
     this.exceptionNotifier = exceptionNotifier;
     this.requestHistoryHelper = requestHistoryHelper;
-    this.metadataManager = metadataManager;
 
     this.configuration = configuration;
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
@@ -19,7 +19,7 @@ import com.hubspot.singularity.sentry.SingularityExceptionNotifier;
 
 public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
 
-  private static final Logger LOG = LoggerFactory.getLogger(SingularityTaskReconciliationPoller.class);
+  private static final Logger LOG = LoggerFactory.getLogger(SingularityUsagePoller.class);
 
   private final SingularityConfiguration configuration;
   private final MesosClient mesosClient;

--- a/SingularityService/src/test/java/com/hubspot/singularity/SingularityHistoryTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/SingularityHistoryTest.java
@@ -26,6 +26,7 @@ import com.hubspot.singularity.api.SingularityDeleteRequestRequest;
 import com.hubspot.singularity.api.SingularityRunNowRequest;
 import com.hubspot.singularity.api.SingularityScaleRequest;
 import com.hubspot.singularity.config.HistoryPurgingConfiguration;
+import com.hubspot.singularity.data.MetadataManager;
 import com.hubspot.singularity.data.TaskManager;
 import com.hubspot.singularity.data.history.HistoryManager;
 import com.hubspot.singularity.data.history.SingularityHistoryPurger;
@@ -47,6 +48,9 @@ public class SingularityHistoryTest extends SingularitySchedulerTestBase {
 
   @Inject
   protected HistoryManager historyManager;
+
+  @Inject
+  protected MetadataManager metadataManager;
 
   @Inject
   protected SingularityTaskHistoryPersister taskHistoryPersister;
@@ -140,7 +144,7 @@ public class SingularityHistoryTest extends SingularitySchedulerTestBase {
 
     Assert.assertEquals(1, getTaskHistoryForRequest(requestId, 0, 100).size());
 
-    SingularityHistoryPurger purger = new SingularityHistoryPurger(historyPurgingConfiguration, historyManager);
+    SingularityHistoryPurger purger = new SingularityHistoryPurger(historyPurgingConfiguration, historyManager, taskManager, deployManager, requestManager, metadataManager);
 
     purger.runActionOnPoll();
 
@@ -162,7 +166,7 @@ public class SingularityHistoryTest extends SingularitySchedulerTestBase {
     historyPurgingConfiguration.setEnabled(true);
     historyPurgingConfiguration.setDeleteTaskHistoryAfterDays(10);
 
-    SingularityHistoryPurger purger = new SingularityHistoryPurger(historyPurgingConfiguration, historyManager);
+    SingularityHistoryPurger purger = new SingularityHistoryPurger(historyPurgingConfiguration, historyManager, taskManager, deployManager, requestManager, metadataManager);
 
     purger.runActionOnPoll();
 


### PR DESCRIPTION
Cleans up a number of stale nodes created for requests.

On request delete:
- remove from `/deploys/requests`
- remove from `/tasks/history`

In purger (`x` -> `purgeStaleRequestIdsAfterDays` setting in config, 7 days by default)
- In `/deploys/requests` delete if not in active request ids + hasn't been updated in `x` days + no `STATE` key present
- In `/tasks/history` delete if not in active request ids + hasn't been updated in `x` days + no child nodes
- In `/metadata/mails` delete if not in active request ids + hasn't been updated in `x` days

/cc @wsorenson 