### PR TITLE
Better task lifecycle tracking and client updates

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskState.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskState.java
@@ -1,0 +1,110 @@
+package com.hubspot.singularity;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Optional;
+
+public class SingularityTaskState {
+  private final SingularityId id;
+  private final Optional<String> runId;
+  private final Optional<ExtendedTaskState> currentState;
+  private final List<SingularityTaskHistoryUpdate> taskHistory;
+  private final boolean pending;
+
+  @JsonCreator
+  public SingularityTaskState(@JsonProperty("taskId") SingularityId id,
+                              @JsonProperty("runId") Optional<String> runId,
+                              @JsonProperty("currentState") Optional<ExtendedTaskState> currentState,
+                              @JsonProperty("taskHistory") List<SingularityTaskHistoryUpdate> taskHistory,
+                              @JsonProperty("pending") boolean pending) {
+    this.id = id;
+    this.runId = runId;
+    this.currentState = currentState;
+    this.taskHistory = taskHistory != null ? taskHistory : Collections.emptyList();
+    this.pending = pending;
+  }
+
+  public static SingularityTaskState fromTaskHistory(SingularityTaskHistory taskHistory) {
+    return new SingularityTaskState(
+        taskHistory.getTask().getTaskId(),
+        taskHistory.getTask().getTaskRequest().getPendingTask().getRunId(),
+        Optional.of(taskHistory.getLastTaskUpdate().get().getTaskState()),
+        taskHistory.getTaskUpdates(),
+        false
+    );
+  }
+
+  /*
+   * If the task is pending, id will be a SingularityPendingTaskId
+   * otherwise id will be a SingularityTaskId
+   */
+  public SingularityId getId() {
+    return id;
+  }
+
+  public Optional<String> getRunId() {
+    return runId;
+  }
+
+  public Optional<ExtendedTaskState> getCurrentState() {
+    return currentState;
+  }
+
+  public List<SingularityTaskHistoryUpdate> getTaskHistory() {
+    return taskHistory;
+  }
+
+  public boolean isPending() {
+    return pending;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    SingularityTaskState that = (SingularityTaskState) o;
+
+    if (pending != that.pending) {
+      return false;
+    }
+    if (id != null ? !id.equals(that.id) : that.id != null) {
+      return false;
+    }
+    if (runId != null ? !runId.equals(that.runId) : that.runId != null) {
+      return false;
+    }
+    if (currentState != null ? !currentState.equals(that.currentState) : that.currentState != null) {
+      return false;
+    }
+    return taskHistory != null ? taskHistory.equals(that.taskHistory) : that.taskHistory == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = id != null ? id.hashCode() : 0;
+    result = 31 * result + (runId != null ? runId.hashCode() : 0);
+    result = 31 * result + (currentState != null ? currentState.hashCode() : 0);
+    result = 31 * result + (taskHistory != null ? taskHistory.hashCode() : 0);
+    result = 31 * result + (pending ? 1 : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "SingularityTaskState{" +
+        "id=" + id +
+        ", runId=" + runId +
+        ", currentState=" + currentState +
+        ", taskHistory=" + taskHistory +
+        ", pending=" + pending +
+        '}';
+  }
+}

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskState.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskState.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
 
@@ -59,6 +60,21 @@ public class SingularityTaskState {
 
   public boolean isPending() {
     return pending;
+  }
+
+  @JsonIgnore
+  public boolean isFailed() {
+    return currentState.isPresent() && currentState.get().isFailed();
+  }
+
+  @JsonIgnore
+  public boolean isDone() {
+    return currentState.isPresent() && currentState.get().isDone();
+  }
+
+  @JsonIgnore
+  public boolean isSuccess() {
+    return currentState.isPresent() && currentState.get().isSuccess();
   }
 
   @Override

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityMachineChangeRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityMachineChangeRequest.java
@@ -16,6 +16,10 @@ public class SingularityMachineChangeRequest extends SingularityExpiringRequestP
     this(Optional.<Long>absent(), Optional.<String>absent(), message, Optional.<MachineState>absent(), Optional.<Boolean>absent());
   }
 
+  public static SingularityMachineChangeRequest empty() {
+    return new SingularityMachineChangeRequest(Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent());
+  }
+
   @JsonCreator
   public SingularityMachineChangeRequest(@JsonProperty("durationMillis") Optional<Long> durationMillis,
                                          @JsonProperty("actionId") Optional<String> actionId,

--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClientProvider.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClientProvider.java
@@ -32,6 +32,7 @@ public class SingularityClientProvider implements Provider<SingularityClient> {
   private String contextPath = DEFAULT_CONTEXT_PATH;
   private List<String> hosts = Collections.emptyList();
   private Optional<SingularityClientCredentials> credentials = Optional.absent();
+  private boolean ssl = false;
 
   @Inject
   public SingularityClientProvider(@Named(SingularityClientModule.HTTP_CLIENT_NAME) HttpClient httpClient) {
@@ -71,23 +72,24 @@ public class SingularityClientProvider implements Provider<SingularityClient> {
     return this;
   }
 
+  @Inject(optional=true)
+  public SingularityClientProvider setSsl(boolean ssl) {
+    this.ssl = ssl;
+    return this;
+  }
+
   @Override
   public SingularityClient get() {
     Preconditions.checkState(contextPath != null, "contextPath null");
     Preconditions.checkState(!hosts.isEmpty(), "no hosts provided");
-    return new SingularityClient(contextPath, httpClient, hosts, credentials);
+    return new SingularityClient(contextPath, httpClient, hosts, credentials, ssl);
   }
 
   public SingularityClient get(Optional<SingularityClientCredentials> credentials) {
     Preconditions.checkState(contextPath != null, "contextPath null");
     Preconditions.checkState(!hosts.isEmpty(), "no hosts provided");
     Preconditions.checkNotNull(credentials);
-    return new SingularityClient(contextPath, httpClient, hosts, credentials);
-  }
-
-  @Deprecated
-  public SingularityClient buildClient(String contextPath, String hosts) {
-    return new SingularityClient(contextPath, httpClient, hosts);
+    return new SingularityClient(contextPath, httpClient, hosts, credentials, ssl);
   }
 
   static String getClusterMembers(CuratorFramework curator) {

--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClusterManager.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClusterManager.java
@@ -40,7 +40,7 @@ public class SingularityClusterManager {
 
   @SuppressWarnings("deprecation")
   public SingularityClient getClusterClient(String cluster) {
-    return clientProvider.buildClient(contextPath, getClusterMembers(cluster));
+    return clientProvider.setContextPath(contextPath).setHosts(getClusterMembers(cluster)).get();
   }
 
 }

--- a/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/SingularityExecutorCleanup.java
+++ b/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/SingularityExecutorCleanup.java
@@ -81,13 +81,16 @@ public class SingularityExecutorCleanup {
     this.baseConfiguration = baseConfiguration;
     this.executorConfiguration = executorConfiguration;
     this.cleanupConfiguration = cleanupConfiguration;
-    this.singularityClient = singularityClientProvider.get(cleanupConfiguration.getSingularityClientCredentials());
     this.templateManager = templateManager;
     this.mesosClient = mesosClient;
     this.processUtils = new ProcessUtils(LOG);
     this.dockerUtils = dockerUtils;
     this.hostname = hostname;
     this.exceptionNotifier = exceptionNotifier;
+    if (cleanupConfiguration.getSingularityClientCredentials().isPresent()) {
+      singularityClientProvider.setCredentials(cleanupConfiguration.getSingularityClientCredentials().get());
+    }
+    this.singularityClient = singularityClientProvider.setSsl(cleanupConfiguration.isSingularityUseSsl()).get();
   }
 
   public SingularityExecutorCleanupStatistics clean() {

--- a/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/config/SingularityExecutorCleanupConfiguration.java
+++ b/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/config/SingularityExecutorCleanupConfiguration.java
@@ -39,6 +39,9 @@ public class SingularityExecutorCleanupConfiguration extends BaseRunnerConfigura
   @JsonProperty
   private List<String> singularityHosts = Collections.emptyList();
 
+  @JsonProperty
+  private boolean singularityUseSsl = false;
+
   @NotEmpty
   @JsonProperty
   private String singularityContextPath = "";
@@ -117,6 +120,14 @@ public class SingularityExecutorCleanupConfiguration extends BaseRunnerConfigura
 
   public void setSingularityHosts(List<String> singularityHosts) {
     this.singularityHosts = singularityHosts;
+  }
+
+  public boolean isSingularityUseSsl() {
+    return singularityUseSsl;
+  }
+
+  public void setSingularityUseSsl(boolean singularityUseSsl) {
+    this.singularityUseSsl = singularityUseSsl;
   }
 
   public String getSingularityContextPath() {
@@ -212,6 +223,7 @@ public class SingularityExecutorCleanupConfiguration extends BaseRunnerConfigura
         ", executorCleanupResultsSuffix='" + executorCleanupResultsSuffix + '\'' +
         ", cleanupAppDirectoryOfFailedTasksAfterMillis=" + cleanupAppDirectoryOfFailedTasksAfterMillis +
         ", singularityHosts=" + singularityHosts +
+        ", singularityUseSsl=" + singularityUseSsl +
         ", singularityContextPath='" + singularityContextPath + '\'' +
         ", runDockerCleanup=" + runDockerCleanup +
         ", singularityClientCredentials=" + singularityClientCredentials +

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -7,6 +7,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.transaction.CuratorTransactionFinal;
@@ -839,6 +840,14 @@ public class TaskManager extends CuratorAsyncManager {
         return pendingTaskId.getRequestId().equals(requestId);
       }
     }));
+  }
+
+  public List<SingularityPendingTask> getPendingTasksForRequest(final String requestId) {
+    return getAsync(
+        PENDING_PATH_ROOT,
+        getPendingTaskIdsForRequest(requestId).stream().map(this::getPendingPath).collect(Collectors.toList()),
+        pendingTaskTranscoder
+    );
   }
 
   public List<SingularityPendingTask> getPendingTasks() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/SingularityResourceModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/SingularityResourceModule.java
@@ -44,6 +44,7 @@ public class SingularityResourceModule extends AbstractModule {
     bind(UsageResource.class);
     bind(RequestGroupResource.class);
     bind(InactiveSlaveResource.class);
+    bind(TaskTrackerResource.class);
 
     switch (uiConfiguration.getRootUrlMode()) {
     case UI_REDIRECT: {

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskTrackerResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskTrackerResource.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.hubspot.singularity.SingularityPendingTask;
+import com.hubspot.singularity.SingularityService;
 import com.hubspot.singularity.SingularityTaskHistory;
 import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.SingularityTaskState;
@@ -26,7 +27,7 @@ import com.wordnik.swagger.annotations.ApiResponses;
 @Path(TaskTrackerResource.PATH)
 @Produces({MediaType.APPLICATION_JSON})
 public class TaskTrackerResource {
-  public static final String PATH = "/track";
+  public static final String PATH = SingularityService.API_BASE_PATH + "/track";
   private static final Logger LOG = LoggerFactory.getLogger(TaskTrackerResource.class);
 
   private final TaskManager taskManager;

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskTrackerResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskTrackerResource.java
@@ -73,6 +73,7 @@ public class TaskTrackerResource {
     for (SingularityPendingTask pendingTask : taskManager.getPendingTasksForRequest(requestId)) {
       if (pendingTask.getRunId().isPresent() && pendingTask.getRunId().get().equals(runId)) {
         return Optional.of(new SingularityTaskState(
+            Optional.absent(),
             pendingTask.getPendingTaskId(),
             pendingTask.getRunId(),
             Optional.absent(),

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskTrackerResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskTrackerResource.java
@@ -1,0 +1,89 @@
+package com.hubspot.singularity.resources;
+
+import java.util.Collections;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Optional;
+import com.google.inject.Inject;
+import com.hubspot.singularity.SingularityPendingTask;
+import com.hubspot.singularity.SingularityTaskHistory;
+import com.hubspot.singularity.SingularityTaskId;
+import com.hubspot.singularity.SingularityTaskState;
+import com.hubspot.singularity.data.TaskManager;
+import com.hubspot.singularity.data.history.HistoryManager;
+import com.wordnik.swagger.annotations.ApiOperation;
+import com.wordnik.swagger.annotations.ApiResponse;
+import com.wordnik.swagger.annotations.ApiResponses;
+
+@Path(TaskTrackerResource.PATH)
+@Produces({MediaType.APPLICATION_JSON})
+public class TaskTrackerResource {
+  public static final String PATH = "/track";
+  private static final Logger LOG = LoggerFactory.getLogger(TaskTrackerResource.class);
+
+  private final TaskManager taskManager;
+  private final HistoryManager historyManager;
+
+  @Inject
+  public TaskTrackerResource(TaskManager taskManager, HistoryManager historyManager) {
+    this.taskManager = taskManager;
+    this.historyManager = historyManager;
+  }
+
+  @GET
+  @Path("/task/{taskId}")
+  @ApiOperation(value="Get the current state of a task by taskId whether it is active, or inactive")
+  @ApiResponses({
+      @ApiResponse(code=404, message="Task with this id does not exist")
+  })
+  public Optional<SingularityTaskState> getTaskState(@PathParam("taskId") String taskId) {
+    return getTaskStateFromId(SingularityTaskId.valueOf(taskId));
+  }
+
+  @GET
+  @Path("/run/{requestId}/{runId}")
+  @ApiOperation(value="Get the current state of a task by taskId whether it is pending, active, or inactive")
+  @ApiResponses({
+      @ApiResponse(code=404, message="Task with this runId does not exist")
+  })
+  public Optional<SingularityTaskState> getTaskStateByRunId(@PathParam("requestId") String requestId, @PathParam("runId") String runId) {
+    // Check if it's pending
+    for (SingularityPendingTask pendingTask : taskManager.getPendingTasksForRequest(requestId)) {
+      if (pendingTask.getRunId().isPresent() && pendingTask.getRunId().get().equals(runId)) {
+        return Optional.of(new SingularityTaskState(
+            pendingTask.getPendingTaskId(),
+            pendingTask.getRunId(),
+            Optional.absent(),
+            Collections.emptyList(),
+            true
+        ));
+      }
+    }
+    // Check if it's active or inactive
+    Optional<SingularityTaskId> maybeTaskId = taskManager.getTaskByRunId(requestId, runId);
+    if (maybeTaskId.isPresent()) {
+      Optional<SingularityTaskState> maybeTaskState = getTaskStateFromId(maybeTaskId.get());
+      if (maybeTaskState.isPresent()) {
+        return maybeTaskState;
+      }
+    }
+    return Optional.absent();
+  }
+
+  private Optional<SingularityTaskState> getTaskStateFromId(SingularityTaskId singularityTaskId) {
+    Optional<SingularityTaskHistory> maybeTaskHistory = taskManager.getTaskHistory(singularityTaskId).or(historyManager.getTaskHistory(singularityTaskId.toString()));
+    if (maybeTaskHistory.isPresent() && maybeTaskHistory.get().getLastTaskUpdate().isPresent()) {
+      return Optional.of(SingularityTaskState.fromTaskHistory(maybeTaskHistory.get()));
+    } else {
+      return Optional.absent();
+    }
+  }
+}


### PR DESCRIPTION
Added a new endpoint to get information about a task regardless of its state. In the previous setup, you would need to grab it from the history endpoint if it was inactive or the tasks endpoint if it was active. Now, this will also check pending (in the case that you include a runId).

The new endpoint will return a `SingularityTaskState` object if the task exists, which will either have the state or a marker that the task is still pending. the `id` in that object will be a `SingularityTaskId` if it is active/inactive, or a `SingularityPendingTaskId` if it is still pending.

I also took the opportunity to update the SingularityClient a bit (/fixes https://github.com/HubSpot/Singularity/issues/1430)

@gchomatas this will help with tracking the state of the task. Would you want any additional information about it, or is the state mostly what you would be after?