### PR TITLE
Deleting request

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
@@ -42,7 +42,6 @@ import com.hubspot.singularity.SingularityRequestDeployState;
 import com.hubspot.singularity.SingularityRequestHistory;
 import com.hubspot.singularity.SingularityRequestLbCleanup;
 import com.hubspot.singularity.SingularityRequestWithState;
-import com.hubspot.singularity.SingularityShellCommand;
 import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.SingularityTaskCleanup;
 import com.hubspot.singularity.SingularityTaskId;
@@ -373,7 +372,7 @@ public class SingularityCleaner {
       if (killActiveTasks) {
         for (SingularityTaskId matchingTaskId : matchingActiveTaskIds) {
           LOG.debug("Killing task {} due to {}", matchingTaskId, requestCleanup);
-          driverManager.killAndRecord(matchingTaskId, requestCleanup.getCleanupType(), Optional.<String>absent());
+          driverManager.killAndRecord(matchingTaskId, requestCleanup.getCleanupType(), Optional.absent());
           numTasksKilled++;
         }
       } else {
@@ -404,7 +403,7 @@ public class SingularityCleaner {
         for (SingularityTaskId taskId : matchingActiveTaskIds) {
           taskIds.add(taskId.getId());
         }
-        requestManager.saveLbCleanupRequest(new SingularityRequestLbCleanup(requestId, maybeDeploy.get().getLoadBalancerGroups().get(), maybeDeploy.get().getServiceBasePath().get(), taskIds, Optional.<SingularityLoadBalancerUpdate>absent()));
+        requestManager.saveLbCleanupRequest(new SingularityRequestLbCleanup(requestId, maybeDeploy.get().getLoadBalancerGroups().get(), maybeDeploy.get().getServiceBasePath().get(), taskIds, Optional.absent()));
         return;
       }
     }
@@ -431,7 +430,7 @@ public class SingularityCleaner {
     }
 
     requestManager.addToPendingQueue(new SingularityPendingRequest(requestCleanup.getRequestId(), requestCleanup.getDeployId().get(), requestCleanup.getTimestamp(),
-        requestCleanup.getUser(), PendingType.BOUNCE, Optional.<List<String>> absent(), Optional.<String> absent(), requestCleanup.getSkipHealthchecks(), requestCleanup.getMessage(), requestCleanup.getActionId()));
+        requestCleanup.getUser(), PendingType.BOUNCE, Optional.absent(), Optional.absent(), requestCleanup.getSkipHealthchecks(), requestCleanup.getMessage(), requestCleanup.getActionId()));
 
     LOG.info("Added {} tasks for request {} to cleanup bounce queue in {}", matchingTaskIds.size(), requestCleanup.getRequestId(), JavaUtils.duration(start));
   }
@@ -535,7 +534,7 @@ public class SingularityCleaner {
             killedTaskIdRecord, JavaUtils.durationFromMillis(duration), JavaUtils.durationFromMillis(configuration.getAskDriverToKillTasksAgainAfterMillis()));
 
         driverManager.killAndRecord(killedTaskIdRecord.getTaskId(), killedTaskIdRecord.getRequestCleanupType(),
-            killedTaskIdRecord.getTaskCleanupType(), Optional.of(killedTaskIdRecord.getOriginalTimestamp()), Optional.of(killedTaskIdRecord.getRetries()), Optional.<String>absent());
+            killedTaskIdRecord.getTaskCleanupType(), Optional.of(killedTaskIdRecord.getOriginalTimestamp()), Optional.of(killedTaskIdRecord.getRetries()), Optional.absent());
 
         rekilled++;
       } else {
@@ -591,13 +590,14 @@ public class SingularityCleaner {
         taskManager.deleteCleanupTask(taskId.getId());
       } else if (shouldKillTask(cleanupTask, activeTaskIds, cleaningTasks, incrementalCleaningTasks) && checkLBStateAndShouldKillTask(cleanupTask)) {
         driverManager.killAndRecord(taskId, cleanupTask.getCleanupType(), cleanupTask.getUser());
-        cleanupRequestIfNoRemainingTasks(cleanupTask, deletedRequestIdToTaskIds);
         taskManager.deleteCleanupTask(taskId.getId());
 
         killedTasks++;
       } else if (cleanupTask.getCleanupType() == TaskCleanupType.BOUNCING || cleanupTask.getCleanupType() == TaskCleanupType.INCREMENTAL_BOUNCE) {
         isBouncing.remove(SingularityDeployKey.fromTaskId(taskId));
       }
+
+      cleanupRequestIfNoRemainingTasks(cleanupTask, deletedRequestIdToTaskIds);
     }
 
     for (SingularityDeployKey bounceSucceeded : isBouncing) {
@@ -627,19 +627,18 @@ public class SingularityCleaner {
 
   private void cleanupRequestIfNoRemainingTasks(SingularityTaskCleanup cleanupTask, Map<String, List<String>> requestIdToTaskIds) {
     String requestId = cleanupTask.getTaskId().getRequestId();
-    if (requestIdToTaskIds.get(requestId) == null) {
-      LOG.info("Couldn't find tasks for requestId {}", requestId);
-      return;
-    }
-    List<String> requestTasks = requestIdToTaskIds.get(requestId);
-    requestTasks.remove(cleanupTask.getTaskId().getId());
-    if (requestTasks.isEmpty()) {
-      LOG.info("All tasks for requestId {} are now killed", requestId);
-      requestManager.createCleanupRequest(
-          new SingularityRequestCleanup(
-              cleanupTask.getUser(), RequestCleanupType.DELETING, System.currentTimeMillis(),
-              Optional.of(Boolean.TRUE), requestId, Optional.<String> absent(),
-              Optional.<Boolean> absent(), cleanupTask.getMessage(), Optional.<String> absent(), Optional.<SingularityShellCommand>absent()));
+
+    if (requestIdToTaskIds.containsKey(requestId)) {
+      List<String> requestTasks = requestIdToTaskIds.get(requestId);
+      requestTasks.remove(cleanupTask.getTaskId().getId());
+      if (requestTasks.isEmpty()) {
+        LOG.info("All tasks for requestId {} are now killed, re-enqueueing request cleanup", requestId);
+        requestManager.createCleanupRequest(
+            new SingularityRequestCleanup(
+                cleanupTask.getUser(), RequestCleanupType.DELETING, System.currentTimeMillis(),
+                Optional.of(Boolean.TRUE), requestId, Optional.absent(),
+                Optional.absent(), cleanupTask.getMessage(), Optional.absent(), Optional.absent()));
+      }
     }
   }
 
@@ -683,7 +682,7 @@ public class SingularityCleaner {
 
   private LoadBalancerRequestId getLoadBalancerRequestId(SingularityTaskId taskId, Optional<SingularityLoadBalancerUpdate> lbRemoveUpdate) {
     if (!lbRemoveUpdate.isPresent()) {
-      return new LoadBalancerRequestId(taskId.getId(), LoadBalancerRequestType.REMOVE, Optional.<Integer> absent());
+      return new LoadBalancerRequestId(taskId.getId(), LoadBalancerRequestType.REMOVE, Optional.absent());
     }
 
     switch (lbRemoveUpdate.get().getLoadBalancerState()) {
@@ -738,7 +737,7 @@ public class SingularityCleaner {
         return CheckLBState.MISSING_TASK;
       }
 
-      lbRemoveUpdate = lbClient.enqueue(loadBalancerRequestId, task.get().getTaskRequest().getRequest(), task.get().getTaskRequest().getDeploy(), Collections.<SingularityTask>emptyList(), Collections.singletonList(task.get()));
+      lbRemoveUpdate = lbClient.enqueue(loadBalancerRequestId, task.get().getTaskRequest().getRequest(), task.get().getTaskRequest().getDeploy(), Collections.emptyList(), Collections.singletonList(task.get()));
 
       taskManager.saveLoadBalancerState(taskId, LoadBalancerRequestType.REMOVE, lbRemoveUpdate);
     } else if (maybeLbRemoveUpdate.get().getLoadBalancerState() == BaragonRequestState.WAITING || maybeLbRemoveUpdate.get().getLoadBalancerState() == BaragonRequestState.CANCELING) {
@@ -926,7 +925,7 @@ public class SingularityCleaner {
 
   private LoadBalancerRequestId getLoadBalancerRequestId(String requestId, Optional<SingularityLoadBalancerUpdate> lbDeleteUpdate) {
     if (!lbDeleteUpdate.isPresent()) {
-      return new LoadBalancerRequestId(String.format("%s-%s", requestId, System.currentTimeMillis()), LoadBalancerRequestType.DELETE, Optional.<Integer>absent());
+      return new LoadBalancerRequestId(String.format("%s-%s", requestId, System.currentTimeMillis()), LoadBalancerRequestType.DELETE, Optional.absent());
     }
 
     switch (lbDeleteUpdate.get().getLoadBalancerState()) {

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -1434,7 +1434,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
   }
 
   @Test
-  public void testDeletingState() {
+  public void itCorrectlyUpdatesRequestDeletingStateHistory() {
     initRequest();
     Assert.assertEquals(RequestState.ACTIVE, requestManager.getRequest(requestId).get().getState());
     Assert.assertEquals(1, requestManager.getRequestHistory(requestId).size());
@@ -1453,6 +1453,62 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     Assert.assertTrue(historyTypes.contains(RequestHistoryType.CREATED));
     Assert.assertTrue(historyTypes.contains(RequestHistoryType.DELETING));
     Assert.assertTrue(historyTypes.contains(RequestHistoryType.DELETED));
+  }
+
+
+  @Test
+  public void itSetsRequestStateToDeletedAfterAllTasksAreCleanedUp() {
+    initRequest();
+
+    SingularityRequest request = requestResource.getRequest(requestId).getRequest();
+    requestResource.postRequest(request.toBuilder().setInstances(Optional.of(2)).build());
+    initFirstDeploy();
+
+    launchTask(request, firstDeploy, 1, TaskState.TASK_RUNNING);
+    launchTask(request, firstDeploy, 2, TaskState.TASK_RUNNING);
+
+    Assert.assertEquals(requestId, requestManager.getActiveRequests().iterator().next().getRequest().getId());
+    Assert.assertEquals(2, taskManager.getActiveTaskIds().size());
+
+    requestManager.startDeletingRequest(request, Optional.absent(), Optional.absent(), Optional.absent());
+
+    Assert.assertEquals(requestId, requestManager.getCleanupRequests().get(0).getRequestId());
+    Assert.assertEquals(RequestState.DELETING, requestManager.getRequest(requestId).get().getState());
+
+    cleaner.drainCleanupQueue();
+    Assert.assertEquals(0, taskManager.getCleanupTaskIds().size());
+    killKilledTasks();
+    cleaner.drainCleanupQueue();
+    Assert.assertFalse(requestManager.getRequest(requestId).isPresent());
+  }
+
+  @Test
+  public void itSetsRequestStateToDeletedIfTaskCleanupFails() {
+    initRequest();
+
+    SingularityRequest request = requestResource.getRequest(requestId).getRequest();
+    requestResource.postRequest(request.toBuilder().setInstances(Optional.of(2)).build());
+    initFirstDeploy();
+
+    SingularityTask firstTask = launchTask(request, firstDeploy, 1, TaskState.TASK_RUNNING);
+    launchTask(request, firstDeploy, 2, TaskState.TASK_RUNNING);
+
+    Assert.assertEquals(requestId, requestManager.getActiveRequests().iterator().next().getRequest().getId());
+    Assert.assertEquals(2, taskManager.getActiveTaskIds().size());
+
+    requestManager.startDeletingRequest(request, Optional.absent(), Optional.absent(), Optional.absent());
+
+    Assert.assertEquals(requestId, requestManager.getCleanupRequests().get(0).getRequestId());
+    Assert.assertEquals(RequestState.DELETING, requestManager.getRequest(requestId).get().getState());
+
+    statusUpdate(firstTask, TaskState.TASK_FAILED);
+    Assert.assertEquals(1, taskManager.getActiveTaskIds().size());
+
+    cleaner.drainCleanupQueue();
+    Assert.assertEquals(0, taskManager.getCleanupTaskIds().size());
+    killKilledTasks();
+    cleaner.drainCleanupQueue();
+    Assert.assertFalse(requestManager.getRequest(requestId).isPresent());
   }
 
   @Test


### PR DESCRIPTION
The main thing here is that I moved the check to re-enqueue the cleaning request outside of the if block `else if (shouldKillTask(cleanupTask, activeTaskIds, cleaningTasks, incrementalCleaningTasks) && checkLBStateAndShouldKillTask(cleanupTask))`

That should allow it to check if it needs to re-enqueue even if the task fails and doesn't clean up properly. Added some tests for this as well

