### PR TITLE
WIP - Allow a request in FINISHED state to be redeployed

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/DeployResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/DeployResource.java
@@ -37,6 +37,7 @@ import com.hubspot.singularity.SingularityPendingRequest;
 import com.hubspot.singularity.SingularityPendingRequest.PendingType;
 import com.hubspot.singularity.SingularityRequest;
 import com.hubspot.singularity.SingularityRequestDeployState;
+import com.hubspot.singularity.SingularityRequestHistory.RequestHistoryType;
 import com.hubspot.singularity.SingularityRequestParent;
 import com.hubspot.singularity.SingularityRequestWithState;
 import com.hubspot.singularity.SingularityTransformHelpers;
@@ -162,6 +163,9 @@ public class DeployResource extends AbstractRequestResource {
     checkConflict(!deployAlreadyInProgress,
         "Pending deploy already in progress for %s - cancel it or wait for it to complete (%s)", requestId, deployManager.getPendingDeploy(requestId).orNull());
 
+    if (requestWithState.getState() == RequestState.FINISHED) {
+      requestManager.activate(request, RequestHistoryType.UPDATED, now, deployUser, deployRequest.getMessage());
+    }
     deployManager.saveDeploy(request, deployMarker, deploy);
 
     if (request.isDeployable()) {


### PR DESCRIPTION
Should probably add some messaging in the ui about what FINISHED actually means (that a provided schedule has no more iterations).

This _should_ cover the case of allowing a finished request to be redeployed, since there is currently no other way to update it other than to pause + deploy to unpause with a new schedule. Previously it was hitting the case in the deploy checker for `isActive` and failing every deploy at that point.

This sets the state of the request back to active when the new deploy is created, which will allow it to pass the deploy checked.

Still need to add tests and determine if a deploy failure will allow it to move back to finished state correctly