### PR TITLE
Catch errors in FetchRequestArgHistory

### DIFF
--- a/SingularityUI/app/actions/api/history.es6
+++ b/SingularityUI/app/actions/api/history.es6
@@ -101,7 +101,7 @@ export const FetchRequestArgHistory = buildApiAction(
   'FETCH_REQUEST_ARG_HISTORY',
   (requestId) => ({
     url: `/history/request/${requestId}/command-line-args`,
-    catchStatusCodes: [400, 404]
+    catchStatusCodes: [400, 404, 500]
   }),
   (requestId) => requestId
 );


### PR DESCRIPTION
This is an optional bit to fill in the args for a task, we can catch errors for this endpoint. There error banner is more worrying than helpful in the run now modal.

/cc @kwm4385 