### PR TITLE
Pull in the shaded-protobuf version of mesos

### DIFF
--- a/SingularityExecutor/pom.xml
+++ b/SingularityExecutor/pom.xml
@@ -58,6 +58,7 @@
     <dependency>
       <groupId>org.apache.mesos</groupId>
       <artifactId>mesos</artifactId>
+      <classifier>shaded-protobuf</classifier>
     </dependency>
 
     <dependency>

--- a/SingularityExecutor/pom.xml
+++ b/SingularityExecutor/pom.xml
@@ -77,11 +77,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>com.github.jknack</groupId>
       <artifactId>handlebars</artifactId>
     </dependency>

--- a/SingularityService/pom.xml
+++ b/SingularityService/pom.xml
@@ -63,11 +63,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>com.hubspot.dropwizard</groupId>
       <artifactId>dropwizard-guicier</artifactId>
     </dependency>

--- a/SingularityService/pom.xml
+++ b/SingularityService/pom.xml
@@ -122,6 +122,7 @@
     <dependency>
       <groupId>org.apache.mesos</groupId>
       <artifactId>mesos</artifactId>
+      <classifier>shaded-protobuf</classifier>
     </dependency>
 
     <dependency>

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerClient.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerClient.java
@@ -5,6 +5,7 @@ import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.mesos.protobuf.ByteString;
 import org.apache.mesos.v1.Protos.AgentID;
 import org.apache.mesos.v1.Protos.ExecutorID;
 import org.apache.mesos.v1.Protos.Filters;
@@ -31,11 +32,10 @@ import org.slf4j.LoggerFactory;
 
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
-import com.google.protobuf.ByteString;
-import com.hubspot.singularity.resources.SingularityServiceUIModule;
 import com.hubspot.singularity.config.MesosConfiguration;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.config.UIConfiguration;
+import com.hubspot.singularity.resources.SingularityServiceUIModule;
 import com.hubspot.singularity.resources.ui.UiResource;
 import com.mesosphere.mesos.rx.java.AwaitableSubscription;
 import com.mesosphere.mesos.rx.java.MesosClient;

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 
 import javax.inject.Singleton;
 
+import org.apache.mesos.protobuf.ByteString;
 import org.apache.mesos.v1.Protos;
 import org.apache.mesos.v1.Protos.AgentID;
 import org.apache.mesos.v1.Protos.ExecutorID;
@@ -37,10 +38,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
-import com.google.protobuf.ByteString;
 import com.hubspot.mesos.JavaUtils;
-import com.hubspot.singularity.helpers.MesosProtosUtils;
-import com.hubspot.singularity.helpers.MesosUtils;
 import com.hubspot.singularity.RequestCleanupType;
 import com.hubspot.singularity.SingularityAbort;
 import com.hubspot.singularity.SingularityAbort.AbortReason;
@@ -55,6 +53,8 @@ import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.DisasterManager;
 import com.hubspot.singularity.data.TaskManager;
 import com.hubspot.singularity.data.transcoders.Transcoder;
+import com.hubspot.singularity.helpers.MesosProtosUtils;
+import com.hubspot.singularity.helpers.MesosUtils;
 import com.hubspot.singularity.mesos.SingularitySlaveAndRackManager.CheckResult;
 import com.hubspot.singularity.scheduler.SingularityLeaderCacheCoordinator;
 import com.hubspot.singularity.sentry.SingularityExceptionNotifier;

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilder.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilder.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 
 import javax.inject.Singleton;
 
+import org.apache.mesos.protobuf.ByteString;
 import org.apache.mesos.v1.Protos.CommandInfo;
 import org.apache.mesos.v1.Protos.CommandInfo.URI;
 import org.apache.mesos.v1.Protos.ContainerInfo;
@@ -36,10 +37,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Ints;
 import com.google.inject.Inject;
-import com.google.protobuf.ByteString;
 import com.hubspot.deploy.ExecutorDataBuilder;
-import com.hubspot.singularity.helpers.MesosProtosUtils;
-import com.hubspot.singularity.helpers.MesosUtils;
 import com.hubspot.mesos.Resources;
 import com.hubspot.mesos.SingularityContainerInfo;
 import com.hubspot.mesos.SingularityDockerInfo;
@@ -47,7 +45,6 @@ import com.hubspot.mesos.SingularityDockerNetworkType;
 import com.hubspot.mesos.SingularityDockerParameter;
 import com.hubspot.mesos.SingularityDockerPortMapping;
 import com.hubspot.mesos.SingularityMesosArtifact;
-import com.hubspot.singularity.helpers.SingularityMesosTaskHolder;
 import com.hubspot.mesos.SingularityMesosTaskLabel;
 import com.hubspot.mesos.SingularityVolume;
 import com.hubspot.singularity.SingularityS3UploaderFile;
@@ -57,6 +54,9 @@ import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.SingularityTaskRequest;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.ExecutorIdGenerator;
+import com.hubspot.singularity.helpers.MesosProtosUtils;
+import com.hubspot.singularity.helpers.MesosUtils;
+import com.hubspot.singularity.helpers.SingularityMesosTaskHolder;
 
 @Singleton
 class SingularityMesosTaskBuilder {

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityTaskShellCommandTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityTaskShellCommandTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import javax.ws.rs.WebApplicationException;
 
+import org.apache.mesos.protobuf.ByteString;
 import org.apache.mesos.v1.Protos.TaskState;
 import org.apache.mesos.v1.scheduler.Protos.Event;
 import org.junit.Assert;
@@ -16,7 +17,6 @@ import org.junit.Test;
 
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
-import com.google.protobuf.ByteString;
 import com.hubspot.singularity.SingularityShellCommand;
 import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.SingularityTaskCleanup;

--- a/pom.xml
+++ b/pom.xml
@@ -318,11 +318,6 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>com.google.protobuf</groupId>
-        <artifactId>protobuf-java</artifactId>
-        <version>2.6.1</version>
-      </dependency>
-      <dependency>
         <groupId>org.jukito</groupId>
         <artifactId>jukito</artifactId>
         <version>1.5</version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>15.11</version>
+    <version>18.1</version>
   </parent>
 
   <artifactId>Singularity</artifactId>
@@ -192,6 +192,12 @@
         <groupId>com.mesosphere.mesos.rx.java</groupId>
         <artifactId>mesos-rxjava-protobuf-client</artifactId>
         <version>${dep.mesos.rxjava.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.mesos</groupId>
+            <artifactId>mesos</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
@@ -437,23 +443,6 @@
               <ignoredResourcePattern>.*licenses\.xml</ignoredResourcePattern>
             </ignoredResourcePatterns>
           </configuration>
-        </plugin>
-        <!-- Fixes issues with checkstlye if you use logback for logging in maven -->
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-checkstyle-plugin</artifactId>
-          <dependencies>
-            <dependency>
-              <groupId>org.slf4j</groupId>
-              <artifactId>slf4j-jdk14</artifactId>
-              <version>1.7.5</version>
-            </dependency>
-            <dependency>
-              <groupId>org.slf4j</groupId>
-              <artifactId>jcl-over-slf4j</artifactId>
-              <version>1.7.5</version>
-            </dependency>
-          </dependencies>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
This bumps to basepom 18.1 and switches the mesos dep to the shaded version (excluding the non-shaded version where necessary)

In terms of dep changes this brings:
dropwizard 1.0.6 -> 1.0.9
guava-retrying 1.0.7 -> 2.0.0
guice 4.0 -> 4.1
jackson-databind 2.7.9 -> 2.7.9.1
jade4j 0.4.0 -> 0.4.2
javax.mail 1.5.2 -> 1.5.6
jersey 2.22.2 -> 2.23.2
jetty 9.3.9.v20160517 -> 9.3.20.v20170531
metrics 3.1.2 -> 3.1.4
mysql 5.1.39 -> 5.1.43
netty3 3.9.2.Final -> 3.9.4.Final
netty4 4.1.4 -> 4.1.8

These upgrades seem pretty benign but if you're concerned about any of them we can force the previous version