### PR TITLE
Second pass at Mesos containers, with volume sources and network mapping

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityAppcImage.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityAppcImage.java
@@ -1,0 +1,58 @@
+package com.hubspot.mesos;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Optional;
+import com.wordnik.swagger.annotations.ApiModelProperty;
+
+public class SingularityAppcImage {
+  private final String name;
+  private final Optional<String> id;
+
+  @JsonCreator
+  public SingularityAppcImage(@JsonProperty("name") String name, @JsonProperty("id") Optional<String> id)
+  {
+    this.name = name;
+    this.id = id;
+  }
+
+  @ApiModelProperty(required=true, value="Appc image name")
+  public String getName()
+  {
+    return name;
+  }
+
+  @ApiModelProperty(required=false, value="")
+  public Optional<String> getId()
+  {
+    return id;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SingularityAppcImage that = (SingularityAppcImage) o;
+    return Objects.equals(name, that.name) &&
+        Objects.equals(id, that.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, id);
+  }
+
+  @Override
+  public String toString() {
+    return "SingularityAppcImage{" +
+        "name='" + name + '\'' +
+        "id='" + id + '\'' +
+        '}';
+  }
+}

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityAppcImage.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityAppcImage.java
@@ -4,9 +4,11 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.Beta;
 import com.google.common.base.Optional;
 import com.wordnik.swagger.annotations.ApiModelProperty;
 
+@Beta
 public class SingularityAppcImage {
   private final String name;
   private final Optional<String> id;

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityContainerInfo.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityContainerInfo.java
@@ -12,15 +12,28 @@ public class SingularityContainerInfo {
   private final SingularityContainerType type;
   private final Optional<List<SingularityVolume>> volumes;
   private final Optional<SingularityDockerInfo> docker;
+  private final Optional<SingularityMesosInfo> mesos;
+  private final Optional<List<SingularityNetworkInfo>> networkInfos;
+
+  public SingularityContainerInfo(
+      SingularityContainerType type,
+      Optional<List<SingularityVolume>> volumes,
+      Optional<SingularityDockerInfo> docker) {
+    this(type, volumes, docker, Optional.absent(), Optional.absent());
+  }
 
   @JsonCreator
   public SingularityContainerInfo(
       @JsonProperty("type") SingularityContainerType type,
       @JsonProperty("volumes") Optional<List<SingularityVolume>> volumes,
-      @JsonProperty("docker") Optional<SingularityDockerInfo> docker) {
+      @JsonProperty("docker") Optional<SingularityDockerInfo> docker,
+      @JsonProperty("mesos") Optional<SingularityMesosInfo> mesos,
+      @JsonProperty("network_infos") Optional<List<SingularityNetworkInfo>> networkInfos) {
     this.type = type;
     this.volumes = volumes;
     this.docker = docker;
+    this.mesos = mesos;
+    this.networkInfos = networkInfos;
   }
 
   @ApiModelProperty(required=true, value="Container type, can be MESOS or DOCKER. Default is MESOS")
@@ -38,6 +51,17 @@ public class SingularityContainerInfo {
     return docker;
   }
 
+  @ApiModelProperty(required=false, value="Information specific to Mesos container type")
+  public Optional<SingularityMesosInfo> getMesos() {
+    return mesos;
+  }
+
+  @JsonProperty("network_infos")
+  @ApiModelProperty(required=false, value="Mesos container network configuration")
+  public Optional<List<SingularityNetworkInfo>> getNetworkInfos() {
+    return networkInfos;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -49,12 +73,14 @@ public class SingularityContainerInfo {
     SingularityContainerInfo that = (SingularityContainerInfo) o;
     return type == that.type &&
         Objects.equals(volumes, that.volumes) &&
-        Objects.equals(docker, that.docker);
+        Objects.equals(docker, that.docker) &&
+        Objects.equals(mesos, that.mesos) &&
+        Objects.equals(networkInfos, that.networkInfos);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(type, volumes, docker);
+    return Objects.hash(type, volumes, docker, mesos, networkInfos);
   }
 
   @Override
@@ -63,6 +89,8 @@ public class SingularityContainerInfo {
         "type=" + type +
         ", volumes=" + volumes +
         ", docker=" + docker +
+        ", mesos=" + mesos +
+        ", network_infos=" + networkInfos +
         '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityContainerInfo.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityContainerInfo.java
@@ -28,7 +28,7 @@ public class SingularityContainerInfo {
       @JsonProperty("volumes") Optional<List<SingularityVolume>> volumes,
       @JsonProperty("docker") Optional<SingularityDockerInfo> docker,
       @JsonProperty("mesos") Optional<SingularityMesosInfo> mesos,
-      @JsonProperty("network_infos") Optional<List<SingularityNetworkInfo>> networkInfos) {
+      @JsonProperty("networkInfos") Optional<List<SingularityNetworkInfo>> networkInfos) {
     this.type = type;
     this.volumes = volumes;
     this.docker = docker;
@@ -56,7 +56,6 @@ public class SingularityContainerInfo {
     return mesos;
   }
 
-  @JsonProperty("network_infos")
   @ApiModelProperty(required=false, value="Mesos container network configuration")
   public Optional<List<SingularityNetworkInfo>> getNetworkInfos() {
     return networkInfos;
@@ -90,7 +89,7 @@ public class SingularityContainerInfo {
         ", volumes=" + volumes +
         ", docker=" + docker +
         ", mesos=" + mesos +
-        ", network_infos=" + networkInfos +
+        ", networkInfos=" + networkInfos +
         '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityDockerImage.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityDockerImage.java
@@ -4,8 +4,10 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.Beta;
 import com.wordnik.swagger.annotations.ApiModelProperty;
 
+@Beta
 public class SingularityDockerImage {
   private final String name;
 

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityDockerImage.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityDockerImage.java
@@ -1,0 +1,46 @@
+package com.hubspot.mesos;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.wordnik.swagger.annotations.ApiModelProperty;
+
+public class SingularityDockerImage {
+  private final String name;
+
+  @JsonCreator
+  public SingularityDockerImage(@JsonProperty("name") String name) {
+    this.name = name;
+  }
+
+  @ApiModelProperty(required=true, value="Docker image name, expected format: [REGISTRY_HOST[:REGISTRY_PORT]/]REPOSITORY[:TAG|@TYPE:DIGEST]")
+  public String getName() {
+    return name;
+  }
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SingularityDockerImage that = (SingularityDockerImage) o;
+    return Objects.equals(name, that.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name);
+  }
+
+  @Override
+  public String toString() {
+    return "SingularityDockerImage{" +
+        "name='" + name + '\'' +
+        '}';
+  }
+}

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityDockerVolume.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityDockerVolume.java
@@ -1,26 +1,28 @@
 package com.hubspot.mesos;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 import com.wordnik.swagger.annotations.ApiModelProperty;
 
 public class SingularityDockerVolume {
     private final Optional<String> driver, name;
-    private final Map<String, Object> driverOptions;
+    private final Map<String, String> driverOptions;
 
     @JsonCreator
     public SingularityDockerVolume(
             @JsonProperty("driver") Optional<String> driver,
             @JsonProperty("name") Optional<String> name,
-            @JsonProperty("driver_options") Map<String, Object> driverOptions)
+            @JsonProperty("driverOptions") Map<String, String> driverOptions)
     {
         this.driver = driver;
         this.name = name;
-        this.driverOptions = driverOptions;
+        this.driverOptions = MoreObjects.firstNonNull(driverOptions, Collections.emptyMap());
     }
 
     @ApiModelProperty(required=false, value="Docker volume driver name")
@@ -28,14 +30,13 @@ public class SingularityDockerVolume {
         return driver;
     }
 
-    @ApiModelProperty(required=false, value="Volume name")
+    @ApiModelProperty(required=false, value="Volume name '%i' will be replaced with the instance index")
     public Optional<String> getName() {
         return name;
     }
 
-    @JsonProperty("driver_options")
     @ApiModelProperty(required=false, value="Volume driver options")
-    public Map<String, Object> getDriverOptions() {
+    public Map<String, String> getDriverOptions() {
         return driverOptions;
     }
 
@@ -63,7 +64,7 @@ public class SingularityDockerVolume {
       return "SingularityDockerVolume{" +
           "driver='" + driver + '\'' +
           ", name=" + name +
-          ", driver_options=" + driverOptions +
+          ", driverOptions=" + driverOptions +
           '}';
     }
 }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityDockerVolume.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityDockerVolume.java
@@ -6,10 +6,12 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.Beta;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 import com.wordnik.swagger.annotations.ApiModelProperty;
 
+@Beta
 public class SingularityDockerVolume {
     private final Optional<String> driver, name;
     private final Map<String, String> driverOptions;

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityDockerVolume.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityDockerVolume.java
@@ -1,0 +1,69 @@
+package com.hubspot.mesos;
+
+import java.util.Map;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Optional;
+import com.wordnik.swagger.annotations.ApiModelProperty;
+
+public class SingularityDockerVolume {
+    private final Optional<String> driver, name;
+    private final Map<String, Object> driverOptions;
+
+    @JsonCreator
+    public SingularityDockerVolume(
+            @JsonProperty("driver") Optional<String> driver,
+            @JsonProperty("name") Optional<String> name,
+            @JsonProperty("driver_options") Map<String, Object> driverOptions)
+    {
+        this.driver = driver;
+        this.name = name;
+        this.driverOptions = driverOptions;
+    }
+
+    @ApiModelProperty(required=false, value="Docker volume driver name")
+    public Optional<String> getDriver() {
+        return driver;
+    }
+
+    @ApiModelProperty(required=false, value="Volume name")
+    public Optional<String> getName() {
+        return name;
+    }
+
+    @JsonProperty("driver_options")
+    @ApiModelProperty(required=false, value="Volume driver options")
+    public Map<String, Object> getDriverOptions() {
+        return driverOptions;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      SingularityDockerVolume that = (SingularityDockerVolume) o;
+      return Objects.equals(driver, that.driver) &&
+          Objects.equals(name, that.name) &&
+          Objects.equals(driverOptions, that.driverOptions);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(driver, name, driverOptions);
+    }
+
+    @Override
+    public String toString() {
+      return "SingularityDockerVolume{" +
+          "driver='" + driver + '\'' +
+          ", name=" + name +
+          ", driver_options=" + driverOptions +
+          '}';
+    }
+}

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityMesosImage.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityMesosImage.java
@@ -4,10 +4,12 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.Beta;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 import com.wordnik.swagger.annotations.ApiModelProperty;
 
+@Beta
 public class SingularityMesosImage {
   private final SingularityMesosImageType type;
   private final Optional<SingularityAppcImage> appc;

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityMesosImage.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityMesosImage.java
@@ -1,0 +1,81 @@
+package com.hubspot.mesos;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Optional;
+import com.wordnik.swagger.annotations.ApiModelProperty;
+
+public class SingularityMesosImage {
+  private final SingularityMesosImageType type;
+  private final Optional<SingularityAppcImage> appc;
+  private final Optional<SingularityDockerImage> docker;
+  private final boolean cached;
+
+  @JsonCreator
+  public SingularityMesosImage(@JsonProperty("type") SingularityMesosImageType type,
+      @JsonProperty("appc") Optional<SingularityAppcImage> appc,
+      @JsonProperty("docker") Optional<SingularityDockerImage> docker,
+      @JsonProperty("cached") Boolean cached) {
+    this.type = type;
+    this.appc = appc;
+    this.docker = docker;
+    this.cached = MoreObjects.firstNonNull(cached, true);
+  }
+
+  @ApiModelProperty(required=true, value="Mesos image type")
+  public SingularityMesosImageType getType() {
+    return type;
+  }
+
+  @ApiModelProperty(required=false, value="Appc image configuration")
+  public Optional<SingularityAppcImage> getAppc()
+  {
+    return appc;
+  }
+
+  @ApiModelProperty(required=false, value="Docker image configuration")
+  public Optional<SingularityDockerImage> getDocker()
+  {
+    return docker;
+  }
+
+  @ApiModelProperty(required=false, value="Determines if a cached image is considered up to date")
+  public boolean isCached()
+  {
+    return cached;
+  }
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SingularityMesosImage that = (SingularityMesosImage) o;
+    return Objects.equals(type, that.type) &&
+        Objects.equals(appc, that.appc) &&
+        Objects.equals(docker, that.docker) &&
+        Objects.equals(cached, that.cached);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, appc, docker, cached);
+  }
+
+  @Override
+  public String toString() {
+    return "SingularityMesosImage{" +
+        "type='" + type + '\'' +
+        "appc='" + appc + '\'' +
+        "docker='" + docker + '\'' +
+        "cached='" + cached + '\'' +
+        '}';
+  }
+}

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityMesosImageType.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityMesosImageType.java
@@ -1,5 +1,8 @@
 package com.hubspot.mesos;
 
+import com.google.common.annotations.Beta;
+
+@Beta
 public enum SingularityMesosImageType {
   APPC, DOCKER
 }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityMesosImageType.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityMesosImageType.java
@@ -1,0 +1,5 @@
+package com.hubspot.mesos;
+
+public enum SingularityMesosImageType {
+  APPC, DOCKER
+}

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityMesosInfo.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityMesosInfo.java
@@ -4,9 +4,11 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.Beta;
 import com.google.common.base.Optional;
 import com.wordnik.swagger.annotations.ApiModelProperty;
 
+@Beta
 public class SingularityMesosInfo {
   private final Optional<SingularityMesosImage> image;
 

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityMesosInfo.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityMesosInfo.java
@@ -1,0 +1,47 @@
+package com.hubspot.mesos;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Optional;
+import com.wordnik.swagger.annotations.ApiModelProperty;
+
+public class SingularityMesosInfo {
+  private final Optional<SingularityMesosImage> image;
+
+  @JsonCreator
+  public SingularityMesosInfo(@JsonProperty("image") Optional<SingularityMesosImage> image) {
+    this.image = image;
+  }
+
+  @ApiModelProperty(required=false, value="Mesos image descriptor")
+  public Optional<SingularityMesosImage> getImage() {
+    return image;
+  }
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SingularityMesosInfo that = (SingularityMesosInfo) o;
+    return Objects.equals(image, that.image);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(image);
+  }
+
+  @Override
+  public String toString() {
+    return "SingularityMesosInfo{" +
+        "image='" + image + '\'' +
+        '}';
+  }
+}

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityNetworkInfo.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityNetworkInfo.java
@@ -5,9 +5,11 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.Beta;
 import com.google.common.base.Optional;
 import com.wordnik.swagger.annotations.ApiModelProperty;
 
+@Beta
 public class SingularityNetworkInfo {
   private final Optional<String> name;
   private final Optional<List<String>> groups;

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityNetworkInfo.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityNetworkInfo.java
@@ -16,7 +16,7 @@ public class SingularityNetworkInfo {
   @JsonCreator
   public SingularityNetworkInfo(@JsonProperty("name") Optional<String> name,
       @JsonProperty("groups") Optional<List<String>> groups,
-      @JsonProperty("port_mappings") Optional<List<SingularityPortMapping>> portMappings) {
+      @JsonProperty("portMappings") Optional<List<SingularityPortMapping>> portMappings) {
     this.name = name;
     this.groups = groups;
     this.portMappings = portMappings;
@@ -61,7 +61,7 @@ public class SingularityNetworkInfo {
     return "SingularityNetworkInfo{" +
         "name='" + name + '\'' +
         ", groups=" + groups +
-        ", port_mappings=" + portMappings +
+        ", portMappings=" + portMappings +
         '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityNetworkInfo.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityNetworkInfo.java
@@ -1,0 +1,67 @@
+package com.hubspot.mesos;
+
+import java.util.List;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Optional;
+import com.wordnik.swagger.annotations.ApiModelProperty;
+
+public class SingularityNetworkInfo {
+  private final Optional<String> name;
+  private final Optional<List<String>> groups;
+  private final Optional<List<SingularityPortMapping>> portMappings;
+
+  @JsonCreator
+  public SingularityNetworkInfo(@JsonProperty("name") Optional<String> name,
+      @JsonProperty("groups") Optional<List<String>> groups,
+      @JsonProperty("port_mappings") Optional<List<SingularityPortMapping>> portMappings) {
+    this.name = name;
+    this.groups = groups;
+    this.portMappings = portMappings;
+  }
+
+  @ApiModelProperty(required=false, value="Name of the network for the network driver to use")
+  public Optional<String> getName() {
+    return name;
+  }
+
+  @ApiModelProperty(required=false, value="List of network groups for the container")
+  public Optional<List<String>> getGroups() {
+    return groups;
+  }
+
+  @ApiModelProperty(required=false, value="List of ip port mappings to expose")
+  public Optional<List<SingularityPortMapping>> getPortMappings() {
+    return portMappings;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SingularityNetworkInfo that = (SingularityNetworkInfo) o;
+    return Objects.equals(name, that.name) &&
+        Objects.equals(groups, that.groups) &&
+        Objects.equals(portMappings, that.portMappings);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, groups, portMappings);
+  }
+
+  @Override
+  public String toString() {
+    return "SingularityNetworkInfo{" +
+        "name='" + name + '\'' +
+        ", groups=" + groups +
+        ", port_mappings=" + portMappings +
+        '}';
+  }
+}

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityPortMapping.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityPortMapping.java
@@ -1,0 +1,67 @@
+package com.hubspot.mesos;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Optional;
+import com.wordnik.swagger.annotations.ApiModelProperty;
+
+public class SingularityPortMapping {
+  private final int hostPort, containerPort;
+  private final Optional<String> protocol;
+
+  @JsonCreator
+  public SingularityPortMapping(@JsonProperty("host_port") int hostPort,
+      @JsonProperty("container_port") int containerPort,
+      @JsonProperty("protocol") Optional<String> protocol) {
+    this.hostPort = hostPort;
+    this.containerPort = containerPort;
+    this.protocol = protocol;
+  }
+
+  @JsonProperty("host_port")
+  @ApiModelProperty(required=true, value="the port to map from on the host network interface")
+  public int getHostPort() {
+    return hostPort;
+  }
+
+  @JsonProperty("container_port")
+  @ApiModelProperty(required=true, value="the port to map to on the container network interface")
+  public int getContainerPort() {
+    return containerPort;
+  }
+
+  @ApiModelProperty(required=false, value="the protocol e.g. 'tcp' or 'udp'")
+  public Optional<String> getProtocol() {
+    return protocol;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SingularityPortMapping that = (SingularityPortMapping) o;
+    return hostPort == that.hostPort &&
+        this.containerPort == that.containerPort &&
+        Objects.equals(protocol, that.protocol);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(hostPort, containerPort, protocol);
+  }
+
+  @Override
+  public String toString() {
+    return "SingularityPortMapping{" +
+        "host_port='" + hostPort + '\'' +
+        ", container_port=" + containerPort +
+        ", protocol=" + protocol +
+        '}';
+  }
+}

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityPortMapping.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityPortMapping.java
@@ -12,21 +12,19 @@ public class SingularityPortMapping {
   private final Optional<String> protocol;
 
   @JsonCreator
-  public SingularityPortMapping(@JsonProperty("host_port") int hostPort,
-      @JsonProperty("container_port") int containerPort,
+  public SingularityPortMapping(@JsonProperty("hostPort") int hostPort,
+      @JsonProperty("containerPort") int containerPort,
       @JsonProperty("protocol") Optional<String> protocol) {
     this.hostPort = hostPort;
     this.containerPort = containerPort;
     this.protocol = protocol;
   }
 
-  @JsonProperty("host_port")
   @ApiModelProperty(required=true, value="the port to map from on the host network interface")
   public int getHostPort() {
     return hostPort;
   }
 
-  @JsonProperty("container_port")
   @ApiModelProperty(required=true, value="the port to map to on the container network interface")
   public int getContainerPort() {
     return containerPort;
@@ -59,8 +57,8 @@ public class SingularityPortMapping {
   @Override
   public String toString() {
     return "SingularityPortMapping{" +
-        "host_port='" + hostPort + '\'' +
-        ", container_port=" + containerPort +
+        "hostPort='" + hostPort + '\'' +
+        ", containerPort=" + containerPort +
         ", protocol=" + protocol +
         '}';
   }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityPortMapping.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityPortMapping.java
@@ -4,9 +4,11 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.Beta;
 import com.google.common.base.Optional;
 import com.wordnik.swagger.annotations.ApiModelProperty;
 
+@Beta
 public class SingularityPortMapping {
   private final int hostPort, containerPort;
   private final Optional<String> protocol;

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityVolume.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityVolume.java
@@ -4,8 +4,10 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.Beta;
 import com.google.common.base.Optional;
 
+@Beta
 public class SingularityVolume {
   private final String containerPath;
   private final Optional<String> hostPath;

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityVolume.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityVolume.java
@@ -10,15 +10,25 @@ public class SingularityVolume {
   private final String containerPath;
   private final Optional<String> hostPath;
   private final Optional<SingularityDockerVolumeMode> mode;
+  private final Optional<SingularityVolumeSource> source;
+
+  public SingularityVolume(
+      String containerPath,
+      Optional<String> hostPath,
+      SingularityDockerVolumeMode mode) {
+    this(containerPath, hostPath, mode, Optional.absent());
+  }
 
   @JsonCreator
   public SingularityVolume(
       @JsonProperty("containerPath") String containerPath,
       @JsonProperty("hostPath") Optional<String> hostPath,
-      @JsonProperty("mode") SingularityDockerVolumeMode mode) {
+      @JsonProperty("mode") SingularityDockerVolumeMode mode,
+      @JsonProperty("source") Optional<SingularityVolumeSource> source) {
     this.containerPath = containerPath;
     this.hostPath = hostPath;
     this.mode = Optional.fromNullable(mode);
+    this.source = source;
   }
 
   public String getContainerPath() {
@@ -31,6 +41,11 @@ public class SingularityVolume {
 
   public Optional<SingularityDockerVolumeMode> getMode() {
     return mode;
+  }
+
+  public Optional<SingularityVolumeSource> getSource()
+  {
+    return source;
   }
 
   @Override

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityVolumeSource.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityVolumeSource.java
@@ -4,10 +4,12 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.Beta;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 import com.wordnik.swagger.annotations.ApiModelProperty;
 
+@Beta
 public class SingularityVolumeSource {
   private final SingularityVolumeSourceType type;
   private final Optional<SingularityDockerVolume> dockerVolume;

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityVolumeSource.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityVolumeSource.java
@@ -15,7 +15,7 @@ public class SingularityVolumeSource {
   @JsonCreator
   public SingularityVolumeSource(
       @JsonProperty("type") SingularityVolumeSourceType type,
-      @JsonProperty("docker_volume") Optional<SingularityDockerVolume> dockerVolume) {
+      @JsonProperty("dockerVolume") Optional<SingularityDockerVolume> dockerVolume) {
     this.type = MoreObjects.firstNonNull(type, SingularityVolumeSourceType.UNKNOWN);
     this.dockerVolume = dockerVolume;
   }
@@ -26,7 +26,6 @@ public class SingularityVolumeSource {
   }
 
   @ApiModelProperty(required=false, value="Docker source volume spec")
-  @JsonProperty("docker_volume")
   public Optional<SingularityDockerVolume> getDockerVolume() {
     return dockerVolume;
   }
@@ -53,7 +52,7 @@ public class SingularityVolumeSource {
   public String toString() {
     return "SingularityVolumeSource{" +
         "type='" + type + '\'' +
-        ", docker_volume=" + dockerVolume +
+        ", dockerVolume=" + dockerVolume +
         '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityVolumeSource.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityVolumeSource.java
@@ -1,0 +1,59 @@
+package com.hubspot.mesos;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Optional;
+import com.wordnik.swagger.annotations.ApiModelProperty;
+
+public class SingularityVolumeSource {
+  private final SingularityVolumeSourceType type;
+  private final Optional<SingularityDockerVolume> dockerVolume;
+
+  @JsonCreator
+  public SingularityVolumeSource(
+      @JsonProperty("type") SingularityVolumeSourceType type,
+      @JsonProperty("docker_volume") Optional<SingularityDockerVolume> dockerVolume) {
+    this.type = MoreObjects.firstNonNull(type, SingularityVolumeSourceType.UNKNOWN);
+    this.dockerVolume = dockerVolume;
+  }
+
+  @ApiModelProperty(required=false, value="Volume source type")
+  public SingularityVolumeSourceType getType() {
+    return type;
+  }
+
+  @ApiModelProperty(required=false, value="Docker source volume spec")
+  @JsonProperty("docker_volume")
+  public Optional<SingularityDockerVolume> getDockerVolume() {
+    return dockerVolume;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SingularityVolumeSource that = (SingularityVolumeSource) o;
+    return Objects.equals(type, that.type) &&
+        Objects.equals(dockerVolume, that.dockerVolume);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, dockerVolume);
+  }
+
+  @Override
+  public String toString() {
+    return "SingularityVolumeSource{" +
+        "type='" + type + '\'' +
+        ", docker_volume=" + dockerVolume +
+        '}';
+  }
+}

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityVolumeSourceType.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityVolumeSourceType.java
@@ -1,5 +1,8 @@
 package com.hubspot.mesos;
 
+import com.google.common.annotations.Beta;
+
+@Beta
 public enum SingularityVolumeSourceType {
     UNKNOWN, DOCKER_VOLUME
     /*, SANDBOX_PATH, SECRET unimplemented */

--- a/SingularityBase/src/main/java/com/hubspot/mesos/SingularityVolumeSourceType.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/SingularityVolumeSourceType.java
@@ -1,0 +1,6 @@
+package com.hubspot.mesos;
+
+public enum SingularityVolumeSourceType {
+    UNKNOWN, DOCKER_VOLUME
+    /*, SANDBOX_PATH, SECRET unimplemented */
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilder.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilder.java
@@ -14,14 +14,18 @@ import org.apache.mesos.v1.Protos.CommandInfo;
 import org.apache.mesos.v1.Protos.CommandInfo.URI;
 import org.apache.mesos.v1.Protos.ContainerInfo;
 import org.apache.mesos.v1.Protos.ContainerInfo.DockerInfo;
+import org.apache.mesos.v1.Protos.ContainerInfo.MesosInfo;
 import org.apache.mesos.v1.Protos.Environment;
 import org.apache.mesos.v1.Protos.Environment.Variable;
 import org.apache.mesos.v1.Protos.ExecutorID;
 import org.apache.mesos.v1.Protos.ExecutorInfo;
+import org.apache.mesos.v1.Protos.Image;
 import org.apache.mesos.v1.Protos.Label;
 import org.apache.mesos.v1.Protos.Labels;
 import org.apache.mesos.v1.Protos.Labels.Builder;
+import org.apache.mesos.v1.Protos.NetworkInfo;
 import org.apache.mesos.v1.Protos.Parameter;
+import org.apache.mesos.v1.Protos.Parameters;
 import org.apache.mesos.v1.Protos.Resource;
 import org.apache.mesos.v1.Protos.TaskID;
 import org.apache.mesos.v1.Protos.TaskInfo;
@@ -33,23 +37,29 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
 import com.google.common.base.Strings;
+import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Ints;
 import com.google.inject.Inject;
 import com.google.protobuf.ByteString;
 import com.hubspot.deploy.ExecutorDataBuilder;
-import com.hubspot.singularity.helpers.MesosProtosUtils;
-import com.hubspot.singularity.helpers.MesosUtils;
 import com.hubspot.mesos.Resources;
+import com.hubspot.mesos.SingularityAppcImage;
 import com.hubspot.mesos.SingularityContainerInfo;
+import com.hubspot.mesos.SingularityDockerImage;
 import com.hubspot.mesos.SingularityDockerInfo;
 import com.hubspot.mesos.SingularityDockerNetworkType;
 import com.hubspot.mesos.SingularityDockerParameter;
 import com.hubspot.mesos.SingularityDockerPortMapping;
+import com.hubspot.mesos.SingularityDockerVolume;
 import com.hubspot.mesos.SingularityMesosArtifact;
-import com.hubspot.singularity.helpers.SingularityMesosTaskHolder;
+import com.hubspot.mesos.SingularityMesosImage;
+import com.hubspot.mesos.SingularityMesosInfo;
 import com.hubspot.mesos.SingularityMesosTaskLabel;
+import com.hubspot.mesos.SingularityNetworkInfo;
+import com.hubspot.mesos.SingularityPortMapping;
 import com.hubspot.mesos.SingularityVolume;
+import com.hubspot.mesos.SingularityVolumeSource;
 import com.hubspot.singularity.SingularityS3UploaderFile;
 import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.SingularityTaskExecutorData;
@@ -57,6 +67,9 @@ import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.SingularityTaskRequest;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.ExecutorIdGenerator;
+import com.hubspot.singularity.helpers.MesosProtosUtils;
+import com.hubspot.singularity.helpers.MesosUtils;
+import com.hubspot.singularity.helpers.SingularityMesosTaskHolder;
 
 @Singleton
 class SingularityMesosTaskBuilder {
@@ -343,10 +356,112 @@ class SingularityMesosTaskBuilder {
       } else {
         volumeBuilder.setMode(Volume.Mode.RO);
       }
+      if (volumeInfo.getSource().isPresent()) {
+        final Volume.Source.Builder sourceBuilder = Volume.Source.newBuilder();
+        final SingularityVolumeSource source = volumeInfo.getSource().get();
+        sourceBuilder.setType(Volume.Source.Type.valueOf(source.getType().toString()));
+        if (source.getDockerVolume().isPresent()) {
+          final Volume.Source.DockerVolume.Builder dockerVolumeBuilder = Volume.Source.DockerVolume.newBuilder();
+          final SingularityDockerVolume dockerVolume = source.getDockerVolume().get();
+          if (dockerVolume.getDriver().isPresent()) {
+            dockerVolumeBuilder.setDriver(dockerVolume.getDriver().get());
+          }
+          if (dockerVolume.getName().isPresent()) {
+            dockerVolumeBuilder.setName(dockerVolume.getName().get().replace("%i", Integer.toString(taskId.getInstanceNo())));
+          }
+          if (!dockerVolume.getDriverOptions().isEmpty()) {
+            final Parameters.Builder parameters = Parameters.newBuilder();
+            for (Entry<String, String> option : dockerVolume.getDriverOptions().entrySet()) {
+              parameters.addParameter(Parameter.newBuilder().setKey(option.getKey()).setValue(option.getValue()).build());
+            }
+            dockerVolumeBuilder.setDriverOptions(parameters.build());
+          }
+          sourceBuilder.setDockerVolume(dockerVolumeBuilder.build());
+        }
+        volumeBuilder.setSource(sourceBuilder.build());
+      }
       containerBuilder.addVolumes(volumeBuilder);
     }
 
+    prepareMesosInfo(containerBuilder, containerInfo);
+
+    prepareNetworkInfos(containerBuilder, containerInfo, ports);
+
     bldr.setContainer(containerBuilder);
+  }
+
+  private void prepareMesosInfo(ContainerInfo.Builder containerBuilder, final SingularityContainerInfo containerInfo) {
+    if (!containerInfo.getMesos().isPresent()) {
+        return;
+    }
+    final MesosInfo.Builder builder = MesosInfo.newBuilder();
+    final SingularityMesosInfo mesos = containerInfo.getMesos().get();
+    if (mesos.getImage().isPresent()) {
+      final SingularityMesosImage image = mesos.getImage().get();
+      final Image.Builder imageBuilder = Image.newBuilder();
+
+      imageBuilder.setType(Image.Type.valueOf(image.getType().toString()));
+      if (image.getAppc().isPresent()) {
+        final SingularityAppcImage appc = image.getAppc().get();
+        final Image.Appc.Builder appcBuilder = Image.Appc.newBuilder();
+        appcBuilder.setName(appc.getName());
+        if (appc.getId().isPresent()) {
+          appcBuilder.setId(appc.getId().get());
+        }
+        imageBuilder.setAppc(appcBuilder.build());
+      }
+
+      if (image.getDocker().isPresent()) {
+        final SingularityDockerImage docker = image.getDocker().get();
+        final Image.Docker.Builder dockerBuilder = Image.Docker.newBuilder();
+        dockerBuilder.setName(docker.getName());
+        imageBuilder.setDocker(dockerBuilder.build());
+      }
+
+      builder.setImage(imageBuilder.build());
+    }
+    containerBuilder.setMesos(builder.build());
+  }
+
+  private void prepareNetworkInfos(ContainerInfo.Builder containerBuilder, final SingularityContainerInfo containerInfo, final Optional<long[]> ports) {
+    for (SingularityNetworkInfo netInfo : containerInfo.getNetworkInfos().or(Collections.emptyList())) {
+      final NetworkInfo.Builder netBuilder = NetworkInfo.newBuilder();
+      if (netInfo.getName().isPresent()) {
+        netBuilder.setName(netInfo.getName().get());
+      }
+      for (String group : netInfo.getGroups().or(Collections.emptyList())) {
+        netBuilder.addGroups(group);
+      }
+      for (SingularityPortMapping mapping : netInfo.getPortMappings().or(defaultPortMappingFor(ports))) {
+        final NetworkInfo.PortMapping.Builder portBuilder = NetworkInfo.PortMapping.newBuilder();
+        final int hostPort = mapping.getHostPort();
+        final int containerPort = mapping.getContainerPort();
+        final long[] offerPorts = ports.or(new long[0]);
+        portBuilder.setHostPort(hostPort < offerPorts.length ? (int) offerPorts[hostPort] : hostPort);
+        portBuilder.setContainerPort(containerPort < offerPorts.length ? (int) offerPorts[containerPort] : containerPort);
+        if (mapping.getProtocol().isPresent()) {
+          portBuilder.setProtocol(mapping.getProtocol().get());
+        }
+        netBuilder.addPortMappings(portBuilder.build());
+      }
+      containerBuilder.addNetworkInfos(netBuilder.build());
+    }
+  }
+
+  private Supplier<List<SingularityPortMapping>> defaultPortMappingFor(Optional<long[]> ports) {
+    return new Supplier<List<SingularityPortMapping>>() {
+      @Override
+      public List<SingularityPortMapping> get() {
+        final long[] portArray = ports.or(new long[0]);
+        final List<SingularityPortMapping> mappings = new ArrayList<>(portArray.length);
+        for (long port : portArray) {
+          final int p = (int) port;
+          mappings.add(new SingularityPortMapping(p, p, Optional.of("tcp")));
+          mappings.add(new SingularityPortMapping(p, p, Optional.of("udp")));
+        }
+        return mappings;
+      }
+    };
   }
 
   private List<Resource> buildMesosResources(final Resources resources, Optional<String> role) {


### PR DESCRIPTION
Lightly tested with a task like:
```
{
  "activeDeploy": {
    "requestId": "opengrok",
    "id": "steven_2018_01_04T00_18_07",
    "command": "/opengrok-ot/run.sh",
    "containerInfo": {
      "type": "MESOS",
      "volumes": [
        {
          "containerPath": "/opengrok",
          "mode": "RW",
          "source": {
            "type": "DOCKER_VOLUME",
            "dockerVolume": {
              "driver": "rexray",
              "name": "opengrok-mesos"
            }
          }
        }
      ],
      "mesos": {
        "image": {
          "type": "DOCKER",
          "docker": {
            "name": "docker.mycorp.com/opengrok:41"
          }
        }
      }
    },
    "resources": {
      "cpus": 1,
      "memoryMb": 5192
    }
  }
```
  
cc @pennello @mikebell90 @carlf @kstdennis
  
  