### PR TITLE
Immediate uploads on executor teardown

### DIFF
--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskLogManager.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskLogManager.java
@@ -252,7 +252,7 @@ public class SingularityExecutorTaskLogManager {
     }
 
     S3UploadMetadata s3UploadMetadata = new S3UploadMetadata(pathToS3Directory.toString(), globForS3Files, s3UploaderBucket, getS3KeyPattern(s3KeyPattern.or(taskDefinition.getExecutorData().getS3UploaderKeyPattern())), finished, Optional.<String> absent(),
-        Optional.<Integer> absent(), Optional.<String> absent(), Optional.<String> absent(), Optional.<Long> absent(), s3StorageClass, applyS3StorageClassAfterBytes, Optional.<Boolean>absent());
+        Optional.<Integer> absent(), Optional.<String> absent(), Optional.<String> absent(), Optional.<Long> absent(), s3StorageClass, applyS3StorageClassAfterBytes, Optional.of(finished));
 
     String s3UploadMetadataFileName = String.format("%s-%s%s", taskDefinition.getTaskId(), filenameHint, baseConfiguration.getS3UploaderMetadataSuffix());
 

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3Uploader.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3Uploader.java
@@ -382,4 +382,43 @@ public class SingularityS3Uploader {
     }
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    SingularityS3Uploader that = (SingularityS3Uploader) o;
+
+    if (uploadMetadata != null ? !uploadMetadata.equals(that.uploadMetadata) : that.uploadMetadata != null) {
+      return false;
+    }
+    if (fileDirectory != null ? !fileDirectory.equals(that.fileDirectory) : that.fileDirectory != null) {
+      return false;
+    }
+    if (s3BucketName != null ? !s3BucketName.equals(that.s3BucketName) : that.s3BucketName != null) {
+      return false;
+    }
+    if (metadataPath != null ? !metadataPath.equals(that.metadataPath) : that.metadataPath != null) {
+      return false;
+    }
+    if (logIdentifier != null ? !logIdentifier.equals(that.logIdentifier) : that.logIdentifier != null) {
+      return false;
+    }
+    return hostname != null ? hostname.equals(that.hostname) : that.hostname == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = uploadMetadata != null ? uploadMetadata.hashCode() : 0;
+    result = 31 * result + (fileDirectory != null ? fileDirectory.hashCode() : 0);
+    result = 31 * result + (s3BucketName != null ? s3BucketName.hashCode() : 0);
+    result = 31 * result + (metadataPath != null ? metadataPath.hashCode() : 0);
+    result = 31 * result + (logIdentifier != null ? logIdentifier.hashCode() : 0);
+    result = 31 * result + (hostname != null ? hostname.hashCode() : 0);
+    return result;
+  }
 }

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3UploaderDriver.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3UploaderDriver.java
@@ -242,6 +242,7 @@ public class SingularityS3UploaderDriver extends WatchServiceHelper implements S
       metrics.getImmediateUploaderCounter().dec();
       immediateUploaders.remove(uploader);
       immediateUploadMetadata.remove(uploader.getUploadMetadata());
+      expiring.remove(uploader);
 
       try {
         LOG.debug("Deleting finished immediate uploader {}", uploader.getMetadataPath());

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3UploaderDriver.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3UploaderDriver.java
@@ -405,13 +405,13 @@ public class SingularityS3UploaderDriver extends WatchServiceHelper implements S
     if (existingUploader != null) {
       if (metadata.getUploadImmediately().isPresent() && metadata.getUploadImmediately().get()) {
         LOG.debug("Existing metadata {} from {} changed to be immediate, forcing upload", metadata, filename);
+        expiring.remove(existingUploader);
         if (canCreateImmediateUploader(metadata)) {
           metrics.getUploaderCounter().dec();
           metrics.getImmediateUploaderCounter().inc();
 
           metadataToUploader.remove(existingUploader.getUploadMetadata());
           uploaderLastHadFilesAt.remove(existingUploader);
-          expiring.remove(existingUploader);
           performImmediateUpload(existingUploader);
           return true;
         } else {

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3UploaderDriver.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3UploaderDriver.java
@@ -283,11 +283,9 @@ public class SingularityS3UploaderDriver extends WatchServiceHelper implements S
         final int foundFiles = uploaderToFuture.getValue().get();
         final boolean isFinished = finishing.get(uploader);
 
-        if (foundFiles == 0) {
-          if (shouldExpire(uploader, isFinished)) {
-            LOG.info("Expiring {}", uploader);
-            expiredUploaders.add(uploader);
-          }
+        if (foundFiles == 0 && shouldExpire(uploader, isFinished)) {
+          LOG.info("Expiring {}", uploader);
+          expiredUploaders.add(uploader);
         } else {
           LOG.trace("Updating uploader {} last expire time", uploader);
           uploaderLastHadFilesAt.put(uploader, now);

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3UploaderDriver.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3UploaderDriver.java
@@ -343,7 +343,7 @@ public class SingularityS3UploaderDriver extends WatchServiceHelper implements S
 
   private void performImmediateUpload(final SingularityS3Uploader uploader) {
     final Set<Path> filesToUpload = Collections
-        .newSetFromMap(new ConcurrentHashMap<Path, Boolean>(metadataToUploader.size() * 2, 0.75f, metadataToUploader.size()));
+        .newSetFromMap(new ConcurrentHashMap<Path, Boolean>(Math.max(metadataToUploader.size(), 1) * 2, 0.75f, Math.max(metadataToUploader.size(), 1)));
     final boolean finished = isFinished(uploader);
     immediateUploaders.put(uploader, executorService.submit(performUploadCallable(uploader, filesToUpload, finished, true)));
   }

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3UploaderDriver.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3UploaderDriver.java
@@ -260,9 +260,10 @@ public class SingularityS3UploaderDriver extends WatchServiceHelper implements S
     }
 
     // Check regular uploaders
-    final Set<Path> filesToUpload = Collections.newSetFromMap(new ConcurrentHashMap<Path, Boolean>(metadataToUploader.size() * 2, 0.75f, metadataToUploader.size()));
-    final Map<SingularityS3Uploader, Future<Integer>> futures = Maps.newHashMapWithExpectedSize(metadataToUploader.size());
-    final Map<SingularityS3Uploader, Boolean> finishing = Maps.newHashMapWithExpectedSize(metadataToUploader.size());
+    int initialExpectedSize = Math.max(metadataToUploader.size(), 1);
+    final Set<Path> filesToUpload = Collections.newSetFromMap(new ConcurrentHashMap<Path, Boolean>(initialExpectedSize * 2, 0.75f, initialExpectedSize));
+    final Map<SingularityS3Uploader, Future<Integer>> futures = Maps.newHashMapWithExpectedSize(initialExpectedSize);
+    final Map<SingularityS3Uploader, Boolean> finishing = Maps.newHashMapWithExpectedSize(initialExpectedSize);
 
     for (final SingularityS3Uploader uploader : metadataToUploader.values()) {
       final boolean isFinished = isFinished(uploader);
@@ -275,7 +276,7 @@ public class SingularityS3UploaderDriver extends WatchServiceHelper implements S
     LOG.info("Waiting on {} future(s)", futures.size());
 
     final long now = System.currentTimeMillis();
-    final Set<SingularityS3Uploader> expiredUploaders = Sets.newHashSetWithExpectedSize(metadataToUploader.size());
+    final Set<SingularityS3Uploader> expiredUploaders = Sets.newHashSetWithExpectedSize(initialExpectedSize);
 
     for (Entry<SingularityS3Uploader, Future<Integer>> uploaderToFuture : futures.entrySet()) {
       final SingularityS3Uploader uploader = uploaderToFuture.getKey();


### PR DESCRIPTION
If the executor is in teardown for a task, we know the task is done writing to logs, so we can trigger the s3 uploader to upload immediately instead of waiting. Also fixes a small piece where some metadata files weren't getting deleted properly by the uploader