### PR TITLE
Add ability to prefix all email subjects

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SMTPConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SMTPConfiguration.java
@@ -83,6 +83,9 @@ public class SMTPConfiguration {
   @JsonProperty
   private TimeZone mailerTimeZone = TimeZone.getTimeZone("UTC");
 
+  @JsonProperty
+  private Optional<String> subjectPrefix = Optional.absent();
+
   @JsonProperty("emails")
   private Map<SingularityEmailType, List<SingularityEmailDestination>> emailConfiguration = Maps.newHashMap(ImmutableMap.<SingularityEmailType, List<SingularityEmailDestination>>builder()
       .put(SingularityEmailType.REQUEST_IN_COOLDOWN, ImmutableList.of(SingularityEmailDestination.ADMINS, SingularityEmailDestination.OWNERS))
@@ -247,4 +250,12 @@ public class SMTPConfiguration {
   public Long getMaxTaskLogSearchOffset() { return maxTaskLogSearchOffset; }
 
   public void setMaxTaskLogSearchOffset(Long maxTaskLogSearchOffset) { this.maxTaskLogSearchOffset = maxTaskLogSearchOffset; }
+
+  public Optional<String> getSubjectPrefix() {
+    return subjectPrefix;
+  }
+
+  public void setSubjectPrefix(Optional<String> subjectPrefix) {
+    this.subjectPrefix = subjectPrefix;
+  }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/smtp/SingularitySmtpSender.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/smtp/SingularitySmtpSender.java
@@ -72,17 +72,13 @@ public class SingularitySmtpSender implements Managed {
       return;
     }
 
-    final Runnable cmd = new Runnable() {
+    final String realSubject = maybeSmtpConfiguration.isPresent() && maybeSmtpConfiguration.get().getSubjectPrefix().isPresent() ?
+        maybeSmtpConfiguration.get().getSubjectPrefix().get() + subject :
+        subject;
 
-      @Override
-      public void run() {
-        sendMail(toList, ccList, subject, body);
-      }
-    };
+    LOG.debug("Queuing an email to {}/{} (subject: {})", toList, ccList, realSubject);
 
-    LOG.debug("Queuing an email to {}/{} (subject: {})", toList, ccList, subject);
-
-    mailSenderExecutorService.get().submit(cmd);
+    mailSenderExecutorService.get().submit(() -> sendMail(toList, ccList, realSubject, body));
   }
 
   private String getEmailLogFormat(List<String> toList, String subject) {


### PR DESCRIPTION
Will make it much easier to determine which instance of Singularity an email is coming from. i.e. `[Prod] Task failed ....` or `[QA] Task Failed ...`