### PR TITLE
Fix Task Search navigation and refresh

### DIFF
--- a/SingularityUI/app/actions/ui/taskSearch.es6
+++ b/SingularityUI/app/actions/ui/taskSearch.es6
@@ -4,10 +4,3 @@ export const UpdateFilter = (filter) => ({
   filter,
   type: 'UPDATE_TASK_SEARCH_FILTER'
 });
-
-export const refresh = (requestId, count, page) => (dispatch) =>
-  Promise.all([
-    dispatch(FetchTaskSearchParams.clear()),
-    dispatch(FetchTaskSearchParams.trigger(requestId, count, page)),
-    dispatch(UpdateFilter({ requestId })),
-  ]);

--- a/SingularityUI/app/components/taskSearch/TaskSearch.jsx
+++ b/SingularityUI/app/components/taskSearch/TaskSearch.jsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router';
 import { Glyphicon, Label } from 'react-bootstrap';
 import rootComponent from '../../rootComponent';
 import { FetchTaskSearchParams } from '../../actions/api/history';
-import { UpdateFilter, refresh } from '../../actions/ui/taskSearch';
+import { UpdateFilter } from '../../actions/ui/taskSearch';
 
 import Breadcrumbs from '../common/Breadcrumbs';
 import TaskSearchFilters from './TaskSearchFilters';
@@ -121,7 +121,7 @@ class TaskSearch extends React.Component {
           ref={(table) => this.bindResetPageAndCount(table)}
         >
           <Column
-            label=""
+            label="Task"
             id="url"
             key="url"
             className="actions-column"
@@ -213,4 +213,4 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(rootComponent(TaskSearch, (props) => refresh(Utils.maybe(props, ['params', 'requestId'], undefined), INITIAL_TASKS_PER_PAGE, 1), false));
+export default connect(mapStateToProps, mapDispatchToProps)(rootComponent(TaskSearch, null, false));


### PR DESCRIPTION
Task search was not loading correctly given initial parameters. It also really doesn't need to load until explicitly told to do so. This removes the refresh from task search, which makes the page load much faster and not error on load.