### PR TITLE
separate timeouts for health check and task running

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -162,6 +162,8 @@ public class SingularityConfiguration extends Configuration {
 
   private Optional<Integer> healthcheckMaxTotalTimeoutSeconds = Optional.absent();
 
+  private long killHealthcheckAfterDefaultSeconds = 600;
+
   @NotNull
   private List<Integer> healthcheckFailureStatusCodes = Collections.emptyList();
 
@@ -596,6 +598,10 @@ public class SingularityConfiguration extends Configuration {
     return healthcheckMaxTotalTimeoutSeconds;
   }
 
+  public long getKillHealthcheckAfterDefaultSeconds() {
+    return killHealthcheckAfterDefaultSeconds;
+  }
+
   public Optional<String> getHostname() {
     return Optional.fromNullable(Strings.emptyToNull(hostname));
   }
@@ -961,6 +967,11 @@ public class SingularityConfiguration extends Configuration {
 
   public void setHealthcheckMaxTotalTimeoutSeconds(Optional<Integer> healthcheckMaxTotalTimeoutSeconds) {
     this.healthcheckMaxTotalTimeoutSeconds = healthcheckMaxTotalTimeoutSeconds;
+  }
+
+  public SingularityConfiguration setKillHealthcheckAfterDefaultSeconds(long killHealthcheckAfterDefaultSeconds) {
+    this.killHealthcheckAfterDefaultSeconds = killHealthcheckAfterDefaultSeconds;
+    return this;
   }
 
   public List<Integer> getHealthcheckFailureStatusCodes() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -162,7 +162,7 @@ public class SingularityConfiguration extends Configuration {
 
   private Optional<Integer> healthcheckMaxTotalTimeoutSeconds = Optional.absent();
 
-  private long killHealthcheckAfterDefaultSeconds = 600;
+  private long killTaskIfNotHealthyAfterSeconds = 600;
 
   @NotNull
   private List<Integer> healthcheckFailureStatusCodes = Collections.emptyList();
@@ -598,8 +598,8 @@ public class SingularityConfiguration extends Configuration {
     return healthcheckMaxTotalTimeoutSeconds;
   }
 
-  public long getKillHealthcheckAfterDefaultSeconds() {
-    return killHealthcheckAfterDefaultSeconds;
+  public long getKillTaskIfNotHealthyAfterSeconds() {
+    return killTaskIfNotHealthyAfterSeconds;
   }
 
   public Optional<String> getHostname() {
@@ -969,8 +969,8 @@ public class SingularityConfiguration extends Configuration {
     this.healthcheckMaxTotalTimeoutSeconds = healthcheckMaxTotalTimeoutSeconds;
   }
 
-  public SingularityConfiguration setKillHealthcheckAfterDefaultSeconds(long killHealthcheckAfterDefaultSeconds) {
-    this.killHealthcheckAfterDefaultSeconds = killHealthcheckAfterDefaultSeconds;
+  public SingularityConfiguration setKillTaskIfNotHealthyAfterSeconds(long killTaskIfNotHealthyAfterSeconds) {
+    this.killTaskIfNotHealthyAfterSeconds = killTaskIfNotHealthyAfterSeconds;
     return this;
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
@@ -83,9 +83,9 @@ public class SingularityValidator {
   private final int maxMemoryMbPerRequest;
   private final int maxMemoryMbPerInstance;
   private final Optional<Integer> maxTotalHealthcheckTimeoutSeconds;
-  private final long defaultKillAfterNotHealthySeconds;
+  private final long defaultKillHealthcheckAfterSeconds;
   private final int defaultHealthcheckIntervalSeconds;
-  private final int defaultHealthcheckStartupTimeooutSeconds;
+  private final int defaultHealthcheckStartupTimeoutSeconds;
   private final int defaultHealthcehckMaxRetries;
   private final int defaultHealthcheckResponseTimeoutSeconds;
   private final int maxDecommissioningSlaves;
@@ -130,9 +130,9 @@ public class SingularityValidator {
     this.allowBounceToSameHost = configuration.isAllowBounceToSameHost();
 
     this.maxTotalHealthcheckTimeoutSeconds = configuration.getHealthcheckMaxTotalTimeoutSeconds();
-    this.defaultKillAfterNotHealthySeconds = configuration.getKillAfterTasksDoNotRunDefaultSeconds();
+    this.defaultKillHealthcheckAfterSeconds = configuration.getKillHealthcheckAfterDefaultSeconds();
     this.defaultHealthcheckIntervalSeconds = configuration.getHealthcheckIntervalSeconds();
-    this.defaultHealthcheckStartupTimeooutSeconds = configuration.getStartupTimeoutSeconds();
+    this.defaultHealthcheckStartupTimeoutSeconds = configuration.getStartupTimeoutSeconds();
     this.defaultHealthcehckMaxRetries = configuration.getHealthcheckMaxRetries().or(0);
     this.defaultHealthcheckResponseTimeoutSeconds = configuration.getHealthcheckTimeoutSeconds();
 
@@ -304,7 +304,7 @@ public class SingularityValidator {
       HealthcheckOptions options = deploy.getHealthcheck().get();
       int intervalSeconds = options.getIntervalSeconds().or(defaultHealthcheckIntervalSeconds);
       int httpTimeoutSeconds = options.getResponseTimeoutSeconds().or(defaultHealthcheckResponseTimeoutSeconds);
-      int startupTime = options.getStartupTimeoutSeconds().or(defaultHealthcheckStartupTimeooutSeconds);
+      int startupTime = options.getStartupTimeoutSeconds().or(defaultHealthcheckStartupTimeoutSeconds);
       int attempts = options.getMaxRetries().or(defaultHealthcehckMaxRetries) + 1;
 
       checkBadRequest((startupTime + ((httpTimeoutSeconds + intervalSeconds) * attempts)) > maxTotalHealthcheckTimeoutSeconds.get(),
@@ -314,8 +314,8 @@ public class SingularityValidator {
     if (deploy.getHealthcheck().isPresent() && deploy.getHealthcheck().get().getStartupDelaySeconds().isPresent()) {
       int startUpDelay = deploy.getHealthcheck().get().getStartupDelaySeconds().get();
 
-      checkBadRequest(startUpDelay < defaultKillAfterNotHealthySeconds,
-          String.format("Health check startup delay time must be less than %s (was %s)", defaultKillAfterNotHealthySeconds, startUpDelay));
+      checkBadRequest(startUpDelay < defaultKillHealthcheckAfterSeconds,
+          String.format("Health check startup delay time must be less than max health check run time %s (was %s)", defaultKillHealthcheckAfterSeconds, startUpDelay));
     }
 
     checkBadRequest(deploy.getCommand().isPresent() && !deploy.getExecutorData().isPresent() ||

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
@@ -130,7 +130,7 @@ public class SingularityValidator {
     this.allowBounceToSameHost = configuration.isAllowBounceToSameHost();
 
     this.maxTotalHealthcheckTimeoutSeconds = configuration.getHealthcheckMaxTotalTimeoutSeconds();
-    this.defaultKillHealthcheckAfterSeconds = configuration.getKillHealthcheckAfterDefaultSeconds();
+    this.defaultKillHealthcheckAfterSeconds = configuration.getKillTaskIfNotHealthyAfterSeconds();
     this.defaultHealthcheckIntervalSeconds = configuration.getHealthcheckIntervalSeconds();
     this.defaultHealthcheckStartupTimeoutSeconds = configuration.getStartupTimeoutSeconds();
     this.defaultHealthcehckMaxRetries = configuration.getHealthcheckMaxRetries().or(0);

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityNewTaskChecker.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityNewTaskChecker.java
@@ -113,7 +113,7 @@ public class SingularityNewTaskChecker {
   }
 
   private long getKillAfterHealthcheckRunningForMillis() {
-    return TimeUnit.SECONDS.toMillis(configuration.getKillHealthcheckAfterDefaultSeconds());
+    return TimeUnit.SECONDS.toMillis(configuration.getKillTaskIfNotHealthyAfterSeconds());
   }
 
   private int getDelaySeconds(SingularityTask task, Optional<SingularityRequestWithState> requestWithState) {

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityHealthchecksTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityHealthchecksTest.java
@@ -227,12 +227,12 @@ public class SingularityHealthchecksTest extends SingularitySchedulerTestBase {
 
     SingularityTask task = launchTask(request, deploy, System.currentTimeMillis(), 1, TaskState.TASK_RUNNING);
 
-    Assert.assertEquals(CheckTaskState.CHECK_IF_OVERDUE, newTaskChecker.getTaskState(task, requestManager.getRequest(requestId), healthchecker));
+    Assert.assertEquals(CheckTaskState.CHECK_IF_HEALTHCHECK_OVERDUE, newTaskChecker.getTaskState(task, requestManager.getRequest(requestId), healthchecker));
     Assert.assertTrue(taskManager.getCleanupTaskIds().isEmpty());
 
     taskManager.saveHealthcheckResult(new SingularityTaskHealthcheckResult(Optional.of(503), Optional.of(1000L), System.currentTimeMillis() + 1, Optional.<String> absent(), Optional.<String> absent(), task.getTaskId(), Optional.<Boolean>absent()));
 
-    Assert.assertEquals(CheckTaskState.CHECK_IF_OVERDUE, newTaskChecker.getTaskState(task, requestManager.getRequest(requestId), healthchecker));
+    Assert.assertEquals(CheckTaskState.CHECK_IF_HEALTHCHECK_OVERDUE, newTaskChecker.getTaskState(task, requestManager.getRequest(requestId), healthchecker));
 
     taskManager.saveHealthcheckResult(new SingularityTaskHealthcheckResult(Optional.of(503), Optional.of(1000L), System.currentTimeMillis() + 1, Optional.<String> absent(), Optional.<String> absent(), task.getTaskId(), Optional.<Boolean>absent()));
 


### PR DESCRIPTION
Looks like the max time for a task to get to TASK_RUNNING and pass health checks was set by `killHealthcheckAfterDefaultSeconds`. Since we were previously using `System.currentTimeMillis() - task.getTaskId().getStartedAt()` we used the same clock for both parts.

This separates the checks for the max time it can take to get a task running and then the max time it can take to pass health checks