### PR TITLE
Put a limit on number of slaves to decommission at once

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -321,6 +321,8 @@ public class SingularityConfiguration extends Configuration {
 
   private int maxActiveOnDemandTasksPerRequest = 0;
 
+  private int maxDecommissioningSlaves = 2;
+
   public long getAskDriverToKillTasksAgainAfterMillis() {
     return askDriverToKillTasksAgainAfterMillis;
   }
@@ -1306,5 +1308,13 @@ public class SingularityConfiguration extends Configuration {
 
   public void setMaxActiveOnDemandTasksPerRequest(int maxActiveOnDemandTasksPerRequest) {
     this.maxActiveOnDemandTasksPerRequest = maxActiveOnDemandTasksPerRequest;
+  }
+
+  public int getMaxDecommissioningSlaves() {
+    return maxDecommissioningSlaves;
+  }
+
+  public void setMaxDecommissioningSlaves(int maxDecommissioningSlaves) {
+    this.maxDecommissioningSlaves = maxDecommissioningSlaves;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
@@ -587,7 +587,7 @@ public class SingularityValidator {
   public void validateDecommissioningCount() {
     int decommissioning = slaveManager.getObjectsFiltered(MachineState.DECOMMISSIONING).size() + slaveManager.getObjectsFiltered(MachineState.STARTING_DECOMMISSION).size();
     checkBadRequest(decommissioning < maxDecommissioningSlaves,
-        "{} slaves are already decommissioning state ({} allowed at once). Allow these slaves to finish before decommissioning another", decommissioning, maxDecommissioningSlaves);
+        "%s slaves are already decommissioning state (%s allowed at once). Allow these slaves to finish before decommissioning another", decommissioning, maxDecommissioningSlaves);
   }
 
   public void checkActionEnabled(SingularityAction action) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
@@ -87,6 +87,7 @@ public class SingularityValidator {
   private final int defaultHealthcheckStartupTimeooutSeconds;
   private final int defaultHealthcehckMaxRetries;
   private final int defaultHealthcheckResponseTimeoutSeconds;
+  private final int maxDecommissioningSlaves;
   private final boolean allowRequestsWithoutOwners;
   private final boolean createDeployIds;
   private final int deployIdLength;
@@ -131,6 +132,8 @@ public class SingularityValidator {
     this.defaultHealthcheckStartupTimeooutSeconds = configuration.getStartupTimeoutSeconds();
     this.defaultHealthcehckMaxRetries = configuration.getHealthcheckMaxRetries().or(0);
     this.defaultHealthcheckResponseTimeoutSeconds = configuration.getHealthcheckTimeoutSeconds();
+
+    this.maxDecommissioningSlaves = configuration.getMaxDecommissioningSlaves();
 
     this.uiConfiguration = uiConfiguration;
 
@@ -579,6 +582,12 @@ public class SingularityValidator {
     checkBadRequest(!systemOnlyStateTransitions.contains(newState), "States {} are reserved for system usage, you cannot manually transition to {}", systemOnlyStateTransitions, newState);
 
     checkBadRequest(!(newState == MachineState.DECOMMISSIONED && !changeRequest.isKillTasksOnDecommissionTimeout()), "Must specify that all tasks on slave get killed if transitioning to DECOMMISSIONED state");
+  }
+
+  public void validateDecommissioningCount() {
+    int decommissioning = slaveManager.getObjectsFiltered(MachineState.DECOMMISSIONING).size() + slaveManager.getObjectsFiltered(MachineState.STARTING_DECOMMISSION).size();
+    checkBadRequest(decommissioning < maxDecommissioningSlaves,
+        "{} slaves are already decommissioning state ({} allowed at once). Allow these slaves to finish before decommissioning another", decommissioning, maxDecommissioningSlaves);
   }
 
   public void checkActionEnabled(SingularityAction action) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractMachineResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractMachineResource.java
@@ -76,6 +76,7 @@ public abstract class AbstractMachineResource<T extends SingularityMachineAbstra
     authorizationHelper.checkAdminAuthorization(user);
     validator.checkActionEnabled(action);
     validator.validateExpiringMachineStateChange(decommissionRequest, MachineState.STARTING_DECOMMISSION, manager.getExpiringObject(objectId));
+    validator.validateDecommissioningCount();
     changeState(objectId, MachineState.STARTING_DECOMMISSION, decommissionRequest, queryUser);
     saveExpiring(decommissionRequest, queryUser, objectId);
   }


### PR DESCRIPTION
Defaulting this to 2 for now, can always override later