### PR TITLE
Reduce timeout on requests to task sandboxes

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -220,7 +220,7 @@ public class SingularityConfiguration extends Configuration {
 
   private boolean sandboxDefaultsToTaskId = false;
 
-  private long sandboxHttpTimeoutMillis = TimeUnit.SECONDS.toMillis(5);
+  private long sandboxHttpTimeoutMillis = TimeUnit.SECONDS.toMillis(2);
 
   private long saveStateEverySeconds = 60;
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SandboxManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SandboxManager.java
@@ -52,9 +52,17 @@ public class SandboxManager {
 
   public Collection<MesosFileObject> browse(String slaveHostname, String fullPath) throws SlaveNotFoundException {
     try {
-      Response response = asyncHttpClient.prepareGet(String.format("http://%s:5051/files/browse", slaveHostname))
+      PerRequestConfig timeoutConfig = new PerRequestConfig();
+      timeoutConfig.setRequestTimeoutInMs((int) configuration.getSandboxHttpTimeoutMillis());
+
+      Response response = asyncHttpClient
+          .prepareGet(String.format("http://%s:5051/files/browse", slaveHostname))
+          .setPerRequestConfig(timeoutConfig)
           .addQueryParameter("path", fullPath)
-          .execute().get();
+          .execute()
+          .get();
+
+
 
       if (response.getStatusCode() == 404) {
         return Collections.emptyList();


### PR DESCRIPTION
Previously there was a timeout associated with http request fetching the log files from the task sandbox, but not one associated with browsing the task's sandbox. This adds the same timeout period to browsing the sandbox. It also slightly drops the timeout period on the request, from 5 seconds to 2 seconds.