### PR TITLE
Allow copying from the JSON button dialog

### DIFF
--- a/SingularityUI/app/components/common/JSONButton.jsx
+++ b/SingularityUI/app/components/common/JSONButton.jsx
@@ -25,11 +25,7 @@ export default class JSONButton extends Component {
       modalOpen: false
     };
 
-    this.showJSON = this.showJSON.bind(this);
-    this.hideJSON = this.hideJSON.bind(this);
-
-    this.attachClipboard = this.attachClipboard.bind(this);
-    this.removeClipboard = this.removeClipboard.bind(this);
+    _.bindAll(this, 'showJSON', 'hideJSON', 'attachClipboard', 'removeClipboard');
   }
 
   showJSON() {

--- a/SingularityUI/app/components/common/JSONButton.jsx
+++ b/SingularityUI/app/components/common/JSONButton.jsx
@@ -27,16 +27,23 @@ export default class JSONButton extends Component {
 
     this.showJSON = this.showJSON.bind(this);
     this.hideJSON = this.hideJSON.bind(this);
-  }
 
-  componentDidMount() {
-    this.clipboard = new Clipboard('.copy-btn');
+    this.attachClipboard = this.attachClipboard.bind(this);
+    this.removeClipboard = this.removeClipboard.bind(this);
   }
 
   showJSON() {
     this.setState({
       modalOpen: true
     });
+  }
+
+  attachClipboard() {
+    this.clipboard = new Clipboard('.copy-btn');
+  }
+
+  removeClipboard() {
+    this.clipboard.destroy();
   }
 
   hideJSON() {
@@ -61,7 +68,11 @@ export default class JSONButton extends Component {
             {button}
           </OverlayTrigger>) : button
         }
-        <Modal show={this.state.modalOpen} onHide={this.hideJSON} bsSize="large">
+        <Modal show={this.state.modalOpen} onHide={this.hideJSON} bsSize="large"
+          enforceFocus={false}
+          onEntered={this.attachClipboard}
+          onExit={this.removeClipboard}
+        >
           <Modal.Body>
             <div className="constrained-modal json-modal">
               <JSONTree


### PR DESCRIPTION
Previously the copy button on the JSON modal would not copy the text of
the modal into the clipboard. This was because by default Bootstrap
Modals demand focus, and clipboard js works by creating a hidden text
field and copying the text out of that.  The fix is allowing the modal
to yield focus to the hidden text field.

There was an additional performance problem that went into the problem.
In particular, attaching the clipboard to a class attaches the clipboard
to every modal on the page, even when the modal isn't open. Tis was
fixed by starting the clipboard only when the modal is open and
destroying it after the modal is closed, to prevent attaching many
handlers that accumulate on the page.