### PR TITLE
Combine offers to schedule tasks more efficiently

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/mesos/MesosUtils.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/MesosUtils.java
@@ -300,6 +300,17 @@ public final class MesosUtils {
     return true;
   }
 
+  public static boolean allResourceCountsNonNegative(List<Resource> resources) {
+    return doesOfferMatchResources(
+        Optional.absent(),
+        new Resources(0, 0, 0, 0),
+        resources,
+        Collections.emptyList() // TODO: does something special need to be done here for ports?
+                                // TODO: No, because individual ports will have already been subtracted by the time we call this.
+                                // TODO: we just need to check that number of ports is nonnegative
+    );
+  }
+
   public static boolean isTaskDone(TaskState state) {
     return state == TaskState.TASK_FAILED || state == TaskState.TASK_LOST || state == TaskState.TASK_KILLED || state == TaskState.TASK_FINISHED;
   }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/MesosUtils.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/MesosUtils.java
@@ -396,7 +396,7 @@ public final class MesosUtils {
   }
 
   public static List<Resource> combineResources(List<List<Resource>> resourcesList) {
-    List<Resource> resources = resourcesList.remove(0);
+    List<Resource> resources = new ArrayList<>();
     for (List<Resource> resourcesToAdd : resourcesList) {
       for (Resource resource : resourcesToAdd) {
         Optional<Resource> matched = getMatchingResource(resource, resources);
@@ -407,6 +407,7 @@ public final class MesosUtils {
           Resource.Builder resourceBuilder = resource.toBuilder().clone();
           if (resource.hasScalar()) {
             resourceBuilder.setScalar(resource.toBuilder().getScalarBuilder().setValue(resource.getScalar().getValue() + matched.get().getScalar().getValue()).build());
+            resources.set(index, resourceBuilder.build());
           } else if (resource.hasRanges()) {
             Ranges.Builder newRanges = Ranges.newBuilder();
             resource.getRanges().getRangeList().forEach(newRanges::addRange);

--- a/SingularityBase/src/main/java/com/hubspot/mesos/MesosUtils.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/MesosUtils.java
@@ -300,17 +300,6 @@ public final class MesosUtils {
     return true;
   }
 
-  public static boolean allResourceCountsNonNegative(List<Resource> resources) {
-    return doesOfferMatchResources(
-        Optional.absent(),
-        new Resources(0, 0, 0, 0),
-        resources,
-        Collections.emptyList() // TODO: does something special need to be done here for ports?
-                                // TODO: No, because individual ports will have already been subtracted by the time we call this.
-                                // TODO: we just need to check that number of ports is nonnegative
-    );
-  }
-
   public static boolean isTaskDone(TaskState state) {
     return state == TaskState.TASK_FAILED || state == TaskState.TASK_LOST || state == TaskState.TASK_KILLED || state == TaskState.TASK_FINISHED;
   }
@@ -434,8 +423,8 @@ public final class MesosUtils {
     return resources;
   }
 
-  public static Resources buildResourcesFromMesosResourceList(List<Resource> resources) {
-    return new Resources(getNumCpus(resources, Optional.<String>absent()), getMemory(resources, Optional.<String>absent()), getNumPorts(resources), getDisk(resources, Optional.<String>absent()));
+  public static Resources buildResourcesFromMesosResourceList(List<Resource> resources, Optional<String> requiredRole) {
+    return new Resources(getNumCpus(resources, requiredRole), getMemory(resources, requiredRole), getNumPorts(resources), getDisk(resources, requiredRole));
   }
 
   public static Path getTaskDirectoryPath(String taskId) {

--- a/SingularityBase/src/main/java/com/hubspot/mesos/MesosUtils.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/MesosUtils.java
@@ -293,7 +293,7 @@ public final class MesosUtils {
       return false;
     }
 
-    if (!getAllPorts(offerResources).containsAll(otherRequestedPorts)) {
+    if (resources.getNumPorts() > 0 && !getAllPorts(offerResources).containsAll(otherRequestedPorts)) {
       return false;
     }
 

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTask.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTask.java
@@ -1,8 +1,10 @@
 package com.hubspot.singularity;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.Protos.SlaveID;
 import org.apache.mesos.Protos.TaskInfo;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -15,16 +17,27 @@ import com.wordnik.swagger.annotations.ApiModelProperty;
 public class SingularityTask extends SingularityTaskIdHolder {
 
   private final SingularityTaskRequest taskRequest;
-  private final Offer offer;
+  private final List<Offer> offers;
   private final TaskInfo mesosTask;
   private final Optional<String> rackId;
 
   @JsonCreator
+  @Deprecated
   public SingularityTask(@JsonProperty("taskRequest") SingularityTaskRequest taskRequest, @JsonProperty("taskId") SingularityTaskId taskId, @JsonProperty("offer") Offer offer,
       @JsonProperty("mesosTask") TaskInfo task, @JsonProperty("rackId") Optional<String> rackId) {
     super(taskId);
     this.taskRequest = taskRequest;
-    this.offer = offer;
+    this.offers = Collections.singletonList(offer);
+    this.mesosTask = task;
+    this.rackId = rackId;
+  }
+
+  @JsonCreator
+  public SingularityTask(@JsonProperty("taskRequest") SingularityTaskRequest taskRequest, @JsonProperty("taskId") SingularityTaskId taskId, @JsonProperty("offers") List<Offer> offers,
+                         @JsonProperty("mesosTask") TaskInfo task, @JsonProperty("rackId") Optional<String> rackId) {
+    super(taskId);
+    this.taskRequest = taskRequest;
+    this.offers = offers;
     this.mesosTask = task;
     this.rackId = rackId;
   }
@@ -33,9 +46,18 @@ public class SingularityTask extends SingularityTaskIdHolder {
     return taskRequest;
   }
 
+  /*
+   * Use getOffers instead. getOffer will currently return the first offer in getOffers
+   */
+  @Deprecated
   @ApiModelProperty(hidden=true)
   public Offer getOffer() {
-    return offer;
+    return offers.get(0);
+  }
+
+  @ApiModelProperty(hidden=true)
+  public List<Offer> getOffers() {
+    return offers;
   }
 
   @ApiModelProperty(hidden=true)
@@ -57,11 +79,21 @@ public class SingularityTask extends SingularityTaskIdHolder {
     }
   }
 
+  @JsonIgnore
+  public SlaveID getSlaveId() {
+    return offers.get(0).getSlaveId();
+  }
+
+  @JsonIgnore
+  public String getHostname() {
+    return offers.get(0).getHostname();
+  }
+
   @Override
   public String toString() {
     return "SingularityTask{" +
         "taskRequest=" + taskRequest +
-        ", offer=" + MesosUtils.formatForLogging(offer) +
+        ", offer=" + MesosUtils.formatForLogging(offers) +
         ", mesosTask=" + MesosUtils.formatForLogging(mesosTask) +
         ", rackId=" + rackId +
         '}';

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTask.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTask.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
 import com.hubspot.mesos.MesosUtils;
 import com.wordnik.swagger.annotations.ApiModelProperty;
 
@@ -21,25 +22,28 @@ public class SingularityTask extends SingularityTaskIdHolder {
   private final TaskInfo mesosTask;
   private final Optional<String> rackId;
 
-  @JsonCreator
   @Deprecated
-  public SingularityTask(@JsonProperty("taskRequest") SingularityTaskRequest taskRequest, @JsonProperty("taskId") SingularityTaskId taskId, @JsonProperty("offer") Offer offer,
-      @JsonProperty("mesosTask") TaskInfo task, @JsonProperty("rackId") Optional<String> rackId) {
-    super(taskId);
-    this.taskRequest = taskRequest;
-    this.offers = Collections.singletonList(offer);
-    this.mesosTask = task;
-    this.rackId = rackId;
+  public SingularityTask(SingularityTaskRequest taskRequest, SingularityTaskId taskId, Offer offer, TaskInfo task, Optional<String> rackId) {
+    this(taskRequest, taskId, null, Collections.singletonList(offer), task, rackId);
+  }
+
+  public SingularityTask(SingularityTaskRequest taskRequest, SingularityTaskId taskId, List<Offer> offers, TaskInfo task, Optional<String> rackId) {
+    this(taskRequest, taskId, null, offers, task, rackId);
   }
 
   @JsonCreator
-  public SingularityTask(@JsonProperty("taskRequest") SingularityTaskRequest taskRequest, @JsonProperty("taskId") SingularityTaskId taskId, @JsonProperty("offers") List<Offer> offers,
+  public SingularityTask(@JsonProperty("taskRequest") SingularityTaskRequest taskRequest, @JsonProperty("taskId") SingularityTaskId taskId, @JsonProperty("offer") Offer offer, @JsonProperty("offers") List<Offer> offers,
                          @JsonProperty("mesosTask") TaskInfo task, @JsonProperty("rackId") Optional<String> rackId) {
     super(taskId);
+    Preconditions.checkArgument(offer != null ^ offers != null, "Must specify one or the other of offer / offers");
     this.taskRequest = taskRequest;
-    this.offers = offers;
     this.mesosTask = task;
     this.rackId = rackId;
+    if (offer == null) {
+      this.offers = offers;
+    } else {
+      this.offers = Collections.singletonList(offer);
+    }
   }
 
   public SingularityTaskRequest getTaskRequest() {
@@ -51,6 +55,7 @@ public class SingularityTask extends SingularityTaskIdHolder {
    */
   @Deprecated
   @ApiModelProperty(hidden=true)
+  @JsonIgnore
   public Offer getOffer() {
     return offers.get(0);
   }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTask.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTask.java
@@ -35,11 +35,11 @@ public class SingularityTask extends SingularityTaskIdHolder {
   public SingularityTask(@JsonProperty("taskRequest") SingularityTaskRequest taskRequest, @JsonProperty("taskId") SingularityTaskId taskId, @JsonProperty("offer") Offer offer, @JsonProperty("offers") List<Offer> offers,
                          @JsonProperty("mesosTask") TaskInfo task, @JsonProperty("rackId") Optional<String> rackId) {
     super(taskId);
-    Preconditions.checkArgument(offer != null ^ offers != null, "Must specify one or the other of offer / offers");
+    Preconditions.checkArgument(offer != null || offers != null, "Must specify at least one of offer / offers");
     this.taskRequest = taskRequest;
     this.mesosTask = task;
     this.rackId = rackId;
-    if (offer == null) {
+    if (offers != null) {
       this.offers = offers;
     } else {
       this.offers = Collections.singletonList(offer);
@@ -55,7 +55,6 @@ public class SingularityTask extends SingularityTaskIdHolder {
    */
   @Deprecated
   @ApiModelProperty(hidden=true)
-  @JsonIgnore
   public Offer getOffer() {
     return offers.get(0);
   }

--- a/SingularityService/src/main/docker/singularity.yaml
+++ b/SingularityService/src/main/docker/singularity.yaml
@@ -38,3 +38,5 @@ enableCorsFilter: true
 
 disasterDetection:
   enabled: true
+
+cacheOffers: true

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -469,7 +469,7 @@ public class TaskManager extends CuratorAsyncManager {
     for (SingularityTaskId activeTaskId : activeTaskIds) {
       if (activeTaskId.getSanitizedHost().equals(sanitizedHost)) {
         Optional<SingularityTask> maybeTask = getTask(activeTaskId);
-        if (maybeTask.isPresent() && slave.getId().equals(maybeTask.get().getOffer().getSlaveId().getValue())) {
+        if (maybeTask.isPresent() && slave.getId().equals(maybeTask.get().getSlaveId().getValue())) {
           tasks.add(maybeTask.get());
         }
       }
@@ -897,7 +897,7 @@ public class TaskManager extends CuratorAsyncManager {
     }
 
     saveTaskHistoryUpdate(new SingularityTaskHistoryUpdate(task.getTaskId(), now, ExtendedTaskState.TASK_LAUNCHED, Optional.of(msg), Optional.<String>absent()));
-    saveLastActiveTaskStatus(new SingularityTaskStatusHolder(task.getTaskId(), Optional.<TaskStatus>absent(), now, serverId, Optional.of(task.getOffer().getSlaveId().getValue())));
+    saveLastActiveTaskStatus(new SingularityTaskStatusHolder(task.getTaskId(), Optional.<TaskStatus>absent(), now, serverId, Optional.of(task.getSlaveId().getValue())));
 
     try {
       final String path = getTaskPath(task.getTaskId());

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/LastTaskStatusMigration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/LastTaskStatusMigration.java
@@ -46,7 +46,7 @@ public class LastTaskStatusMigration extends ZkDataMigration {
 
           taskStatus = Optional.of(TaskStatus.newBuilder()
               .setTaskId(TaskID.newBuilder().setValue(taskId.getId()))
-              .setSlaveId(task.get().getOffer().getSlaveId())
+              .setSlaveId(task.get().getSlaveId())
               .setState(update.getTaskState().toTaskState().get())
               .build());
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/hooks/LoadBalancerClientImpl.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/hooks/LoadBalancerClientImpl.java
@@ -189,7 +189,7 @@ public class LoadBalancerClientImpl implements LoadBalancerClient {
       final Optional<Long> maybeLoadBalancerPort = task.getPortByIndex(task.getTaskRequest().getDeploy().getLoadBalancerPortIndex().or(0));
 
       if (maybeLoadBalancerPort.isPresent()) {
-        String upstream = String.format("%s:%d", task.getOffer().getHostname(), maybeLoadBalancerPort.get());
+        String upstream = String.format("%s:%d", task.getHostname(), maybeLoadBalancerPort.get());
         Optional<String> group = loadBalancerUpstreamGroup;
 
         if (taskLabelForLoadBalancerUpstreamGroup.isPresent()) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosExecutorInfoSupport.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosExecutorInfoSupport.java
@@ -73,7 +73,7 @@ public class SingularityMesosExecutorInfoSupport implements Managed {
   private void loadDirectoryAndContainer(SingularityTask task) {
     final long start = System.currentTimeMillis();
 
-    final String slaveUri = mesosClient.getSlaveUri(task.getOffer().getHostname());
+    final String slaveUri = mesosClient.getSlaveUri(task.getHostname());
 
     LOG.info("Fetching slave data to find log directory and container id for task {} from uri {}", task.getTaskId(), slaveUri);
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
@@ -263,7 +263,7 @@ public class SingularityMesosOfferScheduler {
     if (LOG.isTraceEnabled()) {
       LOG.trace("Attempting to match task {} resources {} with required role '{}' ({} for task + {} for executor) with remaining offer resources {}",
           pendingTaskId, taskRequestHolder.getTotalResources(), taskRequest.getRequest().getRequiredRole().or("*"),
-          taskRequestHolder.getTaskResources(), taskRequestHolder.getExecutorResources(), offerHolder.getCurrentResources());
+          taskRequestHolder.getTaskResources(), taskRequestHolder.getExecutorResources(), MesosUtils.formatForLogging(offerHolder.getCurrentResources()));
     }
 
     final boolean matchesResources = MesosUtils.doesOfferMatchResources(taskRequest.getRequest().getRequiredRole(),

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
@@ -120,9 +120,9 @@ public class SingularityMesosOfferScheduler {
           return new SingularityOfferHolder(
               offersList,
               numDueTasks,
+              slaveAndRackHelper.getRackIdOrDefault(offersList.get(0)),
               slaveId,
               offersList.get(0).getHostname(),
-              slaveAndRackHelper.getRackIdOrDefault(offersList.get(0)),
               slaveAndRackHelper.getTextAttributes(offersList.get(0)),
               slaveAndRackHelper.getReservedSlaveAttributes(offersList.get(0)));
         })

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 import javax.inject.Singleton;
 
@@ -126,9 +127,9 @@ public class SingularityMesosScheduler implements Scheduler {
         if (!offerHolder.getAcceptedTasks().isEmpty()) {
           offerHolder.launchTasks(driver);
 
-          acceptedOffers.add(offerHolder.getOffer().getId());
+          acceptedOffers.addAll(offerHolder.getOffers().stream().map(Offer::getId).collect(Collectors.toList()));
         } else {
-          offerCache.cacheOffer(driver, start, offerHolder.getOffer());
+          offerHolder.getOffers().forEach((o) -> offerCache.cacheOffer(driver, start, o));
         }
       }
     } catch (Throwable t) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
@@ -125,7 +125,9 @@ public class SingularityMesosScheduler implements Scheduler {
 
       for (SingularityOfferHolder offerHolder : offerHolders) {
         if (!offerHolder.getAcceptedTasks().isEmpty()) {
-          offerHolder.launchTasks(driver);
+          // Here we're launching tasks by accepting every offer the master gave us for this host (i.e., all tasks in this offer holder).
+          // We want to launch these tasks using only the offers absolutely necessary, and cache the rest.
+          offerHolder.launchTasks(driver, offerCache);
 
           acceptedOffers.addAll(offerHolder.getOffers().stream().map(Offer::getId).collect(Collectors.toList()));
         } else {

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
@@ -125,8 +125,6 @@ public class SingularityMesosScheduler implements Scheduler {
 
       for (SingularityOfferHolder offerHolder : offerHolders) {
         if (!offerHolder.getAcceptedTasks().isEmpty()) {
-          // Here we're launching tasks by accepting every offer the master gave us for this host (i.e., all tasks in this offer holder).
-          // We want to launch these tasks using only the offers absolutely necessary, and cache the rest.
           List<Offer> leftoverOffers = offerHolder.launchTasksAndGetUnusedOffers(driver);
 
           leftoverOffers.forEach((o) -> {

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
@@ -127,9 +127,15 @@ public class SingularityMesosScheduler implements Scheduler {
         if (!offerHolder.getAcceptedTasks().isEmpty()) {
           // Here we're launching tasks by accepting every offer the master gave us for this host (i.e., all tasks in this offer holder).
           // We want to launch these tasks using only the offers absolutely necessary, and cache the rest.
-          offerHolder.launchTasks(driver, offerCache);
+          List<Offer> leftoverOffers = offerHolder.launchTasksAndGetUnusedOffers(driver);
 
-          acceptedOffers.addAll(offerHolder.getOffers().stream().map(Offer::getId).collect(Collectors.toList()));
+          leftoverOffers.forEach((o) -> {
+            offerCache.cacheOffer(driver, start, o);
+          });
+
+          List<Offer> offersAcceptedFromSlave = offerHolder.getOffers();
+          offersAcceptedFromSlave.removeAll(leftoverOffers);
+          acceptedOffers.addAll(offersAcceptedFromSlave.stream().map(Offer::getId).collect(Collectors.toList()));
         } else {
           offerHolder.getOffers().forEach((o) -> offerCache.cacheOffer(driver, start, o));
         }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityOfferHolder.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityOfferHolder.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.mesos.Protos;
+import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.Resource;
 import org.apache.mesos.Protos.Status;
 import org.apache.mesos.Protos.TaskInfo;
@@ -100,6 +101,7 @@ public class SingularityOfferHolder {
   }
 
   public void addMatchedTask(SingularityTask task) {
+    LOG.trace("Accepting task {} for offers {}", task.getTaskId(), offers.stream().map(Offer::getId).collect(Collectors.toList()));
     acceptedTasks.add(task);
 
     // subtract task resources from offer

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityOfferHolder.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityOfferHolder.java
@@ -154,7 +154,7 @@ public class SingularityOfferHolder {
 
       if (offerCanBeReclaimedFromUnusedResources) {
         // We can reclaim this offer in its entirety! Pull all of its resources out of the combined pool for this SingularityOfferHolder instance.
-        LOG.info(
+        LOG.trace(
             "Able to reclaim offer {} from unused resources in OfferHolder from host {}. cpu: {}, mem: {}, disk: {}",
             offer.getId().getValue(), offer.getHostname(), MesosUtils.getNumCpus(offer), MesosUtils.getMemory(offer), MesosUtils.getDisk(offer)
         );

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityOfferHolder.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityOfferHolder.java
@@ -15,6 +15,7 @@ import org.apache.mesos.SchedulerDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import com.hubspot.mesos.JavaUtils;
 import com.hubspot.mesos.MesosUtils;
@@ -113,7 +114,7 @@ public class SingularityOfferHolder {
     }
   }
 
-  public void launchTasks(SchedulerDriver driver, OfferCache cache) {
+  public List<Offer> launchTasksAndGetUnusedOffers(SchedulerDriver driver) {
     final List<TaskInfo> toLaunch = Lists.newArrayListWithCapacity(acceptedTasks.size());
     final List<SingularityTaskId> taskIds = Lists.newArrayListWithCapacity(acceptedTasks.size());
 
@@ -126,20 +127,50 @@ public class SingularityOfferHolder {
 
     // At this point, `currentResources` contains a list of unused resources, because we subtracted out the required resources of every task we accepted.
     // Let's try and reclaim offers by trying to pull each offer's list of resources out of the combined pool of leftover resources.
-    List<Offer> neededOffers = offers.stream().filter(o -> {
-      List<Resource> remainingAfterSavingOffer = MesosUtils.subtractResources(currentResources, o.getResourcesList());
-      if (MesosUtils.allResourceCountsNonNegative(remainingAfterSavingOffer)) {
-        cache.cacheOffer(driver, System.currentTimeMillis(), o); // TODO: do we need this timestamp to be something specific, e.g. the time at which we got the offer originally?
-        currentResources = remainingAfterSavingOffer;
-        return false;
-      } else {
-        return true;
+    // n.b., This is currently not optimal. We just look through the offers in this instance and try to reclaim them with no particular priority or order.
+    Map<Boolean, List<Offer>> partitionedOffers = offers.stream().collect(Collectors.partitioningBy(offer -> {
+      List<Long> ports = MesosUtils.getAllPorts(offer.getResourcesList());
+      boolean offerCanBeReclaimedFromUnusedResources = offer.getResourcesList().stream()
+          // When matching resource requirements with resource offers, we need to take roles into account.
+          // Therefore, before we can check if this offer can be reclaimed from the pool of Resources in this SingularityOfferHolder,
+          // we have to group the offer's Resources by role first.
+          .collect(Collectors.groupingBy(Resource::getRole))
+          .entrySet().stream()
+          .map((entry) -> {
+            // Now, for each set of offer Resources grouped by role...
+            String role = entry.getKey();
+            List<Resource> offerResources = entry.getValue();
+            Optional<String> maybeRole = (!role.equals("") && !role.equals("*")) ? Optional.of(role) : Optional.absent();
+            // ...Check if we can pull the Resources belonging to this offer out of the pool of `currentResources`.
+            return MesosUtils.doesOfferMatchResources(
+                maybeRole,
+                MesosUtils.buildResourcesFromMesosResourceList(offerResources, maybeRole),
+                currentResources,
+                ports
+            );
+          }).reduce(true, (x, y) -> x && y);
+      //      ^ the `reduce()` call determines whether we can pull *every* role-group of Resources belonging to this offer
+      //        out of the combined `currentResources` pool.
+
+      if (offerCanBeReclaimedFromUnusedResources) {
+        // We can reclaim this offer in its entirety! Pull all of its resources out of the combined pool for this SingularityOfferHolder instance.
+        LOG.info(
+            "Able to reclaim offer {} from unused resources in OfferHolder from host {}. cpu: {}, mem: {}, disk: {}",
+            offer.getId(), offer.getHostname(), MesosUtils.getNumCpus(offer), MesosUtils.getMemory(offer), MesosUtils.getDisk(offer)
+        );
+        currentResources = MesosUtils.subtractResources(currentResources, offer.getResourcesList());
       }
-    }).collect(Collectors.toList());
+
+      return offerCanBeReclaimedFromUnusedResources;
+    }));
+
+    List<Offer> leftoverOffers = partitionedOffers.get(true);
+    List<Offer> neededOffers = partitionedOffers.get(false);
 
     Status initialStatus = driver.launchTasks(neededOffers.stream().map(Protos.Offer::getId).collect(Collectors.toList()), toLaunch);
 
     LOG.info("{} tasks ({}) launched with status {}", taskIds.size(), taskIds, initialStatus);
+    return leftoverOffers;
   }
 
   public List<SingularityTask> getAcceptedTasks() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityOfferHolder.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityOfferHolder.java
@@ -138,4 +138,22 @@ public class SingularityOfferHolder {
   public List<Protos.Offer> getOffers() {
     return offers;
   }
+
+  @Override
+  public String toString() {
+    return "SingularityOfferHolder{" +
+        "offers=" + offers +
+        ", acceptedTasks=" + acceptedTasks +
+        ", rejectedPendingTaskIds=" + rejectedPendingTaskIds +
+        ", currentResources=" + currentResources +
+        ", roles=" + roles +
+        ", rackId='" + rackId + '\'' +
+        ", slaveId='" + slaveId + '\'' +
+        ", hostname='" + hostname + '\'' +
+        ", sanitizedHost='" + sanitizedHost + '\'' +
+        ", sanitizedRackId='" + sanitizedRackId + '\'' +
+        ", textAttributes=" + textAttributes +
+        ", reservedSlaveAttributes=" + reservedSlaveAttributes +
+        '}';
+  }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityOfferHolder.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityOfferHolder.java
@@ -156,7 +156,7 @@ public class SingularityOfferHolder {
         // We can reclaim this offer in its entirety! Pull all of its resources out of the combined pool for this SingularityOfferHolder instance.
         LOG.info(
             "Able to reclaim offer {} from unused resources in OfferHolder from host {}. cpu: {}, mem: {}, disk: {}",
-            offer.getId(), offer.getHostname(), MesosUtils.getNumCpus(offer), MesosUtils.getMemory(offer), MesosUtils.getDisk(offer)
+            offer.getId().getValue(), offer.getHostname(), MesosUtils.getNumCpus(offer), MesosUtils.getMemory(offer), MesosUtils.getDisk(offer)
         );
         currentResources = MesosUtils.subtractResources(currentResources, offer.getResourcesList());
       }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
@@ -76,10 +76,10 @@ public class SingularitySlaveAndRackManager {
     this.activeSlavesLost = activeSlavesLost;
   }
 
-  public SlaveMatchState doesOfferMatch(SingularityOfferHolder offer, SingularityTaskRequest taskRequest, SingularitySchedulerStateCache stateCache) {
-    final String host = offer.getOffer().getHostname();
-    final String rackId = offer.getRackId();
-    final String slaveId = offer.getOffer().getSlaveId().getValue();
+  public SlaveMatchState doesOfferMatch(SingularityOfferHolder offerHolder, SingularityTaskRequest taskRequest, SingularitySchedulerStateCache stateCache) {
+    final String host = offerHolder.getHostname();
+    final String rackId = offerHolder.getRackId();
+    final String slaveId = offerHolder.getSlaveId();
 
     final MachineState currentSlaveState = stateCache.getSlave(slaveId).get().getCurrentState().getState();
 
@@ -108,7 +108,7 @@ public class SingularitySlaveAndRackManager {
       }
     }
 
-    if (!isSlaveAttributesMatch(offer, taskRequest)) {
+    if (!isSlaveAttributesMatch(offerHolder, taskRequest)) {
       return SlaveMatchState.SLAVE_ATTRIBUTES_DO_NOT_MATCH;
     }
 
@@ -128,8 +128,8 @@ public class SingularitySlaveAndRackManager {
     double numOtherDeploysOnSlave = 0;
     boolean taskLaunchedFromBounceWithActionId = taskRequest.getPendingTask().getPendingTaskId().getPendingType() == PendingType.BOUNCE && taskRequest.getPendingTask().getActionId().isPresent();
 
-    final String sanitizedHost = offer.getSanitizedHost();
-    final String sanitizedRackId = offer.getSanitizedRackId();
+    final String sanitizedHost = offerHolder.getSanitizedHost();
+    final String sanitizedRackId = offerHolder.getSanitizedRackId();
     Collection<SingularityTaskId> cleaningTasks = stateCache.getCleaningTasks();
 
     for (SingularityTaskId taskId : stateCache.getActiveTaskIdsForRequest(taskRequest.getRequest().getId())) {
@@ -490,7 +490,7 @@ public class SingularitySlaveAndRackManager {
     for (SingularityTaskId activeTaskId : stateCache.getActiveTaskIds()) {
       if (!activeTaskId.equals(taskId) && activeTaskId.getSanitizedHost().equals(taskId.getSanitizedHost())) {
         Optional<SingularityTask> maybeTask = taskManager.getTask(activeTaskId);
-        if (maybeTask.isPresent() && slaveId.equals(maybeTask.get().getOffer().getSlaveId().getValue())) {
+        if (maybeTask.isPresent() && slaveId.equals(maybeTask.get().getSlaveId().getValue())) {
           return true;
         }
       }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
@@ -77,7 +77,6 @@ public class SingularitySlaveAndRackManager {
   }
 
   public SlaveMatchState doesOfferMatch(SingularityOfferHolder offerHolder, SingularityTaskRequest taskRequest, SingularitySchedulerStateCache stateCache) {
-    LOG.info("OfferHolder: {}", offerHolder);
     final String host = offerHolder.getHostname();
     final String rackId = offerHolder.getRackId();
     final String slaveId = offerHolder.getSlaveId();

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
@@ -77,6 +77,7 @@ public class SingularitySlaveAndRackManager {
   }
 
   public SlaveMatchState doesOfferMatch(SingularityOfferHolder offerHolder, SingularityTaskRequest taskRequest, SingularitySchedulerStateCache stateCache) {
+    LOG.info("OfferHolder: {}", offerHolder);
     final String host = offerHolder.getHostname();
     final String rackId = offerHolder.getRackId();
     final String slaveId = offerHolder.getSlaveId();

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityTaskSizeOptimizer.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityTaskSizeOptimizer.java
@@ -1,5 +1,8 @@
 package com.hubspot.singularity.mesos;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.TaskInfo;
 
@@ -31,10 +34,10 @@ public class SingularityTaskSizeOptimizer {
 
     mesosTask.clearData();
 
-    Offer.Builder offer = task.getOffer().toBuilder();
-
-    offer.clearExecutorIds();
-    offer.clearResources();
+    List<Offer> offers = task.getOffers()
+        .stream()
+        .map((o) -> o.toBuilder().clearExecutorIds().clearResources().build())
+        .collect(Collectors.toList());
 
     SingularityTaskRequest taskRequest = task.getTaskRequest();
 
@@ -48,7 +51,7 @@ public class SingularityTaskSizeOptimizer {
           deploy.build(), task.getTaskRequest().getPendingTask());
     }
 
-    return new SingularityTask(taskRequest, task.getTaskId(), offer.build(), mesosTask.build(), task.getRackId());
+    return new SingularityTask(taskRequest, task.getTaskId(), offers, mesosTask.build(), task.getRackId());
   }
 
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/SandboxResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/SandboxResource.java
@@ -102,7 +102,7 @@ public class SandboxResource extends AbstractHistoryResource {
     final String currentDirectory = getCurrentDirectory(taskId, path);
     final SingularityTaskHistory history = checkHistory(taskId);
 
-    final String slaveHostname = history.getTask().getOffer().getHostname();
+    final String slaveHostname = history.getTask().getHostname();
     final String pathToRoot = history.getDirectory().get();
     final String fullPath = new File(pathToRoot, currentDirectory).toString();
 
@@ -137,7 +137,7 @@ public class SandboxResource extends AbstractHistoryResource {
 
     final SingularityTaskHistory history = checkHistory(taskId);
 
-    final String slaveHostname = history.getTask().getOffer().getHostname();
+    final String slaveHostname = history.getTask().getHostname();
     final String fullPath = new File(history.getDirectory().get(), path).toString();
 
     try {

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
@@ -261,13 +261,13 @@ public class TaskResource extends AbstractLeaderAwareResource {
       executorIdToMatch = taskId;
     }
 
-    for (MesosTaskMonitorObject taskMonitor : mesosClient.getSlaveResourceUsage(task.getOffer().getHostname())) {
+    for (MesosTaskMonitorObject taskMonitor : mesosClient.getSlaveResourceUsage(task.getHostname())) {
       if (taskMonitor.getExecutorId().equals(executorIdToMatch)) {
         return taskMonitor.getStatistics();
       }
     }
 
-    throw notFound("Couldn't find executor %s for %s on slave %s", executorIdToMatch, taskId, task.getOffer().getHostname());
+    throw notFound("Couldn't find executor %s for %s on slave %s", executorIdToMatch, taskId, task.getHostname());
   }
 
   @GET

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityHealthchecker.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityHealthchecker.java
@@ -212,7 +212,7 @@ public class SingularityHealthchecker {
 
     HealthcheckOptions options = task.getTaskRequest().getDeploy().getHealthcheck().get();
 
-    final String hostname = task.getOffer().getHostname();
+    final String hostname = task.getHostname();
 
     Optional<Long> healthcheckPort = options.getPortNumber().or(task.getPortByIndex(options.getPortIndex().or(0)));
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularitySchedulerPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularitySchedulerPoller.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import javax.inject.Singleton;
 
@@ -83,18 +84,16 @@ public class SingularitySchedulerPoller extends SingularityLeaderOnlyPoller {
     int launchedTasks = 0;
 
     for (SingularityOfferHolder offerHolder : offerHolders) {
-      for (Offer offer : offerHolder.getOffers()) {
-        CachedOffer cachedOffer = offerIdToCachedOffer.get(offer.getId().getValue());
+        List<CachedOffer> cachedOffersFromHolder = offerHolder.getOffers().stream().map((o) -> offerIdToCachedOffer.get(o.getId().getValue())).collect(Collectors.toList());
 
         if (!offerHolder.getAcceptedTasks().isEmpty()) {
           offerHolder.launchTasks(driver.get());
           launchedTasks += offerHolder.getAcceptedTasks().size();
           acceptedOffers++;
-          offerCache.useOffer(cachedOffer);
+          cachedOffersFromHolder.forEach(offerCache::useOffer);
         } else {
-          offerCache.returnOffer(cachedOffer);
+          cachedOffersFromHolder.forEach(offerCache::returnOffer);
         }
-      }
     }
 
     LOG.info("Launched {} tasks on {} cached offers (returned {}) in {}", launchedTasks, acceptedOffers, offerHolders.size() - acceptedOffers, JavaUtils.duration(start));

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularitySchedulerPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularitySchedulerPoller.java
@@ -87,7 +87,7 @@ public class SingularitySchedulerPoller extends SingularityLeaderOnlyPoller {
         List<CachedOffer> cachedOffersFromHolder = offerHolder.getOffers().stream().map((o) -> offerIdToCachedOffer.get(o.getId().getValue())).collect(Collectors.toList());
 
         if (!offerHolder.getAcceptedTasks().isEmpty()) {
-          offerHolder.launchTasks(driver.get());
+          offerHolder.launchTasks(driver.get(), offerCache);
           launchedTasks += offerHolder.getAcceptedTasks().size();
           acceptedOffers++;
           cachedOffersFromHolder.forEach(offerCache::useOffer);

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularitySchedulerPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularitySchedulerPoller.java
@@ -83,15 +83,17 @@ public class SingularitySchedulerPoller extends SingularityLeaderOnlyPoller {
     int launchedTasks = 0;
 
     for (SingularityOfferHolder offerHolder : offerHolders) {
-      CachedOffer cachedOffer = offerIdToCachedOffer.get(offerHolder.getOffer().getId().getValue());
+      for (Offer offer : offerHolder.getOffers()) {
+        CachedOffer cachedOffer = offerIdToCachedOffer.get(offer.getId().getValue());
 
-      if (!offerHolder.getAcceptedTasks().isEmpty()) {
-        offerHolder.launchTasks(driver.get());
-        launchedTasks += offerHolder.getAcceptedTasks().size();
-        acceptedOffers++;
-        offerCache.useOffer(cachedOffer);
-      } else {
-        offerCache.returnOffer(cachedOffer);
+        if (!offerHolder.getAcceptedTasks().isEmpty()) {
+          offerHolder.launchTasks(driver.get());
+          launchedTasks += offerHolder.getAcceptedTasks().size();
+          acceptedOffers++;
+          offerCache.useOffer(cachedOffer);
+        } else {
+          offerCache.returnOffer(cachedOffer);
+        }
       }
     }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularitySchedulerPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularitySchedulerPoller.java
@@ -87,9 +87,16 @@ public class SingularitySchedulerPoller extends SingularityLeaderOnlyPoller {
         List<CachedOffer> cachedOffersFromHolder = offerHolder.getOffers().stream().map((o) -> offerIdToCachedOffer.get(o.getId().getValue())).collect(Collectors.toList());
 
         if (!offerHolder.getAcceptedTasks().isEmpty()) {
-          offerHolder.launchTasks(driver.get(), offerCache);
+          List<Offer> unusedOffers = offerHolder.launchTasksAndGetUnusedOffers(driver.get());
           launchedTasks += offerHolder.getAcceptedTasks().size();
-          acceptedOffers++;
+          acceptedOffers += cachedOffersFromHolder.size() - unusedOffers.size();
+
+          // Return to the cache those offers which we checked out of the cache, but didn't end up using.
+          List<CachedOffer> unusedCachedOffers = unusedOffers.stream().map((o) -> offerIdToCachedOffer.get(o.getId().getValue())).collect(Collectors.toList());
+          unusedCachedOffers.forEach(offerCache::returnOffer);
+
+          // Notify the cache of the cached offers that we did use.
+          cachedOffersFromHolder.removeAll(unusedCachedOffers);
           cachedOffersFromHolder.forEach(offerCache::useOffer);
         } else {
           cachedOffersFromHolder.forEach(offerCache::returnOffer);

--- a/SingularityService/src/main/java/com/hubspot/singularity/smtp/MailTemplateHelpers.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/smtp/MailTemplateHelpers.java
@@ -184,7 +184,7 @@ public class MailTemplateHelpers {
       return Optional.absent();
     }
 
-    final String slaveHostname = task.get().getOffer().getHostname();
+    final String slaveHostname = task.get().getHostname();
 
     final String fullPath = String.format("%s/%s", directory.get(), filename);
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/smtp/SmtpMailer.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/smtp/SmtpMailer.java
@@ -158,7 +158,7 @@ public class SmtpMailer implements SingularityMailer, Managed {
     templateProperties.put("color", emailType.getColor());
 
     if (task.isPresent()) {
-      templateProperties.put("slaveHostname", task.get().getOffer().getHostname());
+      templateProperties.put("slaveHostname", task.get().getHostname());
       if (task.get().getTaskRequest().getPendingTask().getCmdLineArgsList().isPresent()) {
         templateProperties.put("extraCmdLineArguments", task.get().getTaskRequest().getPendingTask().getCmdLineArgsList().get());
       }

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilderTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilderTest.java
@@ -80,6 +80,10 @@ public class SingularityMesosTaskBuilderTest {
     taskResources = new Resources(1, 1, 0, 0);
     executorResources = new Resources(0.1, 1, 0, 0);
 
+    when(slaveAndRackHelper.getRackId(offer)).thenReturn(Optional.absent());
+    when(slaveAndRackHelper.getMaybeTruncatedHost(offer)).thenReturn("host");
+    when(slaveAndRackHelper.getRackIdOrDefault(offer)).thenReturn("DEFAULT");
+
     offer = Offer.newBuilder()
         .setSlaveId(SlaveID.newBuilder().setValue("1"))
         .setId(OfferID.newBuilder().setValue("1"))
@@ -89,16 +93,11 @@ public class SingularityMesosTaskBuilderTest {
     offerHolder = new SingularityOfferHolder(
         Collections.singletonList(offer),
         1,
-        slaveAndRackHelper.getRackIdOrDefault(offer),
+        "DEFAULT",
         offer.getSlaveId().getValue(),
         offer.getHostname(),
         Collections.emptyMap(),
         Collections.emptyMap());
-
-
-    when(slaveAndRackHelper.getRackId(offer)).thenReturn(Optional.<String> absent());
-    when(slaveAndRackHelper.getMaybeTruncatedHost(offer)).thenReturn("host");
-    when(slaveAndRackHelper.getRackIdOrDefault(offer)).thenReturn("DEFAULT");
   }
 
   @Test

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/MesosUtilsTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/MesosUtilsTest.java
@@ -17,6 +17,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.hubspot.mesos.MesosUtils;
 import com.hubspot.singularity.ExtendedTaskState;
@@ -29,6 +30,28 @@ public class MesosUtilsTest {
     Resource resource = MesosUtils.getPortsResource(numPorts, buildOffer(ranges));
 
     Assert.assertEquals(numPorts, MesosUtils.getNumPorts(Collections.singletonList(resource)));
+  }
+
+  @Test
+  public void testResourceAddition() {
+    List<List<Resource>> toAdd = ImmutableList.of(
+        ImmutableList.of(
+            Resource.newBuilder().setType(Type.SCALAR).setName(MesosUtils.CPUS).setScalar(Scalar.newBuilder().setValue(1)).build(),
+            Resource.newBuilder().setType(Type.SCALAR).setName(MesosUtils.MEMORY).setScalar(Scalar.newBuilder().setValue(1024)).build()
+        ),
+        ImmutableList.of(
+            Resource.newBuilder().setType(Type.SCALAR).setName(MesosUtils.CPUS).setScalar(Scalar.newBuilder().setValue(2)).build(),
+            Resource.newBuilder().setType(Type.SCALAR).setName(MesosUtils.MEMORY).setScalar(Scalar.newBuilder().setValue(1024)).build()
+        ),
+        ImmutableList.of(
+            Resource.newBuilder().setType(Type.SCALAR).setName(MesosUtils.CPUS).setScalar(Scalar.newBuilder().setValue(3)).build(),
+            Resource.newBuilder().setType(Type.SCALAR).setName(MesosUtils.MEMORY).setScalar(Scalar.newBuilder().setValue(1024)).build()
+        )
+    );
+    List<Resource> combined = MesosUtils.combineResources(toAdd);
+
+    Assert.assertEquals(6, MesosUtils.getNumCpus(combined, Optional.absent()), 0.1);
+    Assert.assertEquals(3072, MesosUtils.getMemory(combined, Optional.absent()), 0.1);
   }
 
   @Test

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityOfferPerformanceTestRunner.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityOfferPerformanceTestRunner.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Random;
 
 import org.apache.mesos.Protos.Offer;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.hubspot.mesos.JavaUtils;
@@ -17,6 +18,7 @@ public class SingularityOfferPerformanceTestRunner extends SingularitySchedulerT
   }
 
   @Test
+  @Ignore
   public void testOfferCache() {
     long start = System.currentTimeMillis();
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import javax.ws.rs.WebApplicationException;
 
@@ -436,7 +437,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     Set<String> offerIds = Sets.newHashSet();
 
     for (SingularityTask activeTask : taskManager.getActiveTasks()) {
-      offerIds.add(activeTask.getOffer().getId().getValue());
+      offerIds.addAll(activeTask.getOffers().stream().map((o) -> o.getId().getValue()).collect(Collectors.toList()));
     }
 
     Assert.assertTrue(offerIds.size() == 2);
@@ -655,7 +656,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
 
     Assert.assertEquals(1, taskManager.getNumActiveTasks());
 
-    slaveResource.decommissionSlave(taskManager.getActiveTasks().get(0).getOffer().getSlaveId().getValue(), null);
+    slaveResource.decommissionSlave(taskManager.getActiveTasks().get(0).getSlaveId().getValue(), null);
 
     scheduler.checkForDecomissions(stateCacheProvider.get());
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -82,6 +82,7 @@ import com.hubspot.singularity.api.SingularityScaleRequest;
 import com.hubspot.singularity.api.SingularityUnpauseRequest;
 import com.hubspot.singularity.data.AbstractMachineManager.StateChangeResult;
 import com.hubspot.singularity.data.SingularityValidator;
+import com.hubspot.singularity.mesos.OfferCache;
 import com.hubspot.singularity.mesos.SingularityMesosTaskPrioritizer;
 import com.hubspot.singularity.scheduler.SingularityDeployHealthHelper.DeployHealth;
 import com.hubspot.singularity.scheduler.SingularityTaskReconciliation.ReconciliationState;
@@ -98,6 +99,9 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
 
   @Inject
   private SingularitySchedulerPoller schedulerPoller;
+
+  @Inject
+  private OfferCache offerCache;
 
   public SingularitySchedulerTest() {
     super(false);
@@ -186,6 +190,67 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     Assert.assertEquals(1, taskManager.getActiveTasks().size());
 
     Assert.assertEquals(2, taskManager.getActiveTasks().get(0).getOffers().size());
+  }
+
+  @Test
+  public void testLeftoverCachedOffersAreReturnedToCache() throws Exception {
+    configuration.setCacheOffers(true);
+
+    Offer neededOffer = createOffer(1, 128, "slave1", "host1", Optional.absent(), Collections.emptyMap(), new String[]{"80:81"});
+    Offer extraOffer = createOffer(4, 256, "slave1", "host1", Optional.absent(), Collections.emptyMap(), new String[]{"83:84"});
+
+    sms.resourceOffers(driver, ImmutableList.of(neededOffer, extraOffer));
+
+    initRequest();
+
+    firstDeploy = initAndFinishDeploy(request, new SingularityDeployBuilder(request.getId(), firstDeployId)
+        .setCommand(Optional.of("sleep 100")).setResources(Optional.of(new Resources(1, 128, 2, 0)))
+    );
+
+    requestManager.addToPendingQueue(
+        new SingularityPendingRequest(
+            requestId,
+            firstDeployId,
+            System.currentTimeMillis(),
+            Optional.absent(),
+            PendingType.TASK_DONE,
+            Optional.absent(),
+            Optional.absent()
+        )
+    );
+
+    schedulerPoller.runActionOnPoll();
+
+    List<Offer> cachedOffers = offerCache.peekOffers();
+    Assert.assertEquals(1, cachedOffers.size());
+  }
+
+  @Test
+  public void testLeftoverNewOffersAreCached() {
+    configuration.setCacheOffers(true);
+
+    Offer neededOffer = createOffer(1, 128, "slave1", "host1");
+    Offer extraOffer = createOffer(4, 256, "slave1", "host1");
+
+    initRequest();
+    initFirstDeploy();
+
+    requestManager.addToPendingQueue(
+        new SingularityPendingRequest(
+            requestId,
+            firstDeployId,
+            System.currentTimeMillis(),
+            Optional.absent(),
+            PendingType.TASK_DONE,
+            Optional.absent(),
+            Optional.absent()
+        )
+    );
+
+    sms.resourceOffers(driver, ImmutableList.of(neededOffer, extraOffer));
+
+    List<Offer> cachedOffers = offerCache.peekOffers();
+    Assert.assertEquals(1, cachedOffers.size());
   }
 
   @Test

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -418,8 +418,8 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
 
     sms.resourceOffers(driver, Arrays.asList(createOffer(2, 1024), createOffer(1, 1024)));
 
-    Assert.assertTrue(taskManager.getActiveTaskIds().size() == 3);
-    Assert.assertTrue(taskManager.getPendingTaskIds().size() == 7);
+    Assert.assertEquals(3, taskManager.getActiveTaskIds().size());
+    Assert.assertEquals(7, taskManager.getPendingTaskIds().size());
   }
 
   @Test

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -22,6 +22,7 @@ import org.mockito.Matchers;
 import org.mockito.Mockito;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
@@ -163,6 +164,28 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     resourceOffers();
 
     Assert.assertEquals(2, taskManager.getActiveTasks().size());
+  }
+
+  @Test
+  public void testOfferCombination() {
+    configuration.setCacheOffers(true);
+    configuration.setOfferCacheSize(2);
+
+    // Each are half of needed memory
+    Offer offer1 = createOffer(1, 64, "slave1", "host1");
+    Offer offer2 = createOffer(1, 64, "slave1", "host1");
+    sms.resourceOffers(driver, ImmutableList.of(offer1, offer2));
+
+    initRequest();
+    initFirstDeploy();
+    requestManager.addToPendingQueue(new SingularityPendingRequest(requestId, firstDeployId, System.currentTimeMillis(), Optional.absent(), PendingType.TASK_DONE,
+        Optional.absent(), Optional.absent()));
+
+    schedulerPoller.runActionOnPoll();
+
+    Assert.assertEquals(1, taskManager.getActiveTasks().size());
+
+    Assert.assertEquals(2, taskManager.getActiveTasks().get(0).getOffers().size());
   }
 
   @Test

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTestBase.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTestBase.java
@@ -317,7 +317,7 @@ public class SingularitySchedulerTestBase extends SingularityCuratorTestBase {
         .setName("name")
         .build();
 
-    SingularityTask task = new SingularityTask(taskRequest, taskId, offer, taskInfo, Optional.of("rack1"));
+    SingularityTask task = new SingularityTask(taskRequest, taskId, Collections.singletonList(offer), taskInfo, Optional.of("rack1"));
 
     taskManager.savePendingTask(pendingTask);
 
@@ -341,7 +341,7 @@ public class SingularitySchedulerTestBase extends SingularityCuratorTestBase {
   protected void statusUpdate(SingularityTask task, TaskState state, Optional<Long> timestamp) {
     TaskStatus.Builder bldr = TaskStatus.newBuilder()
         .setTaskId(task.getMesosTask().getTaskId())
-        .setSlaveId(task.getOffer().getSlaveId())
+        .setSlaveId(task.getSlaveId())
         .setState(state);
 
     if (timestamp.isPresent()) {

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityUsageTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityUsageTest.java
@@ -50,14 +50,14 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
 
     SingularityTask firstTask = taskManager.getActiveTasks().get(0);
 
-    String hostname = firstTask.getOffer().getHostname();
+    String hostname = firstTask.getHostname();
     MesosTaskMonitorObject usage = new MesosTaskMonitorObject(null, null, null, firstTask.getTaskId().getId(), getStatistics(2, 5, 100));
 
     mesosClient.setSlaveResourceUsage(hostname, Collections.singletonList(usage));
 
     usagePoller.runActionOnPoll();
 
-    String slaveId = firstTask.getOffer().getSlaveId().getValue().toString();
+    String slaveId = firstTask.getSlaveId().getValue();
 
     List<String> slaves = usageManager.getSlavesWithUsage();
 

--- a/SingularityUI/app/actions/api/tasks.es6
+++ b/SingularityUI/app/actions/api/tasks.es6
@@ -10,10 +10,10 @@ export const FetchTasksInState = buildApiAction(
 
     switch (stateToFetch) {
       case 'active':
-        propertyString += ['offer.hostname', 'taskId', 'mesosTask.resources', 'rackId', 'taskRequest.request.requestType'].join(propertyJoin);
+        propertyString += ['offers', 'taskId', 'mesosTask.resources', 'rackId', 'taskRequest.request.requestType'].join(propertyJoin);
         break;
       case 'scheduled':
-        propertyString += ['offer.hostname', 'taskId', 'mesosTask.resources', 'rackId', 'taskRequest.request.requestType', 'pendingTask'].join(propertyJoin);
+        propertyString += ['offers', 'taskId', 'mesosTask.resources', 'rackId', 'taskRequest.request.requestType', 'pendingTask'].join(propertyJoin);
         break;
       default:
         propertyString = '';

--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -64,9 +64,9 @@ class TaskDetail extends Component {
             customExecutorCmd: PropTypes.string
           }).isRequired
         }).isRequired,
-        offer: PropTypes.shape({
+        offers: PropTypes.arrayOf(PropTypes.shape({
           hostname: PropTypes.string
-        }).isRequired,
+        })).isRequired,
         mesosTask: PropTypes.shape({
           executor: PropTypes.object
         }).isRequired,
@@ -296,7 +296,7 @@ class TaskDetail extends Component {
           <div className="col-md-12">
             <Breadcrumbs
               items={breadcrumbs}
-              right={<span><strong>Hostname: </strong>{this.props.task.task.offer.hostname}</span>}
+              right={<span><strong>Hostname: </strong>{this.props.task.task.offers[0].hostname}</span>}
             />
           </div>
         </div>

--- a/SingularityUI/app/components/taskDetail/TaskHealthchecks.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskHealthchecks.jsx
@@ -40,7 +40,7 @@ function TaskHealthchecks (props) {
       <div className="well">
         <p>
           Beginning {beginningOnMessage}, wait a max of <strong>{healthcheckOptions.startupTimeoutSeconds || config.defaultStartupTimeoutSeconds}s</strong> for app to start responding, then hit
-          <a className="healthcheck-link" target="_blank" href={`http://${props.task.offer.hostname}:${Utils.healthcheckPort(healthcheckOptions, props.ports)}${healthcheckOptions.uri}`}>
+          <a className="healthcheck-link" target="_blank" href={`http://${props.task.offers[0].hostname}:${Utils.healthcheckPort(healthcheckOptions, props.ports)}${healthcheckOptions.uri}`}>
             {healthcheckOptions.uri}
           </a>
           with a <strong>{healthcheckOptions.responseTimeoutSeconds || config.defaultHealthcheckTimeoutSeconds}</strong> second timeout
@@ -116,9 +116,9 @@ TaskHealthchecks.propTypes = {
         })
       })
     }).isRequired,
-    offer: PropTypes.shape({
+    offers: PropTypes.arrayOf(PropTypes.shape({
       hostname: PropTypes.string
-    }).isRequired,
+    })).isRequired,
   }).isRequired,
   healthcheckResults: PropTypes.arrayOf(PropTypes.shape({
     timestamp: PropTypes.number,

--- a/SingularityUI/app/components/taskDetail/TaskInfo.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskInfo.jsx
@@ -10,7 +10,7 @@ function TaskInfo (props) {
           <InfoBox copyableClassName="info-copyable" name="Task ID" value={props.task.taskId.id} />
           <InfoBox copyableClassName="info-copyable" name="Directory" value={props.directory} />
           {props.task.mesosTask.executor && <InfoBox copyableClassName="info-copyable" name="Executor GUID" value={props.task.mesosTask.executor.executorId.value} />}
-          <InfoBox copyableClassName="info-copyable" name="Hostname" value={props.task.offer.hostname} />
+          <InfoBox copyableClassName="info-copyable" name="Hostname" value={props.task.offers[0].hostname} />
           {!_.isEmpty(props.ports) && <InfoBox copyableClassName="info-copyable" name="Ports" value={props.ports.toString()} />}
           <InfoBox copyableClassName="info-copyable" name="Rack ID" value={props.task.rackId} />
           {props.task.taskRequest.deploy.executorData && <InfoBox copyableClassName="info-copyable" name="Extra Cmd Line Arguments (for Deploy)" join=" " value={props.task.taskRequest.deploy.executorData.extraCmdLineArgs} />}
@@ -43,9 +43,9 @@ TaskInfo.propTypes = {
         cmdLineArgsList: PropTypes.arrayOf(PropTypes.string)
       })
     }).isRequired,
-    offer: PropTypes.shape({
+    offers: PropTypes.arrayOf(PropTypes.shape({
       hostname: PropTypes.string
-    }).isRequired,
+    })).isRequired,
     rackId: PropTypes.string
   }).isRequired,
   ports: PropTypes.arrayOf(PropTypes.number),


### PR DESCRIPTION
This updates the scheduler to group offers by host and use the total resources available on all offers when scheduling tasks. Especially when using the offer cache, it has been common for us to have 10+ offers in the cache at a time from a single host. For tasks that require larger amounts of resources, this should get them scheduled much more quickly.

As far as I can tell, the mesos master will add up all resources on it's side when a task or tasks are scheduled using multiple offers. So, this code is not currently making an effort to match each task with a portion of the resources available, it is launching all tasks with all offers for the host. It could be a future improvement to save chunks of unused offers so the offer cache could hold on to them for the next run.