### PR TITLE
Properly send task destroy message to executor

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
@@ -37,10 +37,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
-import com.google.protobuf.ByteString;
 import com.hubspot.mesos.JavaUtils;
-import com.hubspot.singularity.helpers.MesosProtosUtils;
-import com.hubspot.singularity.helpers.MesosUtils;
 import com.hubspot.singularity.RequestCleanupType;
 import com.hubspot.singularity.SingularityAbort;
 import com.hubspot.singularity.SingularityAbort.AbortReason;
@@ -55,6 +52,8 @@ import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.DisasterManager;
 import com.hubspot.singularity.data.TaskManager;
 import com.hubspot.singularity.data.transcoders.Transcoder;
+import com.hubspot.singularity.helpers.MesosProtosUtils;
+import com.hubspot.singularity.helpers.MesosUtils;
 import com.hubspot.singularity.mesos.SingularitySlaveAndRackManager.CheckResult;
 import com.hubspot.singularity.scheduler.SingularityLeaderCacheCoordinator;
 import com.hubspot.singularity.sentry.SingularityExceptionNotifier;
@@ -424,11 +423,11 @@ public class SingularityMesosSchedulerImpl extends SingularityMesosScheduler {
       if (task.isPresent()) {
         if (task.get().getTaskRequest().getDeploy().getCustomExecutorCmd().isPresent()) {
           byte[] messageBytes = transcoder.toBytes(new SingularityTaskDestroyFrameworkMessage(taskId, user));
-          message(Message.newBuilder()
-              .setAgentId(MesosProtosUtils.toAgentId(task.get().getMesosTask().getAgentId()))
-              .setExecutorId(MesosProtosUtils.toExecutorId(task.get().getMesosTask().getExecutor().getExecutorId()))
-              .setData(ByteString.copyFrom(messageBytes))
-              .build());
+          mesosSchedulerClient.frameworkMessage(
+              MesosProtosUtils.toExecutorId(task.get().getMesosTask().getExecutor().getExecutorId()),
+              MesosProtosUtils.toAgentId(task.get().getMesosTask().getAgentId()),
+              messageBytes
+          );
         } else {
           LOG.warn("Not using custom executor, will not send framework message to destroy task");
         }


### PR DESCRIPTION
I was mistakenly calling `message` here instead of `mesosSchedulerClient.frameworkMessage`, so the scheduler was just talking to itself :facepalm:

/cc @baconmania 