### PR TITLE
Extend the leader and web caching

### DIFF
--- a/SingularityService/pom.xml
+++ b/SingularityService/pom.xml
@@ -171,6 +171,16 @@
     </dependency>
 
     <dependency>
+      <groupId>com.hubspot</groupId>
+      <artifactId>HorizonCore</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.hubspot</groupId>
+      <artifactId>HorizonNing</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-jdbi</artifactId>
     </dependency>

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAuthorizationHelper.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAuthorizationHelper.java
@@ -214,12 +214,12 @@ public class SingularityAuthorizationHelper {
     });
   }
 
-  public Iterable<String> filterAuthorizedRequestIds(final Optional<SingularityUser> user, List<String> requestIds, final SingularityAuthorizationScope scope) {
+  public Iterable<String> filterAuthorizedRequestIds(final Optional<SingularityUser> user, List<String> requestIds, final SingularityAuthorizationScope scope, boolean useWebCache) {
     if (hasAdminAuthorization(user)) {
       return requestIds;
     }
 
-    final Map<String, SingularityRequestWithState> requestMap = Maps.uniqueIndex(requestManager.getRequests(requestIds), new Function<SingularityRequestWithState, String>() {
+    final Map<String, SingularityRequestWithState> requestMap = Maps.uniqueIndex(requestManager.getRequests(requestIds, useWebCache), new Function<SingularityRequestWithState, String>() {
       @Override
       public String apply(@Nonnull SingularityRequestWithState input) {
         return input.getRequest().getId();

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
@@ -354,7 +354,7 @@ public class RequestManager extends CuratorAsyncManager {
   }
 
   public void activateLeaderCache() {
-    leaderCache.cacheRequests(getRequests());
+    leaderCache.cacheRequests(fetchRequests());
   }
 
   public List<SingularityRequestWithState> getRequests() {
@@ -369,7 +369,7 @@ public class RequestManager extends CuratorAsyncManager {
     if (useWebCache && webCache.useCachedRequests()) {
       return webCache.getRequests();
     }
-    List<SingularityRequestWithState> requests = getAsyncChildren(NORMAL_PATH_ROOT, Optional.of(requestIdCache), requestTranscoder);
+    List<SingularityRequestWithState> requests = fetchRequests();
 
     if (useWebCache) {
       webCache.cacheRequests(requests);
@@ -377,7 +377,9 @@ public class RequestManager extends CuratorAsyncManager {
     return requests;
   }
 
-
+  public List<SingularityRequestWithState> fetchRequests() {
+    return getAsyncChildren(NORMAL_PATH_ROOT, Optional.of(requestIdCache), requestTranscoder);
+  }
 
   public Optional<SingularityRequestWithState> getRequest(String requestId) {
     return getData(getRequestPath(requestId), requestTranscoder);

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
@@ -213,11 +213,7 @@ public class RequestManager extends CuratorAsyncManager {
 
   public SingularityCreateResult save(SingularityRequest request, RequestState state, RequestHistoryType eventType, long timestamp, Optional<String> user, Optional<String> message) {
     saveHistory(new SingularityRequestHistory(timestamp, user, eventType, request, message));
-
-    if (leaderCache.active()) {
-      leaderCache.putRequest(new SingularityRequestWithState(request, state, timestamp));
-    }
-
+    leaderCache.putRequest(new SingularityRequestWithState(request, state, timestamp));
     return save(getRequestPath(request.getId()), new SingularityRequestWithState(request, state, timestamp), requestTranscoder);
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
@@ -382,6 +382,18 @@ public class RequestManager extends CuratorAsyncManager {
   }
 
   public Optional<SingularityRequestWithState> getRequest(String requestId) {
+    return getRequest(requestId, false);
+  }
+
+  public Optional<SingularityRequestWithState> getRequest(String requestId, boolean useWebCache) {
+    if (leaderCache.active()) {
+      return leaderCache.getRequest(requestId);
+    }
+
+    if (useWebCache && webCache.useCachedRequests()) {
+      return webCache.getRequest(requestId);
+    }
+
     return getData(getRequestPath(requestId), requestTranscoder);
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
@@ -3,6 +3,7 @@ package com.hubspot.singularity.data;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.utils.ZKPaths;
@@ -41,6 +42,7 @@ import com.hubspot.singularity.expiring.SingularityExpiringPause;
 import com.hubspot.singularity.expiring.SingularityExpiringRequestActionParent;
 import com.hubspot.singularity.expiring.SingularityExpiringScale;
 import com.hubspot.singularity.expiring.SingularityExpiringSkipHealthchecks;
+import com.hubspot.singularity.scheduler.SingularityLeaderCache;
 
 @Singleton
 public class RequestManager extends CuratorAsyncManager {
@@ -55,6 +57,9 @@ public class RequestManager extends CuratorAsyncManager {
 
   private final SingularityEventListener singularityEventListener;
   private final ZkChildrenCache requestIdCache;
+
+  private final SingularityWebCache webCache;
+  private final SingularityLeaderCache leaderCache;
 
   private static final String REQUEST_ROOT = "/requests";
 
@@ -83,7 +88,8 @@ public class RequestManager extends CuratorAsyncManager {
   public RequestManager(CuratorFramework curator, SingularityConfiguration configuration, MetricRegistry metricRegistry, SingularityEventListener singularityEventListener, @Named(SingularityDataModule.REQUEST_ID_CACHE_NAME) ZkChildrenCache requestIdCache,
       Transcoder<SingularityRequestCleanup> requestCleanupTranscoder, Transcoder<SingularityRequestWithState> requestTranscoder, Transcoder<SingularityRequestLbCleanup> requestLbCleanupTranscoder,
       Transcoder<SingularityPendingRequest> pendingRequestTranscoder, Transcoder<SingularityRequestHistory> requestHistoryTranscoder, Transcoder<SingularityExpiringBounce> expiringBounceTranscoder,
-      Transcoder<SingularityExpiringScale> expiringScaleTranscoder,  Transcoder<SingularityExpiringPause> expiringPauseTranscoder, Transcoder<SingularityExpiringSkipHealthchecks> expiringSkipHealthchecksTranscoder) {
+      Transcoder<SingularityExpiringScale> expiringScaleTranscoder,  Transcoder<SingularityExpiringPause> expiringPauseTranscoder, Transcoder<SingularityExpiringSkipHealthchecks> expiringSkipHealthchecksTranscoder,
+      SingularityWebCache webCache, SingularityLeaderCache leaderCache) {
     super(curator, configuration, metricRegistry);
     this.requestTranscoder = requestTranscoder;
     this.requestCleanupTranscoder = requestCleanupTranscoder;
@@ -99,6 +105,9 @@ public class RequestManager extends CuratorAsyncManager {
         SingularityExpiringScale.class, expiringScaleTranscoder,
         SingularityExpiringSkipHealthchecks.class, expiringSkipHealthchecksTranscoder
         );
+
+    this.leaderCache = leaderCache;
+    this.webCache = webCache;
   }
 
   private String getRequestPath(String requestId) {
@@ -282,6 +291,20 @@ public class RequestManager extends CuratorAsyncManager {
   }
 
   public List<SingularityRequestWithState> getRequests(Collection<String> requestIds) {
+    return getRequests(requestIds, false);
+  }
+
+  public List<SingularityRequestWithState> getRequests(Collection<String> requestIds, boolean useWebCache) {
+    if (useWebCache) {
+      if (webCache.useCachedRequests()) {
+        return webCache.getRequests().stream().filter((r) -> requestIds.contains(r.getRequest().getId())).collect(Collectors.toList());
+      } else {
+        List<SingularityRequestWithState> requests = getRequests(useWebCache);
+        webCache.cacheRequests(requests);
+        return requests.stream().filter((r) -> requestIds.contains(r.getRequest().getId())).collect(Collectors.toList());
+      }
+    }
+
     final List<String> paths = Lists.newArrayListWithCapacity(requestIds.size());
     for (String requestId : requestIds) {
       paths.add(getRequestPath(requestId));
@@ -306,29 +329,47 @@ public class RequestManager extends CuratorAsyncManager {
     });
   }
 
-  private Iterable<SingularityRequestWithState> getRequests(RequestState... states) {
-    return filter(getRequests(), states);
+  private Iterable<SingularityRequestWithState> getRequests(boolean useWebCache, RequestState... states) {
+    return filter(getRequests(useWebCache), states);
   }
 
-  public Iterable<SingularityRequestWithState> getPausedRequests() {
-    return getRequests(RequestState.PAUSED);
+  public Iterable<SingularityRequestWithState> getPausedRequests(boolean useWebCache) {
+    return getRequests(useWebCache, RequestState.PAUSED);
   }
 
   public Iterable<SingularityRequestWithState> getActiveRequests() {
-    return getRequests(RequestState.ACTIVE, RequestState.DEPLOYING_TO_UNPAUSE);
+    return getActiveRequests(false);
   }
 
-  public Iterable<SingularityRequestWithState> getCooldownRequests() {
-    return getRequests(RequestState.SYSTEM_COOLDOWN);
+  public Iterable<SingularityRequestWithState> getActiveRequests(boolean useWebCache) {
+    return getRequests(useWebCache, RequestState.ACTIVE, RequestState.DEPLOYING_TO_UNPAUSE);
   }
 
-  public Iterable<SingularityRequestWithState> getFinishedRequests() {
-    return getRequests(RequestState.FINISHED);
+  public Iterable<SingularityRequestWithState> getCooldownRequests(boolean useWebCache) {
+    return getRequests(useWebCache, RequestState.SYSTEM_COOLDOWN);
+  }
+
+  public Iterable<SingularityRequestWithState> getFinishedRequests(boolean useWebCache) {
+    return getRequests(useWebCache, RequestState.FINISHED);
   }
 
   public List<SingularityRequestWithState> getRequests() {
-    return getAsyncChildren(NORMAL_PATH_ROOT, Optional.of(requestIdCache), requestTranscoder);
+    return getRequests(false);
   }
+
+  public List<SingularityRequestWithState> getRequests(boolean useWebCache) {
+    if (useWebCache && webCache.useCachedRequests()) {
+      return webCache.getRequests();
+    }
+    List<SingularityRequestWithState> requests = getAsyncChildren(NORMAL_PATH_ROOT, Optional.of(requestIdCache), requestTranscoder);
+
+    if (useWebCache) {
+      webCache.cacheRequests(requests);
+    }
+    return requests;
+  }
+
+
 
   public Optional<SingularityRequestWithState> getRequest(String requestId) {
     return getData(getRequestPath(requestId), requestTranscoder);

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
@@ -18,7 +18,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import com.google.inject.name.Named;
 import com.hubspot.singularity.RequestCleanupType;
 import com.hubspot.singularity.RequestState;
 import com.hubspot.singularity.SingularityCreateResult;
@@ -56,7 +55,6 @@ public class RequestManager extends CuratorAsyncManager {
   private final Transcoder<SingularityRequestLbCleanup> requestLbCleanupTranscoder;
 
   private final SingularityEventListener singularityEventListener;
-  private final ZkChildrenCache requestIdCache;
 
   private final SingularityWebCache webCache;
   private final SingularityLeaderCache leaderCache;
@@ -85,7 +83,7 @@ public class RequestManager extends CuratorAsyncManager {
   private final Map<Class<? extends SingularityExpiringRequestActionParent<? extends SingularityExpiringRequestParent>>, Transcoder<? extends SingularityExpiringRequestActionParent<? extends SingularityExpiringRequestParent>>> expiringTranscoderMap;
 
   @Inject
-  public RequestManager(CuratorFramework curator, SingularityConfiguration configuration, MetricRegistry metricRegistry, SingularityEventListener singularityEventListener, @Named(SingularityDataModule.REQUEST_ID_CACHE_NAME) ZkChildrenCache requestIdCache,
+  public RequestManager(CuratorFramework curator, SingularityConfiguration configuration, MetricRegistry metricRegistry, SingularityEventListener singularityEventListener,
       Transcoder<SingularityRequestCleanup> requestCleanupTranscoder, Transcoder<SingularityRequestWithState> requestTranscoder, Transcoder<SingularityRequestLbCleanup> requestLbCleanupTranscoder,
       Transcoder<SingularityPendingRequest> pendingRequestTranscoder, Transcoder<SingularityRequestHistory> requestHistoryTranscoder, Transcoder<SingularityExpiringBounce> expiringBounceTranscoder,
       Transcoder<SingularityExpiringScale> expiringScaleTranscoder,  Transcoder<SingularityExpiringPause> expiringPauseTranscoder, Transcoder<SingularityExpiringSkipHealthchecks> expiringSkipHealthchecksTranscoder,
@@ -97,7 +95,6 @@ public class RequestManager extends CuratorAsyncManager {
     this.requestHistoryTranscoder = requestHistoryTranscoder;
     this.singularityEventListener = singularityEventListener;
     this.requestLbCleanupTranscoder = requestLbCleanupTranscoder;
-    this.requestIdCache = requestIdCache;
 
     this.expiringTranscoderMap = ImmutableMap.of(
         SingularityExpiringBounce.class, expiringBounceTranscoder,
@@ -192,7 +189,7 @@ public class RequestManager extends CuratorAsyncManager {
   }
 
   public List<String> getAllRequestIds() {
-    return getChildren(NORMAL_PATH_ROOT, Optional.of(requestIdCache));
+    return getChildren(NORMAL_PATH_ROOT);
   }
 
   public List<String> getRequestIdsWithHistory() {
@@ -378,7 +375,7 @@ public class RequestManager extends CuratorAsyncManager {
   }
 
   public List<SingularityRequestWithState> fetchRequests() {
-    return getAsyncChildren(NORMAL_PATH_ROOT, Optional.of(requestIdCache), requestTranscoder);
+    return getAsyncChildren(NORMAL_PATH_ROOT, requestTranscoder);
   }
 
   public Optional<SingularityRequestWithState> getRequest(String requestId) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityDataModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityDataModule.java
@@ -1,21 +1,15 @@
 package com.hubspot.singularity.data;
 
-import org.apache.curator.framework.CuratorFramework;
-
 import com.codahale.metrics.MetricRegistry;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
-import com.google.inject.name.Named;
 import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.helpers.RequestHelper;
 
 public class SingularityDataModule extends AbstractModule {
-
-  public static final String REQUEST_ID_CACHE_NAME = "requestid.cache";
-  public static final String TASK_CLEANUP_ID_CACHE_NAME = "taskcleanupid.cache";
 
   @Override
   protected void configure() {
@@ -49,19 +43,4 @@ public class SingularityDataModule extends AbstractModule {
   public ZkCache<SingularityTask> taskCache(SingularityConfiguration configuration, MetricRegistry registry) {
     return new ZkCache<>(configuration.getCacheTasksMaxSize(), configuration.getCacheTasksInitialSize(), configuration.getCacheTasksForMillis(), registry, "tasks");
   }
-
-  @Provides
-  @Singleton
-  @Named(REQUEST_ID_CACHE_NAME)
-  public ZkChildrenCache requestIdCache(CuratorFramework curator, MetricRegistry registry) {
-    return new ZkChildrenCache(curator, "requestIds", registry);
-  }
-
-  @Provides
-  @Singleton
-  @Named(TASK_CLEANUP_ID_CACHE_NAME)
-  public ZkChildrenCache cleanupIdCache(CuratorFramework curator, MetricRegistry registry) {
-    return new ZkChildrenCache(curator, "taskCleanupIds", registry);
-  }
-
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityWebCache.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityWebCache.java
@@ -11,6 +11,7 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.hubspot.singularity.SingularityPendingTask;
 import com.hubspot.singularity.SingularityPendingTaskId;
+import com.hubspot.singularity.SingularityRequestWithState;
 import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.SingularityTaskCleanup;
 import com.hubspot.singularity.SingularityTaskId;
@@ -28,6 +29,9 @@ public class SingularityWebCache {
   private volatile Map<SingularityTaskId, SingularityTask> cachedActiveTasks;
   private volatile long lastActiveTaskCache;
 
+  private volatile  Map<String, SingularityRequestWithState> cachedRequests;
+  private volatile long lastRequestsCache;
+
   private final long cacheForMillis;
 
   private final Meter cleanupHitMeter;
@@ -38,6 +42,9 @@ public class SingularityWebCache {
 
   private final Meter activeHitMeter;
   private final Meter activeMissMeter;
+
+  private final Meter requestsHitMeter;
+  private final Meter requestsMissMeter;
 
   @Inject
   public SingularityWebCache(SingularityConfiguration configuration, MetricRegistry metrics) {
@@ -51,6 +58,9 @@ public class SingularityWebCache {
 
     this.activeHitMeter = metrics.meter("zk.web.caches.active.hits");
     this.activeMissMeter = metrics.meter("zk.web.caches.active.miss");
+
+    this.requestsHitMeter = metrics.meter("zk.web.caches.requests.hits");
+    this.requestsMissMeter = metrics.meter("zk.web.caches.requests.miss");
   }
 
   public boolean useCachedPendingTasks() {
@@ -63,6 +73,10 @@ public class SingularityWebCache {
 
   public boolean useCachedActiveTasks() {
     return useCache(lastActiveTaskCache);
+  }
+
+  public boolean useCachedRequests() {
+    return useCache(lastRequestsCache);
   }
 
   private boolean useCache(long lastCache) {
@@ -94,6 +108,11 @@ public class SingularityWebCache {
     return new ArrayList<>(cachedActiveTasks.values());
   }
 
+  public List<SingularityRequestWithState> getRequests() {
+    requestsHitMeter.mark();
+    return new ArrayList<>(cachedRequests.values());
+  }
+
   public void cacheTaskCleanup(List<SingularityTaskCleanup> newTaskCleanup) {
     cleanupMissMeter.mark();
     cachedTaskCleanup = new ArrayList<>(newTaskCleanup);
@@ -118,6 +137,16 @@ public class SingularityWebCache {
     }
     cachedActiveTasks = newActiveTasks;
     lastActiveTaskCache = System.currentTimeMillis();
+  }
+
+  public void cacheRequests(List<SingularityRequestWithState> requests) {
+    activeMissMeter.mark();
+    Map<String, SingularityRequestWithState> newRequests = new HashMap<>(requests.size());
+    for (SingularityRequestWithState request : requests) {
+      newRequests.put(request.getRequest().getId(), request);
+    }
+    cachedRequests = newRequests;
+    lastRequestsCache = System.currentTimeMillis();
   }
 
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityWebCache.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityWebCache.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.hubspot.singularity.SingularityPendingTask;
@@ -111,6 +112,10 @@ public class SingularityWebCache {
   public List<SingularityRequestWithState> getRequests() {
     requestsHitMeter.mark();
     return new ArrayList<>(cachedRequests.values());
+  }
+
+  public Optional<SingularityRequestWithState> getRequest(String requestId) {
+    return Optional.fromNullable(cachedRequests.get(requestId));
   }
 
   public void cacheTaskCleanup(List<SingularityTaskCleanup> newTaskCleanup) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityWebCache.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityWebCache.java
@@ -145,7 +145,7 @@ public class SingularityWebCache {
   }
 
   public void cacheRequests(List<SingularityRequestWithState> requests) {
-    activeMissMeter.mark();
+    requestsMissMeter.mark();
     Map<String, SingularityRequestWithState> newRequests = new HashMap<>(requests.size());
     for (SingularityRequestWithState request : requests) {
       newRequests.put(request.getRequest().getId(), request);

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -777,6 +777,7 @@ public class TaskManager extends CuratorAsyncManager {
   public void activateLeaderCache() {
     leaderCache.cachePendingTasks(fetchPendingTasks());
     leaderCache.cacheActiveTaskIds(getTaskIds(ACTIVE_PATH_ROOT));
+    leaderCache.cacheCleanupTasks(getCleanupTasks());
   }
 
   private List<SingularityPendingTask> fetchPendingTasks() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -117,7 +117,6 @@ public class TaskManager extends CuratorAsyncManager {
   private final ZkCache<SingularityTask> taskCache;
   private final SingularityWebCache webCache;
   private final SingularityLeaderCache leaderCache;
-  private final ZkChildrenCache taskCleanupIdCache;
 
   private final SingularityEventListener singularityEventListener;
   private final String serverId;
@@ -129,7 +128,7 @@ public class TaskManager extends CuratorAsyncManager {
       Transcoder<SingularityTaskCleanup> taskCleanupTranscoder, Transcoder<SingularityTaskHistoryUpdate> taskHistoryUpdateTranscoder, Transcoder<SingularityPendingTask> pendingTaskTranscoder,
       Transcoder<SingularityKilledTaskIdRecord> killedTaskIdRecordTranscoder, Transcoder<SingularityTaskShellCommandRequest> taskShellCommandRequestTranscoder,
       Transcoder<SingularityTaskShellCommandUpdate> taskShellCommandUpdateTranscoder,  Transcoder<SingularityTaskMetadata> taskMetadataTranscoder,
-      ZkCache<SingularityTask> taskCache, SingularityWebCache webCache, SingularityLeaderCache leaderCache, @Named(SingularityDataModule.TASK_CLEANUP_ID_CACHE_NAME) ZkChildrenCache taskCleanupIdCache,
+      ZkCache<SingularityTask> taskCache, SingularityWebCache webCache, SingularityLeaderCache leaderCache,
       @Named(SingularityMainModule.SERVER_ID_PROPERTY) String serverId) {
     super(curator, configuration, metricRegistry);
 
@@ -151,7 +150,6 @@ public class TaskManager extends CuratorAsyncManager {
 
     this.webCache = webCache;
     this.leaderCache = leaderCache;
-    this.taskCleanupIdCache = taskCleanupIdCache;
     this.serverId = serverId;
   }
 
@@ -384,7 +382,7 @@ public class TaskManager extends CuratorAsyncManager {
       return leaderCache.getCleanupTaskIds();
     }
 
-    return getChildrenAsIds(CLEANUP_PATH_ROOT, Optional.of(taskCleanupIdCache), taskIdTranscoder);
+    return getChildrenAsIds(CLEANUP_PATH_ROOT, taskIdTranscoder);
   }
 
   public List<SingularityTaskCleanup> getCleanupTasks(boolean useWebCache) {
@@ -417,7 +415,7 @@ public class TaskManager extends CuratorAsyncManager {
   }
 
   public List<SingularityTaskCleanup> fetchCleanupTasks() {
-    return getAsyncChildren(CLEANUP_PATH_ROOT, Optional.of(taskCleanupIdCache), taskCleanupTranscoder);
+    return getAsyncChildren(CLEANUP_PATH_ROOT, taskCleanupTranscoder);
   }
 
   public List<SingularityTask> getActiveTasks() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -396,7 +396,7 @@ public class TaskManager extends CuratorAsyncManager {
       return webCache.getCleanupTasks();
     }
 
-    List<SingularityTaskCleanup> cleanupTasks = getAsyncChildren(CLEANUP_PATH_ROOT, Optional.of(taskCleanupIdCache), taskCleanupTranscoder);
+    List<SingularityTaskCleanup> cleanupTasks = fetchCleanupTasks();
 
     if (useWebCache) {
       webCache.cacheTaskCleanup(cleanupTasks);
@@ -414,6 +414,10 @@ public class TaskManager extends CuratorAsyncManager {
       return leaderCache.getTaskCleanup(SingularityTaskId.valueOf(taskId));
     }
     return getData(getCleanupPath(taskId), taskCleanupTranscoder);
+  }
+
+  public List<SingularityTaskCleanup> fetchCleanupTasks() {
+    return getAsyncChildren(CLEANUP_PATH_ROOT, Optional.of(taskCleanupIdCache), taskCleanupTranscoder);
   }
 
   public List<SingularityTask> getActiveTasks() {
@@ -778,7 +782,7 @@ public class TaskManager extends CuratorAsyncManager {
   public void activateLeaderCache() {
     leaderCache.cachePendingTasks(fetchPendingTasks());
     leaderCache.cacheActiveTaskIds(getTaskIds(ACTIVE_PATH_ROOT));
-    leaderCache.cacheCleanupTasks(getCleanupTasks());
+    leaderCache.cacheCleanupTasks(fetchCleanupTasks());
   }
 
   private List<SingularityPendingTask> fetchPendingTasks() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
@@ -114,8 +114,9 @@ public class SingularitySlaveAndRackManager {
 
       if ((taskRequest.getRequest().getRequiredSlaveAttributes().isPresent() && !taskRequest.getRequest().getRequiredSlaveAttributes().get().isEmpty())
         || (taskRequest.getRequest().getAllowedSlaveAttributes().isPresent() && !taskRequest.getRequest().getAllowedSlaveAttributes().get().isEmpty())) {
-        Map<String, String> mergedAttributes = taskRequest.getRequest().getRequiredSlaveAttributes().or(new HashMap<String, String>());
-        mergedAttributes.putAll(taskRequest.getRequest().getAllowedSlaveAttributes().or(new HashMap<String, String>()));
+        Map<String, String> mergedAttributes = new HashMap<>();
+        mergedAttributes.putAll(taskRequest.getRequest().getRequiredSlaveAttributes().or(new HashMap<>()));
+        mergedAttributes.putAll(taskRequest.getRequest().getAllowedSlaveAttributes().or(new HashMap<>()));
         if (!slaveAndRackHelper.hasRequiredAttributes(mergedAttributes, reservedSlaveAttributes)) {
           LOG.trace("Slaves with attributes {} are reserved for matching tasks. Task with attributes {} does not match", reservedSlaveAttributes, taskRequest.getRequest().getRequiredSlaveAttributes().or(Collections.<String, String>emptyMap()));
           return SlaveMatchState.SLAVE_ATTRIBUTES_DO_NOT_MATCH;

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractLeaderAwareResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractLeaderAwareResource.java
@@ -2,18 +2,19 @@ package com.hubspot.singularity.resources;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.apache.curator.framework.recipes.leader.LeaderLatch;
+
 import com.hubspot.horizon.HttpClient;
 import com.hubspot.horizon.HttpRequest;
 import com.hubspot.horizon.HttpRequest.Method;
 import com.hubspot.horizon.HttpResponse;
-import com.hubspot.singularity.SingularityLeaderLatch;
 import com.hubspot.singularity.WebExceptions;
 
 public class AbstractLeaderAwareResource {
   protected final HttpClient httpClient;
-  protected final SingularityLeaderLatch leaderLatch;
+  protected final LeaderLatch leaderLatch;
 
-  public AbstractLeaderAwareResource(HttpClient httpClient, SingularityLeaderLatch leaderLatch) {
+  public AbstractLeaderAwareResource(HttpClient httpClient, LeaderLatch leaderLatch) {
     this.httpClient = httpClient;
     this.leaderLatch = leaderLatch;
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractLeaderAwareResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractLeaderAwareResource.java
@@ -10,8 +10,8 @@ import com.hubspot.singularity.SingularityLeaderLatch;
 import com.hubspot.singularity.WebExceptions;
 
 public class AbstractLeaderAwareResource {
-  private final HttpClient httpClient;
-  private final SingularityLeaderLatch leaderLatch;
+  protected final HttpClient httpClient;
+  protected final SingularityLeaderLatch leaderLatch;
 
   public AbstractLeaderAwareResource(HttpClient httpClient, SingularityLeaderLatch leaderLatch) {
     this.httpClient = httpClient;

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractLeaderAwareResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractLeaderAwareResource.java
@@ -44,13 +44,16 @@ public class AbstractLeaderAwareResource {
     try {
       if (body != null) {
         requestBuilder.setBody(objectMapper.writeValueAsBytes(body));
+        LOG.trace("Added body {} to reqeust", body);
       }
     } catch (JsonProcessingException jpe) {
-      LOG.error("Could not write body form object {}", body);
+      LOG.error("Could not write body from object {}", body);
     }
 
     copyHeadersAndParams(requestBuilder, request);
-    HttpResponse response = httpClient.execute(requestBuilder.build());
+    HttpRequest httpRequest = requestBuilder.build();
+    LOG.trace("Sending request to leader: {}", httpRequest);
+    HttpResponse response = httpClient.execute(httpRequest);
     LOG.trace("Got proxied response ({}) {}", response.getStatusCode(), response.getAsString());
     if (response.isServerError()) {
       throw WebExceptions.badRequest(response.getAsString());
@@ -65,10 +68,12 @@ public class AbstractLeaderAwareResource {
     while (request.getHeaderNames().hasMoreElements()) {
       String headerName = request.getHeaderNames().nextElement();
       requestBuilder.addHeader(headerName, request.getHeader(headerName));
+      LOG.trace("Copied header {}:{}", headerName, request.getHeader(headerName));
     }
     while (request.getParameterNames().hasMoreElements()) {
       String parameterName = request.getParameterNames().nextElement();
       requestBuilder.setQueryParam(parameterName).to(request.getParameter(parameterName));
+      LOG.trace("Copied query param {}={}", parameterName, request.getParameter(parameterName));
     }
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractLeaderAwareResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractLeaderAwareResource.java
@@ -83,6 +83,6 @@ public class AbstractLeaderAwareResource {
   }
 
   protected boolean useWebCache(Boolean useWebCache) {
-    return useWebCache != null && useWebCache.booleanValue();
+    return useWebCache != null && useWebCache;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractLeaderAwareResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractLeaderAwareResource.java
@@ -1,0 +1,52 @@
+package com.hubspot.singularity.resources;
+
+import javax.servlet.http.HttpServletRequest;
+
+import com.hubspot.horizon.HttpClient;
+import com.hubspot.horizon.HttpRequest;
+import com.hubspot.horizon.HttpRequest.Method;
+import com.hubspot.horizon.HttpResponse;
+import com.hubspot.singularity.SingularityLeaderLatch;
+import com.hubspot.singularity.WebExceptions;
+
+public class AbstractLeaderAwareResource {
+  private final HttpClient httpClient;
+  private final SingularityLeaderLatch leaderLatch;
+
+  public AbstractLeaderAwareResource(HttpClient httpClient, SingularityLeaderLatch leaderLatch) {
+    this.httpClient = httpClient;
+    this.leaderLatch = leaderLatch;
+  }
+
+  protected <T> T proxyToLeader(HttpServletRequest request, Class<T> clazz) {
+    String leaderUri;
+    try {
+      leaderUri = leaderLatch.getLeader().getId();
+    } catch (Exception e) {
+      throw new RuntimeException("Could not get leader uri to proxy request");
+    }
+    HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+        .setUrl(String.format("%s%s", leaderUri, request.getServletPath()))
+        .setMethod(Method.valueOf(request.getMethod()));
+    copyHeadersAndParams(requestBuilder, request);
+    HttpResponse response = httpClient.execute(requestBuilder.build());
+    if (response.isServerError()) {
+      throw WebExceptions.badRequest(response.getAsString());
+    } else if (response.isServerError()) {
+      throw new RuntimeException(response.getAsString());
+    } else {
+      return response.getAs(clazz);
+    }
+  }
+
+  private void copyHeadersAndParams(HttpRequest.Builder requestBuilder, HttpServletRequest request) {
+    while (request.getHeaderNames().hasMoreElements()) {
+      String headerName = request.getHeaderNames().nextElement();
+      requestBuilder.addHeader(headerName, request.getHeader(headerName));
+    }
+    while (request.getParameterNames().hasMoreElements()) {
+      String parameterName = request.getParameterNames().nextElement();
+      requestBuilder.setQueryParam(parameterName).to(request.getParameter(parameterName));
+    }
+  }
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractLeaderAwareResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractLeaderAwareResource.java
@@ -3,6 +3,7 @@ package com.hubspot.singularity.resources;
 import java.util.Enumeration;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.WebApplicationException;
 
 import org.apache.curator.framework.recipes.leader.LeaderLatch;
 import org.slf4j.Logger;
@@ -14,7 +15,6 @@ import com.hubspot.horizon.HttpClient;
 import com.hubspot.horizon.HttpRequest;
 import com.hubspot.horizon.HttpRequest.Method;
 import com.hubspot.horizon.HttpResponse;
-import com.hubspot.singularity.WebExceptions;
 
 public class AbstractLeaderAwareResource {
   private static final Logger LOG = LoggerFactory.getLogger(AbstractLeaderAwareResource.class);
@@ -56,10 +56,8 @@ public class AbstractLeaderAwareResource {
     HttpRequest httpRequest = requestBuilder.build();
     LOG.trace("Sending request to leader: {}", httpRequest);
     HttpResponse response = httpClient.execute(httpRequest);
-    if (response.isServerError()) {
-      throw WebExceptions.badRequest(response.getAsString());
-    } else if (response.isServerError()) {
-      throw new RuntimeException(response.getAsString());
+    if (response.isError()) {
+      throw new WebApplicationException(response.getAsString(), response.getStatusCode());
     } else {
       return response.getAs(clazz);
     }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractLeaderAwareResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractLeaderAwareResource.java
@@ -56,7 +56,6 @@ public class AbstractLeaderAwareResource {
     HttpRequest httpRequest = requestBuilder.build();
     LOG.trace("Sending request to leader: {}", httpRequest);
     HttpResponse response = httpClient.execute(httpRequest);
-    LOG.trace("Got proxied response ({}) {}", response.getStatusCode(), response.getAsString());
     if (response.isServerError()) {
       throw WebExceptions.badRequest(response.getAsString());
     } else if (response.isServerError()) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractLeaderAwareResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractLeaderAwareResource.java
@@ -1,5 +1,7 @@
 package com.hubspot.singularity.resources;
 
+import java.util.Enumeration;
+
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.curator.framework.recipes.leader.LeaderLatch;
@@ -65,15 +67,21 @@ public class AbstractLeaderAwareResource {
   }
 
   private void copyHeadersAndParams(HttpRequest.Builder requestBuilder, HttpServletRequest request) {
-    while (request.getHeaderNames().hasMoreElements()) {
-      String headerName = request.getHeaderNames().nextElement();
-      requestBuilder.addHeader(headerName, request.getHeader(headerName));
-      LOG.trace("Copied header {}:{}", headerName, request.getHeader(headerName));
+    Enumeration<String> headerNames = request.getHeaderNames();
+    if (headerNames != null) {
+      while (headerNames.hasMoreElements()) {
+        String headerName = headerNames.nextElement();
+        requestBuilder.addHeader(headerName, request.getHeader(headerName));
+        LOG.trace("Copied header {}:{}", headerName, request.getHeader(headerName));
+      }
     }
-    while (request.getParameterNames().hasMoreElements()) {
-      String parameterName = request.getParameterNames().nextElement();
-      requestBuilder.setQueryParam(parameterName).to(request.getParameter(parameterName));
-      LOG.trace("Copied query param {}={}", parameterName, request.getParameter(parameterName));
+    Enumeration<String> parameterNames = request.getParameterNames();
+    if (parameterNames != null) {
+      while (parameterNames.hasMoreElements()) {
+        String parameterName = parameterNames.nextElement();
+        requestBuilder.setQueryParam(parameterName).to(request.getParameter(parameterName));
+        LOG.trace("Copied query param {}={}", parameterName, request.getParameter(parameterName));
+      }
     }
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractLeaderAwareResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractLeaderAwareResource.java
@@ -50,4 +50,8 @@ public class AbstractLeaderAwareResource {
       requestBuilder.setQueryParam(parameterName).to(request.getParameter(parameterName));
     }
   }
+
+  protected boolean useWebCache(Boolean useWebCache) {
+    return useWebCache != null && useWebCache.booleanValue();
+  }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractLeaderAwareResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractLeaderAwareResource.java
@@ -31,14 +31,14 @@ public class AbstractLeaderAwareResource {
       throw new RuntimeException("Could not get leader uri to proxy request");
     }
 
-    String protocol = request.getRequestURI().contains("https") ? "https://" : "http://";
-    String url = protocol + leaderUri + request.getContextPath() + request.getPathInfo();
-    LOG.debug("No the leader, proxying request to {}", url);
+    String url = "http://" + leaderUri + request.getContextPath() + request.getPathInfo();
+    LOG.debug("Not the leader, proxying request to {}", url);
     HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
         .setUrl(url)
         .setMethod(Method.valueOf(request.getMethod()));
     copyHeadersAndParams(requestBuilder, request);
     HttpResponse response = httpClient.execute(requestBuilder.build());
+    LOG.trace("Got proxied response ({}) {}", response.getStatusCode(), response.getAsString());
     if (response.isServerError()) {
       throw WebExceptions.badRequest(response.getAsString());
     } else if (response.isServerError()) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractLeaderAwareResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractLeaderAwareResource.java
@@ -1,6 +1,7 @@
 package com.hubspot.singularity.resources;
 
 import java.util.Enumeration;
+import java.util.function.Supplier;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.WebApplicationException;
@@ -29,12 +30,21 @@ public class AbstractLeaderAwareResource {
     this.objectMapper = objectMapper;
   }
 
-  protected <T, Q> T proxyToLeader(HttpServletRequest request, Class<T> clazz, Q body) {
+  protected <T, Q> T maybeProxyToLeader(HttpServletRequest request, Class<T> clazz, Q body, Supplier<T> runnable) {
+    if (leaderLatch.hasLeadership()) {
+      return runnable.get();
+    }
+
     String leaderUri;
     try {
       leaderUri = leaderLatch.getLeader().getId();
     } catch (Exception e) {
       throw new RuntimeException("Could not get leader uri to proxy request");
+    }
+
+    if (leaderUri.equals(leaderLatch.getId())) {
+      LOG.warn("Got own leader id when not the leader! There is likely no leader, will not proxy");
+      return runnable.get();
     }
 
     String url = "http://" + leaderUri + request.getContextPath() + request.getPathInfo();

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractRequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractRequestResource.java
@@ -2,12 +2,13 @@ package com.hubspot.singularity.resources;
 
 import static com.hubspot.singularity.WebExceptions.checkNotFound;
 
+import org.apache.curator.framework.recipes.leader.LeaderLatch;
+
 import com.google.common.base.Optional;
 import com.hubspot.horizon.HttpClient;
 import com.hubspot.singularity.SingularityAuthorizationScope;
 import com.hubspot.singularity.SingularityDeploy;
 import com.hubspot.singularity.SingularityDeployMarker;
-import com.hubspot.singularity.SingularityLeaderLatch;
 import com.hubspot.singularity.SingularityPendingDeploy;
 import com.hubspot.singularity.SingularityRequest;
 import com.hubspot.singularity.SingularityRequestDeployState;
@@ -28,7 +29,7 @@ public class AbstractRequestResource extends AbstractLeaderAwareResource {
   protected final SingularityAuthorizationHelper authorizationHelper;
 
   public AbstractRequestResource(RequestManager requestManager, DeployManager deployManager, Optional<SingularityUser> user, SingularityValidator validator, SingularityAuthorizationHelper authorizationHelper,
-                                 HttpClient httpClient, SingularityLeaderLatch leaderLatch) {
+                                 HttpClient httpClient, LeaderLatch leaderLatch) {
     super(httpClient, leaderLatch);
     this.requestManager = requestManager;
     this.deployManager = deployManager;

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractRequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractRequestResource.java
@@ -4,6 +4,7 @@ import static com.hubspot.singularity.WebExceptions.checkNotFound;
 
 import org.apache.curator.framework.recipes.leader.LeaderLatch;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
 import com.hubspot.horizon.HttpClient;
 import com.hubspot.singularity.SingularityAuthorizationScope;
@@ -29,8 +30,8 @@ public class AbstractRequestResource extends AbstractLeaderAwareResource {
   protected final SingularityAuthorizationHelper authorizationHelper;
 
   public AbstractRequestResource(RequestManager requestManager, DeployManager deployManager, Optional<SingularityUser> user, SingularityValidator validator, SingularityAuthorizationHelper authorizationHelper,
-                                 HttpClient httpClient, LeaderLatch leaderLatch) {
-    super(httpClient, leaderLatch);
+                                 HttpClient httpClient, LeaderLatch leaderLatch, ObjectMapper objectMapper) {
+    super(httpClient, leaderLatch, objectMapper);
     this.requestManager = requestManager;
     this.deployManager = deployManager;
     this.user = user;

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractRequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractRequestResource.java
@@ -3,9 +3,11 @@ package com.hubspot.singularity.resources;
 import static com.hubspot.singularity.WebExceptions.checkNotFound;
 
 import com.google.common.base.Optional;
+import com.hubspot.horizon.HttpClient;
 import com.hubspot.singularity.SingularityAuthorizationScope;
 import com.hubspot.singularity.SingularityDeploy;
 import com.hubspot.singularity.SingularityDeployMarker;
+import com.hubspot.singularity.SingularityLeaderLatch;
 import com.hubspot.singularity.SingularityPendingDeploy;
 import com.hubspot.singularity.SingularityRequest;
 import com.hubspot.singularity.SingularityRequestDeployState;
@@ -17,7 +19,7 @@ import com.hubspot.singularity.data.DeployManager;
 import com.hubspot.singularity.data.RequestManager;
 import com.hubspot.singularity.data.SingularityValidator;
 
-public class AbstractRequestResource {
+public class AbstractRequestResource extends AbstractLeaderAwareResource {
 
   protected final RequestManager requestManager;
   protected final DeployManager deployManager;
@@ -25,7 +27,9 @@ public class AbstractRequestResource {
   protected final SingularityValidator validator;
   protected final SingularityAuthorizationHelper authorizationHelper;
 
-  public AbstractRequestResource(RequestManager requestManager, DeployManager deployManager, Optional<SingularityUser> user, SingularityValidator validator, SingularityAuthorizationHelper authorizationHelper) {
+  public AbstractRequestResource(RequestManager requestManager, DeployManager deployManager, Optional<SingularityUser> user, SingularityValidator validator, SingularityAuthorizationHelper authorizationHelper,
+                                 HttpClient httpClient, SingularityLeaderLatch leaderLatch) {
+    super(httpClient, leaderLatch);
     this.requestManager = requestManager;
     this.deployManager = deployManager;
     this.user = user;

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractRequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractRequestResource.java
@@ -40,7 +40,11 @@ public class AbstractRequestResource extends AbstractLeaderAwareResource {
   }
 
   protected SingularityRequestWithState fetchRequestWithState(String requestId) {
-    Optional<SingularityRequestWithState> request = requestManager.getRequest(requestId);
+    return fetchRequestWithState(requestId, false);
+  }
+
+  protected SingularityRequestWithState fetchRequestWithState(String requestId, boolean useWebCache) {
+    Optional<SingularityRequestWithState> request = requestManager.getRequest(requestId, useWebCache);
 
     checkNotFound(request.isPresent(), "Couldn't find request with id %s", requestId);
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/DeployResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/DeployResource.java
@@ -17,6 +17,7 @@ import javax.ws.rs.core.MediaType;
 
 import org.apache.curator.framework.recipes.leader.LeaderLatch;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
@@ -31,7 +32,6 @@ import com.hubspot.singularity.SingularityCreateResult;
 import com.hubspot.singularity.SingularityDeploy;
 import com.hubspot.singularity.SingularityDeployMarker;
 import com.hubspot.singularity.SingularityDeployProgress;
-import com.hubspot.singularity.SingularityLeaderLatch;
 import com.hubspot.singularity.SingularityLoadBalancerUpdate;
 import com.hubspot.singularity.SingularityPendingDeploy;
 import com.hubspot.singularity.SingularityPendingRequest;
@@ -69,8 +69,8 @@ public class DeployResource extends AbstractRequestResource {
   @Inject
   public DeployResource(RequestManager requestManager, DeployManager deployManager, SingularityValidator validator, SingularityAuthorizationHelper authorizationHelper, Optional<SingularityUser> user,
                         SingularityConfiguration configuration, TaskManager taskManager, LeaderLatch leaderLatch,
-                        @Named(SingularityResourceModule.PROXY_TO_LEADER_HTTP_CLIENT) HttpClient httpClient) {
-    super(requestManager, deployManager, user, validator, authorizationHelper, httpClient, leaderLatch);
+                        @Named(SingularityResourceModule.PROXY_TO_LEADER_HTTP_CLIENT) HttpClient httpClient, ObjectMapper objectMapper) {
+    super(requestManager, deployManager, user, validator, authorizationHelper, httpClient, leaderLatch, objectMapper);
     this.configuration = configuration;
     this.taskManager = taskManager;
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/DeployResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/DeployResource.java
@@ -17,6 +17,8 @@ import javax.ws.rs.core.MediaType;
 
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import com.hubspot.horizon.HttpClient;
 import com.hubspot.jackson.jaxrs.PropertyFiltering;
 import com.hubspot.mesos.JavaUtils;
 import com.hubspot.singularity.DeployState;
@@ -27,6 +29,7 @@ import com.hubspot.singularity.SingularityCreateResult;
 import com.hubspot.singularity.SingularityDeploy;
 import com.hubspot.singularity.SingularityDeployMarker;
 import com.hubspot.singularity.SingularityDeployProgress;
+import com.hubspot.singularity.SingularityLeaderLatch;
 import com.hubspot.singularity.SingularityLoadBalancerUpdate;
 import com.hubspot.singularity.SingularityPendingDeploy;
 import com.hubspot.singularity.SingularityPendingRequest;
@@ -62,8 +65,10 @@ public class DeployResource extends AbstractRequestResource {
   private final TaskManager taskManager;
 
   @Inject
-  public DeployResource(RequestManager requestManager, DeployManager deployManager, SingularityValidator validator, SingularityAuthorizationHelper authorizationHelper, Optional<SingularityUser> user, SingularityConfiguration configuration, TaskManager taskManager) {
-    super(requestManager, deployManager, user, validator, authorizationHelper);
+  public DeployResource(RequestManager requestManager, DeployManager deployManager, SingularityValidator validator, SingularityAuthorizationHelper authorizationHelper, Optional<SingularityUser> user,
+                        SingularityConfiguration configuration, TaskManager taskManager, SingularityLeaderLatch leaderLatch,
+                        @Named(SingularityResourceModule.PROXY_TO_LEADER_HTTP_CLIENT) HttpClient httpClient) {
+    super(requestManager, deployManager, user, validator, authorizationHelper, httpClient, leaderLatch);
     this.configuration = configuration;
     this.taskManager = taskManager;
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/DeployResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/DeployResource.java
@@ -15,6 +15,8 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+import org.apache.curator.framework.recipes.leader.LeaderLatch;
+
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
@@ -66,7 +68,7 @@ public class DeployResource extends AbstractRequestResource {
 
   @Inject
   public DeployResource(RequestManager requestManager, DeployManager deployManager, SingularityValidator validator, SingularityAuthorizationHelper authorizationHelper, Optional<SingularityUser> user,
-                        SingularityConfiguration configuration, TaskManager taskManager, SingularityLeaderLatch leaderLatch,
+                        SingularityConfiguration configuration, TaskManager taskManager, LeaderLatch leaderLatch,
                         @Named(SingularityResourceModule.PROXY_TO_LEADER_HTTP_CLIENT) HttpClient httpClient) {
     super(requestManager, deployManager, user, validator, authorizationHelper, httpClient, leaderLatch);
     this.configuration = configuration;

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/HistoryResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/HistoryResource.java
@@ -365,13 +365,14 @@ public class HistoryResource extends AbstractHistoryResource {
   public Iterable<String> getRequestHistoryForRequestLike(
       @ApiParam("Request ID prefix to search for") @QueryParam("requestIdLike") String requestIdLike,
       @ApiParam("Maximum number of items to return") @QueryParam("count") Integer count,
-      @ApiParam("Which page of items to view") @QueryParam("page") Integer page) {
+      @ApiParam("Which page of items to view") @QueryParam("page") Integer page,
+      @QueryParam("useWebCache") Boolean useWebCache) {
     final Integer limitCount = getLimitCount(count);
     final Integer limitStart = getLimitStart(limitCount, page);
 
     List<String> requestIds = historyManager.getRequestHistoryLike(requestIdLike, limitStart, limitCount);
 
-    return authorizationHelper.filterAuthorizedRequestIds(user, requestIds, SingularityAuthorizationScope.READ);  // TODO: will this screw up pagination? A: yes.
+    return authorizationHelper.filterAuthorizedRequestIds(user, requestIds, SingularityAuthorizationScope.READ, useWebCache);  // TODO: will this screw up pagination? A: yes.
   }
 
   @GET

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/HistoryResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/HistoryResource.java
@@ -372,7 +372,7 @@ public class HistoryResource extends AbstractHistoryResource {
 
     List<String> requestIds = historyManager.getRequestHistoryLike(requestIdLike, limitStart, limitCount);
 
-    return authorizationHelper.filterAuthorizedRequestIds(user, requestIds, SingularityAuthorizationScope.READ, useWebCache);  // TODO: will this screw up pagination? A: yes.
+    return authorizationHelper.filterAuthorizedRequestIds(user, requestIds, SingularityAuthorizationScope.READ, useWebCache != null && useWebCache);  // TODO: will this screw up pagination? A: yes.
   }
 
   @GET

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -154,10 +154,7 @@ public class RequestResource extends AbstractRequestResource {
   })
   public SingularityRequestParent postRequest(@Context HttpServletRequest requestContext,
                                               @ApiParam("The Singularity request to create or update") SingularityRequest request) {
-    if (!leaderLatch.hasLeadership()) {
-      return proxyToLeader(requestContext, SingularityRequestParent.class, request);
-    }
-    return postRequest(request);
+    return maybeProxyToLeader(requestContext, SingularityRequestParent.class, request, () -> postRequest(request));
   }
 
   public SingularityRequestParent postRequest(SingularityRequest request) {
@@ -188,10 +185,7 @@ public class RequestResource extends AbstractRequestResource {
   public SingularityRequestParent bounce(@ApiParam("The request ID to bounce") @PathParam("requestId") String requestId,
                                          @Context HttpServletRequest requestContext,
                                          @ApiParam("Bounce request options") Optional<SingularityBounceRequest> bounceRequest) {
-    if (!leaderLatch.hasLeadership()) {
-      return proxyToLeader(requestContext, SingularityRequestParent.class, bounceRequest.orNull());
-    }
-    return bounce(requestId, bounceRequest);
+    return maybeProxyToLeader(requestContext, SingularityRequestParent.class, bounceRequest.orNull(), () -> bounce(requestId, bounceRequest));
   }
 
   public SingularityRequestParent bounce(String requestId, Optional<SingularityBounceRequest> bounceRequest) {
@@ -344,10 +338,7 @@ public class RequestResource extends AbstractRequestResource {
   public SingularityRequestParent pause(@ApiParam("The request ID to pause") @PathParam("requestId") String requestId,
                                         @Context HttpServletRequest requestContext,
                                         @ApiParam("Pause Request Options") Optional<SingularityPauseRequest> pauseRequest) {
-    if (!leaderLatch.hasLeadership()) {
-      return proxyToLeader(requestContext, SingularityRequestParent.class, pauseRequest.orNull());
-    }
-    return pause(requestId, pauseRequest);
+    return maybeProxyToLeader(requestContext, SingularityRequestParent.class, pauseRequest.orNull(), () -> pause(requestId, pauseRequest));
   }
 
   public SingularityRequestParent pause(String requestId, Optional<SingularityPauseRequest> pauseRequest) {
@@ -412,10 +403,7 @@ public class RequestResource extends AbstractRequestResource {
   public SingularityRequestParent unpause(@ApiParam("The request ID to unpause") @PathParam("requestId") String requestId,
                                           @Context HttpServletRequest requestContext,
                                           Optional<SingularityUnpauseRequest> unpauseRequest) {
-    if (!leaderLatch.hasLeadership()) {
-      return proxyToLeader(requestContext, SingularityRequestParent.class, unpauseRequest.orNull());
-    }
-    return unpause(requestId, unpauseRequest);
+    return maybeProxyToLeader(requestContext, SingularityRequestParent.class, unpauseRequest.orNull(), () -> unpause(requestId, unpauseRequest));
   }
 
   public SingularityRequestParent unpause(String requestId, Optional<SingularityUnpauseRequest> unpauseRequest) {
@@ -458,9 +446,10 @@ public class RequestResource extends AbstractRequestResource {
   public SingularityRequestParent exitCooldown(@PathParam("requestId") String requestId,
                                                @Context HttpServletRequest requestContext,
                                                Optional<SingularityExitCooldownRequest> exitCooldownRequest) {
-    if(!leaderLatch.hasLeadership()) {
-      return proxyToLeader(requestContext, SingularityRequestParent.class, exitCooldownRequest.orNull());
-    }
+    return maybeProxyToLeader(requestContext, SingularityRequestParent.class, exitCooldownRequest.orNull(), () -> exitCooldown(requestId, exitCooldownRequest));
+  }
+
+  public SingularityRequestParent exitCooldown(String requestId, Optional<SingularityExitCooldownRequest> exitCooldownRequest) {
     final SingularityRequestWithState requestWithState = fetchRequestWithState(requestId);
 
     authorizationHelper.checkForAuthorization(requestWithState.getRequest(), user, SingularityAuthorizationScope.WRITE);
@@ -607,11 +596,7 @@ public class RequestResource extends AbstractRequestResource {
   public SingularityRequest deleteRequest(@ApiParam("The request ID to delete.") @PathParam("requestId") String requestId,
                                           @Context HttpServletRequest requestContext,
                                           @ApiParam("Delete options") Optional<SingularityDeleteRequestRequest> deleteRequest) {
-    if (!leaderLatch.hasLeadership()) {
-      return proxyToLeader(requestContext, SingularityRequest.class, deleteRequest.orNull());
-    }
-
-    return deleteRequest(requestId, deleteRequest);
+    return maybeProxyToLeader(requestContext, SingularityRequest.class, deleteRequest.orNull(), () -> deleteRequest(requestId, deleteRequest));
   }
 
   public SingularityRequest deleteRequest(String requestId, Optional<SingularityDeleteRequestRequest> deleteRequest) {
@@ -645,11 +630,7 @@ public class RequestResource extends AbstractRequestResource {
   public SingularityRequestParent scale(@ApiParam("The Request ID to scale") @PathParam("requestId") String requestId,
                                         @Context HttpServletRequest requestContext,
                                         @ApiParam("Object to hold number of instances to request") SingularityScaleRequest scaleRequest) {
-    if (!leaderLatch.hasLeadership()) {
-      return proxyToLeader(requestContext, SingularityRequestParent.class, scaleRequest);
-    }
-
-    return scale(requestId, scaleRequest);
+    return maybeProxyToLeader(requestContext, SingularityRequestParent.class, scaleRequest, () -> scale(requestId, scaleRequest));
   }
 
   public SingularityRequestParent scale(String requestId, SingularityScaleRequest scaleRequest) {
@@ -778,10 +759,7 @@ public class RequestResource extends AbstractRequestResource {
   public SingularityRequestParent skipHealthchecks(@ApiParam("The Request ID to scale") @PathParam("requestId") String requestId,
                                                    @Context HttpServletRequest requestContext,
                                                    @ApiParam("SkipHealtchecks options") SingularitySkipHealthchecksRequest skipHealthchecksRequest) {
-    if (!leaderLatch.hasLeadership()) {
-      return proxyToLeader(requestContext, SingularityRequestParent.class, skipHealthchecksRequest);
-    }
-    return skipHealthchecks(requestId, skipHealthchecksRequest);
+    return maybeProxyToLeader(requestContext, SingularityRequestParent.class, skipHealthchecksRequest, () -> skipHealthchecks(requestId, skipHealthchecksRequest));
   }
 
   public SingularityRequestParent skipHealthchecks(String requestId, SingularitySkipHealthchecksRequest skipHealthchecksRequest) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -18,6 +18,7 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 import com.google.common.base.Optional;
@@ -435,8 +436,8 @@ public class RequestResource extends AbstractRequestResource {
   @PropertyFiltering
   @Path("/active")
   @ApiOperation(value="Retrieve the list of active requests", response=SingularityRequestParent.class, responseContainer="List")
-  public List<SingularityRequestParent> getActiveRequests() {
-    return getRequestsWithDeployState(requestManager.getActiveRequests(), SingularityAuthorizationScope.READ);
+  public List<SingularityRequestParent> getActiveRequests(@QueryParam("useWebCache") Boolean useWebCache) {
+    return getRequestsWithDeployState(requestManager.getActiveRequests(useWebCache), SingularityAuthorizationScope.READ);
   }
 
   private List<SingularityRequestParent> getRequestsWithDeployState(Iterable<SingularityRequestWithState> requests, final SingularityAuthorizationScope scope) {
@@ -470,31 +471,31 @@ public class RequestResource extends AbstractRequestResource {
   @PropertyFiltering
   @Path("/paused")
   @ApiOperation(value="Retrieve the list of paused requests", response=SingularityRequestParent.class, responseContainer="List")
-  public List<SingularityRequestParent> getPausedRequests() {
-    return getRequestsWithDeployState(requestManager.getPausedRequests(), SingularityAuthorizationScope.READ);
+  public List<SingularityRequestParent> getPausedRequests(@QueryParam("useWebCache") Boolean useWebCache) {
+    return getRequestsWithDeployState(requestManager.getPausedRequests(useWebCache), SingularityAuthorizationScope.READ);
   }
 
   @GET
   @PropertyFiltering
   @Path("/cooldown")
   @ApiOperation(value="Retrieve the list of requests in system cooldown", response=SingularityRequestParent.class, responseContainer="List")
-  public List<SingularityRequestParent> getCooldownRequests() {
-    return getRequestsWithDeployState(requestManager.getCooldownRequests(), SingularityAuthorizationScope.READ);
+  public List<SingularityRequestParent> getCooldownRequests(@QueryParam("useWebCache") Boolean useWebCache) {
+    return getRequestsWithDeployState(requestManager.getCooldownRequests(useWebCache), SingularityAuthorizationScope.READ);
   }
 
   @GET
   @PropertyFiltering
   @Path("/finished")
   @ApiOperation(value="Retreive the list of finished requests (Scheduled requests which have exhausted their schedules)", response=SingularityRequestParent.class, responseContainer="List")
-  public List<SingularityRequestParent> getFinishedRequests() {
-    return getRequestsWithDeployState(requestManager.getFinishedRequests(), SingularityAuthorizationScope.READ);
+  public List<SingularityRequestParent> getFinishedRequests(@QueryParam("useWebCache") Boolean useWebCache) {
+    return getRequestsWithDeployState(requestManager.getFinishedRequests(useWebCache), SingularityAuthorizationScope.READ);
   }
 
   @GET
   @PropertyFiltering
   @ApiOperation(value="Retrieve the list of all requests", response=SingularityRequestParent.class, responseContainer="List")
-  public List<SingularityRequestParent> getRequests() {
-    return getRequestsWithDeployState(requestManager.getRequests(), SingularityAuthorizationScope.READ);
+  public List<SingularityRequestParent> getRequests(@QueryParam("useWebCache") Boolean useWebCache) {
+    return getRequestsWithDeployState(requestManager.getRequests(useWebCache), SingularityAuthorizationScope.READ);
   }
 
   @GET
@@ -713,8 +714,8 @@ public class RequestResource extends AbstractRequestResource {
   @PropertyFiltering
   @Path("/lbcleanup")
   @ApiOperation("Retrieve the list of tasks being cleaned from load balancers.")
-  public Iterable<String> getLbCleanupRequests() {
-    return authorizationHelper.filterAuthorizedRequestIds(user, requestManager.getLbCleanupRequestIds(), SingularityAuthorizationScope.READ);
+  public Iterable<String> getLbCleanupRequests(@QueryParam("useWebCache") Boolean useWebCache) {
+    return authorizationHelper.filterAuthorizedRequestIds(user, requestManager.getLbCleanupRequestIds(), SingularityAuthorizationScope.READ, useWebCache);
   }
 
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -253,6 +253,10 @@ public class RequestResource extends AbstractRequestResource {
     return scheduleImmediately(requestId, requestContext, Optional.absent());
   }
 
+  public SingularityPendingRequestParent scheduleImmediately(String requestId) {
+    return scheduleImmediately(requestId, Optional.absent())
+  }
+
   @POST
   @Path("/request/{requestId}/run")
   @Consumes({ MediaType.APPLICATION_JSON })

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -44,7 +44,6 @@ import com.hubspot.singularity.SingularityAction;
 import com.hubspot.singularity.SingularityAuthorizationScope;
 import com.hubspot.singularity.SingularityCreateResult;
 import com.hubspot.singularity.SingularityDeleteResult;
-import com.hubspot.singularity.SingularityLeaderLatch;
 import com.hubspot.singularity.SingularityPendingDeploy;
 import com.hubspot.singularity.SingularityPendingRequest;
 import com.hubspot.singularity.SingularityPendingRequest.PendingType;
@@ -504,7 +503,7 @@ public class RequestResource extends AbstractRequestResource {
   @Path("/active")
   @ApiOperation(value="Retrieve the list of active requests", response=SingularityRequestParent.class, responseContainer="List")
   public List<SingularityRequestParent> getActiveRequests(@QueryParam("useWebCache") Boolean useWebCache) {
-    return getRequestsWithDeployState(requestManager.getActiveRequests(useWebCache), SingularityAuthorizationScope.READ);
+    return getRequestsWithDeployState(requestManager.getActiveRequests(useWebCache(useWebCache)), SingularityAuthorizationScope.READ);
   }
 
   private List<SingularityRequestParent> getRequestsWithDeployState(Iterable<SingularityRequestWithState> requests, final SingularityAuthorizationScope scope) {
@@ -544,7 +543,7 @@ public class RequestResource extends AbstractRequestResource {
   @Path("/paused")
   @ApiOperation(value="Retrieve the list of paused requests", response=SingularityRequestParent.class, responseContainer="List")
   public List<SingularityRequestParent> getPausedRequests(@QueryParam("useWebCache") Boolean useWebCache) {
-    return getRequestsWithDeployState(requestManager.getPausedRequests(useWebCache), SingularityAuthorizationScope.READ);
+    return getRequestsWithDeployState(requestManager.getPausedRequests(useWebCache(useWebCache)), SingularityAuthorizationScope.READ);
   }
 
   @GET
@@ -552,7 +551,7 @@ public class RequestResource extends AbstractRequestResource {
   @Path("/cooldown")
   @ApiOperation(value="Retrieve the list of requests in system cooldown", response=SingularityRequestParent.class, responseContainer="List")
   public List<SingularityRequestParent> getCooldownRequests(@QueryParam("useWebCache") Boolean useWebCache) {
-    return getRequestsWithDeployState(requestManager.getCooldownRequests(useWebCache), SingularityAuthorizationScope.READ);
+    return getRequestsWithDeployState(requestManager.getCooldownRequests(useWebCache(useWebCache)), SingularityAuthorizationScope.READ);
   }
 
   @GET
@@ -560,14 +559,14 @@ public class RequestResource extends AbstractRequestResource {
   @Path("/finished")
   @ApiOperation(value="Retreive the list of finished requests (Scheduled requests which have exhausted their schedules)", response=SingularityRequestParent.class, responseContainer="List")
   public List<SingularityRequestParent> getFinishedRequests(@QueryParam("useWebCache") Boolean useWebCache) {
-    return getRequestsWithDeployState(requestManager.getFinishedRequests(useWebCache), SingularityAuthorizationScope.READ);
+    return getRequestsWithDeployState(requestManager.getFinishedRequests(useWebCache(useWebCache)), SingularityAuthorizationScope.READ);
   }
 
   @GET
   @PropertyFiltering
   @ApiOperation(value="Retrieve the list of all requests", response=SingularityRequestParent.class, responseContainer="List")
   public List<SingularityRequestParent> getRequests(@QueryParam("useWebCache") Boolean useWebCache) {
-    return getRequestsWithDeployState(requestManager.getRequests(useWebCache), SingularityAuthorizationScope.READ);
+    return getRequestsWithDeployState(requestManager.getRequests(useWebCache(useWebCache)), SingularityAuthorizationScope.READ);
   }
 
   @GET
@@ -815,6 +814,6 @@ public class RequestResource extends AbstractRequestResource {
   @Path("/lbcleanup")
   @ApiOperation("Retrieve the list of tasks being cleaned from load balancers.")
   public Iterable<String> getLbCleanupRequests(@QueryParam("useWebCache") Boolean useWebCache) {
-    return authorizationHelper.filterAuthorizedRequestIds(user, requestManager.getLbCleanupRequestIds(), SingularityAuthorizationScope.READ, useWebCache);
+    return authorizationHelper.filterAuthorizedRequestIds(user, requestManager.getLbCleanupRequestIds(), SingularityAuthorizationScope.READ, useWebCache(useWebCache));
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -28,6 +28,7 @@ import org.apache.curator.framework.recipes.leader.LeaderLatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
@@ -103,8 +104,8 @@ public class RequestResource extends AbstractRequestResource {
   @Inject
   public RequestResource(SingularityValidator validator, DeployManager deployManager, TaskManager taskManager, RequestManager requestManager, SingularityMailer mailer,
                          SingularityAuthorizationHelper authorizationHelper, Optional<SingularityUser> user, RequestHelper requestHelper, LeaderLatch leaderLatch,
-                         DisasterManager disasterManager, @Named(SingularityResourceModule.PROXY_TO_LEADER_HTTP_CLIENT) HttpClient httpClient) {
-    super(requestManager, deployManager, user, validator, authorizationHelper, httpClient, leaderLatch);
+                         DisasterManager disasterManager, @Named(SingularityResourceModule.PROXY_TO_LEADER_HTTP_CLIENT) HttpClient httpClient, ObjectMapper objectMapper) {
+    super(requestManager, deployManager, user, validator, authorizationHelper, httpClient, leaderLatch, objectMapper);
     this.mailer = mailer;
     this.taskManager = taskManager;
     this.requestHelper = requestHelper;
@@ -154,7 +155,7 @@ public class RequestResource extends AbstractRequestResource {
   public SingularityRequestParent postRequest(@Context HttpServletRequest requestContext,
                                               @ApiParam("The Singularity request to create or update") SingularityRequest request) {
     if (!leaderLatch.hasLeadership()) {
-      return proxyToLeader(requestContext, SingularityRequestParent.class);
+      return proxyToLeader(requestContext, SingularityRequestParent.class, request);
     }
     return postRequest(request);
   }
@@ -188,7 +189,7 @@ public class RequestResource extends AbstractRequestResource {
                                          @Context HttpServletRequest requestContext,
                                          @ApiParam("Bounce request options") Optional<SingularityBounceRequest> bounceRequest) {
     if (!leaderLatch.hasLeadership()) {
-      return proxyToLeader(requestContext, SingularityRequestParent.class);
+      return proxyToLeader(requestContext, SingularityRequestParent.class, bounceRequest.orNull());
     }
     return bounce(requestId, bounceRequest);
   }
@@ -263,7 +264,7 @@ public class RequestResource extends AbstractRequestResource {
                                                              @Context HttpServletRequest requestContext,
                                                              Optional<SingularityRunNowRequest> runNowRequest) {
     if (!leaderLatch.hasLeadership()) {
-      return proxyToLeader(requestContext, SingularityPendingRequestParent.class);
+      return proxyToLeader(requestContext, SingularityPendingRequestParent.class, runNowRequest.orNull());
     }
     return scheduleImmediately(requestId, runNowRequest);
   }
@@ -354,7 +355,7 @@ public class RequestResource extends AbstractRequestResource {
                                         @Context HttpServletRequest requestContext,
                                         @ApiParam("Pause Request Options") Optional<SingularityPauseRequest> pauseRequest) {
     if (!leaderLatch.hasLeadership()) {
-      return proxyToLeader(requestContext, SingularityRequestParent.class);
+      return proxyToLeader(requestContext, SingularityRequestParent.class, pauseRequest.orNull());
     }
     return pause(requestId, pauseRequest);
   }
@@ -422,7 +423,7 @@ public class RequestResource extends AbstractRequestResource {
                                           @Context HttpServletRequest requestContext,
                                           Optional<SingularityUnpauseRequest> unpauseRequest) {
     if (!leaderLatch.hasLeadership()) {
-      return proxyToLeader(requestContext, SingularityRequestParent.class);
+      return proxyToLeader(requestContext, SingularityRequestParent.class, unpauseRequest.orNull());
     }
     return unpause(requestId, unpauseRequest);
   }
@@ -468,7 +469,7 @@ public class RequestResource extends AbstractRequestResource {
                                                @Context HttpServletRequest requestContext,
                                                Optional<SingularityExitCooldownRequest> exitCooldownRequest) {
     if(!leaderLatch.hasLeadership()) {
-      return proxyToLeader(requestContext, SingularityRequestParent.class);
+      return proxyToLeader(requestContext, SingularityRequestParent.class, exitCooldownRequest.orNull());
     }
     final SingularityRequestWithState requestWithState = fetchRequestWithState(requestId);
 
@@ -603,7 +604,7 @@ public class RequestResource extends AbstractRequestResource {
   @Path("/request/{requestId}")
   public SingularityRequest deleteRequest(@PathParam("requestId") String requestId,
                                           @Context HttpServletRequest requestContext) {
-    return deleteRequest(requestId, Optional.<SingularityDeleteRequestRequest> absent(), requestContext);
+    return deleteRequest(requestId, requestContext, Optional.absent());
   }
 
   @DELETE
@@ -614,10 +615,10 @@ public class RequestResource extends AbstractRequestResource {
     @ApiResponse(code=404, message="No Request with that ID"),
   })
   public SingularityRequest deleteRequest(@ApiParam("The request ID to delete.") @PathParam("requestId") String requestId,
-                                          @ApiParam("Delete options") Optional<SingularityDeleteRequestRequest> deleteRequest,
-                                          @Context HttpServletRequest requestContext) {
+                                          @Context HttpServletRequest requestContext,
+                                          @ApiParam("Delete options") Optional<SingularityDeleteRequestRequest> deleteRequest) {
     if (!leaderLatch.hasLeadership()) {
-      return proxyToLeader(requestContext, SingularityRequest.class);
+      return proxyToLeader(requestContext, SingularityRequest.class, deleteRequest.orNull());
     }
 
     return deleteRequest(requestId, deleteRequest);
@@ -655,7 +656,7 @@ public class RequestResource extends AbstractRequestResource {
                                         @Context HttpServletRequest requestContext,
                                         @ApiParam("Object to hold number of instances to request") SingularityScaleRequest scaleRequest) {
     if (!leaderLatch.hasLeadership()) {
-      return proxyToLeader(requestContext, SingularityRequestParent.class);
+      return proxyToLeader(requestContext, SingularityRequestParent.class, scaleRequest);
     }
 
     return scale(requestId, scaleRequest);
@@ -788,7 +789,7 @@ public class RequestResource extends AbstractRequestResource {
                                                    @Context HttpServletRequest requestContext,
                                                    @ApiParam("SkipHealtchecks options") SingularitySkipHealthchecksRequest skipHealthchecksRequest) {
     if (!leaderLatch.hasLeadership()) {
-      return proxyToLeader(requestContext, SingularityRequestParent.class);
+      return proxyToLeader(requestContext, SingularityRequestParent.class, skipHealthchecksRequest);
     }
     return skipHealthchecks(requestId, skipHealthchecksRequest);
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -596,12 +596,8 @@ public class RequestResource extends AbstractRequestResource {
   @ApiResponses({
     @ApiResponse(code=404, message="No Request with that ID"),
   })
-  public SingularityRequestParent getRequest(@ApiParam("Request ID") @PathParam("requestId") String requestId) {
-    return fillEntireRequest(fetchRequestWithState(requestId));
-  }
-
-  private SingularityRequest fetchRequest(String requestId) {
-    return fetchRequestWithState(requestId).getRequest();
+  public SingularityRequestParent getRequest(@ApiParam("Request ID") @PathParam("requestId") String requestId, @QueryParam("useWebCache") Boolean useWebCache) {
+    return fillEntireRequest(fetchRequestWithState(requestId, useWebCache(useWebCache)));
   }
 
   @DELETE
@@ -629,7 +625,7 @@ public class RequestResource extends AbstractRequestResource {
   }
 
   public SingularityRequest deleteRequest(String requestId, Optional<SingularityDeleteRequestRequest> deleteRequest) {
-    SingularityRequest request = fetchRequest(requestId);
+    SingularityRequest request = fetchRequestWithState(requestId).getRequest();
 
     authorizationHelper.checkForAuthorization(request, user, SingularityAuthorizationScope.WRITE);
     validator.checkActionEnabled(SingularityAction.REMOVE_REQUEST);

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -248,12 +248,7 @@ public class RequestResource extends AbstractRequestResource {
 
   @POST
   @Path("/request/{requestId}/run")
-  public SingularityPendingRequestParent scheduleImmediately(@PathParam("requestId") String requestId,
-                                                             @Context HttpServletRequest requestContext) {
-    return scheduleImmediately(requestId, requestContext, Optional.absent());
-  }
-
-  public SingularityPendingRequestParent scheduleImmediately(String requestId) {
+  public SingularityPendingRequestParent scheduleImmediately(@PathParam("requestId") String requestId) {
     return scheduleImmediately(requestId, Optional.absent());
   }
 
@@ -265,16 +260,7 @@ public class RequestResource extends AbstractRequestResource {
     @ApiResponse(code=400, message="Singularity Request is not scheduled or one-off"),
   })
   public SingularityPendingRequestParent scheduleImmediately(@ApiParam("The request ID to run") @PathParam("requestId") String requestId,
-                                                             @Context HttpServletRequest requestContext,
                                                              Optional<SingularityRunNowRequest> runNowRequest) {
-    if (!leaderLatch.hasLeadership()) {
-      return proxyToLeader(requestContext, SingularityPendingRequestParent.class, runNowRequest.orNull());
-    }
-    return scheduleImmediately(requestId, runNowRequest);
-  }
-
-  public SingularityPendingRequestParent scheduleImmediately(String requestId, Optional<SingularityRunNowRequest> runNowRequest) {
-
     SingularityRequestWithState requestWithState = fetchRequestWithState(requestId);
 
     authorizationHelper.checkForAuthorization(requestWithState.getRequest(), user, SingularityAuthorizationScope.WRITE);

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -151,8 +151,8 @@ public class RequestResource extends AbstractRequestResource {
     @ApiResponse(code=400, message="Request object is invalid"),
     @ApiResponse(code=409, message="Request object is being cleaned. Try again shortly"),
   })
-  public SingularityRequestParent postRequest(@ApiParam("The Singularity request to create or update") SingularityRequest request,
-                                              @Context HttpServletRequest requestContext) {
+  public SingularityRequestParent postRequest(@Context HttpServletRequest requestContext,
+                                              @ApiParam("The Singularity request to create or update") SingularityRequest request) {
     if (!leaderLatch.hasLeadership()) {
       return proxyToLeader(requestContext, SingularityRequestParent.class);
     }
@@ -176,7 +176,7 @@ public class RequestResource extends AbstractRequestResource {
   @Path("/request/{requestId}/bounce")
   public SingularityRequestParent bounce(@PathParam("requestId") String requestId,
                                          @Context HttpServletRequest requestContext) {
-    return bounce(requestId, Optional.<SingularityBounceRequest> absent(), requestContext);
+    return bounce(requestId, requestContext, Optional.absent());
   }
 
   @POST
@@ -185,8 +185,8 @@ public class RequestResource extends AbstractRequestResource {
   @ApiOperation(value="Bounce a specific Singularity request. A bounce launches replacement task(s), and then kills the original task(s) if the replacement(s) are healthy.",
   response=SingularityRequestParent.class)
   public SingularityRequestParent bounce(@ApiParam("The request ID to bounce") @PathParam("requestId") String requestId,
-                                         @ApiParam("Bounce request options") Optional<SingularityBounceRequest> bounceRequest,
-                                         @Context HttpServletRequest requestContext) {
+                                         @Context HttpServletRequest requestContext,
+                                         @ApiParam("Bounce request options") Optional<SingularityBounceRequest> bounceRequest) {
     if (!leaderLatch.hasLeadership()) {
       return proxyToLeader(requestContext, SingularityRequestParent.class);
     }
@@ -249,7 +249,7 @@ public class RequestResource extends AbstractRequestResource {
   @Path("/request/{requestId}/run")
   public SingularityPendingRequestParent scheduleImmediately(@PathParam("requestId") String requestId,
                                                              @Context HttpServletRequest requestContext) {
-    return scheduleImmediately(requestId, Optional.<SingularityRunNowRequest> absent(), requestContext);
+    return scheduleImmediately(requestId, requestContext, Optional.absent());
   }
 
   @POST
@@ -260,8 +260,8 @@ public class RequestResource extends AbstractRequestResource {
     @ApiResponse(code=400, message="Singularity Request is not scheduled or one-off"),
   })
   public SingularityPendingRequestParent scheduleImmediately(@ApiParam("The request ID to run") @PathParam("requestId") String requestId,
-                                                             Optional<SingularityRunNowRequest> runNowRequest,
-                                                             @Context HttpServletRequest requestContext) {
+                                                             @Context HttpServletRequest requestContext,
+                                                             Optional<SingularityRunNowRequest> runNowRequest) {
     if (!leaderLatch.hasLeadership()) {
       return proxyToLeader(requestContext, SingularityPendingRequestParent.class);
     }
@@ -340,7 +340,7 @@ public class RequestResource extends AbstractRequestResource {
   @Path("/request/{requestId}/pause")
   public SingularityRequestParent pause(@PathParam("requestId") String requestId,
                                         @Context HttpServletRequest requestContext) {
-    return pause(requestId, Optional.<SingularityPauseRequest> absent(), requestContext);
+    return pause(requestId, requestContext, Optional.absent());
   }
 
   @POST
@@ -351,8 +351,8 @@ public class RequestResource extends AbstractRequestResource {
     @ApiResponse(code=409, message="Request is already paused or being cleaned"),
   })
   public SingularityRequestParent pause(@ApiParam("The request ID to pause") @PathParam("requestId") String requestId,
-                                        @ApiParam("Pause Request Options") Optional<SingularityPauseRequest> pauseRequest,
-                                        @Context HttpServletRequest requestContext) {
+                                        @Context HttpServletRequest requestContext,
+                                        @ApiParam("Pause Request Options") Optional<SingularityPauseRequest> pauseRequest) {
     if (!leaderLatch.hasLeadership()) {
       return proxyToLeader(requestContext, SingularityRequestParent.class);
     }
@@ -408,7 +408,7 @@ public class RequestResource extends AbstractRequestResource {
   @Path("/request/{requestId}/unpause")
   public SingularityRequestParent unpauseNoBody(@PathParam("requestId") String requestId,
                                                 @Context HttpServletRequest requestContext) {
-    return unpause(requestId, Optional.<SingularityUnpauseRequest> absent(), requestContext);
+    return unpause(requestId, requestContext, Optional.absent());
   }
 
   @POST
@@ -419,8 +419,8 @@ public class RequestResource extends AbstractRequestResource {
     @ApiResponse(code=409, message="Request is not paused"),
   })
   public SingularityRequestParent unpause(@ApiParam("The request ID to unpause") @PathParam("requestId") String requestId,
-                                          Optional<SingularityUnpauseRequest> unpauseRequest,
-                                          @Context HttpServletRequest requestContext) {
+                                          @Context HttpServletRequest requestContext,
+                                          Optional<SingularityUnpauseRequest> unpauseRequest) {
     if (!leaderLatch.hasLeadership()) {
       return proxyToLeader(requestContext, SingularityRequestParent.class);
     }
@@ -454,7 +454,7 @@ public class RequestResource extends AbstractRequestResource {
   @Path("/request/{requestId}/exit-cooldown")
   public SingularityRequestParent exitCooldown(@PathParam("requestId") String requestId,
                                                @Context HttpServletRequest requestContext) {
-    return exitCooldown(requestId, Optional.<SingularityExitCooldownRequest> absent(), requestContext);
+    return exitCooldown(requestId, requestContext, Optional.absent());
   }
 
   @POST
@@ -464,8 +464,9 @@ public class RequestResource extends AbstractRequestResource {
   @ApiResponses({
     @ApiResponse(code=409, message="Request is not in cooldown"),
   })
-  public SingularityRequestParent exitCooldown(@PathParam("requestId") String requestId, Optional<SingularityExitCooldownRequest> exitCooldownRequest,
-                                               @Context HttpServletRequest requestContext) {
+  public SingularityRequestParent exitCooldown(@PathParam("requestId") String requestId,
+                                               @Context HttpServletRequest requestContext,
+                                               Optional<SingularityExitCooldownRequest> exitCooldownRequest) {
     if(!leaderLatch.hasLeadership()) {
       return proxyToLeader(requestContext, SingularityRequestParent.class);
     }
@@ -651,10 +652,10 @@ public class RequestResource extends AbstractRequestResource {
     @ApiResponse(code=404, message="No Request with that ID"),
   })
   public SingularityRequestParent scale(@ApiParam("The Request ID to scale") @PathParam("requestId") String requestId,
-                                        @ApiParam("Object to hold number of instances to request") SingularityScaleRequest scaleRequest,
-                                        @Context HttpServletRequest request) {
+                                        @Context HttpServletRequest requestContext,
+                                        @ApiParam("Object to hold number of instances to request") SingularityScaleRequest scaleRequest) {
     if (!leaderLatch.hasLeadership()) {
-      return proxyToLeader(request, SingularityRequestParent.class);
+      return proxyToLeader(requestContext, SingularityRequestParent.class);
     }
 
     return scale(requestId, scaleRequest);
@@ -771,9 +772,9 @@ public class RequestResource extends AbstractRequestResource {
       @ApiResponse(code=404, message="No Request with that ID"),
   })
   public SingularityRequestParent skipHealthchecksDeprecated(@ApiParam("The Request ID to scale") @PathParam("requestId") String requestId,
-                                                             @ApiParam("SkipHealtchecks options") SingularitySkipHealthchecksRequest skipHealthchecksRequest,
-                                                             @Context HttpServletRequest request) {
-    return skipHealthchecks(requestId, skipHealthchecksRequest, request);
+                                                             @Context HttpServletRequest requestContext,
+                                                             @ApiParam("SkipHealtchecks options") SingularitySkipHealthchecksRequest skipHealthchecksRequest) {
+    return skipHealthchecks(requestId, requestContext, skipHealthchecksRequest);
   }
 
   @PUT
@@ -784,10 +785,10 @@ public class RequestResource extends AbstractRequestResource {
     @ApiResponse(code=404, message="No Request with that ID"),
   })
   public SingularityRequestParent skipHealthchecks(@ApiParam("The Request ID to scale") @PathParam("requestId") String requestId,
-                                                   @ApiParam("SkipHealtchecks options") SingularitySkipHealthchecksRequest skipHealthchecksRequest,
-                                                   @Context HttpServletRequest request) {
+                                                   @Context HttpServletRequest requestContext,
+                                                   @ApiParam("SkipHealtchecks options") SingularitySkipHealthchecksRequest skipHealthchecksRequest) {
     if (!leaderLatch.hasLeadership()) {
-      return proxyToLeader(request, SingularityRequestParent.class);
+      return proxyToLeader(requestContext, SingularityRequestParent.class);
     }
     return skipHealthchecks(requestId, skipHealthchecksRequest);
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -600,6 +600,10 @@ public class RequestResource extends AbstractRequestResource {
     return fillEntireRequest(fetchRequestWithState(requestId, useWebCache(useWebCache)));
   }
 
+  public SingularityRequestParent getRequest(String requestId) {
+    return fillEntireRequest(fetchRequestWithState(requestId, false));
+  }
+
   @DELETE
   @Path("/request/{requestId}")
   public SingularityRequest deleteRequest(@PathParam("requestId") String requestId,

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -24,6 +24,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 
+import org.apache.curator.framework.recipes.leader.LeaderLatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -102,7 +103,7 @@ public class RequestResource extends AbstractRequestResource {
 
   @Inject
   public RequestResource(SingularityValidator validator, DeployManager deployManager, TaskManager taskManager, RequestManager requestManager, SingularityMailer mailer,
-                         SingularityAuthorizationHelper authorizationHelper, Optional<SingularityUser> user, RequestHelper requestHelper, SingularityLeaderLatch leaderLatch,
+                         SingularityAuthorizationHelper authorizationHelper, Optional<SingularityUser> user, RequestHelper requestHelper, LeaderLatch leaderLatch,
                          DisasterManager disasterManager, @Named(SingularityResourceModule.PROXY_TO_LEADER_HTTP_CLIENT) HttpClient httpClient) {
     super(requestManager, deployManager, user, validator, authorizationHelper, httpClient, leaderLatch);
     this.mailer = mailer;

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -254,7 +254,7 @@ public class RequestResource extends AbstractRequestResource {
   }
 
   public SingularityPendingRequestParent scheduleImmediately(String requestId) {
-    return scheduleImmediately(requestId, Optional.absent())
+    return scheduleImmediately(requestId, Optional.absent());
   }
 
   @POST

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -92,18 +92,16 @@ public class RequestResource extends AbstractRequestResource {
   private final SingularityMailer mailer;
   private final TaskManager taskManager;
   private final RequestHelper requestHelper;
-  private final SingularityLeaderLatch leaderLatch;
 
   @Inject
   public RequestResource(SingularityValidator validator, DeployManager deployManager, TaskManager taskManager, RequestManager requestManager, SingularityMailer mailer,
-    SingularityAuthorizationHelper authorizationHelper, Optional<SingularityUser> user, RequestHelper requestHelper, SingularityLeaderLatch leaderLatch,
+                         SingularityAuthorizationHelper authorizationHelper, Optional<SingularityUser> user, RequestHelper requestHelper, SingularityLeaderLatch leaderLatch,
                          @Named(SingularityResourceModule.PROXY_TO_LEADER_HTTP_CLIENT) HttpClient httpClient) {
     super(requestManager, deployManager, user, validator, authorizationHelper, httpClient, leaderLatch);
 
     this.mailer = mailer;
     this.taskManager = taskManager;
     this.requestHelper = requestHelper;
-    this.leaderLatch = leaderLatch;
   }
 
   private void submitRequest(SingularityRequest request, Optional<SingularityRequestWithState> oldRequestWithState, Optional<RequestHistoryType> historyType,

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/SingularityResourceModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/SingularityResourceModule.java
@@ -6,7 +6,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
 import com.google.inject.Scopes;
+import com.google.inject.Singleton;
+import com.google.inject.name.Named;
+import com.hubspot.horizon.HttpClient;
+import com.hubspot.horizon.ning.NingHttpClient;
 import com.hubspot.singularity.config.UIConfiguration;
 import com.hubspot.singularity.guice.GuicePropertyFilteringMessageBodyWriter;
 
@@ -64,5 +69,12 @@ public class SingularityResourceModule extends AbstractModule {
       break;
     }
     }
+  }
+
+  @Provides
+  @Singleton
+  @Named(PROXY_TO_LEADER_HTTP_CLIENT)
+  public HttpClient provideHttpClient() {
+    return new NingHttpClient();
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/SingularityResourceModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/SingularityResourceModule.java
@@ -5,12 +5,14 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import com.hubspot.horizon.HttpClient;
+import com.hubspot.horizon.HttpConfig;
 import com.hubspot.horizon.ning.NingHttpClient;
 import com.hubspot.singularity.config.UIConfiguration;
 import com.hubspot.singularity.guice.GuicePropertyFilteringMessageBodyWriter;
@@ -74,7 +76,8 @@ public class SingularityResourceModule extends AbstractModule {
   @Provides
   @Singleton
   @Named(PROXY_TO_LEADER_HTTP_CLIENT)
-  public HttpClient provideHttpClient() {
-    return new NingHttpClient();
+  public HttpClient provideHttpClient(ObjectMapper objectMapper) {
+    HttpConfig httpConfig = HttpConfig.newBuilder().setObjectMapper(objectMapper).build();
+    return new NingHttpClient(httpConfig);
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
@@ -295,10 +295,7 @@ public class TaskResource extends AbstractLeaderAwareResource {
   })
   public SingularityTaskCleanup killTask(@PathParam("taskId") String taskId, @Context HttpServletRequest requestContext, Optional<SingularityKillTaskRequest> killTaskRequest
                                          ) {
-    if (!leaderLatch.hasLeadership()) {
-      return proxyToLeader(requestContext, SingularityTaskCleanup.class, killTaskRequest.orNull());
-    }
-    return killTask(taskId, killTaskRequest);
+    return maybeProxyToLeader(requestContext, SingularityTaskCleanup.class, killTaskRequest.orNull(), () -> killTask(taskId, killTaskRequest));
   }
 
   public SingularityTaskCleanup killTask(String taskId, Optional<SingularityKillTaskRequest> killTaskRequest) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
@@ -26,6 +26,7 @@ import org.apache.curator.framework.recipes.leader.LeaderLatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -97,8 +98,8 @@ public class TaskResource extends AbstractLeaderAwareResource {
   @Inject
   public TaskResource(TaskRequestManager taskRequestManager, TaskManager taskManager, SlaveManager slaveManager, MesosClient mesosClient, SingularityTaskMetadataConfiguration taskMetadataConfiguration,
                       SingularityAuthorizationHelper authorizationHelper, Optional<SingularityUser> user, RequestManager requestManager, SingularityValidator validator, DisasterManager disasterManager,
-                      @Named(SingularityResourceModule.PROXY_TO_LEADER_HTTP_CLIENT) HttpClient httpClient, LeaderLatch leaderLatch) {
-    super(httpClient, leaderLatch);
+                      @Named(SingularityResourceModule.PROXY_TO_LEADER_HTTP_CLIENT) HttpClient httpClient, LeaderLatch leaderLatch, ObjectMapper objectMapper) {
+    super(httpClient, leaderLatch, objectMapper);
     this.taskManager = taskManager;
     this.taskRequestManager = taskRequestManager;
     this.taskMetadataConfiguration = taskMetadataConfiguration;
@@ -293,7 +294,7 @@ public class TaskResource extends AbstractLeaderAwareResource {
   public SingularityTaskCleanup killTask(@PathParam("taskId") String taskId, @Context HttpServletRequest requestContext, Optional<SingularityKillTaskRequest> killTaskRequest
                                          ) {
     if (!leaderLatch.hasLeadership()) {
-      return proxyToLeader(requestContext, SingularityTaskCleanup.class);
+      return proxyToLeader(requestContext, SingularityTaskCleanup.class, killTaskRequest.orNull());
     }
     return killTask(taskId, killTaskRequest);
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
@@ -284,7 +284,7 @@ public class TaskResource extends AbstractLeaderAwareResource {
   @DELETE
   @Path("/task/{taskId}")
   public SingularityTaskCleanup killTask(@PathParam("taskId") String taskId, @Context HttpServletRequest requestContext) {
-    return killTask(taskId, Optional.absent(), requestContext);
+    return killTask(taskId, requestContext, Optional.absent());
   }
 
   @DELETE
@@ -294,12 +294,15 @@ public class TaskResource extends AbstractLeaderAwareResource {
   @ApiResponses({
     @ApiResponse(code=409, message="Task already has a cleanup request (can be overridden with override=true)")
   })
-  public SingularityTaskCleanup killTask(@PathParam("taskId") String taskId, Optional<SingularityKillTaskRequest> killTaskRequest,
-                                         @Context HttpServletRequest requestContext) {
+  public SingularityTaskCleanup killTask(@PathParam("taskId") String taskId, @Context HttpServletRequest requestContext, Optional<SingularityKillTaskRequest> killTaskRequest
+                                         ) {
     if (!leaderLatch.hasLeadership()) {
       return proxyToLeader(requestContext, SingularityTaskCleanup.class);
     }
+    return killTask(taskId, killTaskRequest);
+  }
 
+  public SingularityTaskCleanup killTask(String taskId, Optional<SingularityKillTaskRequest> killTaskRequest) {
     final SingularityTask task = checkActiveTask(taskId, SingularityAuthorizationScope.WRITE);
 
     Optional<String> message = Optional.absent();

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
@@ -22,6 +22,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+import org.apache.curator.framework.recipes.leader.LeaderLatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,7 +43,6 @@ import com.hubspot.singularity.SingularityAction;
 import com.hubspot.singularity.SingularityAuthorizationScope;
 import com.hubspot.singularity.SingularityCreateResult;
 import com.hubspot.singularity.SingularityKilledTaskIdRecord;
-import com.hubspot.singularity.SingularityLeaderLatch;
 import com.hubspot.singularity.SingularityPendingRequest;
 import com.hubspot.singularity.SingularityPendingRequest.PendingType;
 import com.hubspot.singularity.SingularityPendingTask;
@@ -97,7 +97,7 @@ public class TaskResource extends AbstractLeaderAwareResource {
   @Inject
   public TaskResource(TaskRequestManager taskRequestManager, TaskManager taskManager, SlaveManager slaveManager, MesosClient mesosClient, SingularityTaskMetadataConfiguration taskMetadataConfiguration,
                       SingularityAuthorizationHelper authorizationHelper, Optional<SingularityUser> user, RequestManager requestManager, SingularityValidator validator, DisasterManager disasterManager,
-                      @Named(SingularityResourceModule.PROXY_TO_LEADER_HTTP_CLIENT) HttpClient httpClient, SingularityLeaderLatch leaderLatch) {
+                      @Named(SingularityResourceModule.PROXY_TO_LEADER_HTTP_CLIENT) HttpClient httpClient, LeaderLatch leaderLatch) {
     super(httpClient, leaderLatch);
     this.taskManager = taskManager;
     this.taskRequestManager = taskRequestManager;

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
@@ -111,10 +111,6 @@ public class TaskResource extends AbstractLeaderAwareResource {
     this.disasterManager = disasterManager;
   }
 
-  private boolean useWebCache(Boolean useWebCache) {
-    return useWebCache != null && useWebCache.booleanValue();
-  }
-
   @GET
   @PropertyFiltering
   @Path("/scheduled")

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCooldownChecker.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCooldownChecker.java
@@ -38,7 +38,7 @@ public class SingularityCooldownChecker {
   public void checkCooldowns() {
     final long start = System.currentTimeMillis();
 
-    final List<SingularityRequestWithState> cooldownRequests = Lists.newArrayList(requestManager.getCooldownRequests());
+    final List<SingularityRequestWithState> cooldownRequests = Lists.newArrayList(requestManager.getCooldownRequests(false));
 
     if (cooldownRequests.isEmpty()) {
       LOG.trace("No cooldown requests");

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCache.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCache.java
@@ -49,7 +49,7 @@ public class SingularityLeaderCache {
 
   public void cacheActiveTaskIds(List<SingularityTaskId> activeTaskIds) {
     this.activeTaskIds = Collections.synchronizedSet(new HashSet<SingularityTaskId>(activeTaskIds.size()));
-    activeTaskIds.forEach(activeTaskIds::add);
+    activeTaskIds.forEach(this.activeTaskIds::add);
   }
 
   public void cacheRequests(List<SingularityRequestWithState> requestsWithState) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCache.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCache.java
@@ -16,6 +16,7 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.hubspot.singularity.SingularityPendingTask;
 import com.hubspot.singularity.SingularityPendingTaskId;
+import com.hubspot.singularity.SingularityRequestWithState;
 import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.SingularityTaskId;
 
@@ -26,6 +27,7 @@ public class SingularityLeaderCache {
 
   private Map<SingularityPendingTaskId, SingularityPendingTask> pendingTaskIdToPendingTask;
   private Set<SingularityTaskId> activeTaskIds;
+  private Map<String, SingularityRequestWithState> requests;
 
   private volatile boolean active;
 
@@ -40,9 +42,7 @@ public class SingularityLeaderCache {
 
   public void cachePendingTasks(List<SingularityPendingTask> pendingTasks) {
     this.pendingTaskIdToPendingTask = new ConcurrentHashMap<>(pendingTasks.size());
-    for (SingularityPendingTask pendingTask : pendingTasks) {
-      this.pendingTaskIdToPendingTask.put(pendingTask.getPendingTaskId(), pendingTask);
-    }
+    pendingTasks.forEach((t) -> pendingTaskIdToPendingTask.put(t.getPendingTaskId(), t));
   }
 
   public void cacheActiveTaskIds(List<SingularityTaskId> activeTaskIds) {
@@ -50,6 +50,11 @@ public class SingularityLeaderCache {
     for (SingularityTaskId activeTaskId : activeTaskIds) {
       this.activeTaskIds.add(activeTaskId);
     }
+  }
+
+  public void cacheRequests(List<SingularityRequestWithState> requestsWithState) {
+    this.requests = new ConcurrentHashMap<>(requestsWithState.size());
+    requestsWithState.forEach((r) -> requests.put(r.getRequest().getId(), r));
   }
 
   public void stop() {
@@ -152,4 +157,25 @@ public class SingularityLeaderCache {
     activeTaskIds.add(task.getTaskId());
   }
 
+  public List<SingularityRequestWithState> getRequests() {
+    return new ArrayList<>(requests.values());
+  }
+
+  public void putRequest(SingularityRequestWithState requestWithState) {
+    if (!active) {
+      LOG.warn("putRequest {}, but not active", requestWithState.getRequest().getId());
+      return;
+    }
+
+    requests.put(requestWithState.getRequest().getId(), requestWithState);
+  }
+
+  public void deleteRequest(String requestId) {
+    if (!active) {
+      LOG.warn("deleteRequest {}, but not active", requestId);
+      return;
+    }
+
+    requests.remove(requestId);
+  }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCache.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCache.java
@@ -167,6 +167,10 @@ public class SingularityLeaderCache {
     return new ArrayList<>(requests.values());
   }
 
+  public Optional<SingularityRequestWithState> getRequest(String requestId) {
+    return Optional.fromNullable(requests.get(requestId));
+  }
+
   public void putRequest(SingularityRequestWithState requestWithState) {
     if (!active) {
       LOG.warn("putRequest {}, but not active", requestWithState.getRequest().getId());

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCacheCoordinator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCacheCoordinator.java
@@ -2,23 +2,27 @@ package com.hubspot.singularity.scheduler;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.hubspot.singularity.data.RequestManager;
 import com.hubspot.singularity.data.TaskManager;
 
 @Singleton
 public class SingularityLeaderCacheCoordinator {
 
   private final TaskManager taskManager;
+  private final RequestManager requestManager;
   private final SingularityLeaderCache leaderCache;
 
   @Inject
-  public SingularityLeaderCacheCoordinator(TaskManager taskManager, SingularityLeaderCache leaderCache) {
+  public SingularityLeaderCacheCoordinator(TaskManager taskManager, RequestManager requestManager, SingularityLeaderCache leaderCache) {
     this.taskManager = taskManager;
+    this.requestManager = requestManager;
     this.leaderCache = leaderCache;
   }
 
   public void activateLeaderCache() {
     leaderCache.activate();
     taskManager.activateLeaderCache();
+    requestManager.activateLeaderCache();
   }
 
   public void stopLeaderCache() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCacheCoordinator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCacheCoordinator.java
@@ -20,9 +20,9 @@ public class SingularityLeaderCacheCoordinator {
   }
 
   public void activateLeaderCache() {
-    leaderCache.activate();
     taskManager.activateLeaderCache();
     requestManager.activateLeaderCache();
+    leaderCache.activate();
   }
 
   public void stopLeaderCache() {

--- a/SingularityService/src/test/java/com/hubspot/singularity/SingularityHistoryTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/SingularityHistoryTest.java
@@ -220,7 +220,7 @@ public class SingularityHistoryTest extends SingularitySchedulerTestBase {
     Assert.assertEquals(runId, historyManager.getTaskHistory(taskId.getId()).get().getTask().getTaskRequest().getPendingTask().getRunId().get());
     Assert.assertEquals(runId, getTaskHistoryForRequest(requestId, 0, 10).get(0).getRunId().get());
 
-    parent = requestResource.scheduleImmediately(requestId, Optional.absent());
+    parent = requestResource.scheduleImmediately(requestId);
 
     Assert.assertTrue(parent.getPendingRequest().getRunId().isPresent());
   }
@@ -261,7 +261,7 @@ public class SingularityHistoryTest extends SingularitySchedulerTestBase {
     initScheduledRequest();
     initFirstDeploy();
 
-    requestResource.scheduleImmediately(requestId, Optional.absent());
+    requestResource.scheduleImmediately(requestId);
 
     resourceOffers();
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/SingularityHistoryTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/SingularityHistoryTest.java
@@ -216,7 +216,7 @@ public class SingularityHistoryTest extends SingularitySchedulerTestBase {
     Assert.assertEquals(runId, historyManager.getTaskHistory(taskId.getId()).get().getTask().getTaskRequest().getPendingTask().getRunId().get());
     Assert.assertEquals(runId, getTaskHistoryForRequest(requestId, 0, 10).get(0).getRunId().get());
 
-    parent = requestResource.scheduleImmediately(requestId);
+    parent = requestResource.scheduleImmediately(requestId, Optional.absent());
 
     Assert.assertTrue(parent.getPendingRequest().getRunId().isPresent());
   }
@@ -257,7 +257,7 @@ public class SingularityHistoryTest extends SingularitySchedulerTestBase {
     initScheduledRequest();
     initFirstDeploy();
 
-    requestResource.scheduleImmediately(requestId);
+    requestResource.scheduleImmediately(requestId, Optional.absent());
 
     resourceOffers();
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityStartupTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityStartupTest.java
@@ -111,7 +111,7 @@ public class SingularityStartupTest extends SingularitySchedulerTestBase {
     boolean caughtException = false;
 
     try {
-      requestResource.scheduleImmediately(requestId);
+      requestResource.scheduleImmediately(requestId, Optional.absent());
     } catch (Exception e) {
       caughtException = true;
     }

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityStartupTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityStartupTest.java
@@ -111,7 +111,7 @@ public class SingularityStartupTest extends SingularitySchedulerTestBase {
     boolean caughtException = false;
 
     try {
-      requestResource.scheduleImmediately(requestId, Optional.absent());
+      requestResource.scheduleImmediately(requestId);
     } catch (Exception e) {
       caughtException = true;
     }

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityExpiringActionsTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityExpiringActionsTest.java
@@ -39,7 +39,7 @@ public class SingularityExpiringActionsTest extends SingularitySchedulerTestBase
     Assert.assertEquals(0, taskManager.getActiveTaskIds().size());
     Assert.assertEquals(0, taskManager.getPendingTasks().size());
     Assert.assertEquals(RequestState.PAUSED, requestManager.getRequest(requestId).get().getState());
-    Assert.assertEquals(requestId, requestManager.getPausedRequests().iterator().next().getRequest().getId());
+    Assert.assertEquals(requestId, requestManager.getPausedRequests(false).iterator().next().getRequest().getId());
 
     try {
       Thread.sleep(2);
@@ -54,7 +54,7 @@ public class SingularityExpiringActionsTest extends SingularitySchedulerTestBase
     Assert.assertEquals(0, taskManager.getPendingTasks().size());
 
     Assert.assertEquals(RequestState.ACTIVE, requestManager.getRequest(requestId).get().getState());
-    Assert.assertEquals(requestId, requestManager.getActiveRequests().iterator().next().getRequest().getId());
+    Assert.assertEquals(requestId, requestManager.getActiveRequests(false).iterator().next().getRequest().getId());
   }
 
   @Test

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityHealthchecksTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityHealthchecksTest.java
@@ -120,7 +120,7 @@ public class SingularityHealthchecksTest extends SingularitySchedulerTestBase {
 
     startTask(firstDeploy);
 
-    requestResource.bounce(requestId);
+    requestResource.bounce(requestId, Optional.absent());
 
     cleaner.drainCleanupQueue();
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -1430,7 +1430,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     deployChecker.checkDeploys();
     SingularityDeployResult deployResult = deployManager.getDeployResult(requestId, firstDeployId).get();
     Assert.assertEquals(DeployState.FAILED, deployResult.getDeployState());
-    Assert.assertTrue(deployResult.getMessage().get().contains("MISSING"));
+    Assert.assertTrue(deployResult.getMessage().get().contains("DELETED"));
   }
 
   @Test

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -479,7 +479,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
 
     Assert.assertTrue(requestManager.getPendingRequests().isEmpty());
 
-    requestResource.scheduleImmediately(requestId, Optional.absent());
+    requestResource.scheduleImmediately(requestId);
 
     resourceOffers();
 
@@ -491,7 +491,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     Assert.assertEquals(0, taskManager.getActiveTaskIds().size());
     Assert.assertEquals(0, taskManager.getPendingTaskIds().size());
 
-    requestResource.scheduleImmediately(requestId, Optional.absent());
+    requestResource.scheduleImmediately(requestId);
 
     resourceOffers();
 
@@ -510,7 +510,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     requestResource.postRequest(bldr.build());
     deploy("d2");
 
-    requestResource.scheduleImmediately(requestId, Optional.absent());
+    requestResource.scheduleImmediately(requestId);
 
     validateTaskDoesntMoveDuringDecommission();
   }
@@ -1294,21 +1294,21 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     deploy("d2");
     deployChecker.checkDeploys();
 
-    requestResource.scheduleImmediately(requestId, Optional.absent());
+    requestResource.scheduleImmediately(requestId);
 
     resourceOffers();
 
-    requestResource.scheduleImmediately(requestId, Optional.absent());
+    requestResource.scheduleImmediately(requestId);
 
     resourceOffers();
 
     Assert.assertEquals(2, taskManager.getActiveTaskIds().size());
 
-    requestResource.scheduleImmediately(requestId, Optional.absent());
+    requestResource.scheduleImmediately(requestId);
 
     scheduler.drainPendingQueue(stateCacheProvider.get());
 
-    requestResource.scheduleImmediately(requestId, Optional.absent());
+    requestResource.scheduleImmediately(requestId);
 
     scheduler.drainPendingQueue(stateCacheProvider.get());
 
@@ -1616,8 +1616,8 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
         new SingularityPriorityFreezeParent(new SingularityPriorityFreeze(0.3, true, Optional.<String>absent(), Optional.<String>absent()), System.currentTimeMillis(), Optional.<String>absent()));
 
     // launch both tasks
-    requestResource.scheduleImmediately(lowPriorityRequest.getId(), Optional.absent());
-    requestResource.scheduleImmediately(mediumPriorityRequest.getId(), Optional.absent());
+    requestResource.scheduleImmediately(lowPriorityRequest.getId());
+    requestResource.scheduleImmediately(mediumPriorityRequest.getId());
 
     // drain pending queue
     scheduler.drainPendingQueue(stateCacheProvider.get());

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -479,7 +479,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
 
     Assert.assertTrue(requestManager.getPendingRequests().isEmpty());
 
-    requestResource.scheduleImmediately(requestId);
+    requestResource.scheduleImmediately(requestId, Optional.absent());
 
     resourceOffers();
 
@@ -491,7 +491,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     Assert.assertEquals(0, taskManager.getActiveTaskIds().size());
     Assert.assertEquals(0, taskManager.getPendingTaskIds().size());
 
-    requestResource.scheduleImmediately(requestId);
+    requestResource.scheduleImmediately(requestId, Optional.absent());
 
     resourceOffers();
 
@@ -510,7 +510,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     requestResource.postRequest(bldr.build());
     deploy("d2");
 
-    requestResource.scheduleImmediately(requestId);
+    requestResource.scheduleImmediately(requestId, Optional.absent());
 
     validateTaskDoesntMoveDuringDecommission();
   }
@@ -1294,21 +1294,21 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     deploy("d2");
     deployChecker.checkDeploys();
 
-    requestResource.scheduleImmediately(requestId);
+    requestResource.scheduleImmediately(requestId, Optional.absent());
 
     resourceOffers();
 
-    requestResource.scheduleImmediately(requestId);
+    requestResource.scheduleImmediately(requestId, Optional.absent());
 
     resourceOffers();
 
     Assert.assertEquals(2, taskManager.getActiveTaskIds().size());
 
-    requestResource.scheduleImmediately(requestId);
+    requestResource.scheduleImmediately(requestId, Optional.absent());
 
     scheduler.drainPendingQueue(stateCacheProvider.get());
 
-    requestResource.scheduleImmediately(requestId);
+    requestResource.scheduleImmediately(requestId, Optional.absent());
 
     scheduler.drainPendingQueue(stateCacheProvider.get());
 
@@ -1616,8 +1616,8 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
         new SingularityPriorityFreezeParent(new SingularityPriorityFreeze(0.3, true, Optional.<String>absent(), Optional.<String>absent()), System.currentTimeMillis(), Optional.<String>absent()));
 
     // launch both tasks
-    requestResource.scheduleImmediately(lowPriorityRequest.getId());
-    requestResource.scheduleImmediately(mediumPriorityRequest.getId());
+    requestResource.scheduleImmediately(lowPriorityRequest.getId(), Optional.absent());
+    requestResource.scheduleImmediately(mediumPriorityRequest.getId(), Optional.absent());
 
     // drain pending queue
     scheduler.drainPendingQueue(stateCacheProvider.get());

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -452,7 +452,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     requestResource.postRequest(request.toBuilder().setQuartzSchedule(Optional.of(schedule)).build());
     scheduler.drainPendingQueue(stateCacheProvider.get());
 
-    Assert.assertTrue(requestResource.getActiveRequests().isEmpty());
+    Assert.assertTrue(requestResource.getActiveRequests(false).isEmpty());
     Assert.assertTrue(requestManager.getRequest(requestId).get().getState() == RequestState.FINISHED);
     Assert.assertTrue(taskManager.getPendingTaskIds().isEmpty());
 
@@ -460,7 +460,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     requestResource.postRequest(request.toBuilder().setQuartzSchedule(Optional.of(schedule)).build());
     scheduler.drainPendingQueue(stateCacheProvider.get());
 
-    Assert.assertTrue(!requestResource.getActiveRequests().isEmpty());
+    Assert.assertTrue(!requestResource.getActiveRequests(false).isEmpty());
     Assert.assertTrue(requestManager.getRequest(requestId).get().getState() == RequestState.ACTIVE);
 
     Assert.assertTrue(!taskManager.getPendingTaskIds().isEmpty());
@@ -1028,7 +1028,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     Assert.assertEquals(0, taskManager.getActiveTaskIds().size());
     Assert.assertEquals(0, taskManager.getPendingTasks().size());
     Assert.assertEquals(RequestState.PAUSED, requestManager.getRequest(requestId).get().getState());
-    Assert.assertEquals(requestId, requestManager.getPausedRequests().iterator().next().getRequest().getId());
+    Assert.assertEquals(requestId, requestManager.getPausedRequests(false).iterator().next().getRequest().getId());
 
     requestResource.unpause(requestId, Optional.<SingularityUnpauseRequest> absent());
 
@@ -1038,7 +1038,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     Assert.assertEquals(0, taskManager.getPendingTasks().size());
 
     Assert.assertEquals(RequestState.ACTIVE, requestManager.getRequest(requestId).get().getState());
-    Assert.assertEquals(requestId, requestManager.getActiveRequests().iterator().next().getRequest().getId());
+    Assert.assertEquals(requestId, requestManager.getActiveRequests(false).iterator().next().getRequest().getId());
   }
 
   @Test

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -232,7 +232,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
 
     SingularityTask firstTask = startTask(firstDeploy);
 
-    taskResource.killTask(firstTask.getTaskId().getId());
+    taskResource.killTask(firstTask.getTaskId().getId(), Optional.absent());
 
     cleaner.drainCleanupQueue();
     killKilledTasks();

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySlavePlacementTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySlavePlacementTest.java
@@ -305,7 +305,7 @@ public class SingularitySlavePlacementTest extends SingularitySchedulerTestBase 
     sms.resourceOffers(driver, Arrays.asList(createOffer(1, 128, "slave2", "host2", Optional.of("rack1"))));
     Assert.assertEquals(2, taskManager.getActiveTaskIds().size());
 
-    requestResource.bounce(requestId);
+    requestResource.bounce(requestId, Optional.absent());
     cleaner.drainCleanupQueue();
     scheduler.drainPendingQueue(stateCacheProvider.get());
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityTestModule.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityTestModule.java
@@ -33,9 +33,12 @@ import com.google.inject.Provider;
 import com.google.inject.Scopes;
 import com.google.inject.Stage;
 import com.google.inject.TypeLiteral;
+import com.google.inject.name.Names;
 import com.google.inject.util.Modules;
 import com.hubspot.dropwizard.guicier.DropwizardModule;
 import com.hubspot.dropwizard.guicier.GuiceBundle;
+import com.hubspot.horizon.HttpClient;
+import com.hubspot.horizon.ning.NingHttpClient;
 import com.hubspot.jackson.datatype.protobuf.ProtobufModule;
 import com.hubspot.mesos.client.MesosClient;
 import com.hubspot.singularity.SingularityAbort;
@@ -63,6 +66,7 @@ import com.hubspot.singularity.resources.DeployResource;
 import com.hubspot.singularity.resources.PriorityResource;
 import com.hubspot.singularity.resources.RackResource;
 import com.hubspot.singularity.resources.RequestResource;
+import com.hubspot.singularity.resources.SingularityResourceModule;
 import com.hubspot.singularity.resources.SlaveResource;
 import com.hubspot.singularity.resources.TaskResource;
 import com.hubspot.singularity.sentry.SingularityExceptionNotifier;
@@ -204,6 +208,8 @@ public class SingularityTestModule implements Module {
     mainBinder.install(new SingularityTranscoderModule());
     mainBinder.install(new SingularityHistoryModule(configuration));
     mainBinder.install(new SingularityZkMigrationsModule());
+
+    mainBinder.bind(HttpClient.class).annotatedWith(Names.named(SingularityResourceModule.PROXY_TO_LEADER_HTTP_CLIENT)).toInstance(new NingHttpClient());
 
     mainBinder.install(new SingularityEventModule(configuration));
     mainBinder.install(Modules.override(new SingularityAuthModule(configuration))


### PR DESCRIPTION
Still a WIP, but this will extend the leader and web cache to other frequently used pieces of information. To start with I extended it to requests (`SingularityRequestWithState`)

/cc @wsorenson 