### PR TITLE
Revert breaking change in enum deserialization

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityContainerType.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityContainerType.java
@@ -1,5 +1,12 @@
 package com.hubspot.mesos;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 public enum SingularityContainerType {
-  MESOS, DOCKER
+  MESOS, DOCKER;
+
+  @JsonCreator
+  public static SingularityContainerType fromString(String name) {
+    return valueOf(name.toUpperCase());
+  }
 }


### PR DESCRIPTION
There appears to have been a change right around Dropwizard 1.0
in how enums are deserialized; my guess is that somehow `@JsonCreator`
cascades and prevents the `FuzzyEnumModule` from being applied properly,
but I'm not really sure. The result was that `SingularityContainerType`
wasn't accepting lowercase `mesos`, `docker` as valid values, which was
a breaking change from before - and in particular, prevented creating
deploys from the UI.

See also dropwizard/dropwizard#1985, which is kind-of related, I think

/cc @ssalinas 