### PR TITLE
Don't show s3 logs error message as a pop up

### DIFF
--- a/SingularityUI/app/actions/ui/taskDetail.es6
+++ b/SingularityUI/app/actions/ui/taskDetail.es6
@@ -32,5 +32,5 @@ export const refresh = (taskId, splat) => (dispatch, getState) => {
 };
 
 export const onLoad = (taskId) => (dispatch) => {
-  return dispatch(FetchTaskS3Logs.trigger(taskId, [404]));
+  return dispatch(FetchTaskS3Logs.trigger(taskId, [404, 500]));
 };

--- a/SingularityUI/app/components/common/Section.jsx
+++ b/SingularityUI/app/components/common/Section.jsx
@@ -1,9 +1,13 @@
 import React, { PropTypes } from 'react';
 
-const Section = ({id, title, children}) => (
+const Section = ({id, title, subtitle, children}) => (
   <div id={id}>
     <div className="page-header">
-      <h2>{title}</h2>
+      <h2>
+        {title}
+        <small>{subtitle}</small>
+      </h2>
+      
     </div>
     {children}
   </div>
@@ -16,6 +20,7 @@ Section.propTypes = {
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.string
   ]).isRequired,
+  subtitle: PropTypes.string,
   children: PropTypes.oneOfType([
     PropTypes.node,
     PropTypes.arrayOf(PropTypes.node)

--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -108,7 +108,7 @@ class TaskDetail extends Component {
       }).isRequired
     })).isRequired,
     router: PropTypes.object.isRequired,
-    s3Logs: PropTypes.array,
+    s3Logs: PropTypes.object,
     deploy: PropTypes.object,
     pendingDeploys: PropTypes.array,
     shellCommandResponse: PropTypes.object,
@@ -457,7 +457,7 @@ class TaskDetail extends Component {
         <TaskHistory taskUpdates={this.props.task.taskUpdates} />
         <TaskLatestLog taskId={this.props.taskId} status={this.props.task.status} files={filesToDisplay} available={filesAvailable} />
         {this.renderFiles(filesToDisplay)}
-        {_.isEmpty(this.props.s3Logs) || <TaskS3Logs taskId={this.props.task.task.taskId.id} s3Files={this.props.s3Logs} taskStartedAt={this.props.task.task.taskId.startedAt} />}
+        <TaskS3Logs taskId={this.props.task.task.taskId.id} s3Files={this.props.s3Logs} taskStartedAt={this.props.task.task.taskId.startedAt} />
         {_.isEmpty(this.props.task.loadBalancerUpdates) || <TaskLbUpdates loadBalancerUpdates={this.props.task.loadBalancerUpdates} />}
         <TaskInfo task={this.props.task.task} ports={this.props.task.ports} directory={this.props.task.directory} />
         {this.renderResourceUsage()}
@@ -540,7 +540,7 @@ function mapStateToProps(state, ownProps) {
     resourceUsageNotFound: state.api.taskResourceUsage.statusCode === 404,
     resourceUsage: state.api.taskResourceUsage.data,
     cpuTimestamp: state.api.taskResourceUsage.data.timestamp,
-    s3Logs: state.api.taskS3Logs.data,
+    s3Logs: state.api.taskS3Logs,
     deploy: state.api.deploy.data,
     pendingDeploys: state.api.deploys.data,
     shellCommandResponse: state.api.taskShellCommandResponse.data,
@@ -557,7 +557,7 @@ function mapDispatchToProps(dispatch) {
     fetchDeployForRequest: (taskId, deployId) => dispatch(FetchDeployForRequest.trigger(taskId, deployId)),
     fetchTaskCleanups: () => dispatch(FetchTaskCleanups.trigger()),
     fetchPendingDeploys: () => dispatch(FetchPendingDeploys.trigger()),
-    fechS3Logs: (taskId) => dispatch(FetchTaskS3Logs.trigger(taskId, [404])),
+    fecthS3Logs: (taskId) => dispatch(FetchTaskS3Logs.trigger(taskId, [404, 500])),
   };
 }
 

--- a/SingularityUI/app/components/taskDetail/TaskS3Logs.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskS3Logs.jsx
@@ -102,28 +102,38 @@ class TaskS3Logs extends Component {
 
   render() {
     const { s3Files } = this.props;
-    const groupedFiles = groupBy(s3Files, this.getFileType);
+    if (s3Files.data && _.isEmpty(s3Files.data)) {
+      const groupedFiles = groupBy(s3Files.data, this.getFileType);
 
-    return (
-      <Section title="S3 Logs">
-        {this.state.viewingGroup
-          ? this.renderTable(groupedFiles[this.state.viewingGroup])
-          : this.renderFolders(Object.keys(groupedFiles))
-        }
-      </Section>
-    );
+      return (
+        <Section title="S3 Logs">
+          {this.state.viewingGroup
+            ? this.renderTable(groupedFiles[this.state.viewingGroup])
+            : this.renderFolders(Object.keys(groupedFiles))
+          }
+        </Section>
+      );
+    } else if (s3Files.error || s3Files.statusCode == 500) {
+      return (
+        <Section title="S3 Logs" subtitle="Error Fetching Logs from S3"></Section>
+      );
+    } else {
+      return null;
+    }
   }
 }
 
 TaskS3Logs.propTypes = {
-  s3Files: PropTypes.arrayOf(PropTypes.shape({
-    getUrl: PropTypes.string.isRequired,
-    key: PropTypes.string.isRequired,
-    size: PropTypes.number.isRequired,
-    lastModified: PropTypes.number.isRequired,
-    startTime: PropTypes.number,
-    endTime: PropTypes.number
-  })).isRequired,
+  s3Files: PropTypes.shape({
+    data: PropTypes.arrayOf(PropTypes.shape({
+      getUrl: PropTypes.string.isRequired,
+      key: PropTypes.string.isRequired,
+      size: PropTypes.number.isRequired,
+      lastModified: PropTypes.number.isRequired,
+      startTime: PropTypes.number,
+      endTime: PropTypes.number
+    }))
+  }).isRequired,
   taskId: PropTypes.string.isRequired,
   taskStartedAt: PropTypes.number.isRequired
 };

--- a/SingularityUI/app/components/taskDetail/TaskS3Logs.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskS3Logs.jsx
@@ -102,7 +102,7 @@ class TaskS3Logs extends Component {
 
   render() {
     const { s3Files } = this.props;
-    if (s3Files.data && _.isEmpty(s3Files.data)) {
+    if (s3Files.data && !_.isEmpty(s3Files.data)) {
       const groupedFiles = groupBy(s3Files.data, this.getFileType);
 
       return (


### PR DESCRIPTION
In the specific case of the S3 logs, folks have found the pop up error message to be more annoying than helpful. This updates the code to catch the 500 and avoid that pop up, replacing it with a message on the S3 Logs section itself

cc @kwm4385 