### PR TITLE
Clear notFound when returning to a tailer page

### DIFF
--- a/SingularityUI/app/actions/tailer.es6
+++ b/SingularityUI/app/actions/tailer.es6
@@ -33,6 +33,13 @@ export const markNotFound = (taskId) => (dispatch, getState) => {
   });
 }
 
+export const clearNotFound = () => (dispatch, getState) => {
+  dispatch({
+    type: TAILER_SET_NOT_FOUND,
+    notFound: {}
+  });
+}
+
 export const jumpToBottom = (id, taskId, path) => (dispatch, getState) => {
   const state = getState();
 

--- a/SingularityUI/app/containers/LogTailerContainer.jsx
+++ b/SingularityUI/app/containers/LogTailerContainer.jsx
@@ -11,7 +11,7 @@ import { actions as tailerActions } from 'singularityui-tailer';
 import { Glyphicon } from 'react-bootstrap';
 import Utils from '../utils';
 
-import { loadColor, removeTailerGroup, pickTailerGroup, jumpToBottom, jumpToTop, markNotFound } from '../actions/tailer';
+import { loadColor, removeTailerGroup, pickTailerGroup, jumpToBottom, jumpToTop, markNotFound, clearNotFound } from '../actions/tailer';
 
 const prefixedLineLinkRenderer = (taskId, path) => ({start}) => {
   return (<a
@@ -28,6 +28,7 @@ class LogTailerContainer extends React.PureComponent {
 
   componentWillMount() {
     this.props.loadColor();
+    this.props.clearNotFound();
     document.addEventListener(tailerActions.SINGULARITY_TAILER_AJAX_ERROR_EVENT, (event) => {
       if (event.detail.response.status == 404 && event.detail.taskId) {
         this.props.markNotFound(event.detail.taskId);
@@ -100,5 +101,6 @@ export default connect((state) => ({
   pickTailerGroup,
   jumpToBottom,
   jumpToTop,
-  markNotFound
+  markNotFound,
+  clearNotFound
 })(LogTailerContainer);


### PR DESCRIPTION
The key for the `notFound` section of the state is the taskId, so after getting a single not found, subsequent page loads would display the same until the page was refreshed.