### PR TITLE
Better catch for statusUpdate exceptions

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
@@ -276,7 +276,7 @@ public class SingularityMesosSchedulerImpl extends SingularityMesosScheduler {
     try {
       return handleStatusUpdateAsync(status);
     } catch (Throwable t) {
-      exceptionNotifier.notify(String.format("Scheduler threw an uncaught exception (%s)", t.getMessage()), t);
+      LOG.error("Scheduler threw an uncaught exception", t);
       notifyStopping();
       abort.abort(AbortReason.UNRECOVERABLE_ERROR, Optional.of(t));
       return CompletableFuture.completedFuture(false);
@@ -468,7 +468,7 @@ public class SingularityMesosSchedulerImpl extends SingularityMesosScheduler {
     return statusUpdateHandler.processStatusUpdateAsync(status)
         .whenCompleteAsync((result, throwable) -> {
           if (throwable != null) {
-            exceptionNotifier.notify(String.format("Scheduler threw an uncaught exception (%s)", throwable.getMessage()), throwable);
+            LOG.error("Scheduler threw an uncaught exception processing status updates", throwable);
             notifyStopping();
             abort.abort(AbortReason.UNRECOVERABLE_ERROR, Optional.of(throwable));
           }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
@@ -273,7 +273,14 @@ public class SingularityMesosSchedulerImpl extends SingularityMesosScheduler {
       queuedUpdates.add(status);
       return CompletableFuture.completedFuture(false);
     }
-    return handleStatusUpdateAsync(status);
+    try {
+      return handleStatusUpdateAsync(status);
+    } catch (Throwable t) {
+      exceptionNotifier.notify(String.format("Scheduler threw an uncaught exception (%s)", t.getMessage()), t);
+      notifyStopping();
+      abort.abort(AbortReason.UNRECOVERABLE_ERROR, Optional.of(t));
+      return CompletableFuture.completedFuture(false);
+    }
   }
 
   @Override


### PR DESCRIPTION
When enqueueing a status update to be processed asynchronously, if we hit the `maxStatusUpdateQueueSize` limit, a `RejectedExecutionException` is thrown _before_ `processStatusUpdateAsync` returns. The exception is not in the CompletableFuture.

This adds an additional catch and some better logging for this case.