### PR TITLE
Refuse to add cleaning tasks to LB

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityNewTaskChecker.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityNewTaskChecker.java
@@ -324,8 +324,11 @@ public class SingularityNewTaskChecker {
     SingularityLoadBalancerUpdate newLbUpdate = null;
 
     final LoadBalancerRequestId loadBalancerRequestId = new LoadBalancerRequestId(task.getTaskId().getId(), LoadBalancerRequestType.ADD, Optional.<Integer> absent());
+    boolean taskCleaning = taskManager.getCleanupTaskIds().contains(task.getTaskId());
 
-    if (!lbUpdate.isPresent() || lbUpdate.get().getLoadBalancerState() == BaragonRequestState.UNKNOWN) {
+    if (!lbUpdate.isPresent()
+        || lbUpdate.get().getLoadBalancerState() == BaragonRequestState.UNKNOWN
+        || ! taskCleaning) {
       taskManager.saveLoadBalancerState(task.getTaskId(), LoadBalancerRequestType.ADD,
           new SingularityLoadBalancerUpdate(BaragonRequestState.UNKNOWN, loadBalancerRequestId, Optional.<String> absent(), System.currentTimeMillis(), LoadBalancerMethod.PRE_ENQUEUE, Optional.<String> absent()));
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityNewTaskChecker.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityNewTaskChecker.java
@@ -326,9 +326,8 @@ public class SingularityNewTaskChecker {
     final LoadBalancerRequestId loadBalancerRequestId = new LoadBalancerRequestId(task.getTaskId().getId(), LoadBalancerRequestType.ADD, Optional.<Integer> absent());
     boolean taskCleaning = taskManager.getCleanupTaskIds().contains(task.getTaskId());
 
-    if ((!lbUpdate.isPresent()
-        || lbUpdate.get().getLoadBalancerState() == BaragonRequestState.UNKNOWN)
-        && !taskCleaning) {
+
+    if ((!lbUpdate.isPresent() || unknownNotRemoving(lbUpdate.get())) && !taskCleaning) {
       taskManager.saveLoadBalancerState(task.getTaskId(), LoadBalancerRequestType.ADD,
           new SingularityLoadBalancerUpdate(BaragonRequestState.UNKNOWN, loadBalancerRequestId, Optional.<String> absent(), System.currentTimeMillis(), LoadBalancerMethod.PRE_ENQUEUE, Optional.<String> absent()));
 
@@ -381,6 +380,11 @@ public class SingularityNewTaskChecker {
     }
 
     return isOverdue;
+  }
+
+  private boolean unknownNotRemoving(SingularityLoadBalancerUpdate update) {
+    return update.getLoadBalancerState() == BaragonRequestState.UNKNOWN
+        && update.getLoadBalancerRequestId().getRequestType() != LoadBalancerRequestType.REMOVE;
   }
 
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityNewTaskChecker.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityNewTaskChecker.java
@@ -326,9 +326,9 @@ public class SingularityNewTaskChecker {
     final LoadBalancerRequestId loadBalancerRequestId = new LoadBalancerRequestId(task.getTaskId().getId(), LoadBalancerRequestType.ADD, Optional.<Integer> absent());
     boolean taskCleaning = taskManager.getCleanupTaskIds().contains(task.getTaskId());
 
-    if (!lbUpdate.isPresent()
-        || lbUpdate.get().getLoadBalancerState() == BaragonRequestState.UNKNOWN
-        || ! taskCleaning) {
+    if ((!lbUpdate.isPresent()
+        || lbUpdate.get().getLoadBalancerState() == BaragonRequestState.UNKNOWN)
+        && !taskCleaning) {
       taskManager.saveLoadBalancerState(task.getTaskId(), LoadBalancerRequestType.ADD,
           new SingularityLoadBalancerUpdate(BaragonRequestState.UNKNOWN, loadBalancerRequestId, Optional.<String> absent(), System.currentTimeMillis(), LoadBalancerMethod.PRE_ENQUEUE, Optional.<String> absent()));
 


### PR DESCRIPTION
Refuse to add tasks which are in the cleaning state the the load
balancer.  This is a slightly ham-handed way to prevent inconsistencies,
like where a task us removed from the load balancer due to the cleaning
process before ever being added to the load balancer.