### PR TITLE
Warn when removing a request with lb configs

### DIFF
--- a/SingularityUI/app/components/common/modalButtons/RemoveButton.jsx
+++ b/SingularityUI/app/components/common/modalButtons/RemoveButton.jsx
@@ -17,6 +17,7 @@ const removeTooltip = (
 export default class RemoveButton extends Component {
   static propTypes = {
     requestId: PropTypes.string.isRequired,
+    loadBalancerData: PropTypes.object,
     children: PropTypes.node,
     then: PropTypes.func
   };
@@ -35,7 +36,7 @@ export default class RemoveButton extends Component {
     return (
       <span>
         {getClickComponent(this)}
-        <RemoveModal ref="modal" requestId={this.props.requestId} then={this.props.then} />
+        <RemoveModal ref="modal" requestId={this.props.requestId} loadBalancerData={this.props.loadBalancerData} then={this.props.then} />
       </span>
     );
   }

--- a/SingularityUI/app/components/common/modalButtons/RemoveModal.jsx
+++ b/SingularityUI/app/components/common/modalButtons/RemoveModal.jsx
@@ -8,6 +8,7 @@ import FormModal from '../modal/FormModal';
 class RemoveModal extends Component {
   static propTypes = {
     requestId: PropTypes.string.isRequired,
+    loadBalancerData: PropTypes.object,
     removeRequest: PropTypes.func.isRequired
   };
 
@@ -16,6 +17,13 @@ class RemoveModal extends Component {
   }
 
   render() {
+    const loadBalancerWarning = (
+      <div>
+        <p>Removing this request will also remove the following settings from the load balancer</p>
+        <pre>{JSON.stringify(this.props.loadBalancerData, null, 2)}</pre>
+      </div>
+    );
+
     return (
       <FormModal
         name="Remove Request"
@@ -33,6 +41,7 @@ class RemoveModal extends Component {
         <p>Are you sure you want to remove this request?</p>
         <pre>{this.props.requestId}</pre>
         <p>If not paused, removing this request will kill all active and scheduled tasks and tasks for it will not run again unless it is reposted to Singularity.</p>
+        {!_.isEmpty(this.props.loadBalancerData) && loadBalancerWarning}
       </FormModal>
     );
   }

--- a/SingularityUI/app/components/requestDetail/header/RequestActionButtons.jsx
+++ b/SingularityUI/app/components/requestDetail/header/RequestActionButtons.jsx
@@ -161,7 +161,10 @@ const RequestActionButtons = ({requestParent, fetchRequest, fetchRequestHistory,
   }
 
   const removeButton = (
-    <RemoveButton requestId={request.id} then={fetchRequestAndHistoryAndActiveTasks}>
+    <RemoveButton 
+      requestId={request.id}
+      loadBalancerData={Utils.maybe(requestParent, ['activeDeploy', 'loadBalancerOptions'], {})}
+      then={fetchRequestAndHistoryAndActiveTasks}>
       <Button bsStyle="danger">
         Remove
       </Button>

--- a/SingularityUI/app/components/requests/Columns.jsx
+++ b/SingularityUI/app/components/requests/Columns.jsx
@@ -222,7 +222,10 @@ export const Actions = (
             {scale}
             {runNow}
             {unpause}
-            <RemoveButton requestId={cellData.id} />
+            <RemoveButton 
+              requestId={cellData.id}
+              loadBalancerData={Utils.maybe(cellData, ['activeDeploy', 'loadBalancerOptions'], {})}
+            />
             <JSONButton className="inline" object={cellData} showOverlay={true}>
               {'{ }'}
             </JSONButton>


### PR DESCRIPTION
It is easy to forget when the request you are removing has associated load balancer options. Those load balancer options will stay in Baragon when the request has been paused, but will be removed if the request is removed. This will show the load balancer settings associated with the request as a warning in the removal dialog. For example:

<img width="606" alt="screen shot 2017-04-10 at 9 42 57 pm" src="https://cloud.githubusercontent.com/assets/6034439/24889272/02199ade-1e37-11e7-81a0-1ce4d7d0a6d5.png">
