### PR TITLE
Easier setup for local dev with SingularityService

### DIFF
--- a/compose-dev.yml
+++ b/compose-dev.yml
@@ -10,8 +10,8 @@ master:
   net: host
   environment:
     MESOS_ZK: zk://localhost:2181/mesos
-    MESOS_HOSTNAME: localhost
-    MESOS_IP: 127.0.0.1
+    MESOS_HOSTNAME: ${DOCKER_IP}
+    MESOS_IP: ${DOCKER_IP}
     MESOS_QUORUM: 1
     MESOS_CLUSTER: docker-compose
     MESOS_WORK_DIR: /var/lib/mesos

--- a/dev
+++ b/dev
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DOCKER_IP=`echo "$DOCKER_HOST" | awk -F/ '{print $3}' | awk -F: '{print $1}'`
+export DOCKER_IP=`echo "$DOCKER_HOST" | awk -F/ '{print $3}' | awk -F: '{print $1}'`
 
 function pull {
   docker-compose -f compose-dev.yml pull


### PR DESCRIPTION
This sets the mesos master ip and hostname in our compose-dev setup to the docker vm ip. That way we can connect a local running intellij/eclipse/etc SingularityService to the docker mesos cluster for faster development

cc @pschoenfelder 