### PR TITLE
Disk usage ui

### DIFF
--- a/SingularityUI/app/actions/api/requests.es6
+++ b/SingularityUI/app/actions/api/requests.es6
@@ -10,7 +10,7 @@ export const FetchRequestsInState = buildApiAction(
   (state, renderNotFoundIf404) => {
     if (_.contains(['pending', 'cleanup'], state)) {
       return {url: `/requests/queued/${state}`, renderNotFoundIf404};
-    } else if (_.contains(['all', 'noDeploy', 'activeDeploy', 'overUtilizedCpu', 'underUtilizedCpu', 'underUtilizedMem'], state)) {
+    } else if (_.contains(['all', 'noDeploy', 'activeDeploy', 'overUtilizedCpu', 'underUtilizedCpu', 'underUtilizedMem', 'underUtilizedDisk'], state)) {
       return {url: '/requests', renderNotFoundIf404};
     }
     return {url: `/requests/${state}`, renderNotFoundIf404};

--- a/SingularityUI/app/components/machines/Constants.jsx
+++ b/SingularityUI/app/components/machines/Constants.jsx
@@ -9,15 +9,17 @@ export const STAT_NAMES = {
   memoryBytesUsedStat : 'memoryBytesUsed',
   numTasksStat : 'numTasks',
   slaveIdStat : 'slaveId',
-  timestampStat : 'timestamp'
+  timestampStat : 'timestamp',
+  diskBytesUsedStat : 'diskBytesUsed'
 };
 
 export const SLAVE_HEALTH_MENU_ITEM_ORDER = [
   'host',
   STAT_NAMES.cpusUsedStat,
   STAT_NAMES.memoryBytesUsedStat,
+  STAT_NAMES.diskBytesUsedStat,
   STAT_NAMES.numTasksStat,
-  STAT_NAMES.timestampStat
+  STAT_NAMES.timestampStat,
 ];
 
 export const HEALTH_SCALE = chroma.scale(['3182bd','9ecae1','deebf7','fee0d2','fc9272','de2d26']).colors(HEALTH_SCALE_MAX);

--- a/SingularityUI/app/components/machines/usage/Aggregate.jsx
+++ b/SingularityUI/app/components/machines/usage/Aggregate.jsx
@@ -20,7 +20,7 @@ const Aggregate = ({width, vcenter, graph, className, value, label, link}) => {
   return (
     <div className={classNames(
       'aggregate',
-      `col-xs-${width}`,
+      `col-md-${width}`,
       {vcenter},
       {graph}
     )}>

--- a/SingularityUI/app/components/machines/usage/ClusterAggregates.jsx
+++ b/SingularityUI/app/components/machines/usage/ClusterAggregates.jsx
@@ -131,8 +131,8 @@ const SlaveAggregates = ({utilization, totalRequests}) => {
         <LabeledColumn width={10}>
           <div className="row">
             <Aggregate width={3} value={Utils.humanizeFileSize(utilization.totalUnderUtilizedDiskBytes)} label="Total Under-utilized Disk" className="text-warning" />
-            <Aggregate width={3} value={Utils.humanizeFileSize(utilization.avgUnderUtilizedDiskBytes)} label="Avg Under-utilized Memory" className="text-warning" />
-            <Aggregate width={3} value={Utils.humanizeFileSize(utilization.minUnderUtilizedDiskBytes)} label="Min Under-utilized Memory" className="text-warning" />
+            <Aggregate width={3} value={Utils.humanizeFileSize(utilization.avgUnderUtilizedDiskBytes)} label="Avg Under-utilized Disk" className="text-warning" />
+            <Aggregate width={3} value={Utils.humanizeFileSize(utilization.minUnderUtilizedDiskBytes)} label="Min Under-utilized Disk" className="text-warning" />
             <Aggregate width={3} value={Utils.humanizeFileSize(utilization.maxUnderUtilizedDiskBytes)} label="Max Under-utilized Disk" className="text-warning" link={utilization.maxUnderUtilizedDiskBytesRequestId && `/request/${utilization.maxUnderUtilizedDiskBytesRequestId}`} />
           </div>
         </LabeledColumn>

--- a/SingularityUI/app/components/machines/usage/ClusterAggregates.jsx
+++ b/SingularityUI/app/components/machines/usage/ClusterAggregates.jsx
@@ -100,6 +100,43 @@ const SlaveAggregates = ({utilization, totalRequests}) => {
           </div>
         </LabeledColumn>
       </div>
+
+      <h3>Disk</h3>
+      <div className="row">
+        <div className="col-md-2">
+          <h4>Requests</h4>
+          {utilization.numRequestsWithUnderUtilizedDiskBytes !== undefined ?
+            <Breakdown
+              total={totalRequests}
+              data={[
+                {
+                  attribute: 'normal',
+                  count: totalRequests - utilization.numRequestsWithUnderUtilizedDiskBytes,
+                  type: 'success',
+                  label: 'Normal',
+                  percent: ((totalRequests - utilization.numRequestsWithUnderUtilizedDiskBytes) / totalRequests) * 100
+                },
+                {
+                  attribute: 'underDisk',
+                  count: utilization.numRequestsWithUnderUtilizedDiskBytes,
+                  type: 'warning',
+                  label: 'Under-utilized',
+                  link: '/requests/underUtilizedDisk/all/',
+                  percent: (utilization.numRequestsWithUnderUtilizedDiskBytes / totalRequests) * 100
+                }
+              ]}
+            /> : <Loader fixed={false} />}
+        </div>
+
+        <LabeledColumn width={10}>
+          <div className="row">
+            <Aggregate width={3} value={Utils.humanizeFileSize(utilization.totalUnderUtilizedDiskBytes)} label="Total Under-utilized Disk" className="text-warning" />
+            <Aggregate width={3} value={Utils.humanizeFileSize(utilization.avgUnderUtilizedDiskBytes)} label="Avg Under-utilized Memory" className="text-warning" />
+            <Aggregate width={3} value={Utils.humanizeFileSize(utilization.minUnderUtilizedDiskBytes)} label="Min Under-utilized Memory" className="text-warning" />
+            <Aggregate width={3} value={Utils.humanizeFileSize(utilization.maxUnderUtilizedDiskBytes)} label="Max Under-utilized Disk" className="text-warning" link={utilization.maxUnderUtilizedDiskBytesRequestId && `/request/${utilization.maxUnderUtilizedDiskBytesRequestId}`} />
+          </div>
+        </LabeledColumn>
+      </div>
     </div>
   );
 };

--- a/SingularityUI/app/components/machines/usage/LabeledColumn.jsx
+++ b/SingularityUI/app/components/machines/usage/LabeledColumn.jsx
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 
 const LabeledSection = ({title, width, children, className}) => (
-  <div className={`col-xs-${width} ${className || ''}`}>
+  <div className={`col-md-${width} ${className || ''}`}>
     <h4>{title}</h4>
     <div className="row">
       <div className="col-xs-12">

--- a/SingularityUI/app/components/machines/usage/ResourceHealthData.jsx
+++ b/SingularityUI/app/components/machines/usage/ResourceHealthData.jsx
@@ -13,6 +13,8 @@ const getTotalForStat = (statName, data) => {
       return data.totalMemoryResource;
     case STAT_NAMES.cpusUsedStat:
       return data.totalCpuResource;
+    case STAT_NAMES.diskBytesUsedStat:
+      return data.totalDiskResource;
     default:
       throw new Error(`${name} is an unsupported statistic`);
   }
@@ -24,6 +26,8 @@ const getUtilizationForStat = (statName, data) => {
       return data.memoryUtilized;
     case STAT_NAMES.cpusUsedStat:
       return data.cpuUtilized;
+    case STAT_NAMES.diskBytesUsedStat:
+      return data.diskUtilized;
     default:
       throw new Error(`${name} is an unsupported statistic`);
   }
@@ -35,7 +39,7 @@ const slaveQuickStats = (data) => {
   return (
     <Popover id="slave-usage-quick-stats-popover">
       <div className="row" id="slave-usage-quick-stats">
-        <div className="col-xs-5" id="slave-name">
+        <div className="col-xs-3" id="slave-name">
           {Utils.humanizeSlaveHostName(data.slaveInfo.host, shortenHostName)}
         </div>
         <div className="col-xs-3" id="memory-stats">
@@ -52,6 +56,14 @@ const slaveQuickStats = (data) => {
           </div>
           <div id="status">
             CPU <span style={{color : HEALTH_SCALE[data.cpuUtilized]}}>{largeBlackCircle}</span>
+          </div>
+        </div>
+        <div className="col-xs-3" id="disk-stats">
+          <div id="pct-utilized">
+            {Utils.roundTo(data.diskUtilized / HEALTH_SCALE_MAX * 100, HUNDREDTHS_PLACE)}%
+          </div>
+          <div id="status">
+            Disk <span style={{color : HEALTH_SCALE[data.diskUtilized]}}>{largeBlackCircle}</span>
           </div>
         </div>
       </div>

--- a/SingularityUI/app/components/machines/usage/SlaveAggregates.jsx
+++ b/SingularityUI/app/components/machines/usage/SlaveAggregates.jsx
@@ -24,21 +24,31 @@ const getMemUtilizationPct = getPctSlaveUsage(
   slave => Utils.getMaxAvailableResource(slave, STAT_NAMES.memoryBytesUsedStat)
 );
 
+const getDiskUtilizationPct = getPctSlaveUsage(
+  usage => usage.diskBytesUsed,
+  slave => Utils.getMaxAvailableResource(slave, STAT_NAMES.diskBytesUsedStat)
+);
+
 const SlaveAggregates = ({slaves, slaveUsages, activeTasks, utilization}) => {
   return (
-    <div className="slave-aggregates row">
-      <Aggregate width={2} value={slaves.length} label="Active Slaves" vcenter={true} />
-      <Aggregate width={2} value={activeTasks} label="Tasks Running" vcenter={true} />
+    <div>
+      <div className="slave-aggregates row">
+        <Aggregate width={2} value={slaves.length} label="Active Slaves" />
+        <Aggregate width={2} value={activeTasks} label="Tasks Running" />
+      </div>
+      <div className="slave-aggregates row">
+        <LabeledColumn title="Current" width={6}>
+          <Aggregate width={2} value={getCpuUtilizationPct(slaves, slaveUsages)} graph={true} label="CPU" />
+          <Aggregate width={2} value={getMemUtilizationPct(slaves, slaveUsages)} graph={true} label="Memory" />
+          <Aggregate width={2} value={getDiskUtilizationPct(slaves, slaveUsages)} graph={true} label="Disk" />
+        </LabeledColumn>
 
-      <LabeledColumn title="Current" width={4}>
-        <Aggregate width={2} value={getCpuUtilizationPct(slaves, slaveUsages)} graph={true} label="CPU" />
-        <Aggregate width={2} value={getMemUtilizationPct(slaves, slaveUsages)} graph={true} label="Memory" />
-      </LabeledColumn>
-
-      <LabeledColumn className="info" title="24-Hour Average" width={4}>
-        <Aggregate width={2} value={Utils.toDisplayPercentage(utilization.totalCpuUsed, utilization.totalCpuAvailable)} graph={true} label="CPU" />
-        <Aggregate width={2} value={Utils.toDisplayPercentage(utilization.totalMemBytesUsed, utilization.totalMemBytesAvailable)} graph={true} label="Memory" />
-      </LabeledColumn>
+        <LabeledColumn className="info" title="24-Hour Average" width={6}>
+          <Aggregate width={2} value={Utils.toDisplayPercentage(utilization.totalCpuUsed, utilization.totalCpuAvailable)} graph={true} label="CPU" />
+          <Aggregate width={2} value={Utils.toDisplayPercentage(utilization.totalMemBytesUsed, utilization.totalMemBytesAvailable)} graph={true} label="Memory" />
+          <Aggregate width={2} value={Utils.toDisplayPercentage(utilization.totalDiskBytesUsed, utilization.totalDiskBytesAvailable)} graph={true} label="Disk" />
+        </LabeledColumn>
+      </div>
     </div>
   );
 };

--- a/SingularityUI/app/components/machines/usage/SlaveResourceHealthMenuItems.jsx
+++ b/SingularityUI/app/components/machines/usage/SlaveResourceHealthMenuItems.jsx
@@ -15,6 +15,8 @@ const humanizeStatName = (name) => {
       return 'CPU';
     case STAT_NAMES.memoryBytesUsedStat:
       return 'MEM';
+    case STAT_NAMES.diskBytesUsedStat:
+      return 'DISK';
     case STAT_NAMES.numTasksStat:
       return 'TASKS';
     default:
@@ -29,6 +31,7 @@ const humanizeStatValue = (name, value, maybeTotalResource) => {
     case STAT_NAMES.cpusUsedStat:
       return `${Utils.roundTo(value, HUNDREDTHS_PLACE)} / ${maybeTotalResource}`;
     case STAT_NAMES.memoryBytesUsedStat:
+    case STAT_NAMES.diskBytesUsedStat:
       return `${Utils.humanizeFileSize(value)} / ${Utils.humanizeFileSize(maybeTotalResource)}`;
     case STAT_NAMES.numTasksStat:
       return value.toString();

--- a/SingularityUI/app/components/machines/usage/Utilization.jsx
+++ b/SingularityUI/app/components/machines/usage/Utilization.jsx
@@ -23,7 +23,10 @@ const getUtilizationData = (slaves, slaveUsages) => {
     const totalMemoryResource = Utils.getMaxAvailableResource(slaveInfo, STAT_NAMES.memoryBytesUsedStat);
     const memoryUtilized = Utils.roundTo((slaveUsage[STAT_NAMES.memoryBytesUsedStat] / totalMemoryResource) * HEALTH_SCALE_MAX, WHOLE_NUMBER);
 
-    return {slaveInfo, slaveUsage, totalCpuResource, cpuUtilized, totalMemoryResource, memoryUtilized};
+    const totalDiskResource = Utils.getMaxAvailableResource(slaveInfo, STAT_NAMES.diskBytesUsedStat);
+    const diskUtilized = Utils.roundTo((slaveUsage[STAT_NAMES.diskBytesUsedStat] / totalDiskResource) * HEALTH_SCALE_MAX, WHOLE_NUMBER);
+
+    return {slaveInfo, slaveUsage, totalCpuResource, cpuUtilized, totalMemoryResource, memoryUtilized, totalDiskResource, diskUtilized};
   });
 };
 
@@ -37,6 +40,10 @@ const SlaveUsage = ({slaves, slaveUsages, activeTasks, clusterUtilization, total
 
   const memoryHealthData = utilizationData.sort((a, b) => a.memoryUtilized - b.memoryUtilized).map((data, index) => {
     return <ResourceHealthData key={index} utilizationData={data} statName={STAT_NAMES.memoryBytesUsedStat} />;
+  });
+
+  const diskHealthData = utilizationData.sort((a, b) => a.diskUtilized - b.diskUtilized).map((data, index) => {
+    return <ResourceHealthData key={index} utilizationData={data} statName={STAT_NAMES.diskBytesUsedStat} />;
   });
 
   return (
@@ -54,6 +61,10 @@ const SlaveUsage = ({slaves, slaveUsages, activeTasks, clusterUtilization, total
         <h4>Memory</h4>
         <div className="memory-health">
           {memoryHealthData}
+        </div>
+        <h4>Disk</h4>
+        <div className="disk-health">
+          {diskHealthData}
         </div>
       </div>
       <hr />

--- a/SingularityUI/app/components/requestDetail/RequestUtilization.jsx
+++ b/SingularityUI/app/components/requestDetail/RequestUtilization.jsx
@@ -58,6 +58,28 @@ const RequestUtilization = ({isFetching, utilization}) => {
             </BootstrapTable>
           </UsageInfo>
         </div>
+        <div className="col-md-3">
+          <UsageInfo
+            title="Disk per task average"
+            total={utilization.diskBytesReserved / utilization.numTasks}
+            used={utilization.diskBytesUsed / utilization.numTasks}
+            style={utilization.diskBytesUsed >= utilization.diskBytesReserved ? 'danger' : null}
+          >
+            <p>{Utils.humanizeFileSize(utilization.diskBytesUsed / utilization.numTasks)} of {Utils.humanizeFileSize(utilization.diskBytesReserved / utilization.numTasks)} reserved</p>
+            <BootstrapTable responsive={false} striped={true} style={{marginTop: '10px'}}>
+              <tbody>
+              <tr>
+                <td>Min disk (all tasks)</td>
+                <td>{Utils.humanizeFileSize(utilization.minDiskBytesUsed)}</td>
+              </tr>
+              <tr>
+                <td>Max disk (all tasks)</td>
+                <td>{Utils.humanizeFileSize(utilization.maxDiskBytesUsed)}</td>
+              </tr>
+              </tbody>
+            </BootstrapTable>
+          </UsageInfo>
+        </div>
     </div>
   );
 

--- a/SingularityUI/app/components/requests/RequestFilters.jsx
+++ b/SingularityUI/app/components/requests/RequestFilters.jsx
@@ -58,6 +58,10 @@ export default class RequestFilters extends React.Component {
     {
       filterVal: 'underUtilizedMem',
       displayVal: 'Under-utilized Memory'
+    },
+    {
+      filterVal: 'underUtilizedDisk',
+      displayVal: 'Under-utilized Disk'
     }
   ];
 

--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -384,29 +384,31 @@ class TaskDetail extends Component {
         </Panel>
       );
       maybeResourceUsage = (
-        <div className="row">
-          <div className="col-md-3 col-sm-4">
-            <UsageInfo
-              title="Memory (rss vs limit)"
-              style="success"
-              total={this.props.resourceUsage.memLimitBytes}
-              used={this.props.resourceUsage.memRssBytes}
-            >
-              {Utils.humanizeFileSize(this.props.resourceUsage.memRssBytes)} / {Utils.humanizeFileSize(this.props.resourceUsage.memLimitBytes)}
-            </UsageInfo>
-          </div>
-          <div className="col-md-3 col-sm-4">
-            {maybeCpuUsage}
-          </div>
-          <div className="col-md-3 col-sm-4">
-            <UsageInfo
-              title="Disk"
-              style={this.props.resourceUsage.diskUsedBytes > this.props.resourceUsage.diskLimitBytes ? 'danger' : 'success'}
-              total={this.props.resourceUsage.diskLimitBytes}
-              used={this.props.resourceUsage.diskUsedBytes}
-            >
-              {Utils.humanizeFileSize(this.props.resourceUsage.diskUsedBytes)} / {Utils.humanizeFileSize(this.props.resourceUsage.diskLimitBytes)}
-            </UsageInfo>
+        <div>
+          <div className="row">
+            <div className="col-md-3 col-sm-4">
+              <UsageInfo
+                title="Memory (rss vs limit)"
+                style="success"
+                total={this.props.resourceUsage.memLimitBytes}
+                used={this.props.resourceUsage.memRssBytes}
+              >
+                {Utils.humanizeFileSize(this.props.resourceUsage.memRssBytes)} / {Utils.humanizeFileSize(this.props.resourceUsage.memLimitBytes)}
+              </UsageInfo>
+            </div>
+            <div className="col-md-3 col-sm-4">
+              {maybeCpuUsage}
+            </div>
+            <div className="col-md-3 col-sm-4">
+              <UsageInfo
+                title="Disk"
+                style={this.props.resourceUsage.diskUsedBytes > this.props.resourceUsage.diskLimitBytes ? 'danger' : 'success'}
+                total={this.props.resourceUsage.diskLimitBytes}
+                used={this.props.resourceUsage.diskUsedBytes}
+              >
+                {Utils.humanizeFileSize(this.props.resourceUsage.diskUsedBytes)} / {Utils.humanizeFileSize(this.props.resourceUsage.diskLimitBytes)}
+              </UsageInfo>
+            </div>
           </div>
           <div className="row">
             <div className="col-md-12">

--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -87,6 +87,8 @@ class TaskDetail extends Component {
       cpusSystemTimeSecs: PropTypes.number,
       cpusUserTimeSecs: PropTypes.number,
       cpusLimit: PropTypes.number,
+      diskUsedBytes: PropTypes.number,
+      diskLimitBytes: PropTypes.number,
       memLimitBytes: PropTypes.number,
       memRssBytes: PropTypes.number,
       cpusNrPeriods: PropTypes.number,
@@ -383,7 +385,7 @@ class TaskDetail extends Component {
       );
       maybeResourceUsage = (
         <div className="row">
-          <div className="col-md-3">
+          <div className="col-md-3 col-sm-4">
             <UsageInfo
               title="Memory (rss vs limit)"
               style="success"
@@ -392,17 +394,31 @@ class TaskDetail extends Component {
             >
               {Utils.humanizeFileSize(this.props.resourceUsage.memRssBytes)} / {Utils.humanizeFileSize(this.props.resourceUsage.memLimitBytes)}
             </UsageInfo>
+          </div>
+          <div className="col-md-3 col-sm-4">
             {maybeCpuUsage}
           </div>
-          <div className="col-md-9">
-            <ul className="list-unstyled horizontal-description-list">
-              {!!this.props.resourceUsage.cpusNrPeriods && <InfoBox copyableClassName="info-copyable" name="CPUs number of periods" value={this.props.resourceUsage.cpusNrPeriods} />}
-              {!!this.props.resourceUsage.cpusNrThrottled && <InfoBox copyableClassName="info-copyable" name="CPUs number throttled" value={this.props.resourceUsage.cpusNrThrottled} />}
-              {!!this.props.resourceUsage.cpusThrottledTimeSecs && <InfoBox copyableClassName="info-copyable" name="Throttled time (sec)" value={this.props.resourceUsage.cpusThrottledTimeSecs} />}
-              <InfoBox copyableClassName="info-copyable" name="Memory (anon)" value={Utils.humanizeFileSize(this.props.resourceUsage.memAnonBytes)} />
-              <InfoBox copyableClassName="info-copyable" name="Memory (file)" value={Utils.humanizeFileSize(this.props.resourceUsage.memFileBytes)} />
-              <InfoBox copyableClassName="info-copyable" name="Memory (mapped file)" value={Utils.humanizeFileSize(this.props.resourceUsage.memMappedFileBytes)} />
-            </ul>
+          <div className="col-md-3 col-sm-4">
+            <UsageInfo
+              title="Disk"
+              style={this.props.resourceUsage.diskUsedBytes > this.props.resourceUsage.diskLimitBytes ? 'danger' : 'success'}
+              total={this.props.resourceUsage.diskLimitBytes}
+              used={this.props.resourceUsage.diskUsedBytes}
+            >
+              {Utils.humanizeFileSize(this.props.resourceUsage.diskUsedBytes)} / {Utils.humanizeFileSize(this.props.resourceUsage.diskLimitBytes)}
+            </UsageInfo>
+          </div>
+          <div className="row">
+            <div className="col-md-12">
+              <ul className="list-unstyled horizontal-description-list">
+                {!!this.props.resourceUsage.cpusNrPeriods && <InfoBox copyableClassName="info-copyable" name="CPUs number of periods" value={this.props.resourceUsage.cpusNrPeriods} />}
+                {!!this.props.resourceUsage.cpusNrThrottled && <InfoBox copyableClassName="info-copyable" name="CPUs number throttled" value={this.props.resourceUsage.cpusNrThrottled} />}
+                {!!this.props.resourceUsage.cpusThrottledTimeSecs && <InfoBox copyableClassName="info-copyable" name="Throttled time (sec)" value={this.props.resourceUsage.cpusThrottledTimeSecs} />}
+                <InfoBox copyableClassName="info-copyable" name="Memory (anon)" value={Utils.humanizeFileSize(this.props.resourceUsage.memAnonBytes)} />
+                <InfoBox copyableClassName="info-copyable" name="Memory (file)" value={Utils.humanizeFileSize(this.props.resourceUsage.memFileBytes)} />
+                <InfoBox copyableClassName="info-copyable" name="Memory (mapped file)" value={Utils.humanizeFileSize(this.props.resourceUsage.memMappedFileBytes)} />
+              </ul>
+            </div>
           </div>
         </div>
       );

--- a/SingularityUI/app/selectors/requests/filterSelector.es6
+++ b/SingularityUI/app/selectors/requests/filterSelector.es6
@@ -37,6 +37,12 @@ export default createSelector([getRequests, getFilter, getUtilizations], (reques
         return !!(utilization && utilization.memBytesUsed < utilization.memBytesReserved);
       };
       break;
+    case 'underUtilizedDisk':
+      stateFilter = (requestParent) => {
+        const utilization = _.find(utilizations, (util) => util.requestId === requestParent.request.id);
+        return !!(utilization && utilization.diskBytesUsed < utilization.diskBytesReserved);
+      };
+      break;
     default:
       break;
   }

--- a/SingularityUI/app/utils.es6
+++ b/SingularityUI/app/utils.es6
@@ -192,13 +192,19 @@ const Utils = {
         } catch (e) {
           throw new Error(`Could not find resource (memory) for slave ${slaveInfo.host} (${slaveInfo.id})`);
         }
+      case STAT_NAMES.diskBytesUsedStat:
+        try {
+          return parseFloat(slaveInfo.attributes.real_disk_mb || slaveInfo.resources.disk) * Math.pow(1024, 2);
+        } catch (e) {
+          throw new Error(`Could not find resource (disk) for slave ${slaveInfo.host} (${slaveInfo.id})`);
+        }
       default:
         throw new Error(`${statName} is an unsupported statistic'`);
     }
   },
 
   isResourceStat(stat) {
-    return stat === STAT_NAMES.cpusUsedStat || stat === STAT_NAMES.memoryBytesUsedStat;
+    return stat === STAT_NAMES.cpusUsedStat || stat === STAT_NAMES.memoryBytesUsedStat || stat === STAT_NAMES.diskBytesUsedStat;
   },
 
   getRequestIdFromTaskId(taskId) {


### PR DESCRIPTION
Adds support for disk utilization metrics on the backend by displaying stats on the Task Detail, Request Detail, and Cluster Utilization pages alongside Memory and CPU. Also adds a `Under-utilized Disk` filter on the Requests page.