### PR TITLE
Highlight new files

### DIFF
--- a/SingularityUI/app/components/common/table/UITable.jsx
+++ b/SingularityUI/app/components/common/table/UITable.jsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 
 import BootstrapTable from 'react-bootstrap/lib/Table';
 import { Pagination } from 'react-bootstrap';
-import Loader from "../Loader";
+import Loader from '../Loader';
 
 class UITable extends Component {
 
@@ -57,6 +57,7 @@ class UITable extends Component {
   };
 
   static defaultProps = {
+    striped: true,
     paginated: false,
     rowChunkSize: 30,
     defaultSortBy: undefined,
@@ -487,10 +488,6 @@ UITable.propTypes = {
     PropTypes.string
   ]),
   striped: PropTypes.bool
-};
-
-UITable.defaultProps = {
-  striped: true
 };
 
 export default UITable;

--- a/SingularityUI/app/components/common/table/UITable.jsx
+++ b/SingularityUI/app/components/common/table/UITable.jsx
@@ -429,7 +429,7 @@ class UITable extends Component {
       return <Loader />;
     }
     let maybeTable = (
-      <BootstrapTable responsive={true} striped={true} className={this.props.className}>
+      <BootstrapTable responsive={true} striped={this.props.striped} className={this.props.className}>
         <thead>
           {this.renderTableHeader()}
         </thead>
@@ -485,7 +485,12 @@ UITable.propTypes = {
   emptyTableMessage: PropTypes.oneOfType([
     PropTypes.node,
     PropTypes.string
-  ])
+  ]),
+  striped: PropTypes.bool
+};
+
+UITable.defaultProps = {
+  striped: true
 };
 
 export default UITable;

--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -44,6 +44,8 @@ import TaskHealthchecks from './TaskHealthchecks';
 import TaskState from './TaskState';
 import TaskStatus from './TaskStatus';
 
+const RECENTLY_MODIFIED_SECONDS = 60;
+
 class TaskDetail extends Component {
 
   static propTypes = {
@@ -166,6 +168,8 @@ class TaskDetail extends Component {
 
         file.fullPath = `${files.fullPathToRoot}/${files.currentDirectory}/${file.name}`;
         file.downloadLink = `${httpPrefix}://${files.slaveHostname}:${httpPort}/files/download.json?path=${file.fullPath}`;
+
+        file.isRecentlyModified = Date.now() / 1000 - file.mtime <= RECENTLY_MODIFIED_SECONDS;
 
         if (!file.isDirectory) {
           const regex = /(?:\.([^.]+))?$/;

--- a/SingularityUI/app/components/taskDetail/TaskFileBrowser.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskFileBrowser.jsx
@@ -71,7 +71,7 @@ function TaskFileBrowser (props) {
   }
 
   function recentlyModifiedTooltip() {
-    return <Tooltip id="tooltip">This file is currently being written to.</Tooltip>;
+    return <Tooltip id="tooltip">File is currently being written to</Tooltip>;
   }
 
   return (

--- a/SingularityUI/app/components/taskDetail/TaskFileBrowser.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskFileBrowser.jsx
@@ -43,7 +43,7 @@ function sortData(cellData, file) {
 }
 
 function isRecentlyModified(mtime) {
-  return new Date().getTime() / 1000 - mtime <= RECENTLY_MODIFIED_SECONDS;
+  return Date.now() / 1000 - mtime <= RECENTLY_MODIFIED_SECONDS;
 }
 
 function TaskFileBrowser (props) {
@@ -70,9 +70,7 @@ function TaskFileBrowser (props) {
     return _.sortBy(props.files, 'isDirectory').reverse();
   }
 
-  function recentlyModifiedTooltip() {
-    return <Tooltip id="tooltip">File is currently being written to</Tooltip>;
-  }
+  const recentlyModifiedTooltip = <Tooltip id="tooltip">File is currently being written to</Tooltip>;
 
   return (
     <div>
@@ -93,7 +91,7 @@ function TaskFileBrowser (props) {
           id="icon"
           key="icon"
           cellData={(file) => isRecentlyModified(file.mtime) &&
-            <OverlayTrigger placement="top" overlay={recentlyModifiedTooltip()}><div className="page-loader loader-small loader-info" /></OverlayTrigger>
+            <OverlayTrigger placement="top" overlay={recentlyModifiedTooltip}><div className="page-loader loader-small loader-info" /></OverlayTrigger>
           }
         />
         <Column
@@ -127,10 +125,7 @@ function TaskFileBrowser (props) {
           label="Last Modified"
           id="last-modified"
           key="last-modified"
-          cellData={(file) => {
-            const timestamp = Utils.absoluteTimestamp(file.mtime * 1000);
-            return isRecentlyModified(file.mtime) ? <strong>{timestamp}</strong> : timestamp;
-          }}
+          cellData={(file) => Utils.absoluteTimestamp(file.mtime * 1000)}
           sortable={true}
           sortFunc={makeComparator('mtime')}
           sortData={sortData}

--- a/SingularityUI/app/components/taskDetail/TaskFileBrowser.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskFileBrowser.jsx
@@ -9,8 +9,6 @@ import Column from '../common/table/Column';
 import UITable from '../common/table/UITable';
 import { Link } from 'react-router';
 
-const RECENTLY_MODIFIED_SECONDS = 60;
-
 function makeComparator(attribute) {
   return (file1, file2) => {
     if (file1.isDirectory && !file2.isDirectory) {
@@ -40,10 +38,6 @@ function makeComparator(attribute) {
 
 function sortData(cellData, file) {
   return file;
-}
-
-function isRecentlyModified(mtime) {
-  return Date.now() / 1000 - mtime <= RECENTLY_MODIFIED_SECONDS;
 }
 
 function TaskFileBrowser (props) {
@@ -78,7 +72,7 @@ function TaskFileBrowser (props) {
       <UITable
         data={getFiles() || []}
         keyGetter={(file) => file.name}
-        rowClassName={({mtime}) => { return isRecentlyModified(mtime) ? 'bg-info-light' : null; }}
+        rowClassName={({isRecentlyModified}) => { return isRecentlyModified ? 'bg-info-light' : null; }}
         rowChunkSize={50}
         paginated={true}
         emptyTableMessage="No files exist in this directory"
@@ -90,7 +84,7 @@ function TaskFileBrowser (props) {
           label=""
           id="icon"
           key="icon"
-          cellData={(file) => isRecentlyModified(file.mtime) &&
+          cellData={({isRecentlyModified}) => isRecentlyModified &&
             <OverlayTrigger placement="top" overlay={recentlyModifiedTooltip}><div className="page-loader loader-small loader-info" /></OverlayTrigger>
           }
         />

--- a/SingularityUI/app/styles/scss/ui-table.scss
+++ b/SingularityUI/app/styles/scss/ui-table.scss
@@ -16,4 +16,10 @@ table {
       }
     }
   }
+
+  td {
+    &.icon-column {
+      width: 3em;
+    }
+  }
 }

--- a/SingularityUI/app/styles/stylus/bootstrap-tweaks.styl
+++ b/SingularityUI/app/styles/stylus/bootstrap-tweaks.styl
@@ -37,3 +37,6 @@
 
 .bg-waiting
   background-color $purple-light
+
+.bg-info-light
+  background-color #d9edf7 + 50%

--- a/SingularityUI/app/styles/stylus/loader.styl
+++ b/SingularityUI/app/styles/stylus/loader.styl
@@ -41,6 +41,12 @@
     width 1em
     display inline-block
     margin 0 0.5em
+    position relative
+    top: 0.25em
+
+.loader-info
+    border-top-color #707070 + 50%
+    border-right-color #707070 + 50%
 
 .page-loader-fixed
     position: fixed


### PR DESCRIPTION
Users want a way to determine if a file is currently being written to, especially in cases where downloading an incomplete file such as a heap dump would be undesirable. 

![image](https://user-images.githubusercontent.com/3221272/29327788-51ca30bc-81be-11e7-9903-df94dedd3bdc.png)

The task file browser will highlight files that have been modified in the last 60 seconds.