### PR TITLE
Keep the state cache up to date within runs of the poller

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -397,7 +397,7 @@ public class SingularityScheduler {
     return deployMarker.isPresent() && deployMarker.get().getDeployId().equals(deployId);
   }
 
-  private void deleteScheduledTasks(final Collection<SingularityPendingTask> scheduledTasks, SingularityPendingRequest pendingRequest) {
+  private void deleteScheduledTasks(SingularitySchedulerStateCache stateCache, final Collection<SingularityPendingTask> scheduledTasks, SingularityPendingRequest pendingRequest) {
     List<SingularityPendingTask> tasksForDeploy = scheduledTasks
         .stream()
         .filter(task -> pendingRequest.getRequestId().equals(task.getPendingTaskId().getRequestId()))
@@ -407,6 +407,7 @@ public class SingularityScheduler {
     for (SingularityPendingTask task : tasksForDeploy) {
       LOG.debug("Deleting pending task {} in order to reschedule {}", task.getPendingTaskId().getId(), pendingRequest);
       taskManager.deletePendingTask(task.getPendingTaskId());
+      stateCache.getScheduledTasks().remove(task);
     }
   }
 
@@ -435,7 +436,7 @@ public class SingularityScheduler {
                             SingularityDeployStatistics deployStatistics, SingularityPendingRequest pendingRequest,
                             List<SingularityTaskId> matchingTaskIds, Optional<SingularityPendingDeploy> maybePendingDeploy) {
     if (request.getRequestType() != RequestType.ON_DEMAND) {
-      deleteScheduledTasks(stateCache.getScheduledTasks(), pendingRequest);
+      deleteScheduledTasks(stateCache, stateCache.getScheduledTasks(), pendingRequest);
     }
 
     final int numMissingInstances = getNumMissingInstances(matchingTaskIds, request, pendingRequest, maybePendingDeploy);

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -444,7 +444,7 @@ public class SingularityScheduler {
       maybePendingDeploy);
 
     if (numMissingInstances > 0) {
-      schedule(numMissingInstances, matchingTaskIds, request, state, deployStatistics, pendingRequest, maybePendingDeploy);
+      schedule(stateCache, numMissingInstances, matchingTaskIds, request, state, deployStatistics, pendingRequest, maybePendingDeploy);
     } else if (numMissingInstances < 0) {
       final long now = System.currentTimeMillis();
 
@@ -479,7 +479,7 @@ public class SingularityScheduler {
         }
         remainingActiveTasks.removeAll(extraCleanedTasks);
         if (extraCleanedTasks.size() > 0) {
-          schedule(extraCleanedTasks.size(), remainingActiveTasks, request, state, deployStatistics, pendingRequest, maybePendingDeploy);
+          schedule(stateCache, extraCleanedTasks.size(), remainingActiveTasks, request, state, deployStatistics, pendingRequest, maybePendingDeploy);
         }
       }
 
@@ -488,7 +488,7 @@ public class SingularityScheduler {
     return numMissingInstances;
   }
 
-  private void schedule(int numMissingInstances, List<SingularityTaskId> matchingTaskIds, SingularityRequest request, RequestState state, SingularityDeployStatistics deployStatistics,
+  private void schedule(SingularitySchedulerStateCache stateCache, int numMissingInstances, List<SingularityTaskId> matchingTaskIds, SingularityRequest request, RequestState state, SingularityDeployStatistics deployStatistics,
     SingularityPendingRequest pendingRequest, Optional<SingularityPendingDeploy> maybePendingDeploy) {
     final List<SingularityPendingTask> scheduledTasks =
       getScheduledTaskIds(numMissingInstances, matchingTaskIds, request, state, deployStatistics, pendingRequest.getDeployId(), pendingRequest, maybePendingDeploy);
@@ -498,6 +498,7 @@ public class SingularityScheduler {
 
       for (SingularityPendingTask scheduledTask : scheduledTasks) {
         taskManager.savePendingTask(scheduledTask);
+        stateCache.getScheduledTasks().add(scheduledTask);
       }
     } else {
       LOG.info("No new scheduled tasks found for {}, setting state to {}", request.getId(), RequestState.FINISHED);


### PR DESCRIPTION
Right now old pending tasks aren't deleted properly for a scheduled request if there is a new deploy pending request immediately followed by an immediate pending request within the same run of the poller. The state cache does not contain the new pending task from the first pending request, so it is not deleted during the second. This updates the `schedule` method to keep the state cache up to date within a run of the poller.

/cc @darcatron 