### PR TITLE
Support usage of DefaultServerFactory to find port

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityMainModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityMainModule.java
@@ -81,6 +81,7 @@ import de.neuland.jade4j.parser.node.Node;
 import de.neuland.jade4j.template.JadeTemplate;
 import io.dropwizard.jetty.ConnectorFactory;
 import io.dropwizard.jetty.HttpConnectorFactory;
+import io.dropwizard.jetty.HttpsConnectorFactory;
 import io.dropwizard.server.DefaultServerFactory;
 import io.dropwizard.server.SimpleServerFactory;
 
@@ -218,7 +219,8 @@ public class SingularityMainModule implements Module {
       } else {
         DefaultServerFactory defaultServerFactory = (DefaultServerFactory) configuration.getServerFactory();
         for (ConnectorFactory connectorFactory : defaultServerFactory.getApplicationConnectors()) {
-          if (connectorFactory instanceof HttpConnectorFactory) {
+          // Currently we will default to needing an http connector for service -> service communication
+          if (connectorFactory instanceof HttpConnectorFactory && !(connectorFactory instanceof HttpsConnectorFactory)) {
             HttpConnectorFactory httpFactory = (HttpConnectorFactory) connectorFactory;
             port = httpFactory.getPort();
           }


### PR DESCRIPTION
Needed for Singularity to handle its own ssl.

For the moment requires that an http port is present either in simple or connector formats in dropwizard yaml. A future improvement will be to also parse an https port and default to that when available