### PR TITLE
Enable server side encryption params for uploads

### DIFF
--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskLogManager.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskLogManager.java
@@ -255,7 +255,7 @@ public class SingularityExecutorTaskLogManager {
     }
 
     S3UploadMetadata s3UploadMetadata = new S3UploadMetadata(pathToS3Directory.toString(), globForS3Files, s3UploaderBucket, getS3KeyPattern(s3KeyPattern.or(taskDefinition.getExecutorData().getS3UploaderKeyPattern())), finished, Optional.<String> absent(),
-        Optional. absent(), Optional. absent(), Optional. absent(), Optional. absent(), s3StorageClass, applyS3StorageClassAfterBytes, Optional.of(finished), Optional.of(checkSubdirectories), Optional.absent(), Collections.emptyMap(), Optional.absent());
+        Optional. absent(), Optional. absent(), Optional. absent(), Optional. absent(), s3StorageClass, applyS3StorageClassAfterBytes, Optional.of(finished), Optional.of(checkSubdirectories), Optional.absent(), Collections.emptyMap(), Optional.absent(), Optional.absent());
 
     String s3UploadMetadataFileName = String.format("%s-%s%s", taskDefinition.getTaskId(), filenameHint, baseConfiguration.getS3UploaderMetadataSuffix());
 

--- a/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/shared/S3UploadMetadata.java
+++ b/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/shared/S3UploadMetadata.java
@@ -58,6 +58,7 @@ public class S3UploadMetadata {
   private final SingularityUploaderType uploaderType;
   private final Map<String, Object> gcsCredentials;
   private final Optional<String> gcsStorageClass;
+  private final Optional<String> encryptionKey;
 
   @JsonCreator
   public S3UploadMetadata(@JsonProperty("directory") String directory,
@@ -76,7 +77,8 @@ public class S3UploadMetadata {
                           @JsonProperty("checkSubdirectories") Optional<Boolean> checkSubdirectories,
                           @JsonProperty("uploaderType") Optional<SingularityUploaderType> uploaderType,
                           @JsonProperty("gcsCredentials") Map<String, Object> gcsCredentials,
-                          @JsonProperty("gcsStorageClass") Optional<String> gcsStorageClass) {
+                          @JsonProperty("gcsStorageClass") Optional<String> gcsStorageClass,
+                          @JsonProperty("encryptionKey") Optional<String> encryptionKey) {
     Preconditions.checkNotNull(directory);
     Preconditions.checkNotNull(fileGlob);
     Preconditions.checkNotNull(s3Bucket);
@@ -99,6 +101,7 @@ public class S3UploadMetadata {
     this.uploaderType = uploaderType.or(SingularityUploaderType.S3);
     this.gcsCredentials = gcsCredentials != null ? gcsCredentials : Collections.emptyMap();
     this.gcsStorageClass = gcsStorageClass;
+    this.encryptionKey = encryptionKey;
   }
 
 
@@ -209,6 +212,10 @@ public class S3UploadMetadata {
     return gcsCredentials;
   }
 
+  public Optional<String> getEncryptionKey() {
+    return encryptionKey;
+  }
+
   @Override
   public String toString() {
     return "S3UploadMetadata{" +
@@ -228,6 +235,7 @@ public class S3UploadMetadata {
         ", checkSubdirectories=" + checkSubdirectories +
         ", uploaderType=" + uploaderType +
         ", gcsStorageClass=" + gcsStorageClass +
+        ", encryptionKey=" + encryptionKey +
         '}';
   }
 }

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityGCSUploader.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityGCSUploader.java
@@ -17,6 +17,7 @@ import com.github.rholder.retry.WaitStrategies;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BlobWriteOption;
 import com.google.cloud.storage.StorageClass;
 import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
@@ -107,7 +108,11 @@ public class SingularityGCSUploader extends SingularityUploader {
       }
 
       try (FileInputStream fileInputStream = new FileInputStream(file.toFile())){
-        storage.create(blobInfoBuilder.build(), fileInputStream);
+        if (uploadMetadata.getEncryptionKey().isPresent()) {
+          storage.create(blobInfoBuilder.build(), fileInputStream, BlobWriteOption.encryptionKey(uploadMetadata.getEncryptionKey().get()));
+        } else {
+          storage.create(blobInfoBuilder.build(), fileInputStream);
+        }
         LOG.info("{} Uploaded {} in {}", logIdentifier, key, JavaUtils.duration(start));
         return true;
       } catch (StorageException se) {

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3Uploader.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3Uploader.java
@@ -20,6 +20,7 @@ import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PartETag;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
 import com.amazonaws.services.s3.model.StorageClass;
 import com.amazonaws.services.s3.model.UploadPartRequest;
 import com.github.rholder.retry.Retryer;
@@ -114,6 +115,9 @@ public class SingularityS3Uploader extends SingularityUploader {
           PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, key, file.toFile()).withMetadata(objectMetadata);
           if (maybeStorageClass.isPresent()) {
             putObjectRequest.setStorageClass(maybeStorageClass.get());
+          }
+          if (uploadMetadata.getEncryptionKey().isPresent()) {
+            putObjectRequest.withSSEAwsKeyManagementParams(new SSEAwsKeyManagementParams(uploadMetadata.getEncryptionKey().get()));
           }
           s3Client.putObject(putObjectRequest);
         }


### PR DESCRIPTION
Enable usage of `SSEAwsKeyManagementParams` for S3 and `BlobWriteOption.encryptionKey` for GCS