### PR TITLE
Allow immediate run in pending queue with deploy

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/data/CuratorAsyncManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/CuratorAsyncManager.java
@@ -58,7 +58,7 @@ public abstract class CuratorAsyncManager extends CuratorManager {
         paths.add(ZKPaths.makePath(parent, child));
       }
 
-      List<T> result = new ArrayList<>(getAsyncThrows(parent, paths, transcoder, Optional.<ZkCache<T>> absent()).values());
+      List<T> result = new ArrayList<>(getAsyncThrows(parent, paths, transcoder, Optional.absent()).values());
 
 
       return result;

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/CuratorManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/CuratorManager.java
@@ -136,7 +136,7 @@ public abstract class CuratorManager {
     } catch (Throwable t) {
       throw Throwables.propagate(t);
     } finally {
-      log(OperationType.GET_CHILDREN, Optional.of(numChildren), Optional.<Integer>absent(), start, root);
+      log(OperationType.GET_CHILDREN, Optional.of(numChildren), Optional.absent(), start, root);
     }
   }
 
@@ -189,7 +189,7 @@ public abstract class CuratorManager {
         createBuilder.forPath(path);
       }
     } finally {
-      log(OperationType.WRITE, Optional.<Integer>absent(), Optional.<Integer>of(data.or(EMPTY_BYTES).length), start, path);
+      log(OperationType.WRITE, Optional.absent(), Optional.of(data.or(EMPTY_BYTES).length), start, path);
     }
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/DeployManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/DeployManager.java
@@ -207,7 +207,7 @@ public class DeployManager extends CuratorAsyncManager {
     final SingularityCreateResult deploySaveResult = create(getDeployDataPath(deploy.getRequestId(), deploy.getId()), deploy, deployTranscoder);
 
     if (deploySaveResult == SingularityCreateResult.EXISTED) {
-      LOG.info(String.format("Deploy object for %s already existed (new marker: %s)", deploy, deployMarker));
+      LOG.info("Deploy object for {} already existed (new marker: {})", deploy, deployMarker);
     }
 
     singularityEventListener.deployHistoryEvent(new SingularityDeployUpdate(deployMarker, Optional.of(deploy), DeployEventType.STARTING, Optional.<SingularityDeployResult>absent()));

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
@@ -25,6 +25,7 @@ import com.hubspot.singularity.SingularityCreateResult;
 import com.hubspot.singularity.SingularityDeleteResult;
 import com.hubspot.singularity.SingularityDeployKey;
 import com.hubspot.singularity.SingularityPendingRequest;
+import com.hubspot.singularity.SingularityPendingRequest.PendingType;
 import com.hubspot.singularity.SingularityRequest;
 import com.hubspot.singularity.SingularityRequestCleanup;
 import com.hubspot.singularity.SingularityRequestHistory;
@@ -139,7 +140,12 @@ public class RequestManager extends CuratorAsyncManager {
 
   private String pendingQueueKey(SingularityPendingRequest pendingRequest) {
     SingularityDeployKey deployKey = new SingularityDeployKey(pendingRequest.getRequestId(), pendingRequest.getDeployId());
-    return String.format("%s%s", deployKey.toString(), pendingRequest.getTimestamp());
+    if (pendingRequest.getPendingType() == PendingType.ONEOFF
+        || pendingRequest.getPendingType() == PendingType.IMMEDIATE) {
+      return String.format("%s%s", deployKey.toString(), pendingRequest.getTimestamp());
+    } else {
+      return deployKey.toString();
+    }
   }
 
   private String getCleanupPath(String requestId, RequestCleanupType type) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
@@ -133,20 +133,22 @@ public class RequestManager extends CuratorAsyncManager {
     return ZKPaths.makePath(PENDING_PATH_ROOT, new SingularityDeployKey(requestId, deployId).getId());
   }
 
-  private String getPendingPath(SingularityPendingRequest pendingRequest) {
-    String nodeName = pendingQueueKey(pendingRequest);
+  private String getPendingPath(SingularityPendingRequest pendingRequest, boolean forceImmediate) {
+    String nodeName = pendingQueueKey(pendingRequest, forceImmediate);
     return ZKPaths.makePath(PENDING_PATH_ROOT, nodeName);
   }
 
-  private String pendingQueueKey(SingularityPendingRequest pendingRequest) {
+  private String pendingQueueKey(SingularityPendingRequest pendingRequest, boolean forceImmediate) {
     SingularityDeployKey deployKey = new SingularityDeployKey(pendingRequest.getRequestId(), pendingRequest.getDeployId());
     if (pendingRequest.getPendingType() == PendingType.ONEOFF) {
       return String.format("%s%s", deployKey, pendingRequest.getTimestamp());
     } else if (pendingRequest.getPendingType() == PendingType.IMMEDIATE) {
       Optional<SingularityPendingRequest> existingRequest = getPendingRequest(pendingRequest.getRequestId(), pendingRequest.getDeployId());
-      if (existingRequest.isPresent() &&
-          (existingRequest.get().getPendingType() == PendingType.TASK_DONE
-          || existingRequest.get().getPendingType() == PendingType.NEW_DEPLOY)) {
+      boolean markImmediate = forceImmediate
+          || (existingRequest.isPresent()
+              && (existingRequest.get().getPendingType() == PendingType.NEW_DEPLOY
+      || existingRequest.get().getPendingType() == PendingType.TASK_DONE));
+      if (markImmediate) {
         return String.format("%s%s", deployKey, "-immediate");
       } else {
         return deployKey.toString();
@@ -173,7 +175,13 @@ public class RequestManager extends CuratorAsyncManager {
   }
 
   public SingularityDeleteResult deletePendingRequest(SingularityPendingRequest pendingRequest) {
-    return delete(getPendingPath(pendingRequest));
+    SingularityDeleteResult deleteResult = delete(getPendingPath(pendingRequest, false));
+    if (deleteResult == SingularityDeleteResult.DIDNT_EXIST
+        && pendingRequest.getPendingType() == PendingType.IMMEDIATE) {
+      return delete(getPendingPath(pendingRequest, true));
+    } else {
+      return deleteResult;
+    }
   }
 
   public SingularityDeleteResult deleteHistoryParent(String requestId) {
@@ -245,7 +253,7 @@ public class RequestManager extends CuratorAsyncManager {
   }
 
   public SingularityCreateResult addToPendingQueue(SingularityPendingRequest pendingRequest) {
-    SingularityCreateResult result = create(getPendingPath(pendingRequest), pendingRequest, pendingRequestTranscoder);
+    SingularityCreateResult result = create(getPendingPath(pendingRequest, false), pendingRequest, pendingRequestTranscoder);
 
     LOG.info("{} added to pending queue with result: {}", pendingRequest, result);
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
@@ -1,6 +1,7 @@
 package com.hubspot.singularity.data;
 
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -133,10 +134,26 @@ public class RequestManager extends CuratorAsyncManager {
   }
 
   private String getPendingPath(SingularityPendingRequest pendingRequest) {
-    String nodeName = String.format("%s%s",
-      new SingularityDeployKey(pendingRequest.getRequestId(), pendingRequest.getDeployId()),
-      pendingRequest.getPendingType().equals(PendingType.ONEOFF) ? pendingRequest.getTimestamp()  : "");
+    String nodeName = pendingQueueKey(pendingRequest);
     return ZKPaths.makePath(PENDING_PATH_ROOT, nodeName);
+  }
+
+  private String pendingQueueKey(SingularityPendingRequest pendingRequest) {
+    SingularityDeployKey deployKey = new SingularityDeployKey(pendingRequest.getRequestId(), pendingRequest.getDeployId());
+    if (pendingRequest.getPendingType() == PendingType.ONEOFF) {
+      return String.format("%s%s", deployKey, pendingRequest.getTimestamp());
+    } else if (pendingRequest.getPendingType() == PendingType.IMMEDIATE) {
+      Optional<SingularityPendingRequest> existingRequest = getPendingRequest(pendingRequest.getRequestId(), pendingRequest.getDeployId());
+      if (existingRequest.isPresent() &&
+          (existingRequest.get().getPendingType() == PendingType.TASK_DONE
+          || existingRequest.get().getPendingType() == PendingType.NEW_DEPLOY)) {
+        return String.format("%s%s", deployKey, "-immediate");
+      } else {
+        return deployKey.toString();
+      }
+    } else {
+      return deployKey.toString();
+    }
   }
 
   private String getCleanupPath(String requestId, RequestCleanupType type) {
@@ -280,7 +297,11 @@ public class RequestManager extends CuratorAsyncManager {
   }
 
   public List<SingularityPendingRequest> getPendingRequests() {
-    return getAsyncChildren(PENDING_PATH_ROOT, pendingRequestTranscoder);
+    List<SingularityPendingRequest> pendingRequests = getAsyncChildren(PENDING_PATH_ROOT, pendingRequestTranscoder);
+    // Strictly enforce ordering of pending requests
+    pendingRequests.sort(Comparator.comparingLong(SingularityPendingRequest::getTimestamp));
+
+    return pendingRequests;
   }
 
   public List<SingularityRequestCleanup> getCleanupRequests() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -7,6 +7,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.transaction.CuratorTransactionFinal;
@@ -833,12 +834,9 @@ public class TaskManager extends CuratorAsyncManager {
 
   public List<SingularityPendingTaskId> getPendingTaskIdsForRequest(final String requestId) {
     List<SingularityPendingTaskId> pendingTaskIds = getPendingTaskIds();
-    return ImmutableList.copyOf(Iterables.filter(pendingTaskIds, new Predicate<SingularityPendingTaskId>() {
-      @Override
-      public boolean apply(SingularityPendingTaskId pendingTaskId) {
-        return pendingTaskId.getRequestId().equals(requestId);
-      }
-    }));
+    return pendingTaskIds.stream()
+        .filter(pendingTaskId -> pendingTaskId.getRequestId().equals(requestId))
+        .collect(Collectors.collectingAndThen(Collectors.toList(), ImmutableList::copyOf));
   }
 
   public List<SingularityPendingTask> getPendingTasks() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/PendingRequestDataMigration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/PendingRequestDataMigration.java
@@ -1,0 +1,78 @@
+package com.hubspot.singularity.data.zkmigrations;
+
+import java.util.List;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.Inject;
+import com.hubspot.mesos.JavaUtils;
+import com.hubspot.singularity.SingularityDeployKey;
+import com.hubspot.singularity.SingularityPendingRequest;
+import com.hubspot.singularity.SingularityPendingRequest.PendingType;
+import com.hubspot.singularity.data.RequestManager;
+import com.hubspot.singularity.data.transcoders.Transcoder;
+
+public class PendingRequestDataMigration extends ZkDataMigration {
+  private static final Logger LOG = LoggerFactory.getLogger(PendingRequestDataMigration.class);
+
+  private final RequestManager requestManager;
+  private final CuratorFramework curator;
+  private final Transcoder<SingularityPendingRequest> requestTranscoder;
+
+
+  @Inject
+  public PendingRequestDataMigration(RequestManager requestManager,
+                                     CuratorFramework curator,
+                                     Transcoder<SingularityPendingRequest> requestTranscoder) {
+    super(10);
+
+    this.requestManager = requestManager;
+    this.curator = curator;
+    this.requestTranscoder = requestTranscoder;
+  }
+
+  @Override
+  public void applyMigration() {
+    String basePath = "/requests/pending";
+    LOG.warn("Starting migration to re-write pending request paths");
+    long start = System.currentTimeMillis();
+    int rewrittenPaths = 0;
+
+    try {
+      if (curator.checkExists().forPath(basePath) == null) {
+        return;
+      }
+    } catch (Exception exn) {
+      LOG.error("Could not check existence of pending request path", exn);
+      throw new RuntimeException(exn);
+    }
+
+    try {
+      List<String> childPaths = curator.getChildren()
+          .forPath(basePath);
+
+      for (String childPath : childPaths) {
+        SingularityPendingRequest pendingRequest = requestTranscoder.fromBytes(curator.getData()
+            .forPath(String.format("%s/%s", basePath, childPath)));
+        if (pendingRequest.getPendingType() == PendingType.IMMEDIATE) {
+          String rewrittenPath = new SingularityDeployKey(pendingRequest.getRequestId(), pendingRequest.getDeployId())
+              .getId();
+          LOG.warn("Rewriting path {} to {}", childPath, String.format("%s%s", rewrittenPath, pendingRequest.getTimestamp()));
+          requestManager.addToPendingQueue(pendingRequest);
+          curator.delete()
+              .forPath(String.format("%s/%s", basePath, childPath));
+          rewrittenPaths += 1;
+        } else {
+          LOG.warn("Not rewriting path {}, already correct", childPath);
+        }
+      }
+    } catch (Exception exn) {
+      LOG.error("Connection to Zookeeper failed while running migration", exn);
+      throw new RuntimeException(exn);
+    }
+
+    LOG.warn("Applied PendingRequestDataMigration to {} requests in {}", rewrittenPaths, JavaUtils.duration(start));
+  }
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/SingularityZkMigrationsModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/SingularityZkMigrationsModule.java
@@ -26,6 +26,7 @@ public class SingularityZkMigrationsModule implements Module {
     dataMigrations.addBinding().to(SlaveAndRackMigration2.class);
     dataMigrations.addBinding().to(ScheduleMigration.class);
     dataMigrations.addBinding().to(SingularityRequestTypeMigration.class);
+    dataMigrations.addBinding().to(PendingRequestDataMigration.class);
   }
 
   @Provides

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -4,6 +4,7 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -11,6 +12,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import javax.inject.Singleton;
 
@@ -42,6 +44,7 @@ import com.hubspot.singularity.RequestState;
 import com.hubspot.singularity.RequestType;
 import com.hubspot.singularity.ScheduleType;
 import com.hubspot.singularity.SingularityCreateResult;
+import com.hubspot.singularity.SingularityDeployKey;
 import com.hubspot.singularity.SingularityDeployMarker;
 import com.hubspot.singularity.SingularityDeployProgress;
 import com.hubspot.singularity.SingularityDeployStatistics;
@@ -214,7 +217,6 @@ public class SingularityScheduler {
   @Timed
   public void drainPendingQueue(final SingularitySchedulerStateCache stateCache) {
     final long start = System.currentTimeMillis();
-
     final ImmutableList<SingularityPendingRequest> pendingRequests = ImmutableList.copyOf(requestManager.getPendingRequests());
 
     if (pendingRequests.isEmpty()) {
@@ -222,58 +224,74 @@ public class SingularityScheduler {
       return;
     }
 
+    Map<SingularityDeployKey, List<SingularityPendingRequest>> deployKeyToPendingRequests = groupPendingRequests(pendingRequests);
+
     LOG.info("Pending queue had {} requests", pendingRequests.size());
 
     int totalNewScheduledTasks = 0;
     int heldForScheduledActiveTask = 0;
     int obsoleteRequests = 0;
 
-    for (SingularityPendingRequest pendingRequest : pendingRequests) {
-      Optional<SingularityRequestWithState> maybeRequest = requestManager.getRequest(pendingRequest.getRequestId());
+    for (Entry<SingularityDeployKey, List<SingularityPendingRequest>> singularityDeployKeyListEntry : deployKeyToPendingRequests.entrySet()) {
+      final String requestId = singularityDeployKeyListEntry.getKey().getRequestId();
+      final SingularityDeployKey deployKey = singularityDeployKeyListEntry.getKey();
+      final List<SingularityPendingRequest> pendingRequestsForDeploy = singularityDeployKeyListEntry.getValue();
+      final Optional<SingularityRequestWithState> maybeRequest = requestManager.getRequest(requestId);
+      final SingularityDeployStatistics deployStatistics = getDeployStatistics(deployKey.getRequestId(), deployKey.getDeployId());
 
       if (!isRequestActive(maybeRequest)) {
-        LOG.debug("Pending request {} was obsolete (request {})", pendingRequest, SingularityRequestWithState.getRequestState(maybeRequest));
+        LOG.debug("Pending request {} was obsolete (request {})", requestId, SingularityRequestWithState.getRequestState(maybeRequest));
         obsoleteRequests++;
+        for (SingularityPendingRequest pendingRequest : pendingRequestsForDeploy) {
+          requestManager.deletePendingRequest(pendingRequest);
+        }
+        continue;
+      }
+
+      Optional<SingularityRequestDeployState> maybeRequestDeployState = deployManager.getRequestDeployState(requestId);
+      Optional<SingularityPendingDeploy> maybePendingDeploy = deployManager.getPendingDeploy(requestId);
+      List<SingularityTaskId> matchingTaskIds = getMatchingTaskIds(stateCache, maybeRequest.get().getRequest(), deployKey);
+
+      List<SingularityPendingRequest> effectivePendingRequests = new ArrayList<>();
+      pendingRequestsForDeploy.sort(Comparator.comparingLong(SingularityPendingRequest::getTimestamp));
+      for (SingularityPendingRequest pendingRequest : pendingRequestsForDeploy) {
+        final SingularityRequest updatedRequest = updatedRequest(maybePendingDeploy, pendingRequest, maybeRequest.get());
+
+        if (!shouldScheduleTasks(updatedRequest, pendingRequest, maybePendingDeploy, maybeRequestDeployState)) {
+          LOG.debug("Pending request {} was obsolete (request {})", pendingRequest, SingularityRequestWithState.getRequestState(maybeRequest));
+          obsoleteRequests++;
+          requestManager.deletePendingRequest(pendingRequest);
+          continue;
+        }
+
+        int missingInstances = getNumMissingInstances(matchingTaskIds, updatedRequest, pendingRequest, maybePendingDeploy);
+        if (missingInstances == 0 && !matchingTaskIds.isEmpty() && updatedRequest.isScheduled() && pendingRequest.getPendingType() == PendingType.NEW_DEPLOY) {
+          LOG.trace("Holding pending request {} because it is scheduled and has an active task", pendingRequest);
+          heldForScheduledActiveTask++;
+          continue;
+        }
+
+        if (effectivePendingRequests.isEmpty()) {
+          effectivePendingRequests.add(pendingRequest);
+        } else if (pendingRequest.getPendingType() == PendingType.IMMEDIATE) {
+          effectivePendingRequests.add(pendingRequest);
+        } else if (pendingRequest.getPendingType() == PendingType.ONEOFF) {
+          effectivePendingRequests.add(pendingRequest);
+        } else {
+          // Any other subsequent requests are not honored until after the pending queue is cleared.
+        }
+
         requestManager.deletePendingRequest(pendingRequest);
-        continue;
       }
 
-      Optional<SingularityRequestDeployState> maybeRequestDeployState = deployManager.getRequestDeployState(pendingRequest.getRequestId());
-      Optional<SingularityPendingDeploy> maybePendingDeploy = deployManager.getPendingDeploy(maybeRequest.get().getRequest().getId());
-
-      final SingularityRequest updatedRequest;
-      if (maybePendingDeploy.isPresent() && pendingRequest.getDeployId().equals(maybePendingDeploy.get().getDeployMarker().getDeployId())) {
-        updatedRequest = maybePendingDeploy.get().getUpdatedRequest().or(maybeRequest.get().getRequest());
-      } else {
-        updatedRequest = maybeRequest.get().getRequest();
+      int scheduledInstances = 0;
+      for (SingularityPendingRequest effectivePendingRequest : effectivePendingRequests) {
+        RequestState requestState = checkCooldown(maybeRequest.get().getState(), maybeRequest.get().getRequest(), deployStatistics);
+        scheduledInstances += scheduleTasks(stateCache, maybeRequest.get().getRequest(), requestState,
+            deployStatistics, effectivePendingRequest, matchingTaskIds, maybePendingDeploy);
       }
 
-      if (!shouldScheduleTasks(updatedRequest, pendingRequest, maybePendingDeploy, maybeRequestDeployState)) {
-        LOG.debug("Pending request {} was obsolete (request {})", pendingRequest, SingularityRequestWithState.getRequestState(maybeRequest));
-        obsoleteRequests++;
-        requestManager.deletePendingRequest(pendingRequest);
-        continue;
-      }
-
-      final List<SingularityTaskId> matchingTaskIds = getMatchingTaskIds(stateCache, updatedRequest, pendingRequest);
-
-      final SingularityDeployStatistics deployStatistics = getDeployStatistics(pendingRequest.getRequestId(), pendingRequest.getDeployId());
-
-      final RequestState requestState = checkCooldown(maybeRequest.get().getState(), updatedRequest, deployStatistics);
-
-      int numScheduledTasks = scheduleTasks(stateCache, updatedRequest, requestState, deployStatistics, pendingRequest, matchingTaskIds, maybePendingDeploy);
-
-      if (numScheduledTasks == 0 && !matchingTaskIds.isEmpty() && updatedRequest.isScheduled() && pendingRequest.getPendingType() == PendingType.NEW_DEPLOY) {
-        LOG.trace("Holding pending request {} because it is scheduled and has an active task", pendingRequest);
-        heldForScheduledActiveTask++;
-        continue;
-      }
-
-      LOG.debug("Pending request {} resulted in {} new scheduled tasks", pendingRequest, numScheduledTasks);
-
-      totalNewScheduledTasks += numScheduledTasks;
-
-      requestManager.deletePendingRequest(pendingRequest);
+      totalNewScheduledTasks += scheduledInstances;
     }
 
     LOG.info("Scheduled {} new tasks ({} obsolete requests, {} held) in {}", totalNewScheduledTasks, obsoleteRequests, heldForScheduledActiveTask, JavaUtils.duration(start));
@@ -398,8 +416,30 @@ public class SingularityScheduler {
     }
   }
 
-  private int scheduleTasks(SingularitySchedulerStateCache stateCache, SingularityRequest request, RequestState state, SingularityDeployStatistics deployStatistics,
-    SingularityPendingRequest pendingRequest, List<SingularityTaskId> matchingTaskIds, Optional<SingularityPendingDeploy> maybePendingDeploy) {
+  private List<SingularityTaskId> getMatchingTaskIds(SingularitySchedulerStateCache stateCache, SingularityRequest request, SingularityDeployKey deployKey) {
+    if (request.isLongRunning()) {
+      List<SingularityTaskId> matchingTaskIds = new ArrayList<>();
+      for (SingularityTaskId taskId : stateCache.getActiveTaskIdsForRequest(deployKey.getRequestId())) {
+        if (!taskId.getDeployId().equals(deployKey.getDeployId())) {
+          continue;
+        }
+        if (stateCache.getCleaningTasks().contains(taskId)) {
+          continue;
+        }
+        if (stateCache.getKilledTasks().contains(taskId)) {
+          continue;
+        }
+        matchingTaskIds.add(taskId);
+      }
+      return matchingTaskIds;
+    } else {
+      return new ArrayList<>(stateCache.getActiveTaskIdsForRequest(deployKey.getRequestId()));
+    }
+  }
+
+  private int scheduleTasks(SingularitySchedulerStateCache stateCache, SingularityRequest request, RequestState state,
+                            SingularityDeployStatistics deployStatistics, SingularityPendingRequest pendingRequest,
+                            List<SingularityTaskId> matchingTaskIds, Optional<SingularityPendingDeploy> maybePendingDeploy) {
     if (request.getRequestType() != RequestType.ON_DEMAND) {
       deleteScheduledTasks(stateCache.getScheduledTasks(), pendingRequest);
     }
@@ -790,5 +830,20 @@ public class SingularityScheduler {
 
     return Optional.of(nextRunAt);
   }
+
+  private SingularityRequest updatedRequest(Optional<SingularityPendingDeploy> maybePendingDeploy, SingularityPendingRequest pendingRequest,
+                                            SingularityRequestWithState currentRequest) {
+    if (maybePendingDeploy.isPresent() && pendingRequest.getDeployId().equals(maybePendingDeploy.get().getDeployMarker().getDeployId())) {
+      return maybePendingDeploy.get().getUpdatedRequest().or(currentRequest.getRequest());
+    } else {
+      return currentRequest.getRequest();
+    }
+  }
+
+  private Map<SingularityDeployKey, List<SingularityPendingRequest>> groupPendingRequests(List<SingularityPendingRequest> inputPendingRequests) {
+    return inputPendingRequests.stream()
+        .collect(Collectors.groupingBy((request) -> new SingularityDeployKey(request.getRequestId(), request.getDeployId())));
+  }
+
 
 }

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityStartupTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityStartupTest.java
@@ -63,21 +63,23 @@ public class SingularityStartupTest extends SingularitySchedulerTestBase {
     deploy(firstDeployId);
     deployChecker.checkDeploys();
 
-    Assert.assertTrue(requestManager.getPendingRequests().size() == 1);
-    Assert.assertTrue(taskManager.getPendingTaskIds().isEmpty());
+    Assert.assertEquals("NEW_DEPLOY request added", 1, requestManager.getPendingRequests().size());
+    Assert.assertTrue("No tasks started yet", taskManager.getPendingTaskIds().isEmpty());
 
     startup.checkSchedulerForInconsistentState();
 
-    Assert.assertTrue(requestManager.getPendingRequests().size() == 1);
-    Assert.assertTrue(requestManager.getPendingRequests().get(0).getPendingType() == PendingType.NEW_DEPLOY);
-    Assert.assertTrue(taskManager.getPendingTaskIds().isEmpty());
+    Assert.assertEquals("NEW_DEPLOY and STARTUP requests added", 2, requestManager.getPendingRequests().size());
+    Assert.assertEquals("NEW_DEPLOY is first", PendingType.NEW_DEPLOY, requestManager.getPendingRequests().get(0).getPendingType());
+    Assert.assertEquals("STARTUP is second", PendingType.STARTUP, requestManager.getPendingRequests().get(1).getPendingType());
+    Assert.assertTrue("No tasks started yet", taskManager.getPendingTaskIds().isEmpty());
 
     scheduler.drainPendingQueue(stateCacheProvider.get());
 
-    Assert.assertTrue(requestManager.getPendingRequests().isEmpty());
+    Assert.assertTrue("Pending queue is cleared", requestManager.getPendingRequests().isEmpty());
     List<SingularityPendingTask> pending = taskManager.getPendingTasks();
 
-    Assert.assertTrue(taskManager.getPendingTaskIds().size() == 1);
+    Assert.assertEquals("One task is started", 1, taskManager.getPendingTaskIds().size());
+    Assert.assertEquals("First request takes precedence", PendingType.NEW_DEPLOY, taskManager.getPendingTaskIds().get(0).getPendingType());
 
     startup.checkSchedulerForInconsistentState();
     scheduler.drainPendingQueue(stateCacheProvider.get());

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityStartupTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityStartupTest.java
@@ -68,9 +68,8 @@ public class SingularityStartupTest extends SingularitySchedulerTestBase {
 
     startup.checkSchedulerForInconsistentState();
 
-    Assert.assertEquals("NEW_DEPLOY and STARTUP requests added", 2, requestManager.getPendingRequests().size());
+    Assert.assertEquals("NEW_DEPLOY request added", 1, requestManager.getPendingRequests().size());
     Assert.assertEquals("NEW_DEPLOY is first", PendingType.NEW_DEPLOY, requestManager.getPendingRequests().get(0).getPendingType());
-    Assert.assertEquals("STARTUP is second", PendingType.STARTUP, requestManager.getPendingRequests().get(1).getPendingType());
     Assert.assertTrue("No tasks started yet", taskManager.getPendingTaskIds().isEmpty());
 
     scheduler.drainPendingQueue(stateCacheProvider.get());

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityOfferPerformanceTestRunner.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityOfferPerformanceTestRunner.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Random;
 
 import org.apache.mesos.Protos.Offer;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.hubspot.mesos.JavaUtils;
@@ -17,6 +18,7 @@ public class SingularityOfferPerformanceTestRunner extends SingularitySchedulerT
   }
 
   @Test
+  @Ignore
   public void testOfferCache() {
     long start = System.currentTimeMillis();
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -1419,7 +1419,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     startFirstDeploy();
     SingularityPendingRequest pendingDeployRequest = new SingularityPendingRequest(requestId, firstDeploy.getId(), now, Optional.absent(), PendingType.NEW_DEPLOY,
         firstDeploy.getSkipHealthchecksOnDeploy(), Optional.absent());
-    SingularityPendingRequest pendingRunNowRequest = new SingularityPendingRequest(requestId, firstDeploy.getId(), now, Optional.absent(), PendingType.IMMEDIATE,
+    SingularityPendingRequest pendingRunNowRequest = new SingularityPendingRequest(requestId, firstDeploy.getId(), now + 200, Optional.absent(), PendingType.IMMEDIATE,
         firstDeploy.getSkipHealthchecksOnDeploy(), Optional.absent());
 
     requestManager.addToPendingQueue(pendingDeployRequest);

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -1399,7 +1399,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
 
 
     SingularityRunNowRequest runNowRequest = new SingularityRunNowRequest(Optional.<String>absent(), Optional.<Boolean>absent(), Optional.<String>absent(), Optional.<List<String>>absent(), Optional.of(new Resources(2, 2, 0)));
-    requestResource.scheduleImmediately(requestId, Optional.of(runNowRequest));
+    requestResource.scheduleImmediately(requestId, runNowRequest);
 
     Assert.assertEquals(2, requestManager.getPendingRequests().size());
     // Was added first
@@ -1789,7 +1789,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     Assert.assertEquals(1, taskManager.getPendingTaskIds().size());
     Assert.assertEquals(PendingType.NEW_DEPLOY, taskManager.getPendingTaskIds().get(0).getPendingType());
 
-    requestResource.scheduleImmediately(requestId, Optional.of(new SingularityRunNowRequest(Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent())));
+    requestResource.scheduleImmediately(requestId, new SingularityRunNowRequest(Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()));
     scheduler.drainPendingQueue(stateCacheProvider.get());
 
     Assert.assertEquals(1, taskManager.getPendingTaskIds().size());

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -1394,12 +1394,14 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     long now = System.currentTimeMillis();
     initRequestWithType(RequestType.SCHEDULED, false);
     startFirstDeploy();
-    requestManager.addToPendingQueue(new SingularityPendingRequest(requestId, firstDeploy.getId(), now, Optional.absent(), PendingType.NEW_DEPLOY,
-        firstDeploy.getSkipHealthchecksOnDeploy(), Optional.absent()));
+    SingularityPendingRequest pendingDeployRequest = new SingularityPendingRequest(requestId, firstDeploy.getId(), now, Optional.absent(), PendingType.NEW_DEPLOY,
+        firstDeploy.getSkipHealthchecksOnDeploy(), Optional.absent());
+    SingularityPendingRequest pendingRunNowRequest = new SingularityPendingRequest(requestId, firstDeploy.getId(), now + 200, Optional.absent(), PendingType.IMMEDIATE,
+        firstDeploy.getSkipHealthchecksOnDeploy(), Optional.absent());
+    requestManager.addToPendingQueue(pendingDeployRequest);
 
 
-    SingularityRunNowRequest runNowRequest = new SingularityRunNowRequest(Optional.<String>absent(), Optional.<Boolean>absent(), Optional.<String>absent(), Optional.<List<String>>absent(), Optional.of(new Resources(2, 2, 0)));
-    requestResource.scheduleImmediately(requestId, runNowRequest);
+    requestManager.addToPendingQueue(pendingRunNowRequest);
 
     Assert.assertEquals(2, requestManager.getPendingRequests().size());
     // Was added first
@@ -1408,6 +1410,34 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     Assert.assertEquals(PendingType.IMMEDIATE, requestManager.getPendingRequests().get(1).getPendingType());
 
     resourceOffers();
+  }
+
+  @Test
+  public void testImmediateRequestsAreConsistentlyDeleted() {
+    long now = System.currentTimeMillis();
+    initRequestWithType(RequestType.SCHEDULED, false);
+    startFirstDeploy();
+    SingularityPendingRequest pendingDeployRequest = new SingularityPendingRequest(requestId, firstDeploy.getId(), now, Optional.absent(), PendingType.NEW_DEPLOY,
+        firstDeploy.getSkipHealthchecksOnDeploy(), Optional.absent());
+    SingularityPendingRequest pendingRunNowRequest = new SingularityPendingRequest(requestId, firstDeploy.getId(), now, Optional.absent(), PendingType.IMMEDIATE,
+        firstDeploy.getSkipHealthchecksOnDeploy(), Optional.absent());
+
+    requestManager.addToPendingQueue(pendingDeployRequest);
+    requestManager.addToPendingQueue(pendingRunNowRequest);
+
+    // Pending queue has two requests: NEW_DEPLOY & IMMEDIATE
+    Assert.assertEquals(2, requestManager.getPendingRequests().size());
+    finishNewTaskChecks();
+
+    requestManager.deletePendingRequest(pendingDeployRequest);
+
+    // Just the immediate run
+    Assert.assertEquals(1, requestManager.getPendingRequests().size());
+
+    requestManager.deletePendingRequest(pendingRunNowRequest);
+
+    // Immediate run was successfully deleted
+    Assert.assertEquals(0, requestManager.getPendingRequests().size());
   }
 
   @Test
@@ -1789,7 +1819,8 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     Assert.assertEquals(1, taskManager.getPendingTaskIds().size());
     Assert.assertEquals(PendingType.NEW_DEPLOY, taskManager.getPendingTaskIds().get(0).getPendingType());
 
-    requestResource.scheduleImmediately(requestId, new SingularityRunNowRequest(Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()));
+    requestManager.addToPendingQueue(new SingularityPendingRequest(requestId, deploy.getId(), System.currentTimeMillis(), Optional.absent(), PendingType.IMMEDIATE,
+        deploy.getSkipHealthchecksOnDeploy(), Optional.absent()));
     scheduler.drainPendingQueue(stateCacheProvider.get());
 
     Assert.assertEquals(1, taskManager.getPendingTaskIds().size());

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTestBase.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTestBase.java
@@ -654,7 +654,7 @@ public class SingularitySchedulerTestBase extends SingularityCuratorTestBase {
     Random random = new Random();
 
     SingularityPendingTaskId pendingTaskId = new SingularityPendingTaskId(requestId, deployId,
-        System.currentTimeMillis() + TimeUnit.DAYS.toMillis(random.nextInt(3)), random.nextInt(10), PendingType.IMMEDIATE, System.currentTimeMillis());
+        System.currentTimeMillis() + TimeUnit.DAYS.toMillis(random.nextInt(3)), random.nextInt(10), PendingType.NEW_DEPLOY, System.currentTimeMillis());
 
     SingularityPendingTask pendingTask = new SingularityPendingTask(pendingTaskId, Optional.<List<String>> absent(), Optional.<String> absent(), Optional.<String> absent(), Optional.<Boolean> absent(), Optional.<String> absent(), Optional.<Resources>absent(), Optional.<String>absent());
 


### PR DESCRIPTION
Give immediate run requests in the pending queue a separate key, so they
are permitted to be in the pending queue at the same time as a new
deploy for the same requestID / deployID. This means that a pending
deploy will not block an immediate run from being enqueued.

/cc @ssalinas 