### PR TITLE
Don't show logs panel if task never running

### DIFF
--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -423,7 +423,7 @@ class TaskDetail extends Component {
         <TaskAlerts task={this.props.task} deploy={this.props.deploy} pendingDeploys={this.props.pendingDeploys} />
         <TaskMetadataAlerts task={this.props.task} />
         <TaskHistory taskUpdates={this.props.task.taskUpdates} />
-        <TaskLatestLog taskId={this.props.taskId} status={this.props.task.status} available={filesToDisplay.files.length !== 0} />
+        <TaskLatestLog taskId={this.props.taskId} status={this.props.task.status} available={!_.isEmpty(filesToDisplay.files)} />
         {this.renderFiles(filesToDisplay)}
         {_.isEmpty(this.props.s3Logs) || <TaskS3Logs taskId={this.props.task.task.taskId.id} s3Files={this.props.s3Logs} taskStartedAt={this.props.task.task.taskId.startedAt} />}
         {_.isEmpty(this.props.task.loadBalancerUpdates) || <TaskLbUpdates loadBalancerUpdates={this.props.task.loadBalancerUpdates} />}

--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -423,7 +423,7 @@ class TaskDetail extends Component {
         <TaskAlerts task={this.props.task} deploy={this.props.deploy} pendingDeploys={this.props.pendingDeploys} />
         <TaskMetadataAlerts task={this.props.task} />
         <TaskHistory taskUpdates={this.props.task.taskUpdates} />
-        <TaskLatestLog taskId={this.props.taskId} status={this.props.task.status} />
+        <TaskLatestLog taskId={this.props.taskId} status={this.props.task.status} available={filesToDisplay.files.length !== 0} />
         {this.renderFiles(filesToDisplay)}
         {_.isEmpty(this.props.s3Logs) || <TaskS3Logs taskId={this.props.task.task.taskId.id} s3Files={this.props.s3Logs} taskStartedAt={this.props.task.task.taskId.startedAt} />}
         {_.isEmpty(this.props.task.loadBalancerUpdates) || <TaskLbUpdates loadBalancerUpdates={this.props.task.loadBalancerUpdates} />}

--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -41,6 +41,7 @@ import TaskLbUpdates from './TaskLbUpdates';
 import TaskInfo from './TaskInfo';
 import TaskEnvVars from './TaskEnvVars';
 import TaskHealthchecks from './TaskHealthchecks';
+import TaskState from './TaskState';
 import TaskStatus from './TaskStatus';
 
 class TaskDetail extends Component {
@@ -221,14 +222,12 @@ class TaskDetail extends Component {
       cleanupType = cleanup.cleanupType;
     }
 
-    const taskState = this.props.task.taskUpdates && (
-      <div className="col-xs-6 task-state-header">
-        <h1>
-          <span className={`label label-${Utils.getLabelClassFromTaskState(_.last(this.props.task.taskUpdates).taskState)} task-state-header-label`}>
-            {Utils.humanizeText(_.last(this.props.task.taskUpdates).taskState)} {cleanupType && `(${Utils.humanizeText(cleanupType)})`}
-          </span>
-        </h1>
-      </div>
+    const taskState = (
+      <TaskState
+        status={this.props.task.status}
+        updates={this.props.task.taskUpdates}
+        cleanupType={cleanupType}
+      />
     );
 
     let destroy = false;

--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -416,7 +416,8 @@ class TaskDetail extends Component {
       return cleanupToTest.taskId.id === this.props.taskId;
     });
     const filesToDisplay = this.props.files[`${this.props.params.taskId}/${this.props.currentFilePath}`] && this.analyzeFiles(this.props.files[`${this.props.taskId}/${this.props.currentFilePath}`].data);
-    const filesAvailable = filesToDisplay && !_.isEmpty(filesToDisplay.files);
+    const topLevelFiles = this.props.files[`${this.props.params.taskId}/`] && this.analyzeFiles(this.props.files[`${this.props.taskId}/`].data);
+    const filesAvailable = topLevelFiles && !_.isEmpty(topLevelFiles.files);
 
     return (
       <div className="task-detail detail-view">

--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -416,6 +416,7 @@ class TaskDetail extends Component {
       return cleanupToTest.taskId.id === this.props.taskId;
     });
     const filesToDisplay = this.props.files[`${this.props.params.taskId}/${this.props.currentFilePath}`] && this.analyzeFiles(this.props.files[`${this.props.taskId}/${this.props.currentFilePath}`].data);
+    const filesAvailable = filesToDisplay && !_.isEmpty(filesToDisplay.files);
 
     return (
       <div className="task-detail detail-view">
@@ -423,7 +424,7 @@ class TaskDetail extends Component {
         <TaskAlerts task={this.props.task} deploy={this.props.deploy} pendingDeploys={this.props.pendingDeploys} />
         <TaskMetadataAlerts task={this.props.task} />
         <TaskHistory taskUpdates={this.props.task.taskUpdates} />
-        <TaskLatestLog taskId={this.props.taskId} status={this.props.task.status} available={!_.isEmpty(filesToDisplay.files)} />
+        <TaskLatestLog taskId={this.props.taskId} status={this.props.task.status} available={filesAvailable} />
         {this.renderFiles(filesToDisplay)}
         {_.isEmpty(this.props.s3Logs) || <TaskS3Logs taskId={this.props.task.task.taskId.id} s3Files={this.props.s3Logs} taskStartedAt={this.props.task.task.taskId.startedAt} />}
         {_.isEmpty(this.props.task.loadBalancerUpdates) || <TaskLbUpdates loadBalancerUpdates={this.props.task.loadBalancerUpdates} />}

--- a/SingularityUI/app/components/taskDetail/TaskLatestLog.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskLatestLog.jsx
@@ -4,18 +4,30 @@ import { Glyphicon } from 'react-bootstrap';
 import { Link } from 'react-router';
 
 import Section from '../common/Section';
+import TaskStatus from './TaskStatus';
+
+const getLink = (status, taskId) => {
+  if (status === TaskStatus.RUNNING) {
+    return (
+      <Link to={Utils.tailerPath(taskId, config.runningTaskLogPath)} title="Log">
+          <span><Glyphicon glyph="file" /> {Utils.fileName(config.runningTaskLogPath)}</span>
+      </Link>
+    );
+  } else if (status === TaskStatus.STOPPED) {
+    return (
+      <Link to={Utils.tailerPath(taskId, config.finishedTaskLogPath)} title="Log">
+          <span><Glyphicon glyph="file" /> {Utils.fileName(config.finishedTaskLogPath)}</span>
+      </Link>
+    );
+  }
+
+  return null;
+};
 
 function TaskLatestLog (props) {
-  const link = props.isStillRunning ? (
-    <Link to={Utils.tailerPath(props.taskId, config.runningTaskLogPath)} title="Log">
-        <span><Glyphicon glyph="file" /> {Utils.fileName(config.runningTaskLogPath)}</span>
-    </Link>
-  ) : (
-    <Link to={Utils.tailerPath(props.taskId, config.finishedTaskLogPath)} title="Log">
-        <span><Glyphicon glyph="file" /> {Utils.fileName(config.finishedTaskLogPath)}</span>
-    </Link>
-  );
-  return (
+  const link = getLink(props.status, props.taskId);
+
+  return (props.status !== TaskStatus.NEVER_RAN &&
     <Section title="Logs" id="logs">
       <div className="row">
         <div className="col-md-4">
@@ -28,7 +40,7 @@ function TaskLatestLog (props) {
 
 TaskLatestLog.propTypes = {
   taskId: PropTypes.string.isRequired,
-  isStillRunning: PropTypes.bool
+  status: PropTypes.oneOf([TaskStatus.RUNNING, TaskStatus.STOPPED, TaskStatus.NEVER_RAN]),
 };
 
 export default TaskLatestLog;

--- a/SingularityUI/app/components/taskDetail/TaskLatestLog.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskLatestLog.jsx
@@ -24,10 +24,10 @@ const getLink = (status, taskId) => {
   return null;
 };
 
-function TaskLatestLog (props) {
-  const link = getLink(props.status, props.taskId);
+function TaskLatestLog({status, taskId, available}) {
+  const link = getLink(status, taskId);
 
-  return (props.status !== TaskStatus.NEVER_RAN &&
+  return (status !== TaskStatus.NEVER_RAN && available &&
     <Section title="Logs" id="logs">
       <div className="row">
         <div className="col-md-4">
@@ -41,6 +41,7 @@ function TaskLatestLog (props) {
 TaskLatestLog.propTypes = {
   taskId: PropTypes.string.isRequired,
   status: PropTypes.oneOf([TaskStatus.RUNNING, TaskStatus.STOPPED, TaskStatus.NEVER_RAN]),
+  available: PropTypes.bool,
 };
 
 export default TaskLatestLog;

--- a/SingularityUI/app/components/taskDetail/TaskLatestLog.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskLatestLog.jsx
@@ -27,15 +27,19 @@ const getLink = (status, taskId) => {
 function TaskLatestLog({status, taskId, available}) {
   const link = getLink(status, taskId);
 
-  return (status !== TaskStatus.NEVER_RAN && available &&
-    <Section title="Logs" id="logs">
-      <div className="row">
-        <div className="col-md-4">
-          <h4>{link}</h4>
+  if (status === TaskStatus.NEVER_RAN || !available) {
+    return null;
+  } else {
+    return (
+      <Section title="Logs" id="logs">
+        <div className="row">
+          <div className="col-md-4">
+            <h4>{link}</h4>
+          </div>
         </div>
-      </div>
-    </Section>
-  );
+      </Section>
+    );
+  }
 }
 
 TaskLatestLog.propTypes = {

--- a/SingularityUI/app/components/taskDetail/TaskState.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskState.jsx
@@ -1,0 +1,48 @@
+import React, { PropTypes } from 'react';
+import Utils from '../../utils';
+import TaskStatus from './TaskStatus';
+
+const labelText = (status, currentState, cleanupType) => {
+  if (status === TaskStatus.NEVER_RAN) {
+    return 'Task aborted';
+  } else if (cleanupType) {
+    return `${Utils.humanizeText(currentState)} (${Utils.humanizeText(cleanupType)})`;
+  }
+
+  return Utils.humanizeText(currentState);
+};
+
+const labelClass = (status, currentState) => {
+  if (status === TaskStatus.NEVER_RAN) {
+    return 'info';
+  }
+
+  return Utils.getLabelClassFromTaskState(currentState);
+};
+
+const TaskState = ({status, updates, cleanupType}) => {
+  if (updates) {
+    const currentState = _.last(updates).taskState;
+    return (
+      <div className="col-xs-6 task-state-header">
+        <h1>
+          <span className={`label label-${labelClass(status, currentState)} task-state-header-label`}>
+            {labelText(status, currentState, cleanupType)}
+          </span>
+        </h1>
+      </div>
+    );
+  }
+
+  return null;
+};
+
+TaskState.propTypes = {
+  status: PropTypes.oneOf([TaskStatus.RUNNING, TaskStatus.STOPPED, TaskStatus.NEVER_RAN]),
+  updates: PropTypes.arrayOf(PropTypes.shape({
+    taskState: PropTypes.string
+  })),
+  cleanupType: PropTypes.string,
+};
+
+export default TaskState;

--- a/SingularityUI/app/components/taskDetail/TaskStatus.es6
+++ b/SingularityUI/app/components/taskDetail/TaskStatus.es6
@@ -1,0 +1,9 @@
+const RUNNING = 'RUNNING';
+const STOPPED = 'STOPPED';
+const NEVER_RAN = 'NEVER_RAN';
+
+export default {
+  RUNNING,
+  STOPPED,
+  NEVER_RAN
+};


### PR DESCRIPTION
If a task is currently stopped and never reached the RUNNING state,
don't show the "Logs" section, or include a link to
"tail_of_finished_service.log".