### PR TITLE
Preserve instance id order when scaling down

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -463,25 +463,18 @@ public class SingularityScheduler {
       }
 
       List<SingularityTaskId> remainingActiveTasks = new ArrayList<>(matchingTaskIds);
-      List<SingularityTaskId> toClean = new ArrayList<>();
       final int expectedInstances = numMissingInstances + matchingTaskIds.size();
       LOG.info("expected {} active {}", expectedInstances, matchingTaskIds);
 
       List<Integer> usedIds = new ArrayList<>();
-      for (SingularityTaskId activeTaskId : remainingActiveTasks) {
-        if (usedIds.contains(activeTaskId.getInstanceNo())) {
-          toClean.add(activeTaskId);
-        } else if (activeTaskId.getInstanceNo() > expectedInstances) {
-          toClean.add(activeTaskId);
+      for (SingularityTaskId taskId : matchingTaskIds) {
+        if (usedIds.contains(taskId.getInstanceNo()) || taskId.getInstanceNo() > expectedInstances) {
+          remainingActiveTasks.remove(taskId);
+          LOG.info("Cleaning up task {} due to new request {} - scaling down to {} instances", taskId.getId(), request.getId(), request.getInstancesSafe());
+          taskManager.createTaskCleanup(new SingularityTaskCleanup(pendingRequest.getUser(), TaskCleanupType.SCALING_DOWN, now, taskId, Optional.absent(), Optional.absent(), Optional.absent()));
         }
-        usedIds.add(activeTaskId.getInstanceNo());
+        usedIds.add(taskId.getInstanceNo());
       }
-      toClean.forEach((taskId) -> {
-        remainingActiveTasks.remove(taskId);
-        LOG.info("Cleaning up task {} due to new request {} - scaling down to {} instances", taskId.getId(), request.getId(), request.getInstancesSafe());
-        taskManager.createTaskCleanup(new SingularityTaskCleanup(pendingRequest.getUser(), TaskCleanupType.SCALING_DOWN, now, taskId, Optional.<String>absent(), Optional.<String>absent(), Optional.<SingularityTaskShellCommandRequestId>absent()));
-        remainingActiveTasks.remove(taskId);
-      });
 
       if (request.isRackSensitive() && configuration.isRebalanceRacksOnScaleDown()) {
         List<SingularityTaskId> extraCleanedTasks = new ArrayList<>();

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -463,7 +463,10 @@ public class SingularityScheduler {
       }
 
       List<SingularityTaskId> remainingActiveTasks = new ArrayList<>(matchingTaskIds);
-      for (int i = 0; i < Math.abs(numMissingInstances); i++) {
+      int numPendingTasksForDeploy = (int) leaderCache.getPendingTasks().stream()
+          .filter((pendingTask) -> pendingTask.getPendingTaskId().getRequestId().equals(request.getId()) && pendingTask.getPendingTaskId().getDeployId().equals(deployStatistics.getDeployId()))
+          .count();
+      for (int i = 0; i < Math.abs(numMissingInstances) + numPendingTasksForDeploy; i++) {
         final SingularityTaskId toCleanup = matchingTaskIds.get(i);
         remainingActiveTasks.remove(toCleanup);
         LOG.info("Cleaning up task {} due to new request {} - scaling down to {} instances", toCleanup.getId(), request.getId(), request.getInstancesSafe());

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityExpiringActionsTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityExpiringActionsTest.java
@@ -115,6 +115,7 @@ public class SingularityExpiringActionsTest extends SingularitySchedulerTestBase
 
     resourceOffers();
     cleaner.drainCleanupQueue();
+    cleaner.drainCleanupQueue();
     killKilledTasks();
 
     Assert.assertEquals(3, taskManager.getActiveTaskIds().size());

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -1659,6 +1659,50 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
   }
 
   @Test
+  public void testScaleDownTakesHighestInstancesWithPendingTask() {
+    initRequest();
+    initFirstDeploy();
+
+    saveAndSchedule(request.toBuilder().setInstances(Optional.of(5)));
+
+    resourceOffers();
+
+    Assert.assertEquals(5, taskManager.getActiveTaskIds().size());
+
+    SingularityTaskId instance2 = null;
+    for (SingularityTaskId taskId : taskManager.getActiveTaskIds()) {
+      if (taskId.getInstanceNo() == 2) {
+        instance2 = taskId;
+      }
+    }
+
+
+    statusUpdate(taskManager.getTask(instance2).get(), TaskState.TASK_KILLED);
+    killKilledTasks();
+
+    scheduler.drainPendingQueue();
+
+    System.out.println(taskManager.getPendingTaskIds());
+
+    requestResource.scale(requestId, new SingularityScaleRequest(Optional.of(3), Optional.<Long> absent(), Optional.<Boolean> absent(),
+        Optional.<String> absent(), Optional.<String>absent(), Optional.<Boolean>absent(), Optional.<Boolean>absent()));
+    scheduler.drainPendingQueue();
+    cleaner.drainCleanupQueue();
+
+    // instances 4 and 5 should get killed
+    Assert.assertEquals(2, taskManager.getKilledTaskIdRecords().size());
+    killKilledTasks();
+
+    resourceOffers();
+
+    // instances 1,2,3 should be active
+    Assert.assertEquals(3, taskManager.getActiveTaskIds().size());
+    for (SingularityTaskId taskId : taskManager.getActiveTaskIds()) {
+      Assert.assertTrue(taskId.getInstanceNo() < 4);
+    }
+  }
+
+  @Test
   public void testRequestsInPendingQueueAreOrderedByTimestamp() {
     long now = System.currentTimeMillis();
     initRequestWithType(RequestType.SCHEDULED, false);


### PR DESCRIPTION
Example situation:
- Tasks with instance number 1,2,4,5 are active and there is a single pending task
- request is scaled down to 4
- pending task is deleted and no tasks are cleaned, remaining instances are 1,2,4,5

This PR updates the scheduler to preserve the instance numbers in order since a number of systems depend on them being contiguous. This causes slightly more task churn in a few cases in return for consistency. If the task churn is an issue, we can always put it behind a configuration flag.

tests added, haven't added the config flag just yet

@darcatron 