### PR TITLE
Write files in subdirectories to splat path

### DIFF
--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -520,4 +520,4 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(rootComponent(withRouter(TaskDetail), (props) => refresh(props.params.taskId), true, true, null, (props) => onLoad(props.params.taskId)));
+export default connect(mapStateToProps, mapDispatchToProps)(rootComponent(withRouter(TaskDetail), (props) => refresh(props.params.taskId, props.params.splat), true, true, null, (props) => onLoad(props.params.taskId)));


### PR DESCRIPTION
When the page was loaded the first time, the call to get the files to
the directory wasn't being called with the directory splat. It was
therefore always fetching the files from the top-level directory. When
linked to the top level directory, this wasn't notable, but links into
the subdirectory of the file browser would seem as if the directory was
empty until going back to the root directory.