### PR TITLE
Add support for configurable navbar title links.

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/config/UIConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/UIConfiguration.java
@@ -111,6 +111,10 @@ public class UIConfiguration {
   @JsonProperty
   private Map<String, Map<String, List<UIQuickLinkConfiguration>>> quickLinks = Collections.emptyMap();
 
+  // e.g. {"QA": "https://singularity-qa.my-paas.net", "Production": "https://singularity-prod.my-paas.net"}
+  @JsonProperty
+  private Map<String, String> navTitleLinks = Collections.emptyMap();
+
   public boolean isHideNewDeployButton() {
     return hideNewDeployButton;
   }
@@ -293,5 +297,13 @@ public class UIConfiguration {
 
   public void setQuickLinks(Map<String, Map<String, List<UIQuickLinkConfiguration>>> quickLinks) {
     this.quickLinks = quickLinks;
+  }
+
+  public Map<String, String> getNavTitleLinks() {
+    return navTitleLinks;
+  }
+
+  public void setNavTitleLinks(Map<String, String> navTitleLinks) {
+    this.navTitleLinks = navTitleLinks;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/views/IndexView.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/views/IndexView.java
@@ -66,6 +66,7 @@ public class IndexView extends View {
   private final String authCookieName;
   private final String authTokenKey;
   private final String quickLinks;
+  private final String navTitleLinks;
 
   public IndexView(String singularityUriBase, String appRoot, IndexViewConfiguration configuration, ObjectMapper mapper) {
     super("index.mustache");
@@ -136,6 +137,12 @@ public class IndexView extends View {
 
     try {
       this.quickLinks = ow.writeValueAsString(uiConfiguration.getQuickLinks());
+    } catch (JsonProcessingException e) {
+      throw Throwables.propagate(e);
+    }
+
+    try {
+      this.navTitleLinks = ow.writeValueAsString(uiConfiguration.getNavTitleLinks());
     } catch (JsonProcessingException e) {
       throw Throwables.propagate(e);
     }
@@ -281,6 +288,10 @@ public class IndexView extends View {
     return quickLinks;
   }
 
+  public String getNavTitleLinks() {
+    return navTitleLinks;
+  }
+
   @Override
   public String toString() {
     return "IndexView{" +
@@ -319,6 +330,7 @@ public class IndexView extends View {
         ", authCookieName='" + authCookieName + '\'' +
         ", authTokenKey='" + authTokenKey + '\'' +
         ", quickLinks='" + quickLinks + '\'' +
+        ", navTitleLinks='" + navTitleLinks + '\'' +
         "} " + super.toString();
   }
 }

--- a/SingularityUI/app/assets/index.mustache
+++ b/SingularityUI/app/assets/index.mustache
@@ -52,7 +52,8 @@
             generateAuthHeader: {{{generateAuthHeader}}},
             authCookieName: "{{{ authCookieName }}}",
             authTokenKey: "{{{ authTokenKey }}}",
-            quickLinks: {{{quickLinks}}}
+            quickLinks: {{{quickLinks}}},
+            navTitleLinks: {{{navTitleLinks}}}
         };
     </script>
     <script src="{{{staticRoot}}}/js/vendor.bundle.js"></script>

--- a/SingularityUI/app/components/common/Navigation.jsx
+++ b/SingularityUI/app/components/common/Navigation.jsx
@@ -35,6 +35,26 @@ function isActive(navbarPath, fragment) {
 // put into page wrapper, render children
 const Navigation = (props) => {
   const fragment = props.location.pathname.split('/')[1];
+  let renderedNavTitle;
+
+  if (Object.keys(config.navTitleLinks).length > 0) {
+    const renderedNavTitleLinks = Object.keys(config.navTitleLinks).map(linkTitle => {
+      return <li><a href={config.navTitleLinks[linkTitle]}>{linkTitle}</a></li>;
+    });
+
+    renderedNavTitle =
+      <div className="dropdown nav">
+        <a href="#" className="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+          {config.title} <span className="caret"></span>
+        </a>
+        <ul className="dropdown-menu">
+          {renderedNavTitleLinks}
+        </ul>
+      </div>
+
+  } else {
+    renderedNavTitle = <Link to="/">{config.title}</Link>;
+  }
   return (
     <nav className="navbar navbar-default">
       <div className="container-fluid">
@@ -45,7 +65,7 @@ const Navigation = (props) => {
             <span className="icon-bar"></span>
             <span className="icon-bar"></span>
           </button>
-          <Link className="navbar-brand" to="/">{config.title}</Link>
+          <div className="navbar-brand">{renderedNavTitle}</div>
         </div>
         <div className="collapse navbar-collapse" id="navbar-collapse">
           <ul className="nav navbar-nav">

--- a/SingularityUI/app/components/common/Navigation.jsx
+++ b/SingularityUI/app/components/common/Navigation.jsx
@@ -35,26 +35,26 @@ function isActive(navbarPath, fragment) {
 // put into page wrapper, render children
 const Navigation = (props) => {
   const fragment = props.location.pathname.split('/')[1];
-  let renderedNavTitle;
+  const navTitle = config.navTitleLinks
+    ? (
+      <ul className="nav navbar-nav">
+        <li className="dropdown nav">
+          <a href="#" className="dropdown-toggle navbar-brand" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+            {config.title} <span className="caret" />
+          </a>
+          <ul className="dropdown-menu">
+            {Object.keys(config.navTitleLinks).map((linkTitle, index) =>
+              <li key={index}>
+                <a href={config.navTitleLinks[linkTitle]}>{linkTitle}</a>
+              </li>
+            )}
+          </ul>
+        </li>
+      </ul>
+    ) : (
+      <Link className="navbar-brand" to="/">{config.title}</Link>
+    );
 
-  if (Object.keys(config.navTitleLinks).length > 0) {
-    const renderedNavTitleLinks = Object.keys(config.navTitleLinks).map(linkTitle => {
-      return <li><a href={config.navTitleLinks[linkTitle]}>{linkTitle}</a></li>;
-    });
-
-    renderedNavTitle =
-      <div className="dropdown nav">
-        <a href="#" className="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-          {config.title} <span className="caret"></span>
-        </a>
-        <ul className="dropdown-menu">
-          {renderedNavTitleLinks}
-        </ul>
-      </div>
-
-  } else {
-    renderedNavTitle = <Link to="/">{config.title}</Link>;
-  }
   return (
     <nav className="navbar navbar-default">
       <div className="container-fluid">
@@ -65,7 +65,7 @@ const Navigation = (props) => {
             <span className="icon-bar"></span>
             <span className="icon-bar"></span>
           </button>
-          <div className="navbar-brand">{renderedNavTitle}</div>
+          {navTitle}
         </div>
         <div className="collapse navbar-collapse" id="navbar-collapse">
           <ul className="nav navbar-nav">
@@ -83,7 +83,7 @@ const Navigation = (props) => {
             </li>
             <li className={classnames('dropdown', {active: isActive('admin', fragment)})}>
               <a href="#" className="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-                Admin <span className="caret"></span>
+                Admin <span className="caret" />
               </a>
               <ul className="dropdown-menu">
                 <li><Link to="/racks">Racks</Link></li>

--- a/SingularityUI/gulpfile.js
+++ b/SingularityUI/gulpfile.js
@@ -49,7 +49,8 @@ var templateData = {
   generateAuthHeader: process.env.SINGULARITY_GENERATE_AUTH_HEADER || 'false',
   authTokenKey: process.env.SINGULARITY_AUTH_TOKEN_KEY || 'token',
   authCookieName: process.env.SINGULARITY_AUTH_COOKIE_NAME || '',
-  quickLinks: process.env.SINGULARITY_QUICK_LINKS || '{}'
+  quickLinks: process.env.SINGULARITY_QUICK_LINKS || '{}',
+  navTitleLinks: process.env.SINGULARITY_NAV_TITLE_LINKS || '{}'
 };
 
 var dest = path.resolve(__dirname, 'dist');


### PR DESCRIPTION
Looks like 
![image](https://user-images.githubusercontent.com/1060767/35758997-fc8b323c-0844-11e8-8663-5f70b01a590c.png)

This setup defaults to having the nav header title link back to the Dashboard (as is the case today) if no links are configured.

Might have to tweak the CSS class setup slightly, since the `Admin` dropdown has squared corners, but this one's got rounded corners.
