### PR TITLE
Configurable taskbuilder disk allocation.

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/config/MesosConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/MesosConfiguration.java
@@ -22,6 +22,10 @@ public class MesosConfiguration {
   private int defaultMemory = 64;
 
   private int defaultDisk = 0;
+  // ^ This refers to SingularityDeploy-scoped resources.
+
+  // v This refers to Mesos TaskInfo-scoped resources. Changing this doesn't require a redeploy of the world.
+  private int mesosTaskBuilderDiskAllocationMb = 1;
 
   private boolean checkpoint = true;
 
@@ -209,6 +213,14 @@ public class MesosConfiguration {
 
   public void setDefaultDisk(int defaultDisk) {
     this.defaultDisk = defaultDisk;
+  }
+
+  public int getMesosTaskBuilderDiskAllocationMb() {
+    return mesosTaskBuilderDiskAllocationMb;
+  }
+
+  public void setMesosTaskBuilderDiskAllocationMb(int mesosTaskBuilderDiskAllocationMb) {
+    this.mesosTaskBuilderDiskAllocationMb = mesosTaskBuilderDiskAllocationMb;
   }
 
   public String getFrameworkUser() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilder.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilder.java
@@ -121,7 +121,7 @@ class SingularityMesosTaskBuilder {
       // This is just a temporary hack to enable disk usage reporting where we can, not an actual way to match task disk requirements to offers.
       // If the requested disk for a task is 0, disk usage reporting is not enabled.
       int taskBuilderDiskAllocationMb = configuration.getMesosConfiguration().getMesosTaskBuilderDiskAllocationMb();
-      offerHolder.subtractResources(Collections.singletonList(MesosUtils.getDiskResource(taskBuilderDiskAllocationMb, Optional.absent())));
+      offerHolder.subtractResources(Collections.singletonList(MesosUtils.getDiskResource(taskBuilderDiskAllocationMb, requiredRole)));
       bldr.addResources(MesosUtils.getDiskResource(taskBuilderDiskAllocationMb, requiredRole));
     }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilder.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilder.java
@@ -119,6 +119,7 @@ class SingularityMesosTaskBuilder {
     } else if (MesosUtils.getDisk(offerHolder.getCurrentResources(), Optional.absent()) >= 1.0) {
       // If this offer contains 1MB of disk resources, claim it to enable disk usage reporting.
       // This is just a temporary hack to enable disk usage reporting where we can, not an actual way to match task disk requirements to offers.
+      // If the requested disk for a task is 0, disk usage reporting is not enabled.
       int taskBuilderDiskAllocationMb = configuration.getMesosConfiguration().getMesosTaskBuilderDiskAllocationMb();
       offerHolder.subtractResources(Collections.singletonList(MesosUtils.getDiskResource(taskBuilderDiskAllocationMb, Optional.absent())));
       bldr.addResources(MesosUtils.getDiskResource(taskBuilderDiskAllocationMb, requiredRole));

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilder.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilder.java
@@ -119,8 +119,9 @@ class SingularityMesosTaskBuilder {
     } else if (MesosUtils.getDisk(offerHolder.getCurrentResources(), Optional.absent()) >= 1.0) {
       // If this offer contains 1MB of disk resources, claim it to enable disk usage reporting.
       // This is just a temporary hack to enable disk usage reporting where we can, not an actual way to match task disk requirements to offers.
-      offerHolder.subtractResources(Collections.singletonList(MesosUtils.getDiskResource(1.0, Optional.absent())));
-      bldr.addResources(MesosUtils.getDiskResource(1.0, requiredRole));
+      int taskBuilderDiskAllocationMb = configuration.getMesosConfiguration().getMesosTaskBuilderDiskAllocationMb();
+      offerHolder.subtractResources(Collections.singletonList(MesosUtils.getDiskResource(taskBuilderDiskAllocationMb, Optional.absent())));
+      bldr.addResources(MesosUtils.getDiskResource(taskBuilderDiskAllocationMb, requiredRole));
     }
 
     bldr.setAgentId(offerHolder.getOffers().get(0).getAgentId());


### PR DESCRIPTION
This is a stopgap until we make `disk` a first-class citizen in scoring our offer scoring computations.

/cc @ssalinas 