### PR TITLE
Remove swagger jackson version override

### DIFF
--- a/SingularitySwagger/pom.xml
+++ b/SingularitySwagger/pom.xml
@@ -10,10 +10,6 @@
 
   <artifactId>SingularitySwagger</artifactId>
 
-  <properties>
-    <dep.jackson.version>2.4.2</dep.jackson.version>
-  </properties>
-
   <dependencies>
       <dependency>
         <groupId>com.github.kongchen</groupId>


### PR DESCRIPTION
It seems as though this was added when the Jackson version was very old and it should no longer be necessary, but I don't really know how to confirm that myself.

This came up in https://github.com/HubSpot/basepom/pull/20

@ssalinas @tpetr @darcatron @baconmania @jhaber 
