### PR TITLE
Ability to update authorized groups separately from full request

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityUpdateGroupsRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityUpdateGroupsRequest.java
@@ -1,0 +1,73 @@
+package com.hubspot.singularity.api;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Optional;
+
+public class SingularityUpdateGroupsRequest {
+  private final Optional<String> group;
+  private final Set<String> readWriteGroups;
+  private final Set<String> readOnlyGroups;
+  private final Optional<String> message;
+
+  @JsonCreator
+  public SingularityUpdateGroupsRequest(@JsonProperty("group") Optional<String> group,
+                                        @JsonProperty("readWriteGroups") Set<String> readWriteGroups,
+                                        @JsonProperty("readOnlyGroups") Set<String> readOnlyGroups,
+                                        @JsonProperty("message") Optional<String> message) {
+    this.group = group;
+    this.readWriteGroups = readWriteGroups != null ? readWriteGroups : Collections.emptySet();
+    this.readOnlyGroups = readOnlyGroups != null ? readOnlyGroups : Collections.emptySet();
+    this.message = message;
+  }
+
+  public Optional<String> getGroup() {
+    return group;
+  }
+
+  public Set<String> getReadWriteGroups() {
+    return readWriteGroups;
+  }
+
+  public Set<String> getReadOnlyGroups() {
+    return readOnlyGroups;
+  }
+
+  public Optional<String> getMessage() {
+    return message;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj instanceof SingularityUpdateGroupsRequest) {
+      final SingularityUpdateGroupsRequest that = (SingularityUpdateGroupsRequest) obj;
+      return Objects.equals(this.group, that.group) &&
+          Objects.equals(this.readWriteGroups, that.readWriteGroups) &&
+          Objects.equals(this.readOnlyGroups, that.readOnlyGroups) &&
+          Objects.equals(this.message, that.message);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(group, readWriteGroups, readOnlyGroups, message);
+  }
+
+  @Override
+  public String toString() {
+    return "SingularityUpdateGroupsRequest{" +
+        "group=" + group +
+        ", readWriteGroups=" + readWriteGroups +
+        ", readOnlyGroups=" + readOnlyGroups +
+        ", message=" + message +
+        '}';
+  }
+}

--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
@@ -1494,21 +1494,6 @@ public class SingularityClient {
     return response.isSuccess();
   }
 
-  /**
-   * Check if the current client's user is authorized for the specified groups
-   *
-   * @param updateGroupsRequest
-   *    The group, readWriteGroups, and readOnlyGroups to be checked
-   *
-   * @return
-   *    true if the user is authorized for WRITE scope, false otherwise
-   */
-  public boolean isUserAuthorizedForGroups(SingularityUpdateGroupsRequest updateGroupsRequest) {
-    final Function<String, String> requestUri = (host) -> String.format(AUTH_GROUPS_CHECK_FORMAT, getApiBase(host));
-    final HttpResponse response = post(requestUri, "check auth for groups", Optional.of(updateGroupsRequest));
-    return response.isSuccess();
-  }
-
   //
   // TASK STATE
   //

--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
@@ -97,6 +97,7 @@ import com.hubspot.singularity.api.SingularityPriorityFreeze;
 import com.hubspot.singularity.api.SingularityRunNowRequest;
 import com.hubspot.singularity.api.SingularityScaleRequest;
 import com.hubspot.singularity.api.SingularityUnpauseRequest;
+import com.hubspot.singularity.api.SingularityUpdateGroupsRequest;
 
 public class SingularityClient {
 
@@ -173,6 +174,8 @@ public class SingularityClient {
   private static final String REQUEST_SCALE_FORMAT = REQUESTS_FORMAT + "/request/%s/scale";
   private static final String REQUEST_RUN_FORMAT = REQUESTS_FORMAT + "/request/%s/run";
   private static final String REQUEST_EXIT_COOLDOWN_FORMAT = REQUESTS_FORMAT + "/request/%s/exit-cooldown";
+  private static final String REQUEST_GROUPS_UPDATE_FORMAT = REQUESTS_FORMAT + "/request/%s/groups";
+  private static final String REQUEST_GROUPS_UPDATE_AUTH_CHECK_FORMAT = REQUEST_GROUPS_UPDATE_FORMAT + "/auth-check";
 
   private static final String DEPLOYS_FORMAT = "%s/deploys";
   private static final String DELETE_DEPLOY_FORMAT = DEPLOYS_FORMAT + "/deploy/%s/request/%s";
@@ -633,6 +636,22 @@ public class SingularityClient {
     final Function<String, String> requestUri = (host) -> String.format(REQUEST_EXIT_COOLDOWN_FORMAT, getApiBase(host), requestId);
 
     post(requestUri, String.format("exit cooldown of request %s", requestId), exitCooldownRequest);
+  }
+
+  public SingularityPendingRequestParent updateAuthorizedGroups(String requestId, SingularityUpdateGroupsRequest updateGroupsRequest) {
+    final Function<String, String> requestUri = (host) -> String.format(REQUEST_GROUPS_UPDATE_FORMAT, getApiBase(host), requestId);
+
+    final HttpResponse response = post(requestUri, String.format("update authorized groups of request %s", requestId), Optional.of(updateGroupsRequest));
+
+    return response.getAs(SingularityPendingRequestParent.class);
+  }
+
+  public boolean checkAuthForRequestGroupsUpdate(String requestId, SingularityUpdateGroupsRequest updateGroupsRequest) {
+    final Function<String, String> requestUri = (host) -> String.format(REQUEST_GROUPS_UPDATE_AUTH_CHECK_FORMAT, getApiBase(host), requestId);
+
+    final HttpResponse response = post(requestUri, String.format("check auth for update authorized groups of request %s", requestId), Optional.of(updateGroupsRequest));
+
+    return response.isSuccess();
   }
 
   //

--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
@@ -105,8 +105,10 @@ public class SingularityClient {
 
   private static final String BASE_API_FORMAT = "%s://%s/%s";
 
-  private static final String AUTH_CHECK_FORMAT = "%s/auth/%s/auth-check";
+  private static final String AUTH_FORMAT = "%s/auth";
+  private static final String AUTH_CHECK_FORMAT = AUTH_FORMAT + "/%s/auth-check";
   private static final String AUTH_CHECK_USER_FORMAT = AUTH_CHECK_FORMAT + "/%s";
+  private static final String AUTH_GROUPS_CHECK_FORMAT = AUTH_FORMAT + "/groups/auth-check";
 
   private static final String STATE_FORMAT = "%s/state";
   private static final String TASK_RECONCILIATION_FORMAT = STATE_FORMAT + "/task-reconciliation";
@@ -1489,6 +1491,21 @@ public class SingularityClient {
     final Function<String, String> requestUri = (host) -> String.format(AUTH_CHECK_FORMAT, getApiBase(host), requestId);
     Map<String, Object> params = Collections.singletonMap("scope", scope.name());
     HttpResponse response = executeGetSingleWithParams(requestUri, "auth check", "", Optional.of(params));
+    return response.isSuccess();
+  }
+
+  /**
+   * Check if the current client's user is authorized for the specified groups
+   *
+   * @param updateGroupsRequest
+   *    The group, readWriteGroups, and readOnlyGroups to be checked
+   *
+   * @return
+   *    true if the user is authorized for WRITE scope, false otherwise
+   */
+  public boolean isUserAuthorizedForGroups(SingularityUpdateGroupsRequest updateGroupsRequest) {
+    final Function<String, String> requestUri = (host) -> String.format(AUTH_GROUPS_CHECK_FORMAT, getApiBase(host));
+    final HttpResponse response = post(requestUri, "check auth for groups", Optional.of(updateGroupsRequest));
     return response.isSuccess();
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/AuthResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/AuthResource.java
@@ -1,6 +1,7 @@
 package com.hubspot.singularity.resources;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -9,16 +10,20 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.hubspot.singularity.SingularityAuthorizationScope;
 import com.hubspot.singularity.SingularityUser;
 import com.hubspot.singularity.SingularityUserHolder;
+import com.hubspot.singularity.api.SingularityUpdateGroupsRequest;
 import com.hubspot.singularity.auth.SingularityAuthorizationHelper;
 import com.hubspot.singularity.auth.datastore.SingularityAuthDatastore;
 import com.hubspot.singularity.config.ApiPaths;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.UserManager;
 import com.wordnik.swagger.annotations.ApiOperation;
+import com.wordnik.swagger.annotations.ApiResponse;
+import com.wordnik.swagger.annotations.ApiResponses;
 
 import io.dropwizard.auth.Auth;
 
@@ -67,6 +72,24 @@ public class AuthResource {
                                     @PathParam("requestId") String requestId, @PathParam("userId") String userId,
                                     @QueryParam("scope") Optional<SingularityAuthorizationScope> scope) {
     authorizationHelper.checkForAuthorizationByRequestId(requestId, user, scope.or(SingularityAuthorizationScope.READ));
+    return Response.ok().build();
+  }
+
+  @POST
+  @Path("/groups/auth-check")
+  @ApiOperation(value="Check authorization for updating the group, readOnlyGroups, and readWriteGroups for a SingularityReques, without commiting the change")
+  @ApiResponses({
+      @ApiResponse(code=200, message="User is authorized to make these changes"),
+      @ApiResponse(code=401, message="User is not authorized to make these updates"),
+  })
+  public Response checkAuthForGroups(@Auth SingularityUser user,
+                                     SingularityUpdateGroupsRequest updateGroupsRequest) {
+    authorizationHelper.checkForAuthorization(
+        user,
+        Sets.union(updateGroupsRequest.getGroup().asSet(), updateGroupsRequest.getReadWriteGroups()),
+        updateGroupsRequest.getReadOnlyGroups(),
+        SingularityAuthorizationScope.WRITE,
+        Optional.absent());
     return Response.ok().build();
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/AuthResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/AuthResource.java
@@ -1,7 +1,6 @@
 package com.hubspot.singularity.resources;
 
 import javax.ws.rs.GET;
-import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -10,20 +9,16 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import com.google.common.base.Optional;
-import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.hubspot.singularity.SingularityAuthorizationScope;
 import com.hubspot.singularity.SingularityUser;
 import com.hubspot.singularity.SingularityUserHolder;
-import com.hubspot.singularity.api.SingularityUpdateGroupsRequest;
 import com.hubspot.singularity.auth.SingularityAuthorizationHelper;
 import com.hubspot.singularity.auth.datastore.SingularityAuthDatastore;
 import com.hubspot.singularity.config.ApiPaths;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.UserManager;
 import com.wordnik.swagger.annotations.ApiOperation;
-import com.wordnik.swagger.annotations.ApiResponse;
-import com.wordnik.swagger.annotations.ApiResponses;
 
 import io.dropwizard.auth.Auth;
 
@@ -72,24 +67,6 @@ public class AuthResource {
                                     @PathParam("requestId") String requestId, @PathParam("userId") String userId,
                                     @QueryParam("scope") Optional<SingularityAuthorizationScope> scope) {
     authorizationHelper.checkForAuthorizationByRequestId(requestId, user, scope.or(SingularityAuthorizationScope.READ));
-    return Response.ok().build();
-  }
-
-  @POST
-  @Path("/groups/auth-check")
-  @ApiOperation(value="Check authorization for updating the group, readOnlyGroups, and readWriteGroups for a SingularityReques, without commiting the change")
-  @ApiResponses({
-      @ApiResponse(code=200, message="User is authorized to make these changes"),
-      @ApiResponse(code=401, message="User is not authorized to make these updates"),
-  })
-  public Response checkAuthForGroups(@Auth SingularityUser user,
-                                     SingularityUpdateGroupsRequest updateGroupsRequest) {
-    authorizationHelper.checkForAuthorization(
-        user,
-        Sets.union(updateGroupsRequest.getGroup().asSet(), updateGroupsRequest.getReadWriteGroups()),
-        updateGroupsRequest.getReadOnlyGroups(),
-        SingularityAuthorizationScope.WRITE,
-        Optional.absent());
     return Response.ok().build();
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -21,6 +21,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 import org.apache.curator.framework.recipes.leader.LeaderLatch;
 import org.slf4j.Logger;
@@ -64,6 +65,7 @@ import com.hubspot.singularity.api.SingularityRunNowRequest;
 import com.hubspot.singularity.api.SingularityScaleRequest;
 import com.hubspot.singularity.api.SingularitySkipHealthchecksRequest;
 import com.hubspot.singularity.api.SingularityUnpauseRequest;
+import com.hubspot.singularity.api.SingularityUpdateGroupsRequest;
 import com.hubspot.singularity.auth.SingularityAuthorizationHelper;
 import com.hubspot.singularity.config.ApiPaths;
 import com.hubspot.singularity.data.DeployManager;
@@ -175,6 +177,46 @@ public class RequestResource extends AbstractRequestResource {
     checkConflict(maybeDeployId.isPresent(), "Can not schedule/bounce a request (%s) with no deploy", requestId);
 
     return maybeDeployId.get();
+  }
+
+  @POST
+  @Path("/request/{requestId}/groups")
+  public SingularityRequestParent updateAuthorizedGroups(@Auth SingularityUser user,
+                                                         @PathParam("requestId") String requestId,
+                                                         @Context HttpServletRequest requestContext,
+                                                         @ApiParam("Updated groups") SingularityUpdateGroupsRequest updateGroupsRequest) {
+    return maybeProxyToLeader(requestContext, SingularityRequestParent.class, updateGroupsRequest, () -> updateAuthorizedGroups(user, requestId, updateGroupsRequest));
+  }
+
+  public SingularityRequestParent updateAuthorizedGroups(SingularityUser user, String requestId, SingularityUpdateGroupsRequest updateGroupsRequest) {
+    SingularityRequestWithState oldRequestWithState = fetchRequestWithState(requestId, user);
+    authorizationHelper.checkForAuthorization(oldRequestWithState.getRequest(), user, SingularityAuthorizationScope.WRITE);
+
+    SingularityRequest newRequest = oldRequestWithState.getRequest().toBuilder()
+        .setGroup(updateGroupsRequest.getGroup())
+        .setReadWriteGroups(Optional.of(updateGroupsRequest.getReadWriteGroups()))
+        .setReadOnlyGroups(Optional.of(updateGroupsRequest.getReadOnlyGroups()))
+        .build();
+
+    submitRequest(newRequest, Optional.of(oldRequestWithState), Optional.of(RequestHistoryType.UPDATED), Optional.absent(), updateGroupsRequest.getMessage(), Optional.absent(), user);
+    return fillEntireRequest(fetchRequestWithState(requestId, user));
+  }
+
+  @POST
+  @Path("/request/{requestId}/groups/auth-verify")
+  public Response checkAuthForGroupsUpdate(@Auth SingularityUser user,
+                                           @PathParam("requestId") String requestId,
+                                           @ApiParam("Updated groups") SingularityUpdateGroupsRequest updateGroupsRequest) {
+    SingularityRequestWithState oldRequestWithState = fetchRequestWithState(requestId, user);
+    authorizationHelper.checkForAuthorization(oldRequestWithState.getRequest(), user, SingularityAuthorizationScope.WRITE);
+
+    SingularityRequest newRequest = oldRequestWithState.getRequest().toBuilder()
+        .setGroup(updateGroupsRequest.getGroup())
+        .setReadWriteGroups(Optional.of(updateGroupsRequest.getReadWriteGroups()))
+        .setReadOnlyGroups(Optional.of(updateGroupsRequest.getReadOnlyGroups()))
+        .build();
+    authorizationHelper.checkForAuthorizedChanges(newRequest, oldRequestWithState.getRequest(), user);
+    return Response.ok().build();
   }
 
   @POST

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -181,6 +181,11 @@ public class RequestResource extends AbstractRequestResource {
 
   @POST
   @Path("/request/{requestId}/groups")
+  @ApiOperation(value="Update the group, readOnlyGroups, and readWriteGroups for a SingularityRequest")
+  @ApiResponses({
+      @ApiResponse(code=400, message="Request object is invalid"),
+      @ApiResponse(code=401, message="User is not authorized to make these updates"),
+  })
   public SingularityRequestParent updateAuthorizedGroups(@Auth SingularityUser user,
                                                          @PathParam("requestId") String requestId,
                                                          @Context HttpServletRequest requestContext,
@@ -203,7 +208,12 @@ public class RequestResource extends AbstractRequestResource {
   }
 
   @POST
-  @Path("/request/{requestId}/groups/auth-verify")
+  @Path("/request/{requestId}/groups/auth-check")
+  @ApiOperation(value="Check authorization for updating the group, readOnlyGroups, and readWriteGroups for a SingularityReques, without commiting the change")
+  @ApiResponses({
+      @ApiResponse(code=200, message="User is authorized to make these changes"),
+      @ApiResponse(code=401, message="User is not authorized to make these updates"),
+  })
   public Response checkAuthForGroupsUpdate(@Auth SingularityUser user,
                                            @PathParam("requestId") String requestId,
                                            @ApiParam("Updated groups") SingularityUpdateGroupsRequest updateGroupsRequest) {


### PR DESCRIPTION
This PR does a few things:
- Allows a readWrite user to update readWriteGroups or group as long as they are authorized for both the new _and_ old groups
- Adds an endpoint to only update group, readWriteGroups, readOnlyGroups for a request, without needing to post the full request body
- Adds an endpoint to verify a user is authorized to perform a group update on a request