### PR TITLE
Add skip lb removal flag to DeleteRequestRequest

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestCleanup.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestCleanup.java
@@ -9,6 +9,7 @@ public class SingularityRequestCleanup {
   private final Optional<String> user;
   private final RequestCleanupType cleanupType;
   private final Optional<Boolean> killTasks;
+  private final Optional<Boolean> removeFromLoadBalancer;
   private final Optional<Boolean> skipHealthchecks;
   private final Optional<String> deployId;
   private final long timestamp;
@@ -18,16 +19,24 @@ public class SingularityRequestCleanup {
   private final Optional<SingularityShellCommand> runShellCommandBeforeKill;
 
   @JsonCreator
-  public SingularityRequestCleanup(@JsonProperty("user") Optional<String> user, @JsonProperty("cleanupType") RequestCleanupType cleanupType, @JsonProperty("timestamp") long timestamp,
-      @JsonProperty("killTasks") Optional<Boolean> killTasks, @JsonProperty("requestId") String requestId, @JsonProperty("deployId") Optional<String> deployId,
-      @JsonProperty("skipHealthchecks") Optional<Boolean> skipHealthchecks, @JsonProperty("message") Optional<String> message, @JsonProperty("actionId") Optional<String> actionId,
-      @JsonProperty("runShellCommandBeforeKill") Optional<SingularityShellCommand> runShellCommandBeforeKill) {
+  public SingularityRequestCleanup(@JsonProperty("user") Optional<String> user,
+                                   @JsonProperty("cleanupType") RequestCleanupType cleanupType,
+                                   @JsonProperty("timestamp") long timestamp,
+                                   @JsonProperty("killTasks") Optional<Boolean> killTasks,
+                                   @JsonProperty("removeFromLoadBalancer") Optional<Boolean> removeFromLoadBalancer,
+                                   @JsonProperty("requestId") String requestId,
+                                   @JsonProperty("deployId") Optional<String> deployId,
+                                   @JsonProperty("skipHealthchecks") Optional<Boolean> skipHealthchecks,
+                                   @JsonProperty("message") Optional<String> message,
+                                   @JsonProperty("actionId") Optional<String> actionId,
+                                   @JsonProperty("runShellCommandBeforeKill") Optional<SingularityShellCommand> runShellCommandBeforeKill) {
     this.user = user;
     this.cleanupType = cleanupType;
     this.timestamp = timestamp;
     this.requestId = requestId;
     this.deployId = deployId;
     this.killTasks = killTasks;
+    this.removeFromLoadBalancer = removeFromLoadBalancer;
     this.skipHealthchecks = skipHealthchecks;
     this.actionId = actionId;
     this.message = message;
@@ -40,6 +49,10 @@ public class SingularityRequestCleanup {
 
   public Optional<Boolean> getKillTasks() {
     return killTasks;
+  }
+
+  public Optional<Boolean> getRemoveFromLoadBalancer() {
+    return removeFromLoadBalancer;
   }
 
   public String getRequestId() {
@@ -80,6 +93,7 @@ public class SingularityRequestCleanup {
         "user=" + user +
         ", cleanupType=" + cleanupType +
         ", killTasks=" + killTasks +
+        ", removeFromLoadBalancer=" + removeFromLoadBalancer +
         ", skipHealthchecks=" + skipHealthchecks +
         ", deployId=" + deployId +
         ", timestamp=" + timestamp +

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskCleanup.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskCleanup.java
@@ -13,11 +13,14 @@ public class SingularityTaskCleanup {
   private final Optional<String> message;
   private final Optional<String> actionId;
   private final Optional<SingularityTaskShellCommandRequestId> runBeforeKillId;
+  private final Optional<Boolean> removeFromLoadBalancer;
 
   @JsonCreator
   public SingularityTaskCleanup(@JsonProperty("user") Optional<String> user, @JsonProperty("cleanupType") TaskCleanupType cleanupType, @JsonProperty("timestamp") long timestamp,
       @JsonProperty("taskId") SingularityTaskId taskId, @JsonProperty("message") Optional<String> message, @JsonProperty("actionId") Optional<String> actionId,
-      @JsonProperty("runBeforeKillId") Optional<SingularityTaskShellCommandRequestId> runBeforeKillId) {
+      @JsonProperty("runBeforeKillId") Optional<SingularityTaskShellCommandRequestId> runBeforeKillId,
+                                @JsonProperty("removeFromLoadBalancer") Optional<Boolean> removeFromLoadBalancer
+  ) {
     this.user = user;
     this.cleanupType = cleanupType;
     this.timestamp = timestamp;
@@ -25,6 +28,17 @@ public class SingularityTaskCleanup {
     this.message = message;
     this.actionId = actionId;
     this.runBeforeKillId = runBeforeKillId;
+    this.removeFromLoadBalancer = removeFromLoadBalancer;
+  }
+
+  public SingularityTaskCleanup(Optional<String> user,
+                                TaskCleanupType cleanupType,
+                                long timestamp,
+                                SingularityTaskId taskId,
+                                Optional<String> message,
+                                Optional<String> actionId,
+                                Optional<SingularityTaskShellCommandRequestId> runBeforeKillId) {
+    this(user, cleanupType, timestamp, taskId, message, actionId, runBeforeKillId, Optional.absent());
   }
 
   public Optional<String> getActionId() {
@@ -53,6 +67,10 @@ public class SingularityTaskCleanup {
 
   public Optional<SingularityTaskShellCommandRequestId> getRunBeforeKillId() {
     return runBeforeKillId;
+  }
+
+  public Optional<Boolean> getRemoveFromLoadBalancer() {
+    return removeFromLoadBalancer;
   }
 
   @Override

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityDeleteRequestRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityDeleteRequestRequest.java
@@ -9,12 +9,15 @@ public class SingularityDeleteRequestRequest {
 
   private final Optional<String> message;
   private final Optional<String> actionId;
+  private final Optional<Boolean> deleteFromLoadBalancer;
 
   @JsonCreator
   public SingularityDeleteRequestRequest(@JsonProperty("message") Optional<String> message,
-      @JsonProperty("actionId") Optional<String> actionId) {
+                                         @JsonProperty("actionId") Optional<String> actionId,
+                                         @JsonProperty("deleteFromLoadBalancer") Optional<Boolean> deleteFromLoadBalancer) {
     this.message = message;
     this.actionId = actionId;
+    this.deleteFromLoadBalancer = deleteFromLoadBalancer;
   }
 
   @ApiModelProperty(required=false, value="A message to show to users about why this action was taken")
@@ -27,11 +30,17 @@ public class SingularityDeleteRequestRequest {
     return actionId;
   }
 
+  @ApiModelProperty(required = false, value = "Should the service associated with the request be removed from the load balancer")
+  public Optional<Boolean> getDeleteFromLoadBalancer() {
+    return deleteFromLoadBalancer;
+  }
+
   @Override
   public String toString() {
     return "SingularityDeleteRequestRequest{" +
         "message=" + message +
         ", actionId=" + actionId +
+        ", deleteFromLoadBalancer=" + deleteFromLoadBalancer +
         '}';
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
@@ -398,11 +398,11 @@ public class RequestManager extends CuratorAsyncManager {
     return getData(getRequestPath(requestId), requestTranscoder);
   }
 
-  public void startDeletingRequest(SingularityRequest request, Optional<String> user, Optional<String> actionId, Optional<String> message) {
+  public void startDeletingRequest(SingularityRequest request, Optional<Boolean> removeFromLoadBalancer, Optional<String> user, Optional<String> actionId, Optional<String> message) {
     final long now = System.currentTimeMillis();
 
     // delete it no matter if the delete request already exists.
-    createCleanupRequest(new SingularityRequestCleanup(user, RequestCleanupType.DELETING, now, Optional.of(Boolean.TRUE), request.getId(), Optional.<String> absent(),
+    createCleanupRequest(new SingularityRequestCleanup(user, RequestCleanupType.DELETING, now, Optional.of(Boolean.TRUE), removeFromLoadBalancer, request.getId(), Optional.<String> absent(),
         Optional.<Boolean> absent(), message, actionId, Optional.<SingularityShellCommand>absent()));
 
     markDeleting(request, System.currentTimeMillis(), user, message);

--- a/SingularityService/src/main/java/com/hubspot/singularity/helpers/RequestHelper.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/helpers/RequestHelper.java
@@ -97,9 +97,10 @@ public class RequestHelper {
       if (maybeDeployId.isPresent()) {
         if (maybeBounceRequest.isPresent()) {
           Optional<String> actionId = maybeBounceRequest.get().getActionId().or(Optional.of(UUID.randomUUID().toString()));
+          Optional<Boolean> removeFromLoadBalancer = Optional.absent();
           SingularityCreateResult createResult = requestManager.createCleanupRequest(
             new SingularityRequestCleanup(user, maybeBounceRequest.get().getIncremental().or(true) ? RequestCleanupType.INCREMENTAL_BOUNCE : RequestCleanupType.BOUNCE,
-              System.currentTimeMillis(), Optional.<Boolean> absent(), newRequest.getId(), Optional.of(maybeDeployId.get()), skipHealthchecks, message, actionId, maybeBounceRequest.get().getRunShellCommandBeforeKill()));
+              System.currentTimeMillis(), Optional.<Boolean> absent(), removeFromLoadBalancer, newRequest.getId(), Optional.of(maybeDeployId.get()), skipHealthchecks, message, actionId, maybeBounceRequest.get().getRunShellCommandBeforeKill()));
 
           if (createResult != SingularityCreateResult.EXISTED) {
             requestManager.bounce(newRequest, System.currentTimeMillis(), user, Optional.of("Bouncing due to bounce after scale"));

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -235,11 +235,10 @@ public class RequestResource extends AbstractRequestResource {
     final String deployId = getAndCheckDeployId(requestId);
 
     checkConflict(!(requestManager.markAsBouncing(requestId) == SingularityCreateResult.EXISTED), "%s is already bouncing", requestId);
-    Optional<Boolean> removeFromLoadBalancer = Optional.absent();
 
     requestManager.createCleanupRequest(
         new SingularityRequestCleanup(JavaUtils.getUserEmail(user), isIncrementalBounce ? RequestCleanupType.INCREMENTAL_BOUNCE : RequestCleanupType.BOUNCE,
-            System.currentTimeMillis(), Optional.<Boolean> absent(), removeFromLoadBalancer, requestId, Optional.of(deployId), skipHealthchecks, message, actionId, runBeforeKill));
+            System.currentTimeMillis(), Optional.<Boolean> absent(), Optional.absent(), requestId, Optional.of(deployId), skipHealthchecks, message, actionId, runBeforeKill));
 
     requestManager.bounce(requestWithState.getRequest(), System.currentTimeMillis(), JavaUtils.getUserEmail(user), message);
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -235,10 +235,11 @@ public class RequestResource extends AbstractRequestResource {
     final String deployId = getAndCheckDeployId(requestId);
 
     checkConflict(!(requestManager.markAsBouncing(requestId) == SingularityCreateResult.EXISTED), "%s is already bouncing", requestId);
+    Optional<Boolean> removeFromLoadBalancer = Optional.absent();
 
     requestManager.createCleanupRequest(
         new SingularityRequestCleanup(JavaUtils.getUserEmail(user), isIncrementalBounce ? RequestCleanupType.INCREMENTAL_BOUNCE : RequestCleanupType.BOUNCE,
-            System.currentTimeMillis(), Optional.<Boolean> absent(), requestId, Optional.of(deployId), skipHealthchecks, message, actionId, runBeforeKill));
+            System.currentTimeMillis(), Optional.<Boolean> absent(), removeFromLoadBalancer, requestId, Optional.of(deployId), skipHealthchecks, message, actionId, runBeforeKill));
 
     requestManager.bounce(requestWithState.getRequest(), System.currentTimeMillis(), JavaUtils.getUserEmail(user), message);
 
@@ -378,9 +379,10 @@ public class RequestResource extends AbstractRequestResource {
     }
 
     final long now = System.currentTimeMillis();
+    Optional<Boolean> removeFromLoadBalancer = Optional.absent();
 
     SingularityCreateResult result = requestManager.createCleanupRequest(new SingularityRequestCleanup(JavaUtils.getUserEmail(user),
-        RequestCleanupType.PAUSING, now, killTasks, requestId, Optional.<String> absent(), Optional.<Boolean> absent(), message, actionId, runBeforeKill));
+        RequestCleanupType.PAUSING, now, killTasks, removeFromLoadBalancer, requestId, Optional.<String> absent(), Optional.<Boolean> absent(), message, actionId, runBeforeKill));
 
     checkConflict(result == SingularityCreateResult.CREATED, "%s is already pausing - try again soon", requestId, result);
 
@@ -617,13 +619,15 @@ public class RequestResource extends AbstractRequestResource {
 
     Optional<String> message = Optional.absent();
     Optional<String> actionId = Optional.absent();
+    Optional<Boolean> deleteFromLoadBalancer = Optional.absent();
 
     if (deleteRequest.isPresent()) {
       actionId = deleteRequest.get().getActionId();
       message = deleteRequest.get().getMessage();
+      deleteFromLoadBalancer = deleteRequest.get().getDeleteFromLoadBalancer();
     }
 
-    requestManager.startDeletingRequest(request, JavaUtils.getUserEmail(user), actionId, message);
+    requestManager.startDeletingRequest(request, deleteFromLoadBalancer, JavaUtils.getUserEmail(user), actionId, message);
 
     mailer.sendRequestRemovedMail(request, JavaUtils.getUserEmail(user), message);
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
@@ -497,7 +497,7 @@ public class SingularityCleaner {
         runBeforeKillId = Optional.of(shellRequest.getId());
       }
 
-      taskManager.createTaskCleanup(new SingularityTaskCleanup(requestCleanup.getUser(), TaskCleanupType.REQUEST_DELETING, start, taskId, requestCleanup.getMessage(), requestCleanup.getActionId(), runBeforeKillId));
+      taskManager.createTaskCleanup(new SingularityTaskCleanup(requestCleanup.getUser(), TaskCleanupType.REQUEST_DELETING, start, taskId, requestCleanup.getMessage(), requestCleanup.getActionId(), runBeforeKillId, requestCleanup.getRemoveFromLoadBalancer()));
     }
   }
 
@@ -661,7 +661,7 @@ public class SingularityCleaner {
       requestManager.createCleanupRequest(
           new SingularityRequestCleanup(
               cleanupTask.getUser(), RequestCleanupType.DELETING, System.currentTimeMillis(),
-              Optional.of(Boolean.TRUE), Optional.absent(), requestId, Optional.<String> absent(),
+              Optional.of(Boolean.TRUE), cleanupTask.getRemoveFromLoadBalancer(), requestId, Optional.<String> absent(),
               Optional.<Boolean> absent(), cleanupTask.getMessage(), Optional.<String> absent(), Optional.<SingularityShellCommand>absent()));
     }
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
@@ -366,7 +366,9 @@ public class SingularityCleaner {
           } else {
             Optional<SingularityRequestHistory> maybeHistory = requestHistoryHelper.getLastHistory(requestId);
             if (maybeHistory.isPresent()) {
-              if (maybeHistory.get().getRequest().isLoadBalanced() && configuration.isDeleteRemovedRequestsFromLoadBalancer()) {
+              if (maybeHistory.get().getRequest().isLoadBalanced()
+                  && configuration.isDeleteRemovedRequestsFromLoadBalancer()
+                  && requestCleanup.getRemoveFromLoadBalancer().or(true)) {
                 createLbCleanupRequest(requestId, matchingActiveTaskIds);
               }
               requestManager.markDeleted(maybeHistory.get().getRequest(), start, requestCleanup.getUser(), requestCleanup.getMessage());
@@ -659,7 +661,7 @@ public class SingularityCleaner {
       requestManager.createCleanupRequest(
           new SingularityRequestCleanup(
               cleanupTask.getUser(), RequestCleanupType.DELETING, System.currentTimeMillis(),
-              Optional.of(Boolean.TRUE), requestId, Optional.<String> absent(),
+              Optional.of(Boolean.TRUE), Optional.absent(), requestId, Optional.<String> absent(),
               Optional.<Boolean> absent(), cleanupTask.getMessage(), Optional.<String> absent(), Optional.<SingularityShellCommand>absent()));
     }
   }

--- a/SingularityService/src/test/java/com/hubspot/singularity/SingularityHistoryTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/SingularityHistoryTest.java
@@ -491,7 +491,7 @@ public class SingularityHistoryTest extends SingularitySchedulerTestBase {
     }
 
     requestResource.scale(requestId, new SingularityScaleRequest(Optional.of(2), Optional.<Long> absent(), Optional.<Boolean> absent(), Optional.<String> absent(), Optional.of(msg), Optional.<Boolean>absent(), Optional.<Boolean>absent()));
-    requestResource.deleteRequest(requestId, Optional.of(new SingularityDeleteRequestRequest(Optional.of("a msg"), Optional.<String> absent())));
+    requestResource.deleteRequest(requestId, Optional.of(new SingularityDeleteRequestRequest(Optional.of("a msg"), Optional.<String> absent(), Optional.absent())));
 
     cleaner.drainCleanupQueue();
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/HistoryPersisterTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/HistoryPersisterTest.java
@@ -48,7 +48,7 @@ public class HistoryPersisterTest extends SingularitySchedulerTestBase {
 
     Assert.assertTrue(!requestManager.getRequestHistory(requestId).isEmpty());
 
-    requestManager.startDeletingRequest(request, user, Optional.<String> absent(), Optional.<String> absent());
+    requestManager.startDeletingRequest(request, Optional.absent(), user, Optional.<String> absent(), Optional.<String> absent());
 
     requestManager.deleteHistoryParent(requestId);
 
@@ -79,17 +79,17 @@ public class HistoryPersisterTest extends SingularitySchedulerTestBase {
     configuration.setMaxRequestsWithHistoryInZkWhenNoDatabase(Optional.of(2));
     configuration.setDeleteStaleRequestsFromZkWhenNoDatabaseAfterHours(7);
 
-    requestManager.startDeletingRequest(requestOne, user, Optional.<String>absent(), Optional.<String>absent());
+    requestManager.startDeletingRequest(requestOne, Optional.absent(), user, Optional.<String>absent(), Optional.<String>absent());
     requestManager.deleteHistoryParent(requestOne.getId());
     requestManager.activate(requestOne, RequestHistoryType.CREATED, System.currentTimeMillis() - TimeUnit.HOURS.toMillis(4), Optional.<String> absent(), Optional.<String> absent());
     requestManager.cooldown(requestOne, System.currentTimeMillis() - TimeUnit.HOURS.toMillis(3));
 
-    requestManager.startDeletingRequest(requestTwo, user, Optional.<String>absent(), Optional.<String>absent());
+    requestManager.startDeletingRequest(requestTwo, Optional.absent(), user, Optional.<String>absent(), Optional.<String>absent());
     requestManager.deleteHistoryParent(requestTwo.getId());
     requestManager.activate(requestTwo, RequestHistoryType.CREATED, System.currentTimeMillis() - TimeUnit.HOURS.toMillis(4), Optional.<String> absent(), Optional.<String> absent());
     requestManager.cooldown(requestTwo, System.currentTimeMillis() - TimeUnit.HOURS.toMillis(3));
 
-    requestManager.startDeletingRequest(requestThree, user, Optional.<String>absent(), Optional.<String>absent());
+    requestManager.startDeletingRequest(requestThree, Optional.absent(), user, Optional.<String>absent(), Optional.<String>absent());
     requestManager.deleteHistoryParent(requestThree.getId());
     requestManager.activate(requestThree, RequestHistoryType.CREATED, System.currentTimeMillis() - TimeUnit.HOURS.toMillis(4), Optional.<String> absent(), Optional.<String> absent());
     requestManager.cooldown(requestThree, System.currentTimeMillis() - TimeUnit.HOURS.toMillis(3));
@@ -198,7 +198,7 @@ public class HistoryPersisterTest extends SingularitySchedulerTestBase {
     initRequest();
     initFirstDeploy();
 
-    requestManager.startDeletingRequest(request, user, Optional.<String> absent(), Optional.<String> absent());
+    requestManager.startDeletingRequest(request, Optional.absent(), user, Optional.<String> absent(), Optional.<String> absent());
 
     requestManager.deleteHistoryParent(requestId);
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -883,6 +883,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     configuration.setDeleteRemovedRequestsFromLoadBalancer(true);
     initLoadBalancedRequest();
     initLoadBalancedDeploy();
+    startTask(firstDeploy);
 
     boolean removeFromLoadBalancer = false;
     SingularityDeleteRequestRequest deleteRequest = new SingularityDeleteRequestRequest(Optional.absent(), Optional.absent(), Optional.of(removeFromLoadBalancer));
@@ -891,9 +892,14 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
 
     testingLbClient.setNextBaragonRequestState(BaragonRequestState.WAITING);
 
-    Assert.assertFalse("Should be a request cleanup request", requestManager.getCleanupRequests().isEmpty());
+    Assert.assertFalse("Tasks should get cleaned up", requestManager.getCleanupRequests().isEmpty());
     cleaner.drainCleanupQueue();
-    Assert.assertTrue("Should not be a load balancer cleanup request", requestManager.getLbCleanupRequests().isEmpty());
+    killKilledTasks();
+
+    Assert.assertFalse("The request should get cleaned up", requestManager.getCleanupRequests().isEmpty());
+    cleaner.drainCleanupQueue();
+
+    Assert.assertTrue("The request should not be removed from the load balancer", requestManager.getLbCleanupRequestIds().isEmpty());
   }
 
   @Test
@@ -901,14 +907,20 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     configuration.setDeleteRemovedRequestsFromLoadBalancer(true);
     initLoadBalancedRequest();
     initLoadBalancedDeploy();
+    startTask(firstDeploy);
 
     requestResource.deleteRequest(requestId, Optional.absent());
 
     testingLbClient.setNextBaragonRequestState(BaragonRequestState.WAITING);
 
-    Assert.assertFalse("Should be a request cleanup request", requestManager.getCleanupRequests().isEmpty());
+    Assert.assertFalse("Tasks should get cleaned up", requestManager.getCleanupRequests().isEmpty());
     cleaner.drainCleanupQueue();
-    Assert.assertFalse("Should be a request to cleanup the load balancer", requestManager.getLbCleanupRequestIds().isEmpty());
+    killKilledTasks();
+
+    Assert.assertFalse("The request should get cleaned up", requestManager.getCleanupRequests().isEmpty());
+    cleaner.drainCleanupQueue();
+
+    Assert.assertFalse("The request should get removed from the load balancer", requestManager.getLbCleanupRequestIds().isEmpty());
   }
 
   @Test

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -879,6 +879,39 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
   }
 
   @Test
+  public void testLbCleanupSkippedOnSkipRemoveFlag() {
+    configuration.setDeleteRemovedRequestsFromLoadBalancer(true);
+    initLoadBalancedRequest();
+    initLoadBalancedDeploy();
+
+    boolean removeFromLoadBalancer = false;
+    SingularityDeleteRequestRequest deleteRequest = new SingularityDeleteRequestRequest(Optional.absent(), Optional.absent(), Optional.of(removeFromLoadBalancer));
+
+    requestResource.deleteRequest(requestId, Optional.of(deleteRequest));
+
+    testingLbClient.setNextBaragonRequestState(BaragonRequestState.WAITING);
+
+    Assert.assertFalse("Should be a request cleanup request", requestManager.getCleanupRequests().isEmpty());
+    cleaner.drainCleanupQueue();
+    Assert.assertTrue("Should not be a load balancer cleanup request", requestManager.getLbCleanupRequests().isEmpty());
+  }
+
+  @Test
+  public void testLbCleanupOccursOnRequestDelete() {
+    configuration.setDeleteRemovedRequestsFromLoadBalancer(true);
+    initLoadBalancedRequest();
+    initLoadBalancedDeploy();
+
+    requestResource.deleteRequest(requestId, Optional.absent());
+
+    testingLbClient.setNextBaragonRequestState(BaragonRequestState.WAITING);
+
+    Assert.assertFalse("Should be a request cleanup request", requestManager.getCleanupRequests().isEmpty());
+    cleaner.drainCleanupQueue();
+    Assert.assertFalse("Should be a request to cleanup the load balancer", requestManager.getLbCleanupRequestIds().isEmpty());
+  }
+
+  @Test
   public void testReconciliation() {
     Assert.assertTrue(!taskReconciliation.isReconciliationRunning());
 
@@ -960,7 +993,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     initRequest();
 
     requestManager.createCleanupRequest(new SingularityRequestCleanup(Optional.<String>absent(), RequestCleanupType.PAUSING, System.currentTimeMillis(),
-        Optional.<Boolean>absent(), requestId, Optional.<String>absent(), Optional.<Boolean> absent(), Optional.<String>absent(), Optional.<String>absent(), Optional.<SingularityShellCommand>absent()));
+        Optional.<Boolean>absent(), Optional.absent(), requestId, Optional.<String>absent(), Optional.<Boolean> absent(), Optional.<String>absent(), Optional.<String>absent(), Optional.<SingularityShellCommand>absent()));
 
     cleaner.drainCleanupQueue();
 
@@ -1142,7 +1175,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     SingularityTask taskTwo = startSeparatePlacementTask(firstDeploy, 2);
 
     requestManager.createCleanupRequest(new SingularityRequestCleanup(user, RequestCleanupType.INCREMENTAL_BOUNCE, System.currentTimeMillis(),
-        Optional.<Boolean>absent(), requestId, Optional.of(firstDeployId), Optional.<Boolean> absent(), Optional.<String>absent(), Optional.<String>absent(), Optional.<SingularityShellCommand>absent()));
+        Optional.<Boolean>absent(), Optional.absent(), requestId, Optional.of(firstDeployId), Optional.<Boolean> absent(), Optional.<String>absent(), Optional.<String>absent(), Optional.<SingularityShellCommand>absent()));
 
     Assert.assertTrue(requestManager.cleanupRequestExists(requestId));
 
@@ -1426,7 +1459,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     deployChecker.checkDeploys();
     Assert.assertEquals(DeployState.WAITING, deployManager.getPendingDeploys().get(0).getCurrentDeployState());
 
-    requestManager.startDeletingRequest(request, Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent());
+    requestManager.startDeletingRequest(request, Optional.absent(), Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent());
     requestManager.markDeleted(request, now, Optional.<String>absent(), Optional.<String>absent());
     deployChecker.checkDeploys();
     SingularityDeployResult deployResult = deployManager.getDeployResult(requestId, firstDeployId).get();
@@ -1440,7 +1473,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     Assert.assertEquals(RequestState.ACTIVE, requestManager.getRequest(requestId).get().getState());
     Assert.assertEquals(1, requestManager.getRequestHistory(requestId).size());
 
-    requestManager.startDeletingRequest(request, Optional.<String>absent(), Optional.<String>absent(), Optional.of("the cake is a lie"));
+    requestManager.startDeletingRequest(request, Optional.absent(), Optional.<String>absent(), Optional.<String>absent(), Optional.of("the cake is a lie"));
     Assert.assertEquals(RequestState.DELETING, requestManager.getRequest(requestId).get().getState());
     Assert.assertEquals(2, requestManager.getRequestHistory(requestId).size());
 
@@ -1846,6 +1879,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     Assert.assertEquals(5, taskManager.getPendingTaskIds().size());
   }
 
+  @Test
   public void testAcceptOffersWithRoleForRequestWithRole() {
     SingularityRequestBuilder bldr = new SingularityRequestBuilder(requestId, RequestType.ON_DEMAND);
     bldr.setRequiredRole(Optional.of("test-role"));

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTestBase.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTestBase.java
@@ -528,6 +528,14 @@ public class SingularitySchedulerTestBase extends SingularityCuratorTestBase {
     firstDeploy = initAndFinishDeploy(request, new SingularityDeployBuilder(request.getId(), firstDeployId).setCommand(Optional.of("sleep 100")).setHealthcheck(Optional.of(new HealthcheckOptionsBuilder("http://uri").build())));
   }
 
+  protected void initLoadBalancedDeploy() {
+    SingularityDeployBuilder builder = new SingularityDeployBuilder(requestId, firstDeployId)
+        .setCommand(Optional.of("sleep 100"))
+        .setServiceBasePath(Optional.of("/basepath"))
+        .setLoadBalancerGroups(Optional.of(Collections.singleton("test")));
+    firstDeploy = initAndFinishDeploy(request, builder);
+  }
+
   protected SingularityDeploy initAndFinishDeploy(SingularityRequest request, String deployId) {
     return initAndFinishDeploy(request, new SingularityDeployBuilder(request.getId(), deployId).setCommand(Optional.of("sleep 100")));
   }

--- a/SingularityUI/app/actions/api/requests.es6
+++ b/SingularityUI/app/actions/api/requests.es6
@@ -39,9 +39,9 @@ export const SaveRequest = buildJsonApiAction(
 export const RemoveRequest = buildJsonApiAction(
   'REMOVE_REQUEST',
   'DELETE',
-  (requestId, { message }) => ({
+  (requestId, { message, deleteFromLoadBalancer }) => ({
     url: `/requests/request/${requestId}`,
-    body: { message }
+    body: { message, deleteFromLoadBalancer }
   })
 );
 

--- a/SingularityUI/app/components/common/modalButtons/RemoveButton.jsx
+++ b/SingularityUI/app/components/common/modalButtons/RemoveButton.jsx
@@ -17,6 +17,7 @@ const removeTooltip = (
 export default class RemoveButton extends Component {
   static propTypes = {
     requestId: PropTypes.string.isRequired,
+    loadBalanced: PropTypes.bool,
     loadBalancerData: PropTypes.object,
     children: PropTypes.node,
     then: PropTypes.func
@@ -36,7 +37,13 @@ export default class RemoveButton extends Component {
     return (
       <span>
         {getClickComponent(this)}
-        <RemoveModal ref="modal" requestId={this.props.requestId} loadBalancerData={this.props.loadBalancerData} then={this.props.then} />
+        <RemoveModal
+          ref="modal"
+          requestId={this.props.requestId}
+          loadBalanced={this.props.loadBalanced}
+          loadBalancerData={this.props.loadBalancerData}
+          then={this.props.then}
+        />
       </span>
     );
   }

--- a/SingularityUI/app/components/common/modalButtons/RemoveModal.jsx
+++ b/SingularityUI/app/components/common/modalButtons/RemoveModal.jsx
@@ -5,9 +5,29 @@ import { RemoveRequest } from '../../../actions/api/requests';
 
 import FormModal from '../modal/FormModal';
 
+const controls = (loadBalanced) => {
+  const formElements = [];
+  formElements.push({
+    name: 'message',
+    type: FormModal.INPUT_TYPES.STRING,
+    label: 'Message (optional)'
+  });
+  if (loadBalanced) {
+    formElements.push({
+      name: 'deleteFromLoadBalancer',
+      type: FormModal.INPUT_TYPES.BOOLEAN,
+      label: 'Remove from load balancer',
+      defaultValue: true
+    });
+  }
+
+  return formElements;
+};
+
 class RemoveModal extends Component {
   static propTypes = {
     requestId: PropTypes.string.isRequired,
+    loadBalanced: PropTypes.bool,
     loadBalancerData: PropTypes.object,
     removeRequest: PropTypes.func.isRequired
   };
@@ -19,7 +39,7 @@ class RemoveModal extends Component {
   render() {
     const loadBalancerWarning = (
       <div>
-        <p>Removing this request will also remove the following settings from the load balancer</p>
+        <p>If you remove this request from the load balancer, the following settings will also be removed:</p>
         <pre>{JSON.stringify(this.props.loadBalancerData, null, 2)}</pre>
       </div>
     );
@@ -31,13 +51,7 @@ class RemoveModal extends Component {
         action="Remove Request"
         onConfirm={this.props.removeRequest}
         buttonStyle="danger"
-        formElements={[
-          {
-            name: 'message',
-            type: FormModal.INPUT_TYPES.STRING,
-            label: 'Message (optional)'
-          }
-        ]}>
+        formElements={controls(this.props.loadBalanced)}>
         <p>Are you sure you want to remove this request?</p>
         <pre>{this.props.requestId}</pre>
         <p>If not paused, removing this request will kill all active and scheduled tasks and tasks for it will not run again unless it is reposted to Singularity.</p>

--- a/SingularityUI/app/components/requestDetail/header/RequestActionButtons.jsx
+++ b/SingularityUI/app/components/requestDetail/header/RequestActionButtons.jsx
@@ -8,7 +8,7 @@ import { Link } from 'react-router';
 import JSONButton from '../../common/JSONButton';
 
 import { FetchRequest } from '../../../actions/api/requests';
-import { 
+import {
   FetchActiveTasksForRequest,
   FetchRequestHistory
 } from '../../../actions/api/history';
@@ -161,8 +161,9 @@ const RequestActionButtons = ({requestParent, fetchRequest, fetchRequestHistory,
   }
 
   const removeButton = (
-    <RemoveButton 
+    <RemoveButton
       requestId={request.id}
+      loadBalanced={request.loadBalanced}
       loadBalancerData={Utils.maybe(requestParent, ['activeDeploy', 'loadBalancerOptions'], {})}
       then={fetchRequestAndHistoryAndActiveTasks}>
       <Button bsStyle="danger">


### PR DESCRIPTION
Add a flag that can be set on the request deletion request to avoid
removing the basepath associated with the service from the load
balancer. The suggested use case is when the application associated with
the service is moving out of Singularity, but will still be running and
should remain load-balanced.

/cc @ssalinas 