### PR TITLE
Also relocate guava-retrying in SingularityClient

### DIFF
--- a/SingularityClient/pom.xml
+++ b/SingularityClient/pom.xml
@@ -115,6 +115,7 @@
               <includes>
                 <include>com.hubspot:SingularityClient</include>
                 <include>com.google.guava:guava</include>
+                <include>com.github.rholder:guava-retrying</include>
               </includes>
             </artifactSet>
             <filters>
@@ -139,6 +140,10 @@
               <relocation>
                 <pattern>com.google.thirdparty</pattern>
                 <shadedPattern>com.hubspot.singularity.shaded.com.google.thirdparty</shadedPattern>
+              </relocation>
+              <relocation>
+                <pattern>com.github.rholder</pattern>
+                <shadedPattern>com.hubspot.singularity.shaded.com.github.rholder</shadedPattern>
               </relocation>
             </relocations>
           </configuration>


### PR DESCRIPTION
The interactions of unshaded retryer with shaded guava were causing issues. Shading retryer as well in SingularityClient

/cc @stevegutz 