### PR TITLE
Allow WORKER <-> SERVICE type change if not load balanced

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
@@ -44,6 +44,7 @@ import com.hubspot.mesos.SingularityMesosTaskLabel;
 import com.hubspot.mesos.SingularityPortMappingType;
 import com.hubspot.mesos.SingularityVolume;
 import com.hubspot.singularity.MachineState;
+import com.hubspot.singularity.RequestType;
 import com.hubspot.singularity.ScheduleType;
 import com.hubspot.singularity.SingularityAction;
 import com.hubspot.singularity.SingularityDeploy;
@@ -548,7 +549,11 @@ public class SingularityValidator {
   }
 
   private void checkForIllegalChanges(SingularityRequest request, SingularityRequest existingRequest) {
-    checkBadRequest(request.getRequestType() == existingRequest.getRequestType(), String.format("Request can not change requestType from %s to %s", existingRequest.getRequestType(), request.getRequestType()));
+    if (request.getRequestType() != existingRequest.getRequestType()) {
+      boolean validWorkerServiceTransition = (existingRequest.getRequestType() == RequestType.SERVICE && !existingRequest.isLoadBalanced() && request.getRequestType() == RequestType.WORKER) ||
+          (request.getRequestType() == RequestType.SERVICE && !request.isLoadBalanced() && existingRequest.getRequestType() == RequestType.WORKER);
+      checkBadRequest(validWorkerServiceTransition, String.format("Request can not change requestType from %s to %s", existingRequest.getRequestType(), request.getRequestType()));
+    }
     checkBadRequest(request.isLoadBalanced() == existingRequest.isLoadBalanced(), "Request can not change whether it is load balanced");
   }
 


### PR DESCRIPTION
A non-load-balanced SERVICE and WORKER are the same. We can switch these without having to delete and recreate the request