### PR TITLE
Provide option to prevent emails for scale events

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityScaleRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityScaleRequest.java
@@ -11,16 +11,23 @@ public class SingularityScaleRequest extends SingularityExpiringRequestParent {
   private final Optional<Boolean> skipHealthchecks;
   private final Optional<Boolean> bounce;
   private final Optional<Boolean> incremental;
+  private final Optional<Boolean> skipEmailNotification;
 
   @JsonCreator
-  public SingularityScaleRequest(@JsonProperty("instances") Optional<Integer> instances, @JsonProperty("durationMillis") Optional<Long> durationMillis,
-      @JsonProperty("skipHealthchecks") Optional<Boolean> skipHealthchecks, @JsonProperty("actionId") Optional<String> actionId, @JsonProperty("message") Optional<String> message,
-      @JsonProperty("bounce") Optional<Boolean> bounce, @JsonProperty("incremental") Optional<Boolean> incremental) {
+  public SingularityScaleRequest(@JsonProperty("instances") Optional<Integer> instances,
+                                 @JsonProperty("durationMillis") Optional<Long> durationMillis,
+                                 @JsonProperty("skipHealthchecks") Optional<Boolean> skipHealthchecks,
+                                 @JsonProperty("actionId") Optional<String> actionId,
+                                 @JsonProperty("message") Optional<String> message,
+                                 @JsonProperty("bounce") Optional<Boolean> bounce,
+                                 @JsonProperty("incremental") Optional<Boolean> incremental,
+                                 @JsonProperty("skipEmailNotification") Optional<Boolean> skipEmailNotification) {
     super(durationMillis, actionId, message);
     this.instances = instances;
     this.skipHealthchecks = skipHealthchecks;
     this.bounce = bounce;
     this.incremental = incremental;
+    this.skipEmailNotification = skipEmailNotification;
   }
 
   @ApiModelProperty(required=false, value="If set to true, healthchecks will be skipped while scaling this request (only)")
@@ -43,6 +50,11 @@ public class SingularityScaleRequest extends SingularityExpiringRequestParent {
     return incremental;
   }
 
+  @ApiModelProperty(required=false, value="If set to true, no email notification will be sent out for this specific scale event")
+  public Optional<Boolean> getSkipEmailNotification() {
+    return skipEmailNotification;
+  }
+
   @Override
   public String toString() {
     return "SingularityScaleRequest{" +
@@ -50,6 +62,7 @@ public class SingularityScaleRequest extends SingularityExpiringRequestParent {
         ", skipHealthchecks=" + skipHealthchecks +
         ", bounce=" + bounce +
         ", incremental=" + incremental +
+        ", skipEmailNotification=" + skipEmailNotification +
         "} " + super.toString();
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityScaleRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityScaleRequest.java
@@ -13,6 +13,17 @@ public class SingularityScaleRequest extends SingularityExpiringRequestParent {
   private final Optional<Boolean> incremental;
   private final Optional<Boolean> skipEmailNotification;
 
+  @Deprecated
+  public SingularityScaleRequest(Optional<Integer> instances,
+                                 Optional<Long> durationMillis,
+                                 Optional<Boolean> skipHealthchecks,
+                                 Optional<String> actionId,
+                                 Optional<String> message,
+                                 Optional<Boolean> bounce,
+                                 Optional<Boolean> incremental) {
+    this(instances, durationMillis, skipHealthchecks, actionId, message, bounce, incremental, Optional.absent());
+  }
+
   @JsonCreator
   public SingularityScaleRequest(@JsonProperty("instances") Optional<Integer> instances,
                                  @JsonProperty("durationMillis") Optional<Long> durationMillis,

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -667,7 +667,9 @@ public class RequestResource extends AbstractRequestResource {
           System.currentTimeMillis(), scaleRequest, oldRequest.getInstances(), scaleRequest.getActionId().or(UUID.randomUUID().toString()), scaleRequest.getBounce()));
     }
 
-    mailer.sendRequestScaledMail(newRequest, Optional.of(scaleRequest), oldRequest.getInstances(), user.getEmail());
+    if (!scaleRequest.getSkipEmailNotification().isPresent() || !scaleRequest.getSkipEmailNotification().get()) {
+      mailer.sendRequestScaledMail(newRequest, Optional.of(scaleRequest), oldRequest.getInstances(), user.getEmail());
+    }
 
     return fillEntireRequest(fetchRequestWithState(requestId, user));
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/smtp/SmtpMailer.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/smtp/SmtpMailer.java
@@ -392,7 +392,7 @@ public class SmtpMailer implements SingularityMailer, Managed {
     final List<SingularityEmailDestination> emailDestination = getDestination(request, type.getEmailType());
 
     if (emailDestination.isEmpty()) {
-      LOG.debug("Not configured to send request cooldown mail for");
+      LOG.debug("Not configured to send request mail for {}", request);
       return;
     }
 
@@ -507,7 +507,7 @@ public class SmtpMailer implements SingularityMailer, Managed {
     final List<SingularityEmailDestination> emailDestination = getDestination(request, SingularityEmailType.REQUEST_IN_COOLDOWN);
 
     if (emailDestination.isEmpty()) {
-      LOG.debug("Not configured to send request cooldown mail for");
+      LOG.debug("Not configured to send request cooldown mail for {}", request);
       return;
     }
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/SingularityHistoryTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/SingularityHistoryTest.java
@@ -488,7 +488,7 @@ public class SingularityHistoryTest extends SingularitySchedulerTestBase {
       msg = msg + i;
     }
 
-    requestResource.scale(requestId, new SingularityScaleRequest(Optional.of(2), Optional.absent(), Optional.absent(), Optional.absent(), Optional.of(msg), Optional.absent(), Optional.absent()), singularityUser);
+    requestResource.scale(requestId, new SingularityScaleRequest(Optional.of(2), Optional.absent(), Optional.absent(), Optional.absent(), Optional.of(msg), Optional.absent(), Optional.absent(), Optional.absent()), singularityUser);
     requestResource.deleteRequest(requestId, Optional.of(new SingularityDeleteRequestRequest(Optional.of("a msg"), Optional.absent(), Optional.absent())), singularityUser);
 
     cleaner.drainCleanupQueue();

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityExpiringActionsTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityExpiringActionsTest.java
@@ -128,7 +128,7 @@ public class SingularityExpiringActionsTest extends SingularitySchedulerTestBase
   public void testExpiringIncrementalBounce() {
     initRequest();
 
-    requestResource.scale(requestId, new SingularityScaleRequest(Optional.of(3), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()), singularityUser);
+    requestResource.scale(requestId, new SingularityScaleRequest(Optional.of(3), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()), singularityUser);
 
     initFirstDeploy();
 
@@ -186,7 +186,7 @@ public class SingularityExpiringActionsTest extends SingularitySchedulerTestBase
     initRequest();
     initFirstDeploy();
 
-    requestResource.scale(requestId, new SingularityScaleRequest(Optional.of(5), Optional.of(1L), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()), singularityUser);
+    requestResource.scale(requestId, new SingularityScaleRequest(Optional.of(5), Optional.of(1L), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()), singularityUser);
 
     try {
       Thread.sleep(2);
@@ -237,7 +237,7 @@ public class SingularityExpiringActionsTest extends SingularitySchedulerTestBase
 
     requestResource.postRequest(request.toBuilder().setBounceAfterScale(Optional.of(true)).build(), singularityUser);
 
-    requestResource.scale(requestId, new SingularityScaleRequest(Optional.of(5), Optional.of(1L), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()), singularityUser);
+    requestResource.scale(requestId, new SingularityScaleRequest(Optional.of(5), Optional.of(1L), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()), singularityUser);
 
     Assert.assertEquals(1, requestManager.getCleanupRequests().size());
     cleaner.drainCleanupQueue();

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -1183,7 +1183,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
   public void testBounce() {
     initRequest();
 
-    requestResource.scale(requestId, new SingularityScaleRequest(Optional.of(3), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()), singularityUser);
+    requestResource.scale(requestId, new SingularityScaleRequest(Optional.of(3), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()), singularityUser);
 
     initFirstDeploy();
 
@@ -1229,7 +1229,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
   public void testIncrementalBounceShutsDownOldTasksPerNewHealthyTask() {
     initRequest();
 
-    requestResource.scale(requestId, new SingularityScaleRequest(Optional.of(3), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()), singularityUser);
+    requestResource.scale(requestId, new SingularityScaleRequest(Optional.of(3), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()), singularityUser);
 
     initFirstDeploy();
 
@@ -1649,7 +1649,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     Assert.assertEquals(5, taskManager.getActiveTaskIds().size());
 
     requestResource.scale(requestId, new SingularityScaleRequest(Optional.of(2), Optional.absent(), Optional.absent(),
-        Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()), singularityUser);
+        Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()), singularityUser);
 
     resourceOffers();
     cleaner.drainCleanupQueue();
@@ -1690,7 +1690,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     System.out.println(taskManager.getPendingTaskIds());
 
     requestResource.scale(requestId, new SingularityScaleRequest(Optional.of(3), Optional.absent(), Optional.absent(),
-        Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()), singularityUser);
+        Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()), singularityUser);
     scheduler.drainPendingQueue();
     cleaner.drainCleanupQueue();
 
@@ -2323,7 +2323,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     initFirstDeploy();
     launchTask(request, firstDeploy, 1, TaskState.TASK_RUNNING);
 
-    requestResource.scale(requestId, new SingularityScaleRequest(Optional.of(5), Optional.of(1L), Optional.absent(), Optional.absent(), Optional.absent(), Optional.of(true), Optional.absent()), singularityUser);
+    requestResource.scale(requestId, new SingularityScaleRequest(Optional.of(5), Optional.of(1L), Optional.absent(), Optional.absent(), Optional.absent(), Optional.of(true), Optional.absent(), Optional.absent()), singularityUser);
 
     Assert.assertEquals(1, requestManager.getCleanupRequests().size());
     cleaner.drainCleanupQueue();

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTestBase.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTestBase.java
@@ -512,7 +512,7 @@ public class SingularitySchedulerTestBase extends SingularityCuratorTestBase {
   protected void initWithTasks(int num) {
     initRequest();
 
-    requestResource.scale(requestId, new SingularityScaleRequest(Optional.of(num), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()), singularityUser);
+    requestResource.scale(requestId, new SingularityScaleRequest(Optional.of(num), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()), singularityUser);
 
     initFirstDeploy();
 


### PR DESCRIPTION
This updates the scaleRequest object to include another optional boolean `skipEmailNotification`. By default, we'll send emails for scale events, but users can toggle their request to prevent email notifications. 