### PR TITLE
Ability to set baseUrl separately for email links

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SMTPConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SMTPConfiguration.java
@@ -86,6 +86,9 @@ public class SMTPConfiguration {
   @JsonProperty
   private Optional<String> subjectPrefix = Optional.absent();
 
+  @JsonProperty
+  private Optional<String> uiBaseUrl = Optional.absent();
+
   @JsonProperty("emails")
   private Map<SingularityEmailType, List<SingularityEmailDestination>> emailConfiguration = Maps.newHashMap(ImmutableMap.<SingularityEmailType, List<SingularityEmailDestination>>builder()
       .put(SingularityEmailType.REQUEST_IN_COOLDOWN, ImmutableList.of(SingularityEmailDestination.ADMINS, SingularityEmailDestination.OWNERS))
@@ -257,5 +260,13 @@ public class SMTPConfiguration {
 
   public void setSubjectPrefix(Optional<String> subjectPrefix) {
     this.subjectPrefix = subjectPrefix;
+  }
+
+  public Optional<String> getUiBaseUrl() {
+    return uiBaseUrl;
+  }
+
+  public void setUiBaseUrl(Optional<String> uiBaseUrl) {
+    this.uiBaseUrl = uiBaseUrl;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/smtp/MailTemplateHelpers.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/smtp/MailTemplateHelpers.java
@@ -51,7 +51,7 @@ public class MailTemplateHelpers {
 
   @Inject
   public MailTemplateHelpers(SandboxManager sandboxManager, SingularityConfiguration singularityConfiguration) {
-    this.uiBaseUrl = singularityConfiguration.getUiConfiguration().getBaseUrl();
+    this.uiBaseUrl = singularityConfiguration.getSmtpConfiguration().getUiBaseUrl().or(singularityConfiguration.getUiConfiguration().getBaseUrl());
     this.sandboxManager = sandboxManager;
     this.smtpConfiguration = singularityConfiguration.getSmtpConfigurationOptional();
     if (this.smtpConfiguration.isPresent()) {


### PR DESCRIPTION
This is for cases where there might be a proxy/etc or different ways of accessing the ui. Singularity will use the baseUrl set for emails first, and fall back to the one from the ui configuration that it was using previously.