### PR TITLE
Bug: Ignore healthcheck config when skipping checks

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
@@ -295,8 +295,10 @@ public class SingularityValidator {
 
     if (deploy.getHealthcheck().isPresent() && !Strings.isNullOrEmpty(deploy.getHealthcheck().get().getUri())) {
       if (!deploy.getResources().isPresent() || deploy.getResources().get().getNumPorts() == 0) {
-        checkBadRequest(deploy.getHealthcheck().get().getPortNumber().isPresent(),
-          "Either an explicit port number, or port resources and port index must be specified to run healthchecks against a uri");
+        if (!(deploy.getSkipHealthchecksOnDeploy().isPresent() && deploy.getSkipHealthchecksOnDeploy().get())) {
+          checkBadRequest(deploy.getHealthcheck().get().getPortNumber().isPresent(),
+            "Either an explicit port number, or port resources and port index must be specified to run healthchecks against a uri");
+        }
       }
     }
 


### PR DESCRIPTION
Fix deployment failures when deploying to a request with no ports
assigned (and therefore no valid value for healthcheck port index) when
a healthcheck URI is supplied.

Example:

```json
{
  "requestId": "my-test-service",
  "healthcheck": {
    "uri": "/health"
  },
  "resources": {
    "cpus": 0.1,
    "memoryMb": 128,
    "numPorts": 0
  }
}
```

This configuration currently fails even when skipHealthchecks is true.
Ideally Singularity should either

1. Error immediately because supplying healthcheck config for a request
with checks disabled is logically invalid, or

2. Ignore healthcheck metadata entirely when the request isn't going to
use it anyway.

This adds the latter solution, but I believe both are sensible options.