### PR TITLE
Release lock on bounce when bounced with no running instances

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
@@ -448,6 +448,16 @@ public class SingularityCleaner {
       taskManager.createTaskCleanup(new SingularityTaskCleanup(requestCleanup.getUser(), requestCleanup.getCleanupType().getTaskCleanupType().get(), start, matchingTaskId, requestCleanup.getMessage(), requestCleanup.getActionId(), runBeforeKillId));
     }
 
+    if (matchingTaskIds.isEmpty() && requestCleanup.getDeployId().isPresent()) {
+      Optional<SingularityExpiringBounce> expiringBounce = requestManager.getExpiringBounce(requestCleanup.getRequestId());
+      if (expiringBounce.isPresent() && expiringBounce.get().getDeployId().equalsIgnoreCase(requestCleanup.getDeployId().get())) {
+        LOG.info("No running tasks for request {}. Marking bounce {} complete and starting new tasks", expiringBounce.get().getRequestId(), expiringBounce.get());
+
+        requestManager.deleteExpiringObject(SingularityExpiringBounce.class, requestCleanup.getRequestId());
+      }
+      requestManager.markBounceComplete(requestCleanup.getRequestId());
+    }
+
     requestManager.addToPendingQueue(new SingularityPendingRequest(requestCleanup.getRequestId(), requestCleanup.getDeployId().get(), requestCleanup.getTimestamp(),
         requestCleanup.getUser(), PendingType.BOUNCE, Optional.absent(), Optional.absent(), requestCleanup.getSkipHealthchecks(), requestCleanup.getMessage(), requestCleanup.getActionId()));
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -72,7 +72,6 @@ import com.hubspot.singularity.data.RequestManager;
 import com.hubspot.singularity.data.SlaveManager;
 import com.hubspot.singularity.data.TaskManager;
 import com.hubspot.singularity.data.TaskRequestManager;
-import com.hubspot.singularity.expiring.SingularityExpiringBounce;
 import com.hubspot.singularity.helpers.RFC5545Schedule;
 import com.hubspot.singularity.smtp.SingularityMailer;
 
@@ -412,12 +411,6 @@ public class SingularityScheduler {
 
     if (numMissingInstances > 0) {
       schedule(numMissingInstances, matchingTaskIds, request, state, deployStatistics, pendingRequest, maybePendingDeploy);
-
-      List<SingularityTaskId> remainingActiveTasks = new ArrayList<>(matchingTaskIds);
-      if (requestManager.getExpiringBounce(request.getId()).isPresent() && remainingActiveTasks.size() == 0) {
-        requestManager.deleteExpiringObject(SingularityExpiringBounce.class, request.getId());
-        requestManager.markBounceComplete(request.getId());
-      }
     } else if (numMissingInstances < 0) {
       final long now = System.currentTimeMillis();
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityOfferPerformanceTestRunner.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityOfferPerformanceTestRunner.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Random;
 
 import org.apache.mesos.Protos.Offer;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.hubspot.mesos.JavaUtils;
@@ -17,6 +18,7 @@ public class SingularityOfferPerformanceTestRunner extends SingularitySchedulerT
   }
 
   @Test
+  @Ignore
   public void testOfferCache() {
     long start = System.currentTimeMillis();
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -1138,10 +1138,11 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     Assert.assertEquals("Bounce starts when tasks have not yet been launched", 0, taskManager.getActiveTaskIds().size());
 
     requestResource.bounce(requestId, Optional.of(new SingularityBounceRequest(Optional.absent(), Optional.of(true), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent())));
-    cleaner.drainCleanupQueue();
 
     // It acquires a lock on the bounce
     Assert.assertTrue("Lock on bounce should be acquired during bounce", requestManager.getExpiringBounce(requestId).isPresent());
+
+    cleaner.drainCleanupQueue();
 
     scheduler.drainPendingQueue(stateCacheProvider.get());
     resourceOffers();

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -1155,6 +1155,13 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
 
     // It finishes with one task running and the bounce released
     Assert.assertEquals("Should end bounce with target number of tasks", 1, taskManager.getActiveTaskIds().size());
+    for (SingularityTaskId singularityTaskId : taskManager.getActiveTaskIds()) {
+      String statusMessage = taskManager.getTaskHistoryUpdates(singularityTaskId)
+          .get(0)
+          .getStatusMessage()
+          .get();
+      Assert.assertTrue("Task was started by bounce", statusMessage.contains("BOUNCE"));
+    }
     Assert.assertFalse("Lock on bounce should be released after bounce", requestManager.getExpiringBounce(requestId).isPresent());
   }
 
@@ -1188,6 +1195,13 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
 
     // It finishes with one task running and the bounce released
     Assert.assertEquals("Should end bounce with target number of tasks", 1, taskManager.getActiveTaskIds().size());
+    for (SingularityTaskId singularityTaskId : taskManager.getActiveTaskIds()) {
+      String statusMessage = taskManager.getTaskHistoryUpdates(singularityTaskId)
+          .get(0)
+          .getStatusMessage()
+          .get();
+      Assert.assertTrue("Task was started by bounce", statusMessage.contains("BOUNCE"));
+    }
     Assert.assertFalse("Lock on bounce should be released after bounce", requestManager.getExpiringBounce(requestId).isPresent());
   }
 


### PR DESCRIPTION
Currently the lock on the bounce is released when all the tasks that were running at the time of the bounce have been killed. This means that when a bounce happens when there are no running tasks - like when Singularity is still starting tasks after every task has failed - the expiring bounce can't be removed.  This shims a fix by removing the lock when it schedules the new tasks if there are no currently running tasks, it is adding more running tasks, and there is an expiring bounce on the request. This shouldn't interfere with a scale or an incremental bounce, because they always keep at least the minimum number of instances. 

I am concerned that it releases the bounce lock too early, though, because normally the bounce is guaranteed to be present until all the new instances have successfully started, which isn't something that this change preservers. 

/cc @ssalinas 