### PR TITLE
Option to provide credentials supplier in client

### DIFF
--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
@@ -282,8 +282,12 @@ public class SingularityClient {
         .withWaitStrategy(WaitStrategies.exponentialWait())
         .retryIfResult((response) -> {
           if (response != null && response.getStatusCode() == 401 && credentialsSupplier != null && retryOnUnauthorized) {
-            authenticate();
-            return true;
+            try {
+              authenticate();
+              return true;
+            } catch (Exception e) {
+              throw new SingularityClientException("Could not authenticate", e);
+            }
           }
           return false;
         })

--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClientModule.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClientModule.java
@@ -42,6 +42,9 @@ public class SingularityClientModule extends AbstractModule {
   // bind this to a Supplier<SingularityClientCredentials> to generate client credentials
   public static final String CREDENTIALS_SUPPLIER = "singularity.client.credentials.supplier";
 
+  // bind this to a boolean to determine if unauthorized responses should be retried when credentialsSupplier is present
+  public static final String RETRY_ON_UNAUTHORIZED = "singularity.client.retry.on.unauthorized";
+
   private final List<String> hosts;
   private final Optional<HttpConfig> httpConfig;
 

--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClientModule.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClientModule.java
@@ -39,6 +39,9 @@ public class SingularityClientModule extends AbstractModule {
   // bind this to a Predicate<HttpResponse> to say whether a request should be retried
   public static final String RETRY_STRATEGY = "singularity.client.retry.strategy";
 
+  // bind this to a Supplier<SingularityClientCredentials> to generate client credentials
+  public static final String CREDENTIALS_SUPPLIER = "singularity.client.credentials.supplier";
+
   private final List<String> hosts;
   private final Optional<HttpConfig> httpConfig;
 

--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClientProvider.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClientProvider.java
@@ -47,29 +47,29 @@ public class SingularityClientProvider implements Provider<SingularityClient> {
     this.httpClient = httpClient;
   }
 
-  @Inject(optional=true) // optional because we have a default
+  @Inject(optional = true) // optional because we have a default
   public SingularityClientProvider setContextPath(@Named(SingularityClientModule.CONTEXT_PATH) String contextPath) {
     this.contextPath = contextPath;
     return this;
   }
 
-  @Inject(optional=true) // optional in case we use fixed hosts
+  @Inject(optional = true) // optional in case we use fixed hosts
   public SingularityClientProvider setHosts(@Named(SingularityClientModule.HOSTS_PROPERTY_NAME) String commaSeparatedHosts) {
     return setHosts(commaSeparatedHosts.split(","));
   }
 
-  @Inject(optional=true) // optional in case we use Curator
+  @Inject(optional = true) // optional in case we use Curator
   public SingularityClientProvider setCurator(@Named(SingularityClientModule.CURATOR_NAME) CuratorFramework curator) {
     return setHosts(getClusterMembers(curator));
   }
 
-  @Inject(optional=true)
+  @Inject(optional = true)
   public SingularityClientProvider setHosts(@Named(SingularityClientModule.HOSTS_PROPERTY_NAME) List<String> hosts) {
     this.hosts = ImmutableList.copyOf(hosts);
     return this;
   }
 
-  @Inject(optional=true)
+  @Inject(optional = true)
   public SingularityClientProvider setCredentials(@Named(SingularityClientModule.CREDENTIALS_PROPERTY_NAME) SingularityClientCredentials credentials) {
     this.credentials = Optional.of(credentials);
     return this;
@@ -93,7 +93,7 @@ public class SingularityClientProvider implements Provider<SingularityClient> {
     return this;
   }
 
-  @Inject
+  @Inject(optional = true)
   public SingularityClientProvider setRetryOnUnauthorized(@Named(SingularityClientModule.RETRY_ON_UNAUTHORIZED) Boolean retryOnUnauthorized) {
     this.retryOnUnauthorized = retryOnUnauthorized;
     return this;
@@ -105,7 +105,7 @@ public class SingularityClientProvider implements Provider<SingularityClient> {
     return this;
   }
 
-  @Inject(optional=true)
+  @Inject(optional = true)
   public SingularityClientProvider setSsl(boolean ssl) {
     this.ssl = ssl;
     return this;

--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClientProvider.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClientProvider.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import javax.inject.Named;
 import javax.inject.Provider;
@@ -38,6 +39,7 @@ public class SingularityClientProvider implements Provider<SingularityClient> {
 
   private int retryAttempts = 3;
   private Predicate<HttpResponse> retryStrategy = HttpResponse::isServerError;
+  private Supplier<SingularityClientCredentials> credentialsSupplier = null;
 
   @Inject
   public SingularityClientProvider(@Named(SingularityClientModule.HTTP_CLIENT_NAME) HttpClient httpClient) {
@@ -81,6 +83,12 @@ public class SingularityClientProvider implements Provider<SingularityClient> {
   @Inject(optional = true)
   public SingularityClientProvider setRetryStrategy(@Named(SingularityClientModule.RETRY_STRATEGY) Predicate<HttpResponse> retryStrategy) {
     this.retryStrategy = retryStrategy;
+    return this;
+  }
+
+  @Inject(optional = true)
+  public SingularityClientProvider setAuthenticateMethod(@Named(SingularityClientModule.CREDENTIALS_SUPPLIER) Supplier<SingularityClientCredentials> credentialsSupplier) {
+    this.credentialsSupplier = credentialsSupplier;
     return this;
   }
 


### PR DESCRIPTION
With the new webhook auth, it is more likely that a long running system would have to re-authenticate, or provide a means of grabbing an auth token to send. This adds changes to the `SingulairtyClient` to optionally provide a `Supplier<SingularityClientCredentials>`. By default, if the supplier is present, the function will be called on the first request made by the client in order to grab credentials. And, if an unauthorized response is later received the client will try to re-authenticate as part of its retry strategy. This should be useful for longer running systems where a session may expire after some time