### PR TITLE
More flexible match on filename from logrotate

### DIFF
--- a/SingularityExecutor/src/main/resources/logrotate.conf.hbs
+++ b/SingularityExecutor/src/main/resources/logrotate.conf.hbs
@@ -21,7 +21,7 @@ notifempty
     NOW="$(($(date +%s%N)/1000000))"
     LOGSTART=`getfattr --only-values -n user.logstart {{{ logfile }}}`
     timestring=`date +%Y-%m-%d-%s`
-    for filename in "{{{ taskDirectory }}}/{{{ rotateDirectory }}}/{{{ logfileName }}}-${timestring%??}"*
+    for filename in "{{{ taskDirectory }}}/{{{ rotateDirectory }}}/{{{ logfileName }}}-${timestring%???}"*
     do
       setfattr -n user.logend -v "$NOW" $filename
       if [ "$LOGSTART" != "" ]; then
@@ -45,7 +45,7 @@ notifempty
     do
       LOGSTART=`getfattr --only-values -n user.logstart $oldfile`
       timestring=`date +%Y-%m-%d-%s`
-      for filename in "$oldfile-${timestring%??}"*
+      for filename in "$oldfile-${timestring%???}"*
       do
         if [ "$LOGSTART" != "" ]; then
           setfattr -n user.logstart -v "$LOGSTART" $filename


### PR DESCRIPTION
Especially for things like large access log files, logrotate can take a little while to run. If it took longer than ~10s the matcher was no longer picking up the files and adding the attributes. This makes the matcher one digit less precise so attributes get added appropriately a larger amount of the time