### PR TITLE
Refactor tailer instance selection dropdown

### DIFF
--- a/SingularityUI/app/components/logs/NewTasksDropdown.jsx
+++ b/SingularityUI/app/components/logs/NewTasksDropdown.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import classNames from 'classnames';
+import Checkbox from 'react-bootstrap/lib/Checkbox';
 
-class NewTasksDropdown extends React.Component  {
+class NewTasksDropdown extends React.Component {
 
   renderTaskItems() {
     if (!this.props.ready || !this.props.runningTasks) {
@@ -13,18 +13,21 @@ class NewTasksDropdown extends React.Component  {
     }
 
     return this.props.runningTasks.map((task, key) => {
-      const checkedClass = this.props.visibleTasks.includes(task.taskId.id)
-        ? 'glyphicon-check'
-        : 'glyphicon-unchecked';
-
-      return (<li key={key}>
-          <a onClick={() => this.props.onToggle(task.taskId.id)}>
-              <span className={classNames('glyphicon', checkedClass)} />
-              <span>Instance {task.taskId.instanceNo}</span>
+      return (
+        <li key={key}>
+          <a>
+            <Checkbox
+              inline={true}
+              checked={this.props.visibleTasks.includes(task.taskId.id)}
+              onClick={() => this.props.onToggle(task.taskId.id)}
+            >
+              Instance {task.taskId.instanceNo}
+            </Checkbox>
           </a>
-      </li>);
+        </li>
+      );
     });
-  };
+  }
 
   render() {
     return (
@@ -38,7 +41,7 @@ class NewTasksDropdown extends React.Component  {
       </div>
     );
   }
-};
+}
 
 NewTasksDropdown.propTypes = {
   ready: React.PropTypes.bool,

--- a/SingularityUI/app/components/logs/NewTasksDropdown.jsx
+++ b/SingularityUI/app/components/logs/NewTasksDropdown.jsx
@@ -31,19 +31,21 @@ class NewTasksDropdown extends React.Component {
 
     const listItems = [];
 
-    listItems.push(
-      <li key="select-all">
-        <a>
-          <Checkbox
-            inline={true}
-            checked={this.props.visibleTasks.length === this.props.runningTasks.length}
-            onChange={() => this.handleSelectAll()}
-          >
-            Select All
-          </Checkbox>
-        </a>
-      </li>
-    );
+    if (this.props.runningTasks.length > 1) {
+      listItems.push(
+        <li key="select-all">
+          <a>
+            <Checkbox
+              inline={true}
+              checked={this.props.visibleTasks.length === this.props.runningTasks.length}
+              onChange={() => this.handleSelectAll()}
+            >
+              Select All
+            </Checkbox>
+          </a>
+        </li>
+      );
+    }
 
     listItems.push(this.props.runningTasks.map((task, key) => {
       return (

--- a/SingularityUI/app/components/logs/NewTasksDropdown.jsx
+++ b/SingularityUI/app/components/logs/NewTasksDropdown.jsx
@@ -5,15 +5,23 @@ import {ButtonGroup, DropdownButton} from 'react-bootstrap';
 class NewTasksDropdown extends React.Component {
 
   handleSelectAll() {
-    if (this.props.visibleTasks.length === this.props.runningTasks.length) {
+    if (this.props.visibleTasks.length >= Math.min(this.props.runningTasks.length, 8)) {
+      if (!this.props.visibleTasks.includes(_.first(this.props.runningTasks).taskId.id)) {
+        this.props.onToggle(_.first(this.props.runningTasks).taskId.id);
+      }
       _.rest(this.props.runningTasks).forEach((task) => {
         if (this.props.visibleTasks.includes(task.taskId.id)) {
           this.props.onToggle(task.taskId.id);
         }
       });
     } else {
-      this.props.runningTasks.forEach((task) => {
+      _.take(this.props.runningTasks, 8).forEach((task) => {
         if (!this.props.visibleTasks.includes(task.taskId.id)) {
+          this.props.onToggle(task.taskId.id);
+        }
+      });
+      _.rest(this.props.runningTasks, 9).forEach((task) => {
+        if (this.props.visibleTasks.includes(task.taskId.id)) {
           this.props.onToggle(task.taskId.id);
         }
       });
@@ -37,7 +45,7 @@ class NewTasksDropdown extends React.Component {
           <a>
             <Checkbox
               inline={true}
-              checked={this.props.visibleTasks.length === this.props.runningTasks.length}
+              checked={this.props.visibleTasks.length >= Math.min(this.props.runningTasks.length, 8)}
               onChange={() => this.handleSelectAll()}
             >
               Select All

--- a/SingularityUI/app/components/logs/NewTasksDropdown.jsx
+++ b/SingularityUI/app/components/logs/NewTasksDropdown.jsx
@@ -1,7 +1,24 @@
 import React from 'react';
 import Checkbox from 'react-bootstrap/lib/Checkbox';
 import {ButtonGroup, DropdownButton} from 'react-bootstrap';
+
 class NewTasksDropdown extends React.Component {
+
+  handleSelectAll() {
+    if (this.props.visibleTasks.length === this.props.runningTasks.length) {
+      _.rest(this.props.runningTasks).forEach((task) => {
+        if (this.props.visibleTasks.includes(task.taskId.id)) {
+          this.props.onToggle(task.taskId.id);
+        }
+      });
+    } else {
+      this.props.runningTasks.forEach((task) => {
+        if (!this.props.visibleTasks.includes(task.taskId.id)) {
+          this.props.onToggle(task.taskId.id);
+        }
+      });
+    }
+  }
 
   renderTaskItems() {
     if (!this.props.ready || !this.props.runningTasks) {
@@ -13,6 +30,20 @@ class NewTasksDropdown extends React.Component {
     }
 
     const listItems = [];
+
+    listItems.push(
+      <li key="select-all">
+        <a>
+          <Checkbox
+            inline={true}
+            checked={this.props.visibleTasks.length === this.props.runningTasks.length}
+            onChange={() => this.handleSelectAll()}
+          >
+            Select All
+          </Checkbox>
+        </a>
+      </li>
+    );
 
     listItems.push(this.props.runningTasks.map((task, key) => {
       return (

--- a/SingularityUI/app/components/logs/NewTasksDropdown.jsx
+++ b/SingularityUI/app/components/logs/NewTasksDropdown.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Checkbox from 'react-bootstrap/lib/Checkbox';
-
+import {ButtonGroup, DropdownButton} from 'react-bootstrap';
 class NewTasksDropdown extends React.Component {
 
   renderTaskItems() {
@@ -12,33 +12,35 @@ class NewTasksDropdown extends React.Component {
       return (<li><a className="disabled">No running instances</a></li>);
     }
 
-    return this.props.runningTasks.map((task, key) => {
+    const listItems = [];
+
+    listItems.push(this.props.runningTasks.map((task, key) => {
       return (
         <li key={key}>
           <a>
             <Checkbox
               inline={true}
               checked={this.props.visibleTasks.includes(task.taskId.id)}
-              onClick={() => this.props.onToggle(task.taskId.id)}
+              onChange={() => this.props.onToggle(task.taskId.id)}
+              disabled={this.props.visibleTasks.includes(task.taskId.id) && this.props.visibleTasks.length === 1}
             >
               Instance {task.taskId.instanceNo}
             </Checkbox>
           </a>
         </li>
       );
-    });
+    }));
+
+    return listItems;
   }
 
   render() {
     return (
-      <div className="btn-group" title="Select Instances">
-        <button type="button" className="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <span className="glyphicon glyphicon-tasks"></span> <span className="caret"></span>
-        </button>
-        <ul className="dropdown-menu dropdown-menu-right">
-            {this.renderTaskItems()}
-        </ul>
-      </div>
+      <ButtonGroup title="Select Instances">
+        <DropdownButton id="instance-dropdown" bsSize="small" title={<span className="glyphicon glyphicon-tasks"></span>}>
+          {this.renderTaskItems()}
+        </DropdownButton>
+      </ButtonGroup>
     );
   }
 }

--- a/SingularityUI/app/components/logs/NewTasksDropdown.jsx
+++ b/SingularityUI/app/components/logs/NewTasksDropdown.jsx
@@ -1,23 +1,24 @@
 import React from 'react';
 import classNames from 'classnames';
 
-const NewTasksDropdown = ({ready, runningTasks, visibleTasks=[], onToggle}) => {
-  const renderTaskItems = () => {
-    if (!ready || !runningTasks) {
+class NewTasksDropdown extends React.Component  {
+
+  renderTaskItems() {
+    if (!this.props.ready || !this.props.runningTasks) {
       return (<li><a className="disabled">Loading...</a></li>);
     }
 
-    if (runningTasks.length === 0) {
+    if (this.props.runningTasks.length === 0) {
       return (<li><a className="disabled">No running instances</a></li>);
     }
 
-    return runningTasks.map((task, key) => {
-      const checkedClass = visibleTasks.includes(task.taskId.id)
+    return this.props.runningTasks.map((task, key) => {
+      const checkedClass = this.props.visibleTasks.includes(task.taskId.id)
         ? 'glyphicon-check'
         : 'glyphicon-unchecked';
 
       return (<li key={key}>
-          <a onClick={() => onToggle(task.taskId.id)}>
+          <a onClick={() => this.props.onToggle(task.taskId.id)}>
               <span className={classNames('glyphicon', checkedClass)} />
               <span>Instance {task.taskId.instanceNo}</span>
           </a>
@@ -25,14 +26,29 @@ const NewTasksDropdown = ({ready, runningTasks, visibleTasks=[], onToggle}) => {
     });
   };
 
-  return (<div className="btn-group" title="Select Instances">
-    <button type="button" className="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-      <span className="glyphicon glyphicon-tasks"></span> <span className="caret"></span>
-    </button>
-    <ul className="dropdown-menu dropdown-menu-right">
-      {renderTaskItems()}
-    </ul>
-  </div>);
+  render() {
+    return (
+      <div className="btn-group" title="Select Instances">
+        <button type="button" className="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <span className="glyphicon glyphicon-tasks"></span> <span className="caret"></span>
+        </button>
+        <ul className="dropdown-menu dropdown-menu-right">
+            {this.renderTaskItems()}
+        </ul>
+      </div>
+    );
+  }
+};
+
+NewTasksDropdown.propTypes = {
+  ready: React.PropTypes.bool,
+  runningTasks: React.PropTypes.array,
+  visibleTasks: React.PropTypes.array,
+  onToggle: React.PropTypes.func
+};
+
+NewTasksDropdown.defaultProps = {
+  visibleTasks: []
 };
 
 export default NewTasksDropdown;


### PR DESCRIPTION
The instance select dropdown has been refactored into a class and to use react-bootstrap components.

This also fixes two issues:

- The dropdown will not close when selecting or deselecting an instance, now multiple can be checked without reopening the dropdown.
- A Select All option has been added which will either select all instances or deselect all but the first instance (at least one instance always needs to be selected or the tailer UI will break).

Caveats: 

- The dropdown will still close when transitioning between one instance selected and greater than one. This is because the header needs to re-render with the appropriate buttons for tailing a single instance.