### PR TITLE
Remove extra scheduled entries from pending queue

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -25,11 +25,9 @@ import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.annotation.Timed;
 import com.google.common.base.Optional;
-import com.google.common.base.Predicates;
 import com.google.common.base.Throwables;
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -253,6 +251,8 @@ public class SingularityScheduler {
       List<SingularityTaskId> matchingTaskIds = getMatchingTaskIds(stateCache, maybeRequest.get().getRequest(), deployKey);
 
       List<SingularityPendingRequest> effectivePendingRequests = new ArrayList<>();
+
+      // Things that are closest to now (ie smaller timestamps) should come first in the queue
       pendingRequestsForDeploy.sort(Comparator.comparingLong(SingularityPendingRequest::getTimestamp));
       int scheduledTasks = 0;
       for (SingularityPendingRequest pendingRequest : pendingRequestsForDeploy) {
@@ -289,6 +289,12 @@ public class SingularityScheduler {
           RequestState requestState = checkCooldown(maybeRequest.get().getState(), maybeRequest.get().getRequest(), deployStatistics);
           scheduledTasks += scheduleTasks(stateCache, maybeRequest.get().getRequest(), requestState,
               deployStatistics, pendingRequest, matchingTaskIds, maybePendingDeploy);
+          requestManager.deletePendingRequest(pendingRequest);
+        } else if (updatedRequest.isScheduled()
+            && (pendingRequest.getPendingType() == PendingType.NEW_DEPLOY
+            || pendingRequest.getPendingType() == PendingType.TASK_DONE)) {
+          // If we are here, there is already an immediate of run of the scheduled task launched. Drop anything that would
+          // leave a second instance of the request in the pending queue.
           requestManager.deletePendingRequest(pendingRequest);
         } else {
           // Any other subsequent requests are not honored until after the pending queue is cleared.
@@ -392,8 +398,13 @@ public class SingularityScheduler {
   }
 
   private void deleteScheduledTasks(final Collection<SingularityPendingTask> scheduledTasks, SingularityPendingRequest pendingRequest) {
-    for (SingularityPendingTask task : Iterables
-      .filter(scheduledTasks, Predicates.and(SingularityPendingTask.matchingRequest(pendingRequest.getRequestId()), SingularityPendingTask.matchingDeploy(pendingRequest.getDeployId())))) {
+    List<SingularityPendingTask> tasksForDeploy = scheduledTasks
+        .stream()
+        .filter(task -> pendingRequest.getRequestId().equals(task.getPendingTaskId().getRequestId()))
+        .filter(task -> pendingRequest.getDeployId().equals(task.getPendingTaskId().getDeployId()))
+        .collect(Collectors.toList());
+
+    for (SingularityPendingTask task : tasksForDeploy) {
       LOG.debug("Deleting pending task {} in order to reschedule {}", task.getPendingTaskId().getId(), pendingRequest);
       taskManager.deletePendingTask(task.getPendingTaskId());
     }


### PR DESCRIPTION
There are now - deliberately - cases when multiple scheduled tasks can
enter the pending queue at once. However, scheduled tasks need to be
globally unique - there should only ever be one between the pending
queue and the active tasks list. Currently any duplicates that reach the
pending queue are held there. This instead clears them out when they are
duplicated, relying instead on the task being started on `TASK_DONE`.

/cc @ssalinas 