### PR TITLE
Mark as not bouncing if paused before bounce completes

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
@@ -210,6 +210,7 @@ public class RequestManager extends CuratorAsyncManager {
   }
 
   public SingularityCreateResult pause(SingularityRequest request, long timestamp, Optional<String> user, Optional<String> message) {
+    markBounceComplete(request.getId());
     return save(request, RequestState.PAUSED, RequestHistoryType.PAUSED, timestamp, user, message);
   }
 


### PR DESCRIPTION
Pretty much what the title says. Previously the `isBouncing` marker would hang around if the request was paused in the middle of a bounce