### PR TITLE
Smarter table pagination

### DIFF
--- a/SingularityUI/app/components/common/table/UITable.jsx
+++ b/SingularityUI/app/components/common/table/UITable.jsx
@@ -448,7 +448,7 @@ class UITable extends Component {
       <div>
         {this.props.rowChunkSizeChoices && <div className="row"><div className="col-md-12">{this.renderRowChunkSizeChoices()}</div></div>}
         {maybeTable}
-        {this.renderPagination()}
+        <div className="text-center">{this.renderPagination()}</div>
       </div>
     );
   }

--- a/SingularityUI/app/components/common/table/UITable.jsx
+++ b/SingularityUI/app/components/common/table/UITable.jsx
@@ -74,7 +74,6 @@ class UITable extends Component {
       table.setState({
         chunkNum: 1,
         rowChunkSize: this.props.rowChunkSize,
-        lastPage: false,
       });
     };
   }

--- a/SingularityUI/app/components/common/table/UITable.jsx
+++ b/SingularityUI/app/components/common/table/UITable.jsx
@@ -344,7 +344,7 @@ class UITable extends Component {
       return (
         <Pagination
           prev={true}
-          next={!this.state.lastPage && numRows === rowsPerPage}
+          next={true}
           first={numPages > maxPaginationButtons}
           last={!this.isApiPaginated() && numPages > maxPaginationButtons}
           ellipsis={false}


### PR DESCRIPTION
Make table pagination more obvious by fetching ahead to see if there is more data. If not, hide the "next" button.

![kapture 2018-02-07 at 15 30 45](https://user-images.githubusercontent.com/4924620/35940055-f2fa966a-0c1b-11e8-8164-62f357350c6d.gif)
