### PR TITLE
Enable auth headers in old tailer

### DIFF
--- a/SingularityUI/app/actions/log.es6
+++ b/SingularityUI/app/actions/log.es6
@@ -5,8 +5,16 @@ import { fetchTasksForRequest } from './activeTasks';
 
 let fetchData = function(taskId, path, offset = undefined, length = 0) {
   length = Math.max(length, 0); // API breaks if you request a negative length
+  const headers = {};
+  if (config.generateAuthHeader) {
+    headers['Authorization'] = Utils.getAuthTokenHeader();
+  }
   return $.ajax(
-    {url: `${ config.apiRoot }/sandbox/${ taskId }/read?${$.param({path, length, offset})}`});
+    {
+      url: `${ config.apiRoot }/sandbox/${ taskId }/read?${$.param({path, length, offset})}`,
+      headers: headers
+    }
+  );
 };
 
 const fetchTaskHistory = (taskId) =>


### PR DESCRIPTION
The old tailer has a call that was missed in the original auth updates