### PR TITLE
Retry failed client requests

### DIFF
--- a/SingularityClient/pom.xml
+++ b/SingularityClient/pom.xml
@@ -22,6 +22,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.github.rholder</groupId>
+      <artifactId>guava-retrying</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
@@ -74,6 +79,18 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
@@ -479,7 +479,7 @@ public class SingularityClient {
         String url = hostToUri.apply(host);
         hosts.remove(selection);
         LOG.info("Making {} request to {}", method, url);
-        request.setUrl(hostToUri.apply(url));
+        request.setUrl(url);
         return httpClient.execute(request.build());
       });
     } catch (ExecutionException | RetryException exn) {

--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClientModule.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClientModule.java
@@ -33,6 +33,12 @@ public class SingularityClientModule extends AbstractModule {
 
   public static final String CREDENTIALS_PROPERTY_NAME = "singularity.client.credentials";
 
+  // bind this to an int for the number of retry attempts on the request
+  public static final String RETRY_ATTEMPTS = "singularity.client.retry.attempts";
+
+  // bind this to a Predicate<HttpResponse> to say whether a request should be retried
+  public static final String RETRY_STRATEGY = "singularity.client.retry.strategy";
+
   private final List<String> hosts;
   private final Optional<HttpConfig> httpConfig;
 

--- a/SingularityClient/src/test/java/com/hubspot/singularity/client/SingularityClientTest.java
+++ b/SingularityClient/src/test/java/com/hubspot/singularity/client/SingularityClientTest.java
@@ -1,0 +1,72 @@
+package com.hubspot.singularity.client;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+import java.net.URI;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.hubspot.horizon.HttpClient;
+import com.hubspot.horizon.HttpRequest;
+import com.hubspot.horizon.HttpResponse;
+
+public class SingularityClientTest {
+  @Mock
+  private HttpClient httpClient;
+  @Mock
+  private HttpResponse response;
+  @Mock
+  private HttpRequest request;
+  private SingularityClient singularityClient;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+    singularityClient = buildClient();
+
+    when(response.getRequest())
+        .thenReturn(request);
+    when(request.getUrl())
+        .thenReturn(new URI("test-url"));
+  }
+
+  @Test
+  public void itRetriesRequestsThatErrorDueToDeadHost() {
+    when(httpClient.execute(any()))
+        .thenReturn(response);
+    when(response.getStatusCode())
+        .thenReturn(503)
+        .thenReturn(200);
+
+    singularityClient.pauseSingularityRequest("requestId", Optional.absent());
+
+    verify(httpClient, times(2))
+        .execute(any());
+  }
+
+  @Test
+  public void itThrowsAnExceptionOnServerErrors() {
+    when(httpClient.execute(any()))
+        .thenReturn(response);
+    when(response.getStatusCode())
+        .thenReturn(500);
+    when(response.isError())
+        .thenReturn(true);
+
+    assertThatExceptionOfType(SingularityClientException.class)
+        .isThrownBy(() -> singularityClient.pauseSingularityRequest("requestId", Optional.absent()));
+  }
+
+  private SingularityClient buildClient() {
+    return new SingularityClient("singularity/v2/api", httpClient, ImmutableList.of("host1", "host2"), Optional.absent());
+  }
+}

--- a/SingularityClient/src/test/java/com/hubspot/singularity/client/SingularityClientTest.java
+++ b/SingularityClient/src/test/java/com/hubspot/singularity/client/SingularityClientTest.java
@@ -1,5 +1,6 @@
 package com.hubspot.singularity.client;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
@@ -10,6 +11,8 @@ import java.net.URI;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -26,6 +29,9 @@ public class SingularityClientTest {
   private HttpResponse response;
   @Mock
   private HttpRequest request;
+  @Captor
+  private ArgumentCaptor<HttpRequest> requestCaptor;
+
   private SingularityClient singularityClient;
 
   @Before
@@ -53,7 +59,10 @@ public class SingularityClientTest {
     singularityClient.pauseSingularityRequest("requestId", Optional.absent());
 
     verify(httpClient, times(2))
-        .execute(any());
+        .execute(requestCaptor.capture());
+    HttpRequest sentRequest = requestCaptor.getValue();
+    assertThat(sentRequest.getUrl().toString())
+        .matches("http://host(1|2)/singularity/v2/api/requests/request/requestId/pause");
   }
 
   @Test

--- a/SingularityClient/src/test/java/com/hubspot/singularity/client/SingularityClientTest.java
+++ b/SingularityClient/src/test/java/com/hubspot/singularity/client/SingularityClientTest.java
@@ -46,6 +46,9 @@ public class SingularityClientTest {
     when(response.getStatusCode())
         .thenReturn(503)
         .thenReturn(200);
+    when(response.isServerError())
+        .thenReturn(true)
+        .thenReturn(false);
 
     singularityClient.pauseSingularityRequest("requestId", Optional.absent());
 

--- a/pom.xml
+++ b/pom.xml
@@ -262,6 +262,12 @@
           </exclusion>
         </exclusions>
       </dependency>
+
+      <dependency>
+        <groupId>org.jukito</groupId>
+        <artifactId>jukito</artifactId>
+        <version>1.5</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
In situations when the client fails with certain error codes,
it should be able to retry the request. Ideally, it would
retry the request to a different host so that in the event that
an instance malfunctioned or was removed, the request wasn't
consistently failing.

/cc @ssalinas 