### PR TITLE
Permalinks for bounce and scale modals

### DIFF
--- a/SingularityUI/app/components/common/modalButtons/BounceModal.jsx
+++ b/SingularityUI/app/components/common/modalButtons/BounceModal.jsx
@@ -11,6 +11,12 @@ class BounceModal extends Component {
     bounceRequest: PropTypes.func.isRequired
   };
 
+  componentDidMount() {
+    if (window.location.search.includes('bounce=true')) {
+      this.show();
+    }
+  }
+
   show() {
     this.refs.bouceModal.show();
   }

--- a/SingularityUI/app/components/common/modalButtons/ScaleModal.jsx
+++ b/SingularityUI/app/components/common/modalButtons/ScaleModal.jsx
@@ -32,6 +32,12 @@ class ScaleModal extends Component {
     }
   };
 
+  componentDidMount() {
+    if (window.location.search.includes('scale=true')) {
+      this.show();
+    }
+  }
+
   handleScale(data) {
     const { instances, durationMillis, message, bounce, incremental } = data;
     const isIncremental = incremental === 'incremental';


### PR DESCRIPTION
Appending `?bounce=true` or `?scale=true` on any request page will have the respective modal automatically open.
