### PR TITLE
Mesos backpressure

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/config/MesosConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/MesosConfiguration.java
@@ -49,7 +49,7 @@ public class MesosConfiguration {
   private Optional<String> credentialPrincipal = Optional.absent();
   private Optional<String> credentialSecret = Optional.absent();
 
-  private long rxEventBufferSize = 5000;
+  private long rxEventBufferSize = 10000;
 
   public int getMaxNumInstancesPerRequest() {
     return maxNumInstancesPerRequest;

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
     <project.build.targetJdk>1.8</project.build.targetJdk>
     <dep.metrics-guice.version>3.1.3</dep.metrics-guice.version>
     <dep.dropwizard-metrics.version>3.1.4</dep.dropwizard-metrics.version>
+    <dep.mesos.rxjava.version>0.2.0</dep.mesos.rxjava.version>
   </properties>
 
   <modules>
@@ -173,7 +174,7 @@
       <dependency>
         <groupId>com.mesosphere.mesos.rx.java</groupId>
         <artifactId>mesos-rxjava-protobuf-client</artifactId>
-        <version>0.1.2</version>
+        <version>${dep.mesos.rxjava.version}</version>
       </dependency>
 
       <dependency>
@@ -185,13 +186,13 @@
       <dependency>
         <groupId>com.mesosphere.mesos.rx.java</groupId>
         <artifactId>mesos-rxjava-client</artifactId>
-        <version>0.1.2</version>
+        <version>${dep.mesos.rxjava.version}</version>
       </dependency>
 
       <dependency>
         <groupId>com.mesosphere.mesos.rx.java</groupId>
         <artifactId>mesos-rxjava-util</artifactId>
-        <version>0.1.2</version>
+        <version>${dep.mesos.rxjava.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Diff will look nicer once the other mesos_1 PR is merged. Relevant commit is https://github.com/HubSpot/Singularity/commit/d15af0f7b0148388ae6bc5ba5a1cb61e59227eab

Moves the backpressure to the mesos client itself now that 0.2.0 of mesos-rxjava allows us to set backpressure behaviors. Also doubles the default event buffer size to handle large influxes of status updates from reconciliation

/cc @darcatron @baconmania 