### PR TITLE
Corrected path for executor download fallback

### DIFF
--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorArtifactFetcher.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorArtifactFetcher.java
@@ -194,7 +194,7 @@ public class SingularityExecutorArtifactFetcher {
       if (Objects.toString(fetched.getFileName()).endsWith(".tar.gz")) {
         artifactManager.untar(fetched, task.getArtifactPath(remoteArtifact, task.getTaskDefinition().getTaskDirectoryPath()));
       } else {
-        artifactManager.copy(fetched, task.getArtifactPath(remoteArtifact, task.getTaskDefinition().getTaskAppDirectoryPath()), remoteArtifact.getFilename());
+        artifactManager.copy(fetched, task.getArtifactPath(remoteArtifact, task.getTaskDefinition().getTaskDirectoryPath()), remoteArtifact.getFilename());
       }
     }
 


### PR DESCRIPTION
Previously this was using the task app directory when copying (not unzipping) which does not match what the S3Downloader service does, and does not match what untar does. This updates it to match