### PR TITLE
correctly redirect when no instances are found

### DIFF
--- a/SingularityUI/app/components/requestDetail/TaskInstanceRedirect.jsx
+++ b/SingularityUI/app/components/requestDetail/TaskInstanceRedirect.jsx
@@ -19,10 +19,8 @@ class TaskInstanceRedirect extends Component {
           this.props.router.replace(`task/${task.taskId.id}`);
         }
       });
-      if (!found) {
-        this.props.router.replace(`request/${nextProps.params.requestId}`);
-      }
     }
+    this.props.router.replace(`request/${nextProps.params.requestId}`);
   }
 
   render() {


### PR DESCRIPTION
This is a ui shortcut for navigating to the currently running instance 'x'. It wasn't redirecting correctly when no active tasks were found (which can be often for things like scheduled jobs)