### PR TITLE
Collect cpu usage for tasks that have just started

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskCurrentUsage.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskCurrentUsage.java
@@ -8,12 +8,17 @@ public class SingularityTaskCurrentUsage {
   private final long memoryTotalBytes;
   private final long timestamp;
   private final double cpusUsed;
+  private final long diskTotalBytes;
 
   @JsonCreator
-  public SingularityTaskCurrentUsage(@JsonProperty("memoryTotalBytes") long memoryTotalBytes, @JsonProperty("long") long timestamp, @JsonProperty("cpusUsed") double cpusUsed) {
+  public SingularityTaskCurrentUsage(@JsonProperty("memoryTotalBytes") long memoryTotalBytes,
+                                     @JsonProperty("long") long timestamp,
+                                     @JsonProperty("cpusUsed") double cpusUsed,
+                                     @JsonProperty("diskTotalBytes") long diskTotalBytes) {
     this.memoryTotalBytes = memoryTotalBytes;
     this.timestamp = timestamp;
     this.cpusUsed = cpusUsed;
+    this.diskTotalBytes = diskTotalBytes;
   }
 
   public long getMemoryTotalBytes() {
@@ -28,9 +33,17 @@ public class SingularityTaskCurrentUsage {
     return cpusUsed;
   }
 
-  @Override
-  public String toString() {
-    return "SingularityTaskCurrentUsage [memoryTotalBytes=" + memoryTotalBytes + ", timestamp=" + timestamp + ", cpusUsed=" + cpusUsed + "]";
+  public long getDiskTotalBytes() {
+    return diskTotalBytes;
   }
 
+  @Override
+  public String toString() {
+    return "SingularityTaskCurrentUsage{" +
+        "memoryTotalBytes=" + memoryTotalBytes +
+        ", timestamp=" + timestamp +
+        ", cpusUsed=" + cpusUsed +
+        ", diskTotalBytes=" + diskTotalBytes +
+        '}';
+  }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskCurrentUsageWithId.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskCurrentUsageWithId.java
@@ -5,7 +5,7 @@ public class SingularityTaskCurrentUsageWithId extends SingularityTaskCurrentUsa
   private final SingularityTaskId taskId;
 
   public SingularityTaskCurrentUsageWithId(SingularityTaskId taskId, SingularityTaskCurrentUsage taskCurrentUsage) {
-    super(taskCurrentUsage.getMemoryTotalBytes(), taskCurrentUsage.getTimestamp(), taskCurrentUsage.getCpusUsed());
+    super(taskCurrentUsage.getMemoryTotalBytes(), taskCurrentUsage.getTimestamp(), taskCurrentUsage.getCpusUsed(), taskCurrentUsage.getDiskTotalBytes());
 
     this.taskId = taskId;
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
@@ -163,7 +163,7 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
               if (isLongRunning(task) ||  isConsideredLongRunning(task)) {
                 updateLongRunningTasksUsage(longRunningTasksUsage, latestUsage.getMemoryTotalBytes(), usedCpusSinceStart, latestUsage.getDiskTotalBytes());
               }
-              SingularityTaskCurrentUsage currentUsage = new SingularityTaskCurrentUsage(latestUsage.getMemoryTotalBytes(), now, usedCpusSinceStart);
+              SingularityTaskCurrentUsage currentUsage = new SingularityTaskCurrentUsage(latestUsage.getMemoryTotalBytes(), now, usedCpusSinceStart, latestUsage.getDiskTotalBytes());
               usageManager.saveCurrentTaskUsage(taskId, currentUsage);
 
               cpusUsedOnSlave += usedCpusSinceStart;
@@ -176,7 +176,7 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
             if (isLongRunning(task) ||  isConsideredLongRunning(task)) {
               updateLongRunningTasksUsage(longRunningTasksUsage, latestUsage.getMemoryTotalBytes(), taskCpusUsed, latestUsage.getDiskTotalBytes());
             }
-            SingularityTaskCurrentUsage currentUsage = new SingularityTaskCurrentUsage(latestUsage.getMemoryTotalBytes(), now, taskCpusUsed);
+            SingularityTaskCurrentUsage currentUsage = new SingularityTaskCurrentUsage(latestUsage.getMemoryTotalBytes(), now, taskCpusUsed, latestUsage.getDiskTotalBytes());
 
             usageManager.saveCurrentTaskUsage(taskId, currentUsage);
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
@@ -16,6 +16,7 @@ import com.google.inject.Inject;
 import com.hubspot.mesos.client.MesosClient;
 import com.hubspot.mesos.json.MesosSlaveMetricsSnapshotObject;
 import com.hubspot.mesos.json.MesosTaskMonitorObject;
+import com.hubspot.singularity.ExtendedTaskState;
 import com.hubspot.singularity.InvalidSingularityTaskIdException;
 import com.hubspot.singularity.RequestUtilization;
 import com.hubspot.singularity.SingularityClusterUtilization;
@@ -28,6 +29,7 @@ import com.hubspot.singularity.SingularitySlaveUsage;
 import com.hubspot.singularity.SingularitySlaveUsage.ResourceUsageType;
 import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.SingularityTaskCurrentUsage;
+import com.hubspot.singularity.SingularityTaskHistoryUpdate;
 import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.SingularityTaskUsage;
 import com.hubspot.singularity.config.SingularityConfiguration;
@@ -153,7 +155,20 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
           memoryBytesUsedOnSlave += latestUsage.getMemoryTotalBytes();
           diskMbUsedOnSlave += latestUsage.getDiskTotalBytes();
 
-          if (!pastTaskUsages.isEmpty()) {
+          if (pastTaskUsages.isEmpty()) {
+            Optional<SingularityTaskHistoryUpdate> maybeStartingUpdate = taskManager.getTaskHistoryUpdate(task, ExtendedTaskState.TASK_STARTING);
+            if (maybeStartingUpdate.isPresent()) {
+              long startTimestampSeconds = TimeUnit.MILLISECONDS.toSeconds(maybeStartingUpdate.get().getTimestamp());
+              double usedCpusSinceStart = latestUsage.getCpuSeconds() / (latestUsage.getTimestamp() - startTimestampSeconds);
+              if (isLongRunning(task) ||  isConsideredLongRunning(task)) {
+                updateLongRunningTasksUsage(longRunningTasksUsage, latestUsage.getMemoryTotalBytes(), usedCpusSinceStart, latestUsage.getDiskTotalBytes());
+              }
+              SingularityTaskCurrentUsage currentUsage = new SingularityTaskCurrentUsage(latestUsage.getMemoryTotalBytes(), now, usedCpusSinceStart);
+              usageManager.saveCurrentTaskUsage(taskId, currentUsage);
+
+              cpusUsedOnSlave += usedCpusSinceStart;
+            }
+          } else {
             SingularityTaskUsage lastUsage = pastTaskUsages.get(pastTaskUsages.size() - 1);
 
             double taskCpusUsed = ((latestUsage.getCpuSeconds() - lastUsage.getCpuSeconds()) / (latestUsage.getTimestamp() - lastUsage.getTimestamp()));


### PR DESCRIPTION
Right now we won't update the overall slave usage for a task that has just started. This lets us calculate the cpus from the task starting timestamp to include those as well in the slave usage metrics