### PR TITLE
Use total system cpus, not totalCpus in system calculation

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularitySlaveUsage.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularitySlaveUsage.java
@@ -28,6 +28,7 @@ public class SingularitySlaveUsage {
   private final long timestamp;
   private final double systemMemTotalBytes;
   private final double systemMemFreeBytes;
+  private final double systemCpusTotal;
   private final double systemLoad1Min;
   private final double systemLoad5Min;
   private final double systemLoad15Min;
@@ -49,6 +50,7 @@ public class SingularitySlaveUsage {
                                @JsonProperty("timestamp") long timestamp,
                                @JsonProperty("systemMemTotalBytes") double systemMemTotalBytes,
                                @JsonProperty("systemMemFreeBytes") double systemMemFreeBytes,
+                               @JsonProperty("systemCpusTotal") double systemCpusTotal,
                                @JsonProperty("systemLoad1Min") double systemLoad1Min,
                                @JsonProperty("systemLoad5Min") double systemLoad5Min,
                                @JsonProperty("systemLoad15Min") double systemLoad15Min,
@@ -68,6 +70,7 @@ public class SingularitySlaveUsage {
     this.timestamp = timestamp;
     this.systemMemTotalBytes = systemMemTotalBytes;
     this.systemMemFreeBytes = systemMemFreeBytes;
+    this.systemCpusTotal = systemCpusTotal;
     this.systemLoad1Min = systemLoad1Min;
     this.systemLoad5Min = systemLoad5Min;
     this.systemLoad15Min = systemLoad15Min;
@@ -139,6 +142,10 @@ public class SingularitySlaveUsage {
     return systemMemFreeBytes;
   }
 
+  public double getSystemCpusTotal() {
+    return systemCpusTotal;
+  }
+
   public double getSystemLoad1Min() {
     return systemLoad1Min;
   }
@@ -176,6 +183,7 @@ public class SingularitySlaveUsage {
         ", timestamp=" + timestamp +
         ", systemMemTotalBytes=" + systemMemTotalBytes +
         ", systemMemFreeBytes=" + systemMemFreeBytes +
+        ", systemCpusTotal=" + systemCpusTotal +
         ", systemLoad1Min=" + systemLoad1Min +
         ", systemLoad5Min=" + systemLoad5Min +
         ", systemLoad15Min=" + systemLoad15Min +

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularitySlaveUsageWithId.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularitySlaveUsageWithId.java
@@ -23,6 +23,7 @@ public class SingularitySlaveUsageWithId extends SingularitySlaveUsage {
         usage.getTimestamp(),
         usage.getSystemMemTotalBytes(),
         usage.getSystemMemFreeBytes(),
+        usage.getSystemCpusTotal(),
         usage.getSystemLoad1Min(),
         usage.getSystemLoad5Min(),
         usage.getSystemLoad15Min(),

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
@@ -246,7 +246,7 @@ public class SingularityMesosOfferScheduler {
         );
       case SPREAD_SYSTEM_USAGE:
       default:
-        double systemCpuFreeScore = Math.max(0, 1 - slaveUsage.getSystemLoad15Min());
+        double systemCpuFreeScore = Math.max(0, 1 - (slaveUsage.getSystemLoad15Min() / slaveUsage.getSystemCpusTotal()));
         double systemMemFreeScore = 1 - (slaveUsage.getSystemMemTotalBytes() - slaveUsage.getSystemMemFreeBytes()) / slaveUsage.getSystemMemTotalBytes();
         double systemDiskFreeScore = 1 - (slaveUsage.getSlaveDiskUsed() / slaveUsage.getSlaveDiskTotal());
         return new SingularitySlaveUsageWithCalculatedScores(

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
@@ -111,6 +111,7 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
         double systemLoad15Min = 0;
         double slaveDiskUsed = 0;
         double slaveDiskTotal = 0;
+        double systemCpusTotal = 0;
         if (slaveMetricsSnapshot != null) {
           systemMemTotalBytes = slaveMetricsSnapshot.getSystemMemTotalBytes();
           systemMemFreeBytes = slaveMetricsSnapshot.getSystemMemFreeBytes();
@@ -119,6 +120,7 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
           systemLoad15Min = slaveMetricsSnapshot.getSystemLoad15Min();
           slaveDiskUsed = slaveMetricsSnapshot.getSlaveDiskUsed();
           slaveDiskTotal = slaveMetricsSnapshot.getSlaveDiskTotal();
+          systemCpusTotal = slaveMetricsSnapshot.getSystemCpusTotal();
         }
 
         for (MesosTaskMonitorObject taskUsage : allTaskUsage) {
@@ -181,7 +183,7 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
 
         SingularitySlaveUsage slaveUsage = new SingularitySlaveUsage(cpusUsedOnSlave, cpuReservedOnSlave, cpusTotal, memoryBytesUsedOnSlave, memoryMbReservedOnSlave,
             memoryMbTotal, diskMbUsedOnSlave, diskMbReservedOnSlave, diskMbTotal, longRunningTasksUsage, allTaskUsage.size(), now,
-            systemMemTotalBytes, systemMemFreeBytes, systemLoad1Min, systemLoad5Min, systemLoad15Min, slaveDiskUsed, slaveDiskTotal);
+            systemMemTotalBytes, systemMemFreeBytes, systemCpusTotal, systemLoad1Min, systemLoad5Min, systemLoad15Min, slaveDiskUsed, slaveDiskTotal);
         List<Long> slaveTimestamps = usageManager.getSlaveUsageTimestamps(slave.getId());
         if (slaveTimestamps.size() + 1 > configuration.getNumUsageToKeep()) {
           usageManager.deleteSpecificSlaveUsage(slave.getId(), slaveTimestamps.get(0));

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosOfferSchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosOfferSchedulerTest.java
@@ -320,7 +320,7 @@ public class SingularityMesosOfferSchedulerTest extends SingularityCuratorTestBa
   private SingularitySlaveUsageWithCalculatedScores getUsage(long memMbReserved, long memMbTotal, double cpusReserved, double cpusTotal, long diskMbReserved, long diskMbTotal, Map<ResourceUsageType, Number> longRunningTasksUsage) {
     return scheduler.buildSlaveUsageWithScores(new SingularitySlaveUsage(
             0, cpusReserved, Optional.of(cpusTotal), 0, memMbReserved, Optional.of(memMbTotal), 0, diskMbReserved, Optional.of(diskMbTotal), longRunningTasksUsage, 1, 0L,
-        0, 0, 0, 0, 0, 0 , 0)
+        0, 0, 0, 0, 0, 0, 0 , 0)
     );
   }
 


### PR DESCRIPTION
When oversubscribing the resource, these values will be different. the load metrics are not as relevant without a true base value (systemCpus)