### PR TITLE
don't include cleaning tasks in instance count

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/mesos/CounterMap.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/CounterMap.java
@@ -17,11 +17,11 @@ public class CounterMap<K> {
   private final Map<K, Counter> map;
 
   public CounterMap() {
-    this.map = new HashMap<K, Counter>();
+    this.map = new HashMap<>();
   }
 
   public CounterMap(int initialCapacity) {
-    this.map = new HashMap<K, Counter>(initialCapacity);
+    this.map = new HashMap<>(initialCapacity);
   }
 
   public Map<K, Long> toCountMap() {
@@ -52,7 +52,7 @@ public class CounterMap<K> {
   }
 
   public void incr(K key, long amount) {
-    Counter c = map.putIfAbsent(key, new Counter());
+    Counter c = map.computeIfAbsent(key, k -> new Counter());
 
     c.count += amount;
   }
@@ -62,7 +62,7 @@ public class CounterMap<K> {
   }
 
   public void decr(K key) {
-    Counter c = map.putIfAbsent(key, new Counter());
+    Counter c = map.computeIfAbsent(key, k -> new Counter());
 
     c.count--;
   }
@@ -86,7 +86,7 @@ public class CounterMap<K> {
   }
 
   public List<Entry<K, Counter>> asSortedEntryList() {
-    List<Entry<K, Counter>> entries = new ArrayList<Entry<K, Counter>>(map.size());
+    List<Entry<K, Counter>> entries = new ArrayList<>(map.size());
 
     for (Entry<K, Counter> entry : map.entrySet()) {
       entries.add(entry);

--- a/SingularityBase/src/main/java/com/hubspot/mesos/CounterMap.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/CounterMap.java
@@ -52,7 +52,7 @@ public class CounterMap<K> {
   }
 
   public void incr(K key, long amount) {
-    Counter c = map.computeIfAbsent(key, k -> new Counter());
+    Counter c = map.putIfAbsent(key, new Counter());
 
     c.count += amount;
   }
@@ -62,7 +62,7 @@ public class CounterMap<K> {
   }
 
   public void decr(K key) {
-    Counter c = map.computeIfAbsent(key, k -> new Counter());
+    Counter c = map.putIfAbsent(key, new Counter());
 
     c.count--;
   }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/CounterMap.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/CounterMap.java
@@ -52,18 +52,19 @@ public class CounterMap<K> {
   }
 
   public void incr(K key, long amount) {
-    Counter c = map.get(key);
-
-    if (c == null) {
-      c = new Counter();
-      map.put(key, c);
-    }
+    Counter c = map.computeIfAbsent(key, k -> new Counter());
 
     c.count += amount;
   }
 
   public void incr(K key) {
     incr(key, 1);
+  }
+
+  public void decr(K key) {
+    Counter c = map.computeIfAbsent(key, k -> new Counter());
+
+    c.count--;
   }
 
   public long getCount(K key) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/StateManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/StateManager.java
@@ -27,6 +27,7 @@ import com.hubspot.singularity.SingularityPendingDeploy;
 import com.hubspot.singularity.SingularityPendingTaskId;
 import com.hubspot.singularity.SingularityPriorityFreezeParent;
 import com.hubspot.singularity.SingularityRack;
+import com.hubspot.singularity.SingularityRequest;
 import com.hubspot.singularity.SingularityRequestDeployState;
 import com.hubspot.singularity.SingularityRequestWithState;
 import com.hubspot.singularity.SingularityScheduledTasksInfo;
@@ -133,6 +134,10 @@ public class StateManager extends CuratorManager {
       numTasks.incr(pendingTaskId.getRequestId());
     }
 
+    for (SingularityTaskId cleaningTaskId : taskManager.getCleanupTaskIds()) {
+      numTasks.decr(cleaningTaskId.getRequestId());
+    }
+
     return numTasks.toCountMap();
   }
 
@@ -208,14 +213,15 @@ public class StateManager extends CuratorManager {
       }
 
       if (requestWithState.getState().isRunnable() && requestWithState.getRequest().isAlwaysRunning()) {
-        final int instances = requestWithState.getRequest().getInstancesSafe();
+        SingularityRequest request = requestWithState.getRequest();
+        final int expectedInstances = request.getInstancesSafe();
 
-        final Long numActualInstances = numInstances.get(requestWithState.getRequest().getId());
+        final Long numActualInstances = numInstances.get(request.getId());
 
-        if (numActualInstances == null || numActualInstances.longValue() < instances) {
-          possiblyUnderProvisionedRequestIds.add(requestWithState.getRequest().getId());
-        } else if (numActualInstances.longValue() > instances) {
-          overProvisionedRequestIds.add(requestWithState.getRequest().getId());
+        if (numActualInstances == null || numActualInstances < expectedInstances) {
+          possiblyUnderProvisionedRequestIds.add(request.getId());
+        } else if (numActualInstances > expectedInstances) {
+          overProvisionedRequestIds.add(request.getId());
         }
       }
     }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/StateManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/StateManager.java
@@ -25,7 +25,6 @@ import com.hubspot.singularity.SingularityCreateResult;
 import com.hubspot.singularity.SingularityHostState;
 import com.hubspot.singularity.SingularityPendingDeploy;
 import com.hubspot.singularity.SingularityPendingTaskId;
-import com.hubspot.singularity.SingularityPriorityFreezeParent;
 import com.hubspot.singularity.SingularityRack;
 import com.hubspot.singularity.SingularityRequest;
 import com.hubspot.singularity.SingularityRequestDeployState;
@@ -61,9 +60,21 @@ public class StateManager extends CuratorManager {
   private final PriorityManager priorityManager;
 
   @Inject
-  public StateManager(CuratorFramework curatorFramework, SingularityConfiguration configuration, MetricRegistry metricRegistry, RequestManager requestManager, TaskManager taskManager,
-      DeployManager deployManager, SlaveManager slaveManager, RackManager rackManager, Transcoder<SingularityState> stateTranscoder, Transcoder<SingularityHostState> hostStateTranscoder,
-      SingularityConfiguration singularityConfiguration, SingularityAuthDatastore authDatastore, PriorityManager priorityManager, Transcoder<SingularityTaskReconciliationStatistics> taskReconciliationStatisticsTranscoder) {
+  public StateManager(CuratorFramework curatorFramework,
+                      SingularityConfiguration configuration,
+                      MetricRegistry metricRegistry,
+                      RequestManager requestManager,
+                      TaskManager taskManager,
+                      DeployManager deployManager,
+                      SlaveManager slaveManager,
+                      RackManager rackManager,
+                      Transcoder<SingularityState> stateTranscoder,
+                      Transcoder<SingularityHostState> hostStateTranscoder,
+                      SingularityConfiguration singularityConfiguration,
+                      SingularityAuthDatastore authDatastore,
+                      PriorityManager priorityManager,
+                      Transcoder<SingularityTaskReconciliationStatistics> taskReconciliationStatisticsTranscoder) {
+
     super(curatorFramework, configuration, metricRegistry);
 
     this.requestManager = requestManager;
@@ -102,43 +113,6 @@ public class StateManager extends CuratorManager {
         throw Throwables.propagate(t);
       }
     }
-  }
-
-  public List<SingularityHostState> getHostStates() {
-    List<String> children = getChildren(ROOT_PATH);
-    List<SingularityHostState> states = Lists.newArrayListWithCapacity(children.size());
-
-    for (String child : children) {
-
-      try {
-        byte[] bytes = curator.getData().forPath(ZKPaths.makePath(ROOT_PATH, child));
-
-        states.add(hostStateTranscoder.fromBytes(bytes));
-      } catch (NoNodeException nne) {
-      } catch (Exception e) {
-        throw Throwables.propagate(e);
-      }
-    }
-
-    return states;
-  }
-
-  private Map<String, Long> getNumTasks(List<SingularityRequestWithState> requests) {
-    final CounterMap<String> numTasks = new CounterMap<>(requests.size());
-
-    for (SingularityTaskId taskId : taskManager.getActiveTaskIds()) {
-      numTasks.incr(taskId.getRequestId());
-    }
-
-    for (SingularityPendingTaskId pendingTaskId : taskManager.getPendingTaskIds()) {
-      numTasks.incr(pendingTaskId.getRequestId());
-    }
-
-    for (SingularityTaskId cleaningTaskId : taskManager.getCleanupTaskIds()) {
-      numTasks.decr(cleaningTaskId.getRequestId());
-    }
-
-    return numTasks.toCountMap();
   }
 
   public SingularityState getState(boolean skipCache, boolean includeRequestIds) {
@@ -212,30 +186,10 @@ public class StateManager extends CuratorManager {
           break;
       }
 
-      if (requestWithState.getState().isRunnable() && requestWithState.getRequest().isAlwaysRunning()) {
-        SingularityRequest request = requestWithState.getRequest();
-        final int expectedInstances = request.getInstancesSafe();
-
-        final Long numActualInstances = numInstances.get(request.getId());
-
-        if (numActualInstances == null || numActualInstances < expectedInstances) {
-          possiblyUnderProvisionedRequestIds.add(request.getId());
-        } else if (numActualInstances > expectedInstances) {
-          overProvisionedRequestIds.add(request.getId());
-        }
-      }
+      updatePossiblyUnderProvisionedAndOverProvisionedIds(requestWithState, numInstances, overProvisionedRequestIds, possiblyUnderProvisionedRequestIds);
     }
 
-    final List<String> underProvisionedRequestIds = new ArrayList<>(possiblyUnderProvisionedRequestIds.size());
-    if (!possiblyUnderProvisionedRequestIds.isEmpty()) {
-      Map<String, SingularityRequestDeployState> deployStates = deployManager.getRequestDeployStatesByRequestIds(possiblyUnderProvisionedRequestIds);
-
-      for (SingularityRequestDeployState deployState : deployStates.values()) {
-        if (deployState.getActiveDeploy().isPresent() || deployState.getPendingDeploy().isPresent()) {
-          underProvisionedRequestIds.add(deployState.getRequestId());
-        }
-      }
-    }
+    final List<String> underProvisionedRequestIds = getUnderProvisionedRequestIds(possiblyUnderProvisionedRequestIds);
 
     final int pendingRequests = requestManager.getSizeOfPendingQueue();
     final int cleaningRequests = requestManager.getSizeOfCleanupQueue();
@@ -314,18 +268,83 @@ public class StateManager extends CuratorManager {
 
     final Optional<Boolean> authDatastoreHealthy = authDatastore.isHealthy();
 
-    final Optional<SingularityPriorityFreezeParent> maybePriorityFreeze = priorityManager.getActivePriorityFreeze();
-    final Optional<Double> minimumPriorityLevel;
-
-    if (maybePriorityFreeze.isPresent()) {
-      minimumPriorityLevel = Optional.of(maybePriorityFreeze.get().getPriorityFreeze().getMinimumPriorityLevel());
-    } else {
-      minimumPriorityLevel = Optional.absent();
-    }
+    final Optional<Double> minimumPriorityLevel = getMinimumPriorityLevel();
 
     return new SingularityState(activeTasks, launchingTasks, numActiveRequests, cooldownRequests, numPausedRequests, scheduledTasks, pendingRequests, lbCleanupTasks, lbCleanupRequests, cleaningRequests, activeSlaves,
         deadSlaves, decommissioningSlaves, activeRacks, deadRacks, decommissioningRacks, cleaningTasks, states, oldestDeploy, numDeploys, scheduledTasksInfo.getNumLateTasks(),
         scheduledTasksInfo.getNumFutureTasks(), scheduledTasksInfo.getMaxTaskLag(), System.currentTimeMillis(), includeRequestIds ? overProvisionedRequestIds : null,
             includeRequestIds ? underProvisionedRequestIds : null, overProvisionedRequestIds.size(), underProvisionedRequestIds.size(), numFinishedRequests, unknownRacks, unknownSlaves, authDatastoreHealthy, minimumPriorityLevel);
+  }
+
+  private Map<String, Long> getNumTasks(List<SingularityRequestWithState> requests) {
+    final CounterMap<String> numTasks = new CounterMap<>(requests.size());
+
+    for (SingularityTaskId taskId : taskManager.getActiveTaskIds()) {
+      numTasks.incr(taskId.getRequestId());
+    }
+
+    for (SingularityPendingTaskId pendingTaskId : taskManager.getPendingTaskIds()) {
+      numTasks.incr(pendingTaskId.getRequestId());
+    }
+
+    for (SingularityTaskId cleaningTaskId : taskManager.getCleanupTaskIds()) {
+      numTasks.decr(cleaningTaskId.getRequestId());
+    }
+
+    return numTasks.toCountMap();
+  }
+
+  private void updatePossiblyUnderProvisionedAndOverProvisionedIds(SingularityRequestWithState requestWithState, Map<String, Long> numInstances, List<String> overProvisionedRequestIds, List<String> possiblyUnderProvisionedRequestIds) {
+    if (requestWithState.getState().isRunnable() && requestWithState.getRequest().isAlwaysRunning()) {
+      SingularityRequest request = requestWithState.getRequest();
+      final int expectedInstances = request.getInstancesSafe();
+
+      final Long numActualInstances = numInstances.get(request.getId());
+
+      if (numActualInstances == null || numActualInstances < expectedInstances) {
+        possiblyUnderProvisionedRequestIds.add(request.getId());
+      } else if (numActualInstances > expectedInstances) {
+        overProvisionedRequestIds.add(request.getId());
+      }
+    }
+  }
+
+  private List<String> getUnderProvisionedRequestIds(List<String> possiblyUnderProvisionedRequestIds) {
+    final List<String> underProvisionedRequestIds = new ArrayList<>(possiblyUnderProvisionedRequestIds.size());
+
+    if (!possiblyUnderProvisionedRequestIds.isEmpty()) {
+      Map<String, SingularityRequestDeployState> deployStates = deployManager.getRequestDeployStatesByRequestIds(possiblyUnderProvisionedRequestIds);
+
+      for (SingularityRequestDeployState deployState : deployStates.values()) {
+        if (deployState.getActiveDeploy().isPresent() || deployState.getPendingDeploy().isPresent()) {
+          underProvisionedRequestIds.add(deployState.getRequestId());
+        }
+      }
+    }
+
+    return underProvisionedRequestIds;
+  }
+
+  private List<SingularityHostState> getHostStates() {
+    List<String> children = getChildren(ROOT_PATH);
+    List<SingularityHostState> states = Lists.newArrayListWithCapacity(children.size());
+
+    for (String child : children) {
+
+      try {
+        byte[] bytes = curator.getData().forPath(ZKPaths.makePath(ROOT_PATH, child));
+
+        states.add(hostStateTranscoder.fromBytes(bytes));
+      } catch (NoNodeException nne) {
+      } catch (Exception e) {
+        throw Throwables.propagate(e);
+      }
+    }
+
+    return states;
+  }
+
+  private Optional<Double> getMinimumPriorityLevel() {
+    return priorityManager.getActivePriorityFreeze().isPresent() ? Optional.of(priorityManager.getActivePriorityFreeze().get().getPriorityFreeze().getMinimumPriorityLevel()) : Optional.absent();
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/StateManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/StateManager.java
@@ -288,6 +288,11 @@ public class StateManager extends CuratorManager {
     }
 
     for (SingularityTaskId cleaningTaskId : taskManager.getCleanupTaskIds()) {
+      Optional<SingularityRequestWithState> request = requestManager.getRequest(cleaningTaskId.getRequestId());
+      if (request.isPresent() && request.get().getRequest().isScheduled()) {
+        continue;
+      }
+
       numTasks.decr(cleaningTaskId.getRequestId());
     }
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/data/StateManagerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/data/StateManagerTest.java
@@ -1,0 +1,54 @@
+package com.hubspot.singularity.data;
+
+import org.apache.mesos.Protos.TaskState;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.common.base.Optional;
+import com.google.inject.Inject;
+import com.hubspot.singularity.SingularityRequest;
+import com.hubspot.singularity.SingularityTask;
+import com.hubspot.singularity.SingularityTaskCleanup;
+import com.hubspot.singularity.TaskCleanupType;
+import com.hubspot.singularity.scheduler.SingularitySchedulerTestBase;
+
+public class StateManagerTest extends SingularitySchedulerTestBase{
+
+  protected SingularityRequest request;
+
+  @Inject
+  private StateManager stateManager;
+
+  public StateManagerTest() {
+    super(false);
+  }
+
+  @Test
+  public void itDoesntCountCleaningTasks() {
+    initRequest();
+    initFirstDeploy();
+
+    SingularityRequest request = requestResource.getRequest(requestId).getRequest();
+    saveAndSchedule(request.toBuilder().setInstances(Optional.of(3)));
+    resourceOffers();
+
+    Assert.assertEquals(3, taskManager.getActiveTaskIds().size());
+    Assert.assertEquals(0, stateManager.getState(true, false).getOverProvisionedRequests());
+    Assert.assertEquals(0, stateManager.getState(true, false).getUnderProvisionedRequests());
+
+
+    SingularityTask task = taskManager.getActiveTasks().get(0);
+    statusUpdate(task, TaskState.TASK_KILLED);
+    taskManager.createTaskCleanup(new SingularityTaskCleanup(Optional.absent(), TaskCleanupType.BOUNCING, 1L, task.getTaskId(), Optional.absent(), Optional.absent(), Optional.absent()));
+    Assert.assertEquals(2, taskManager.getActiveTaskIds().size());
+    Assert.assertEquals(0, stateManager.getState(true, false).getOverProvisionedRequests());
+    Assert.assertEquals(1, stateManager.getState(true, false).getUnderProvisionedRequests());
+
+
+    launchTask(request, firstDeploy, 4, TaskState.TASK_RUNNING);
+    launchTask(request, firstDeploy, 5, TaskState.TASK_RUNNING);
+    Assert.assertEquals(4, taskManager.getActiveTaskIds().size());
+    Assert.assertEquals(0, stateManager.getState(true, false).getUnderProvisionedRequests());
+    Assert.assertEquals(1, stateManager.getState(true, false).getOverProvisionedRequests());
+  }
+}


### PR DESCRIPTION
Tasks that are cleaning should not be part of the instance count when checking for over provisioned requests

@ssalinas