### PR TITLE
Fix for Optional request bodies

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/DisastersResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/DisastersResource.java
@@ -107,7 +107,8 @@ public class DisastersResource {
   @POST
   @Path("/disabled-actions/{action}")
   @ApiOperation(value="Disable a specific action")
-  public void disableAction(@PathParam("action") SingularityAction action, Optional<SingularityDisabledActionRequest> maybeRequest) {
+  public void disableAction(@PathParam("action") SingularityAction action, SingularityDisabledActionRequest disabledActionRequest) {
+    final Optional<SingularityDisabledActionRequest> maybeRequest = Optional.fromNullable(disabledActionRequest);
     authorizationHelper.checkAdminAuthorization(user);
     Optional<String> message = maybeRequest.isPresent() ? maybeRequest.get().getMessage() : Optional.<String>absent();
     disasterManager.disable(action, message, user, false, Optional.<Long>absent());

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RackResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RackResource.java
@@ -71,22 +71,25 @@ public class RackResource extends AbstractMachineResource<SingularityRack> {
   @POST
   @Path("/rack/{rackId}/decommission")
   @ApiOperation("Begin decommissioning a specific active rack")
-  public void decommissionRack(@ApiParam("Active rack ID") @PathParam("rackId") String rackId, Optional<SingularityMachineChangeRequest> changeRequest) {
-    super.decommission(rackId, changeRequest, JavaUtils.getUserEmail(user), SingularityAction.DECOMMISSION_RACK);
+  public void decommissionRack(@ApiParam("Active rack ID") @PathParam("rackId") String rackId, SingularityMachineChangeRequest changeRequest) {
+    final Optional<SingularityMachineChangeRequest> maybeChangeRequest = Optional.fromNullable(changeRequest);
+    super.decommission(rackId, maybeChangeRequest, JavaUtils.getUserEmail(user), SingularityAction.DECOMMISSION_RACK);
   }
 
   @POST
   @Path("/rack/{rackId}/freeze")
   @ApiOperation("Freeze a specific rack")
-  public void freezeRack(@ApiParam("Rack ID") @PathParam("rackId") String rackId, Optional<SingularityMachineChangeRequest> changeRequest) {
-    super.freeze(rackId, changeRequest, JavaUtils.getUserEmail(user), SingularityAction.FREEZE_RACK);
+  public void freezeRack(@ApiParam("Rack ID") @PathParam("rackId") String rackId, SingularityMachineChangeRequest changeRequest) {
+    final Optional<SingularityMachineChangeRequest> maybeChangeRequest = Optional.fromNullable(changeRequest);
+    super.freeze(rackId, maybeChangeRequest, JavaUtils.getUserEmail(user), SingularityAction.FREEZE_RACK);
   }
 
   @POST
   @Path("/rack/{rackId}/activate")
   @ApiOperation("Activate a decomissioning rack, canceling decomission without erasing history")
-  public void activateRack(@ApiParam("Active rackId") @PathParam("rackId") String rackId, Optional<SingularityMachineChangeRequest> changeRequest) {
-    super.activate(rackId, changeRequest, JavaUtils.getUserEmail(user), SingularityAction.ACTIVATE_RACK);
+  public void activateRack(@ApiParam("Active rackId") @PathParam("rackId") String rackId, SingularityMachineChangeRequest changeRequest) {
+    final Optional<SingularityMachineChangeRequest> maybeChangeRequest = Optional.fromNullable(changeRequest);
+    super.activate(rackId, maybeChangeRequest, JavaUtils.getUserEmail(user), SingularityAction.ACTIVATE_RACK);
   }
 
   @DELETE

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -184,7 +184,7 @@ public class RequestResource extends AbstractRequestResource {
   @Path("/request/{requestId}/bounce")
   public SingularityRequestParent bounce(@PathParam("requestId") String requestId,
                                          @Context HttpServletRequest requestContext) {
-    return bounce(requestId, requestContext, Optional.absent());
+    return bounce(requestId, requestContext, null);
   }
 
   @POST
@@ -194,8 +194,9 @@ public class RequestResource extends AbstractRequestResource {
   response=SingularityRequestParent.class)
   public SingularityRequestParent bounce(@ApiParam("The request ID to bounce") @PathParam("requestId") String requestId,
                                          @Context HttpServletRequest requestContext,
-                                         @ApiParam("Bounce request options") Optional<SingularityBounceRequest> bounceRequest) {
-    return maybeProxyToLeader(requestContext, SingularityRequestParent.class, bounceRequest.orNull(), () -> bounce(requestId, bounceRequest));
+                                         @ApiParam("Bounce request options") SingularityBounceRequest bounceRequest) {
+    final Optional<SingularityBounceRequest> maybeBounceRequest = Optional.fromNullable(bounceRequest);
+    return maybeProxyToLeader(requestContext, SingularityRequestParent.class, maybeBounceRequest.orNull(), () -> bounce(requestId, maybeBounceRequest));
   }
 
   public SingularityRequestParent bounce(String requestId, Optional<SingularityBounceRequest> bounceRequest) {
@@ -253,7 +254,7 @@ public class RequestResource extends AbstractRequestResource {
   @POST
   @Path("/request/{requestId}/run")
   public SingularityPendingRequestParent scheduleImmediately(@PathParam("requestId") String requestId) {
-    return scheduleImmediately(requestId, Optional.absent());
+    return scheduleImmediately(requestId, null);
   }
 
   @POST
@@ -264,7 +265,8 @@ public class RequestResource extends AbstractRequestResource {
     @ApiResponse(code=400, message="Singularity Request is not scheduled or one-off"),
   })
   public SingularityPendingRequestParent scheduleImmediately(@ApiParam("The request ID to run") @PathParam("requestId") String requestId,
-                                                             Optional<SingularityRunNowRequest> runNowRequest) {
+                                                             SingularityRunNowRequest runNowRequest) {
+    final Optional<SingularityRunNowRequest> maybeRunNowRequest = Optional.fromNullable(runNowRequest);
     SingularityRequestWithState requestWithState = fetchRequestWithState(requestId);
 
     authorizationHelper.checkForAuthorization(requestWithState.getRequest(), user, SingularityAuthorizationScope.WRITE);
@@ -296,12 +298,12 @@ public class RequestResource extends AbstractRequestResource {
     Optional<List<String>> commandLineArgs = Optional.absent();
     Optional<Resources> resources = Optional.absent();
 
-    if (runNowRequest.isPresent()) {
-      message = runNowRequest.get().getMessage();
-      runId = runNowRequest.get().getRunId();
-      skipHealthchecks = runNowRequest.get().getSkipHealthchecks();
-      commandLineArgs = runNowRequest.get().getCommandLineArgs();
-      resources = runNowRequest.get().getResources();
+    if (maybeRunNowRequest.isPresent()) {
+      message = maybeRunNowRequest.get().getMessage();
+      runId = maybeRunNowRequest.get().getRunId();
+      skipHealthchecks = maybeRunNowRequest.get().getSkipHealthchecks();
+      commandLineArgs = maybeRunNowRequest.get().getCommandLineArgs();
+      resources = maybeRunNowRequest.get().getResources();
     }
 
     if (runId.isPresent() && runId.get().length() > 100) {
@@ -335,7 +337,7 @@ public class RequestResource extends AbstractRequestResource {
   @Path("/request/{requestId}/pause")
   public SingularityRequestParent pause(@PathParam("requestId") String requestId,
                                         @Context HttpServletRequest requestContext) {
-    return pause(requestId, requestContext, Optional.absent());
+    return pause(requestId, requestContext, null);
   }
 
   @POST
@@ -347,8 +349,9 @@ public class RequestResource extends AbstractRequestResource {
   })
   public SingularityRequestParent pause(@ApiParam("The request ID to pause") @PathParam("requestId") String requestId,
                                         @Context HttpServletRequest requestContext,
-                                        @ApiParam("Pause Request Options") Optional<SingularityPauseRequest> pauseRequest) {
-    return maybeProxyToLeader(requestContext, SingularityRequestParent.class, pauseRequest.orNull(), () -> pause(requestId, pauseRequest));
+                                        @ApiParam("Pause Request Options") SingularityPauseRequest pauseRequest) {
+    final Optional<SingularityPauseRequest> maybePauseRequest = Optional.fromNullable(pauseRequest);
+    return maybeProxyToLeader(requestContext, SingularityRequestParent.class, maybePauseRequest.orNull(), () -> pause(requestId, maybePauseRequest));
   }
 
   public SingularityRequestParent pause(String requestId, Optional<SingularityPauseRequest> pauseRequest) {
@@ -400,7 +403,7 @@ public class RequestResource extends AbstractRequestResource {
   @Path("/request/{requestId}/unpause")
   public SingularityRequestParent unpauseNoBody(@PathParam("requestId") String requestId,
                                                 @Context HttpServletRequest requestContext) {
-    return unpause(requestId, requestContext, Optional.absent());
+    return unpause(requestId, requestContext, null);
   }
 
   @POST
@@ -412,8 +415,9 @@ public class RequestResource extends AbstractRequestResource {
   })
   public SingularityRequestParent unpause(@ApiParam("The request ID to unpause") @PathParam("requestId") String requestId,
                                           @Context HttpServletRequest requestContext,
-                                          Optional<SingularityUnpauseRequest> unpauseRequest) {
-    return maybeProxyToLeader(requestContext, SingularityRequestParent.class, unpauseRequest.orNull(), () -> unpause(requestId, unpauseRequest));
+                                          SingularityUnpauseRequest unpauseRequest) {
+    final Optional<SingularityUnpauseRequest> maybeUnpauseRequest = Optional.fromNullable(unpauseRequest);
+    return maybeProxyToLeader(requestContext, SingularityRequestParent.class, maybeUnpauseRequest.orNull(), () -> unpause(requestId, maybeUnpauseRequest));
   }
 
   public SingularityRequestParent unpause(String requestId, Optional<SingularityUnpauseRequest> unpauseRequest) {
@@ -443,7 +447,7 @@ public class RequestResource extends AbstractRequestResource {
   @Path("/request/{requestId}/exit-cooldown")
   public SingularityRequestParent exitCooldown(@PathParam("requestId") String requestId,
                                                @Context HttpServletRequest requestContext) {
-    return exitCooldown(requestId, requestContext, Optional.absent());
+    return exitCooldown(requestId, requestContext, null);
   }
 
   @POST
@@ -455,8 +459,9 @@ public class RequestResource extends AbstractRequestResource {
   })
   public SingularityRequestParent exitCooldown(@PathParam("requestId") String requestId,
                                                @Context HttpServletRequest requestContext,
-                                               Optional<SingularityExitCooldownRequest> exitCooldownRequest) {
-    return maybeProxyToLeader(requestContext, SingularityRequestParent.class, exitCooldownRequest.orNull(), () -> exitCooldown(requestId, exitCooldownRequest));
+                                               SingularityExitCooldownRequest exitCooldownRequest) {
+    final Optional<SingularityExitCooldownRequest> maybeExitCooldownRequest = Optional.fromNullable(exitCooldownRequest);
+    return maybeProxyToLeader(requestContext, SingularityRequestParent.class, maybeExitCooldownRequest.orNull(), () -> exitCooldown(requestId, maybeExitCooldownRequest));
   }
 
   public SingularityRequestParent exitCooldown(String requestId, Optional<SingularityExitCooldownRequest> exitCooldownRequest) {
@@ -591,13 +596,6 @@ public class RequestResource extends AbstractRequestResource {
 
   @DELETE
   @Path("/request/{requestId}")
-  public SingularityRequest deleteRequest(@PathParam("requestId") String requestId,
-                                          @Context HttpServletRequest requestContext) {
-    return deleteRequest(requestId, requestContext, Optional.absent());
-  }
-
-  @DELETE
-  @Path("/request/{requestId}")
   @Consumes({ MediaType.APPLICATION_JSON })
   @ApiOperation(value="Delete a specific Request by ID and return the deleted Request", response=SingularityRequest.class)
   @ApiResponses({
@@ -605,8 +603,9 @@ public class RequestResource extends AbstractRequestResource {
   })
   public SingularityRequest deleteRequest(@ApiParam("The request ID to delete.") @PathParam("requestId") String requestId,
                                           @Context HttpServletRequest requestContext,
-                                          @ApiParam("Delete options") Optional<SingularityDeleteRequestRequest> deleteRequest) {
-    return maybeProxyToLeader(requestContext, SingularityRequest.class, deleteRequest.orNull(), () -> deleteRequest(requestId, deleteRequest));
+                                          @ApiParam("Delete options") SingularityDeleteRequestRequest deleteRequest) {
+    final Optional<SingularityDeleteRequestRequest> maybeDeleteRequest = Optional.fromNullable(deleteRequest);
+    return maybeProxyToLeader(requestContext, SingularityRequest.class, maybeDeleteRequest.orNull(), () -> deleteRequest(requestId, maybeDeleteRequest));
   }
 
   public SingularityRequest deleteRequest(String requestId, Optional<SingularityDeleteRequestRequest> deleteRequest) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/SlaveResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/SlaveResource.java
@@ -76,22 +76,25 @@ public class SlaveResource extends AbstractMachineResource<SingularitySlave> {
   @POST
   @Path("/slave/{slaveId}/decommission")
   @ApiOperation("Begin decommissioning a specific active slave")
-  public void decommissionSlave(@ApiParam("Active slaveId") @PathParam("slaveId") String slaveId, Optional<SingularityMachineChangeRequest> changeRequest) {
-    super.decommission(slaveId, changeRequest, JavaUtils.getUserEmail(user), SingularityAction.DECOMMISSION_SLAVE);
+  public void decommissionSlave(@ApiParam("Active slaveId") @PathParam("slaveId") String slaveId, SingularityMachineChangeRequest changeRequest) {
+    final Optional<SingularityMachineChangeRequest> maybeChangeRequest = Optional.fromNullable(changeRequest);
+    super.decommission(slaveId, maybeChangeRequest, JavaUtils.getUserEmail(user), SingularityAction.DECOMMISSION_SLAVE);
   }
 
   @POST
   @Path("/slave/{slaveId}/freeze")
   @ApiOperation("Freeze tasks on a specific slave")
-  public void freezeSlave(@ApiParam("Slave ID") @PathParam("slaveId") String slaveId, Optional<SingularityMachineChangeRequest> changeRequest) {
-    super.freeze(slaveId, changeRequest, JavaUtils.getUserEmail(user), SingularityAction.FREEZE_SLAVE);
+  public void freezeSlave(@ApiParam("Slave ID") @PathParam("slaveId") String slaveId, SingularityMachineChangeRequest changeRequest) {
+    final Optional<SingularityMachineChangeRequest> maybeChangeRequest = Optional.fromNullable(changeRequest);
+    super.freeze(slaveId, maybeChangeRequest, JavaUtils.getUserEmail(user), SingularityAction.FREEZE_SLAVE);
   }
 
   @POST
   @Path("/slave/{slaveId}/activate")
   @ApiOperation("Activate a decomissioning slave, canceling decomission without erasing history")
-  public void activateSlave(@ApiParam("Active slaveId") @PathParam("slaveId") String slaveId, Optional<SingularityMachineChangeRequest> changeRequest) {
-    super.activate(slaveId, changeRequest, JavaUtils.getUserEmail(user), SingularityAction.ACTIVATE_SLAVE);
+  public void activateSlave(@ApiParam("Active slaveId") @PathParam("slaveId") String slaveId, SingularityMachineChangeRequest changeRequest) {
+    final Optional<SingularityMachineChangeRequest> maybeChangeRequest = Optional.fromNullable(changeRequest);
+    super.activate(slaveId, maybeChangeRequest, JavaUtils.getUserEmail(user), SingularityAction.ACTIVATE_SLAVE);
   }
 
   @DELETE

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
@@ -282,7 +282,7 @@ public class TaskResource extends AbstractLeaderAwareResource {
   @DELETE
   @Path("/task/{taskId}")
   public SingularityTaskCleanup killTask(@PathParam("taskId") String taskId, @Context HttpServletRequest requestContext) {
-    return killTask(taskId, requestContext, Optional.absent());
+    return killTask(taskId, requestContext, null);
   }
 
   @DELETE
@@ -292,9 +292,11 @@ public class TaskResource extends AbstractLeaderAwareResource {
   @ApiResponses({
     @ApiResponse(code=409, message="Task already has a cleanup request (can be overridden with override=true)")
   })
-  public SingularityTaskCleanup killTask(@PathParam("taskId") String taskId, @Context HttpServletRequest requestContext, Optional<SingularityKillTaskRequest> killTaskRequest
-                                         ) {
-    return maybeProxyToLeader(requestContext, SingularityTaskCleanup.class, killTaskRequest.orNull(), () -> killTask(taskId, killTaskRequest));
+  public SingularityTaskCleanup killTask(@PathParam("taskId") String taskId,
+                                         @Context HttpServletRequest requestContext,
+                                         SingularityKillTaskRequest killTaskRequest) {
+    final Optional<SingularityKillTaskRequest> maybeKillTaskRequest = Optional.fromNullable(killTaskRequest);
+    return maybeProxyToLeader(requestContext, SingularityTaskCleanup.class, maybeKillTaskRequest.orNull(), () -> killTask(taskId, maybeKillTaskRequest));
   }
 
   public SingularityTaskCleanup killTask(String taskId, Optional<SingularityKillTaskRequest> killTaskRequest) {

--- a/SingularityService/src/test/java/com/hubspot/singularity/SingularityHistoryTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/SingularityHistoryTest.java
@@ -200,7 +200,7 @@ public class SingularityHistoryTest extends SingularitySchedulerTestBase {
     String runId = "my-run-id";
 
     SingularityPendingRequestParent parent = requestResource.scheduleImmediately(requestId,
-        Optional.of(new SingularityRunNowRequest(Optional.<String> absent(), Optional.<Boolean> absent(), Optional.of(runId), Optional.<List<String>> absent(), Optional.<Resources>absent())));
+        new SingularityRunNowRequest(Optional.<String> absent(), Optional.<Boolean> absent(), Optional.of(runId), Optional.<List<String>> absent(), Optional.<Resources>absent()));
 
     Assert.assertEquals(runId, parent.getPendingRequest().getRunId().get());
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityMachineStatesTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityMachineStatesTest.java
@@ -219,7 +219,7 @@ public class SingularityMachineStatesTest extends SingularitySchedulerTestBase {
 
     Assert.assertEquals(0, taskManager.getTasksOnSlave(taskManager.getActiveTaskIds(), slaveManager.getObject("slave1").get()).size());
 
-    slaveResource.activateSlave("slave1", Optional.<SingularityMachineChangeRequest> absent());
+    slaveResource.activateSlave("slave1", null);
 
     sms.resourceOffers(driver, Arrays.asList(createOffer(1, 129, "slave1", "host1", Optional.of("rack1"))));
 
@@ -437,7 +437,7 @@ public class SingularityMachineStatesTest extends SingularitySchedulerTestBase {
 
     SingularitySlave slave = slaveManager.getObjects().get(0);
 
-    slaveResource.freezeSlave(slave.getId(), Optional.of(new SingularityMachineChangeRequest(Optional.of(1L), Optional.<String>absent(), Optional.<String>absent(), Optional.of(MachineState.ACTIVE), Optional.<Boolean>absent())));
+    slaveResource.freezeSlave(slave.getId(), new SingularityMachineChangeRequest(Optional.of(1L), Optional.absent(), Optional.absent(), Optional.of(MachineState.ACTIVE), Optional.absent()));
 
     Assert.assertEquals(MachineState.FROZEN, slaveManager.getObjects().get(0).getCurrentState().getState());
 
@@ -454,19 +454,19 @@ public class SingularityMachineStatesTest extends SingularitySchedulerTestBase {
   @Test(expected = WebApplicationException.class)
   public void testCannotUseStateReservedForSystem() {
     SingularitySlave slave = getSingleSlave();
-    slaveResource.freezeSlave(slave.getId(), Optional.of(new SingularityMachineChangeRequest(Optional.of(1L), Optional.<String>absent(), Optional.<String>absent(), Optional.of(MachineState.DEAD), Optional.<Boolean>absent())));
+    slaveResource.freezeSlave(slave.getId(), new SingularityMachineChangeRequest(Optional.of(1L), Optional.absent(), Optional.absent(), Optional.of(MachineState.DEAD), Optional.absent()));
   }
 
   @Test(expected = WebApplicationException.class)
   public void testBadExpiringStateTransition() {
     SingularitySlave slave = getSingleSlave();
-    slaveResource.decommissionSlave(slave.getId(), Optional.of(new SingularityMachineChangeRequest(Optional.of(1L), Optional.<String>absent(), Optional.<String>absent(), Optional.of(MachineState.FROZEN), Optional.<Boolean>absent())));
+    slaveResource.decommissionSlave(slave.getId(), new SingularityMachineChangeRequest(Optional.of(1L), Optional.absent(), Optional.absent(), Optional.of(MachineState.FROZEN), Optional.absent()));
   }
 
   @Test(expected = WebApplicationException.class)
   public void testInvalidTransitionToDecommissioned() {
     SingularitySlave slave = getSingleSlave();
-    slaveResource.decommissionSlave(slave.getId(), Optional.of(new SingularityMachineChangeRequest(Optional.of(1L), Optional.<String>absent(), Optional.<String>absent(), Optional.of(MachineState.DECOMMISSIONED), Optional.<Boolean>absent())));
+    slaveResource.decommissionSlave(slave.getId(), new SingularityMachineChangeRequest(Optional.of(1L), Optional.absent(), Optional.absent(), Optional.of(MachineState.DECOMMISSIONED), Optional.absent()));
   }
 
   @Test
@@ -478,7 +478,7 @@ public class SingularityMachineStatesTest extends SingularitySchedulerTestBase {
     resourceOffers();
     SingularitySlave slave = slaveManager.getObjects().get(0);
 
-    slaveResource.decommissionSlave(slave.getId(), Optional.of(new SingularityMachineChangeRequest(Optional.of(1L), Optional.<String>absent(), Optional.<String>absent(), Optional.of(MachineState.DECOMMISSIONED), Optional.of(true))));
+    slaveResource.decommissionSlave(slave.getId(), new SingularityMachineChangeRequest(Optional.of(1L), Optional.absent(), Optional.absent(), Optional.of(MachineState.DECOMMISSIONED), Optional.of(true)));
     Assert.assertEquals(MachineState.STARTING_DECOMMISSION, slaveManager.getObjects().get(0).getCurrentState().getState());
     scheduler.checkForDecomissions(stateCacheProvider.get());
     scheduler.drainPendingQueue(stateCacheProvider.get());
@@ -492,10 +492,10 @@ public class SingularityMachineStatesTest extends SingularitySchedulerTestBase {
   @Test
   public void testSystemChangeClearsExpiringChangeIfInvalid() {
     SingularitySlave slave = getSingleSlave();
-    slaveResource.freezeSlave(slave.getId(), Optional.<SingularityMachineChangeRequest>absent());
-    slaveResource.activateSlave(slave.getId(), Optional.of(new SingularityMachineChangeRequest(Optional.of(1L), Optional.<String>absent(), Optional.<String>absent(), Optional.of(MachineState.FROZEN), Optional.<Boolean>absent())));
+    slaveResource.freezeSlave(slave.getId(), null);
+    slaveResource.activateSlave(slave.getId(), new SingularityMachineChangeRequest(Optional.of(1L), Optional.absent(), Optional.absent(), Optional.of(MachineState.FROZEN), Optional.absent()));
     Assert.assertTrue(slaveManager.getExpiringObject(slave.getId()).isPresent());
-    slaveResource.decommissionSlave(slave.getId(), Optional.<SingularityMachineChangeRequest>absent());
+    slaveResource.decommissionSlave(slave.getId(), null);
     Assert.assertFalse(slaveManager.getExpiringObject(slave.getId()).isPresent());
   }
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -73,7 +73,6 @@ import com.hubspot.singularity.api.SingularityBounceRequest;
 import com.hubspot.singularity.api.SingularityDeleteRequestRequest;
 import com.hubspot.singularity.api.SingularityDeployRequest;
 import com.hubspot.singularity.api.SingularityKillTaskRequest;
-import com.hubspot.singularity.api.SingularityMachineChangeRequest;
 import com.hubspot.singularity.api.SingularityPauseRequest;
 import com.hubspot.singularity.api.SingularityPriorityFreeze;
 import com.hubspot.singularity.api.SingularityRunNowRequest;
@@ -547,7 +546,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     deploy("d2");
 
     SingularityRunNowRequest runNowRequest = new SingularityRunNowRequest(Optional.<String>absent(), Optional.<Boolean>absent(), Optional.<String>absent(), Optional.<List<String>>absent(), Optional.of(new Resources(2, 2, 0)));
-    requestResource.scheduleImmediately(requestId, Optional.of(runNowRequest));
+    requestResource.scheduleImmediately(requestId, runNowRequest);
 
     scheduler.drainPendingQueue(stateCacheProvider.get());
 
@@ -654,7 +653,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
 
     Assert.assertEquals(1, taskManager.getNumActiveTasks());
 
-    slaveResource.decommissionSlave(taskManager.getActiveTasks().get(0).getOffer().getSlaveId().getValue(), Optional.<SingularityMachineChangeRequest> absent());
+    slaveResource.decommissionSlave(taskManager.getActiveTasks().get(0).getOffer().getSlaveId().getValue(), null);
 
     scheduler.checkForDecomissions(stateCacheProvider.get());
 
@@ -1328,7 +1327,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     requestResource.postRequest(newRequest);
     initFirstDeploy();
 
-    requestResource.scheduleImmediately(requestId, Optional.of(new SingularityRunNowRequest(Optional.<String>absent(), Optional.<Boolean>absent(), Optional.<String>absent(), Optional.<List<String>>absent(), Optional.<Resources>absent())));
+    requestResource.scheduleImmediately(requestId, new SingularityRunNowRequest(Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()));
     resourceOffers();
 
     SingularityTask task = taskManager.getActiveTasks().get(0);
@@ -1853,7 +1852,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     deploy("d2");
 
     SingularityRunNowRequest runNowRequest = new SingularityRunNowRequest(Optional.<String>absent(), Optional.<Boolean>absent(), Optional.<String>absent(), Optional.<List<String>>absent(), Optional.of(new Resources(2, 2, 0)));
-    requestResource.scheduleImmediately(requestId, Optional.of(runNowRequest));
+    requestResource.scheduleImmediately(requestId, runNowRequest);
 
     scheduler.drainPendingQueue(stateCacheProvider.get());
 
@@ -1879,7 +1878,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     deploy("d2");
 
     SingularityRunNowRequest runNowRequest = new SingularityRunNowRequest(Optional.<String>absent(), Optional.<Boolean>absent(), Optional.<String>absent(), Optional.<List<String>>absent(), Optional.of(new Resources(2, 2, 0)));
-    requestResource.scheduleImmediately(requestId, Optional.of(runNowRequest));
+    requestResource.scheduleImmediately(requestId, runNowRequest);
 
     scheduler.drainPendingQueue(stateCacheProvider.get());
 


### PR DESCRIPTION
Seems that after the jersey/dropwizard upgrade the Optional bodies are not coming through correctly and are `null` instead of `absent()` when the body is not present. Updated the impacted endpoints (anything with an `Optional` body) to take the object (nullable) and construct the `Optional` afterwards. Actually made the tests look a bit nicer not wrapping everything in `Optional.of()` too.

I can test this out and try to get a 15.1 out if it looks good.
/cc @darcatron @stevenschlansker @dstryker @pennello @sannessa
/fixes #1525 