### PR TITLE
Better webhook auth timeouts and exception messages

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityAsyncHttpClient.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityAsyncHttpClient.java
@@ -3,10 +3,15 @@ package com.hubspot.singularity;
 import javax.inject.Inject;
 
 import com.ning.http.client.AsyncHttpClient;
+import com.ning.http.client.AsyncHttpClientConfig;
 
 import io.dropwizard.lifecycle.Managed;
 
 public class SingularityAsyncHttpClient extends AsyncHttpClient implements Managed {
+
+  public SingularityAsyncHttpClient(AsyncHttpClientConfig clientConfig) {
+    super(clientConfig);
+  }
 
   @Inject
   public SingularityAsyncHttpClient() {}

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityAuthModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityAuthModule.java
@@ -3,6 +3,7 @@ package com.hubspot.singularity;
 import com.google.inject.Binder;
 import com.google.inject.Scopes;
 import com.google.inject.multibindings.Multibinder;
+import com.google.inject.name.Names;
 import com.hubspot.dropwizard.guicier.DropwizardAwareModule;
 import com.hubspot.singularity.auth.SingularityAuthFeature;
 import com.hubspot.singularity.auth.SingularityAuthenticatorClass;
@@ -10,9 +11,13 @@ import com.hubspot.singularity.auth.SingularityAuthorizationHelper;
 import com.hubspot.singularity.auth.authenticator.SingularityAuthenticator;
 import com.hubspot.singularity.auth.authenticator.SingularityMultiMethodAuthenticator;
 import com.hubspot.singularity.auth.datastore.SingularityAuthDatastore;
+import com.hubspot.singularity.config.AuthConfiguration;
 import com.hubspot.singularity.config.SingularityConfiguration;
+import com.ning.http.client.AsyncHttpClient;
+import com.ning.http.client.AsyncHttpClientConfig;
 
 public class SingularityAuthModule extends DropwizardAwareModule<SingularityConfiguration> {
+  public static final String WEBHOOK_AUTH_HTTP_CLIENT = "singularity.webhook.auth.http.client";
 
   public SingularityAuthModule() {}
 
@@ -21,6 +26,16 @@ public class SingularityAuthModule extends DropwizardAwareModule<SingularityConf
     Multibinder<SingularityAuthenticator> multibinder = Multibinder.newSetBinder(binder, SingularityAuthenticator.class);
     for (SingularityAuthenticatorClass clazz : getConfiguration().getAuthConfiguration().getAuthenticators()) {
       multibinder.addBinding().to(clazz.getAuthenticatorClass());
+      if (clazz == SingularityAuthenticatorClass.WEBHOOK) {
+        AuthConfiguration authConfiguration = getConfiguration().getAuthConfiguration();
+        AsyncHttpClientConfig clientConfig = new AsyncHttpClientConfig.Builder()
+            .setConnectionTimeoutInMs(authConfiguration.getWebhookAuthConnectTimeoutMs())
+            .setRequestTimeoutInMs(authConfiguration.getWebhookAuthRequestTimeoutMs())
+            .setMaxRequestRetry(authConfiguration.getWebhookAuthRetries())
+            .build();
+        SingularityAsyncHttpClient webhookAsyncHttpClient = new SingularityAsyncHttpClient(clientConfig);
+        binder.bind(AsyncHttpClient.class).annotatedWith(Names.named(WEBHOOK_AUTH_HTTP_CLIENT)).toInstance(webhookAsyncHttpClient);
+      }
     }
 
     binder.bind(SingularityAuthFeature.class);

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAuthedUserFactory.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAuthedUserFactory.java
@@ -1,12 +1,14 @@
 package com.hubspot.singularity.auth;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import javax.ws.rs.WebApplicationException;
-
 import org.glassfish.jersey.server.internal.inject.AbstractContainerRequestValueFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.inject.Singleton;
 import com.hubspot.singularity.SingularityUser;
@@ -16,6 +18,8 @@ import com.hubspot.singularity.config.SingularityConfiguration;
 
 @Singleton
 public class SingularityAuthedUserFactory extends AbstractContainerRequestValueFactory<SingularityUser> {
+  private static final Logger LOG = LoggerFactory.getLogger(SingularityAuthedUserFactory.class);
+
   private final Set<SingularityAuthenticator> authenticators;
   private final SingularityConfiguration configuration;
 
@@ -27,25 +31,25 @@ public class SingularityAuthedUserFactory extends AbstractContainerRequestValueF
 
   @Override
   public SingularityUser provide() {
-    WebApplicationException unauthenticatedException = null;
+    List<String> unauthorizedExceptionMessages = new ArrayList<>();
     for (SingularityAuthenticator authenticator : authenticators) {
       try {
         Optional<SingularityUser> maybeUser = authenticator.getUser(getContainerRequest());
         if (maybeUser.isPresent()) {
           return maybeUser.get();
         }
-      } catch (WebApplicationException e) {
-        unauthenticatedException = e;
+      } catch (Throwable t) {
+        LOG.trace("Unauthenticated: {}", t.getMessage());
+        unauthorizedExceptionMessages.add(String.format("%s (%s)", authenticator.getClass().getSimpleName(), t.getMessage()));
       }
     }
 
     // No user found if we got here
     if (configuration.getAuthConfiguration().isEnabled()) {
-      if (unauthenticatedException != null) {
-        throw unauthenticatedException;
+      if (!unauthorizedExceptionMessages.isEmpty()) {
+        throw WebExceptions.unauthorized(String.format("Unable to authenticate using methods: %s", unauthorizedExceptionMessages));
       } else {
-        throw WebExceptions.unauthorized(String.format("Unable to authenticate user using methods: %s",
-            authenticators.stream().map(SingularityAuthenticator::getClass).collect(Collectors.toList())));
+        throw WebExceptions.unauthorized(String.format("Unable to authenticate user using methods: %s", authenticators.stream().map(SingularityAuthenticator::getClass).collect(Collectors.toList())));
       }
     }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAuthedUserFactory.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAuthedUserFactory.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.ws.rs.WebApplicationException;
+
 import org.glassfish.jersey.server.internal.inject.AbstractContainerRequestValueFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,8 +41,12 @@ public class SingularityAuthedUserFactory extends AbstractContainerRequestValueF
           return maybeUser.get();
         }
       } catch (Throwable t) {
-        LOG.trace("Unauthenticated: {}", t.getMessage());
-        unauthorizedExceptionMessages.add(String.format("%s (%s)", authenticator.getClass().getSimpleName(), t.getMessage()));
+        if (t instanceof WebApplicationException) {
+          WebApplicationException wae = (WebApplicationException) t;
+          unauthorizedExceptionMessages.add(String.format("%s (%s)", authenticator.getClass().getSimpleName(), wae.getResponse().getEntity().toString()));
+        } else {
+          unauthorizedExceptionMessages.add(String.format("%s (%s)", authenticator.getClass().getSimpleName(), t.getMessage()));
+        }
       }
     }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/authenticator/SingularityMultiMethodAuthenticator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/authenticator/SingularityMultiMethodAuthenticator.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
 
 import org.slf4j.Logger;
@@ -38,9 +37,9 @@ public class SingularityMultiMethodAuthenticator implements Authenticator<Contai
         if (maybeUser.isPresent()) {
           return maybeUser;
         }
-      } catch (WebApplicationException e) {
-        LOG.trace("Unauthenticated: {}", e.getMessage());
-        unauthorizedExceptionMessages.add(String.format("%s (%s)", authenticator.getClass().getSimpleName(), e.getMessage()));
+      } catch (Throwable t) {
+        LOG.trace("Unauthenticated: {}", t.getMessage());
+        unauthorizedExceptionMessages.add(String.format("%s (%s)", authenticator.getClass().getSimpleName(), t.getMessage()));
       }
     }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/authenticator/SingularityMultiMethodAuthenticator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/authenticator/SingularityMultiMethodAuthenticator.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
 
 import org.slf4j.Logger;
@@ -39,7 +40,12 @@ public class SingularityMultiMethodAuthenticator implements Authenticator<Contai
         }
       } catch (Throwable t) {
         LOG.trace("Unauthenticated: {}", t.getMessage());
-        unauthorizedExceptionMessages.add(String.format("%s (%s)", authenticator.getClass().getSimpleName(), t.getMessage()));
+        if (t instanceof WebApplicationException) {
+          WebApplicationException wae = (WebApplicationException) t;
+          unauthorizedExceptionMessages.add(String.format("%s (%s)", authenticator.getClass().getSimpleName(), wae.getResponse().getEntity().toString()));
+        } else {
+          unauthorizedExceptionMessages.add(String.format("%s (%s)", authenticator.getClass().getSimpleName(), t.getMessage()));
+        }
       }
     }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/authenticator/SingularityWebhookAuthenticator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/authenticator/SingularityWebhookAuthenticator.java
@@ -42,8 +42,8 @@ public class SingularityWebhookAuthenticator implements SingularityAuthenticator
         .refreshAfterWrite(webhookAuthConfiguration.getCacheValidationMs(), TimeUnit.MILLISECONDS)
         .build(new CacheLoader<String, SingularityUserPermissionsResponse>() {
           @Override
-          public SingularityUserPermissionsResponse load(String authHeaderVaule) throws Exception {
-            return verifyUncached(authHeaderVaule);
+          public SingularityUserPermissionsResponse load(String authHeaderValue) throws Exception {
+            return verifyUncached(authHeaderValue);
           }
 
           @Override

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/authenticator/SingularityWebhookAuthenticator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/authenticator/SingularityWebhookAuthenticator.java
@@ -5,6 +5,9 @@ import java.util.concurrent.TimeUnit;
 
 import javax.ws.rs.container.ContainerRequestContext;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import com.google.common.cache.CacheBuilder;
@@ -26,6 +29,8 @@ import com.ning.http.client.Response;
 
 @Singleton
 public class SingularityWebhookAuthenticator implements SingularityAuthenticator {
+  private static final Logger LOG = LoggerFactory.getLogger(SingularityWebhookAuthenticator.class);
+
   private final AsyncHttpClient asyncHttpClient;
   private final WebhookAuthConfiguration webhookAuthConfiguration;
   private final ObjectMapper objectMapper;
@@ -52,6 +57,7 @@ public class SingularityWebhookAuthenticator implements SingularityAuthenticator
               try {
                 return verifyUncached(authHeaderVaule);
               } catch (Throwable t) {
+                LOG.warn("Unable to refresh user information", t);
                 return oldVaule;
               }
             });

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/authenticator/SingularityWebhookAuthenticator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/authenticator/SingularityWebhookAuthenticator.java
@@ -1,17 +1,18 @@
 package com.hubspot.singularity.auth.authenticator;
 
-import java.io.IOException;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import javax.ws.rs.container.ContainerRequestContext;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
-import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.google.common.net.HttpHeaders;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListenableFutureTask;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
@@ -28,7 +29,7 @@ public class SingularityWebhookAuthenticator implements SingularityAuthenticator
   private final AsyncHttpClient asyncHttpClient;
   private final WebhookAuthConfiguration webhookAuthConfiguration;
   private final ObjectMapper objectMapper;
-  private final Cache<String, SingularityUserPermissionsResponse> permissionsCache;
+  private final LoadingCache<String, SingularityUserPermissionsResponse> permissionsCache;
 
   @Inject
   public SingularityWebhookAuthenticator(@Named(SingularityAuthModule.WEBHOOK_AUTH_HTTP_CLIENT) AsyncHttpClient asyncHttpClient,
@@ -38,8 +39,24 @@ public class SingularityWebhookAuthenticator implements SingularityAuthenticator
     this.webhookAuthConfiguration = configuration.getWebhookAuthConfiguration();
     this.objectMapper = objectMapper;
     this.permissionsCache = CacheBuilder.<String, SingularityUserPermissionsResponse>newBuilder()
-        .expireAfterWrite(webhookAuthConfiguration.getCacheValidationMs(), TimeUnit.MILLISECONDS)
-        .build();
+        .refreshAfterWrite(webhookAuthConfiguration.getCacheValidationMs(), TimeUnit.MILLISECONDS)
+        .build(new CacheLoader<String, SingularityUserPermissionsResponse>() {
+          @Override
+          public SingularityUserPermissionsResponse load(String authHeaderVaule) throws Exception {
+            return verifyUncached(authHeaderVaule);
+          }
+
+          @Override
+          public ListenableFuture<SingularityUserPermissionsResponse> reload(String authHeaderVaule, SingularityUserPermissionsResponse oldVaule) {
+            return ListenableFutureTask.create(() -> {
+              try {
+                return verifyUncached(authHeaderVaule);
+              } catch (Throwable t) {
+                return oldVaule;
+              }
+            });
+          }
+        });
   }
 
   @Override
@@ -62,32 +79,35 @@ public class SingularityWebhookAuthenticator implements SingularityAuthenticator
   }
 
   private SingularityUserPermissionsResponse verify(String authHeaderValue) {
-    SingularityUserPermissionsResponse maybeCachedPermissions = permissionsCache.getIfPresent(authHeaderValue);
-    if (maybeCachedPermissions != null) {
-      return maybeCachedPermissions;
-    } else {
-      try {
-        Response response = asyncHttpClient.prepareGet(webhookAuthConfiguration.getAuthVerificationUrl())
-            .addHeader("Authorization", authHeaderValue)
-            .execute()
-            .get();
-        if (response.getStatusCode() > 299) {
-          throw WebExceptions.unauthorized(String.format("Got status code %d when verifying jwt", response.getStatusCode()));
-        } else {
-          String responseBody = response.getResponseBody();
-          SingularityUserPermissionsResponse permissionsResponse = objectMapper.readValue(responseBody, SingularityUserPermissionsResponse.class);
-          if (!permissionsResponse.getUser().isPresent()) {
-            throw WebExceptions.unauthorized(String.format("No user present in response %s", permissionsResponse));
-          }
-          if (!permissionsResponse.getUser().get().isAuthenticated()) {
-            throw WebExceptions.unauthorized(String.format("User not authenticated (response: %s)", permissionsResponse));
-          }
-          permissionsCache.put(authHeaderValue, permissionsResponse);
-          return permissionsResponse;
+    try {
+      return permissionsCache.get(authHeaderValue);
+    } catch (Throwable t) {
+      throw WebExceptions.unauthorized(String.format("Exception while verifying token: %s", t.getMessage()));
+    }
+  }
+
+  private SingularityUserPermissionsResponse verifyUncached(String authHeaderValue) {
+    try {
+      Response response = asyncHttpClient.prepareGet(webhookAuthConfiguration.getAuthVerificationUrl())
+          .addHeader("Authorization", authHeaderValue)
+          .execute()
+          .get();
+      if (response.getStatusCode() > 299) {
+        throw WebExceptions.unauthorized(String.format("Got status code %d when verifying jwt", response.getStatusCode()));
+      } else {
+        String responseBody = response.getResponseBody();
+        SingularityUserPermissionsResponse permissionsResponse = objectMapper.readValue(responseBody, SingularityUserPermissionsResponse.class);
+        if (!permissionsResponse.getUser().isPresent()) {
+          throw WebExceptions.unauthorized(String.format("No user present in response %s", permissionsResponse));
         }
-      } catch (IOException|ExecutionException|InterruptedException e) {
-        throw WebExceptions.unauthorized(String.format("Exception while verifying token: %s", e.getMessage()));
+        if (!permissionsResponse.getUser().get().isAuthenticated()) {
+          throw WebExceptions.unauthorized(String.format("User not authenticated (response: %s)", permissionsResponse));
+        }
+        permissionsCache.put(authHeaderValue, permissionsResponse);
+        return permissionsResponse;
       }
+    } catch (Throwable t) {
+      throw new RuntimeException(t);
     }
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/AuthConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/AuthConfiguration.java
@@ -52,6 +52,15 @@ public class AuthConfiguration {
   @NotNull
   private String requestUserHeaderName = "X-Username";  // used by SingularityHeaderPassthroughAuthenticator
 
+  @JsonProperty
+  private int webhookAuthRequestTimeoutMs = 2000;
+
+  @JsonProperty
+  private int webhookAuthRetries = 2;
+
+  @JsonProperty
+  private int webhookAuthConnectTimeoutMs = 2000;
+
   public boolean isEnabled() {
     return enabled;
   }
@@ -132,5 +141,32 @@ public class AuthConfiguration {
 
   public void setRequestUserHeaderName(String requestUserHeaderName) {
     this.requestUserHeaderName = requestUserHeaderName;
+  }
+
+  public int getWebhookAuthRequestTimeoutMs() {
+    return webhookAuthRequestTimeoutMs;
+  }
+
+  public AuthConfiguration setWebhookAuthRequestTimeoutMs(int webhookAuthRequestTimeoutMs) {
+    this.webhookAuthRequestTimeoutMs = webhookAuthRequestTimeoutMs;
+    return this;
+  }
+
+  public int getWebhookAuthRetries() {
+    return webhookAuthRetries;
+  }
+
+  public AuthConfiguration setWebhookAuthRetries(int webhookAuthRetries) {
+    this.webhookAuthRetries = webhookAuthRetries;
+    return this;
+  }
+
+  public int getWebhookAuthConnectTimeoutMs() {
+    return webhookAuthConnectTimeoutMs;
+  }
+
+  public AuthConfiguration setWebhookAuthConnectTimeoutMs(int webhookAuthConnectTimeoutMs) {
+    this.webhookAuthConnectTimeoutMs = webhookAuthConnectTimeoutMs;
+    return this;
   }
 }


### PR DESCRIPTION
Previously, when using multiple auth methods, if all failed singularity would only return the message from the final one attempted. Also, the AsyncHttpClient used for webhook auth calls had all of the default timeouts and retries set, which are too high to auth calls.

This PR updates the multiple auth method caller to gather exception messages from each attempted auth method and return a combined message. It also updates the webhook auth http client to user much shorter timeouts (now defaults to 2s connect, 2s request, 2 retries) which are configurable in the auth configuration