### PR TITLE
look at new scale request before opting to old request

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -627,7 +627,7 @@ public class RequestResource extends AbstractRequestResource {
       scaleMessage = String.format("%s", scaleMessage);
     }
 
-    if (newRequest.getBounceAfterScale().or(scaleRequest.getBounce().or(false))) {
+    if (scaleRequest.getBounce().or(newRequest.getBounceAfterScale().or(false))) {
       validator.checkActionEnabled(SingularityAction.BOUNCE_REQUEST);
 
       checkBadRequest(newRequest.isLongRunning(), "Can not bounce a %s request (%s)", newRequest.getRequestType(), newRequest);


### PR DESCRIPTION
if the scaleRequest had an optional value, that should be considered first. If it's absent, we can consider the previous request