### PR TITLE
Fix mobile menu responsiveness

### DIFF
--- a/SingularityUI/app/components/common/Navigation.jsx
+++ b/SingularityUI/app/components/common/Navigation.jsx
@@ -38,7 +38,7 @@ const Navigation = (props) => {
   const navTitle = config.navTitleLinks
     ? (
       <ul className="nav navbar-nav">
-        <li className="dropdown nav">
+        <li className="dropdown">
           <a href="#" className="dropdown-toggle navbar-brand" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
             {config.title} <span className="caret" />
           </a>


### PR DESCRIPTION
The `nav` class on the `li` element was causing its height to fill the nav bar, preventing users from clicking the hamburger button. The hamburger button is only visible in views where the width is less than 768px.