### PR TITLE
Remove unneeded call to unsafeProcessStatusUpdate, fix tasksPerOfferHost check

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosStatusUpdateHandler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosStatusUpdateHandler.java
@@ -269,8 +269,8 @@ public class SingularityMesosStatusUpdateHandler {
         schedulerLock.runWithRequestLock(
             () -> unsafeProcessStatusUpdate(status, maybeTaskId.get()),
             maybeTaskId.get().getRequestId(),
-            getClass().getSimpleName());
-          unsafeProcessStatusUpdate(status, maybeTaskId.get());
+            getClass().getSimpleName()
+        );
         return true;
       }, statusUpdatesExecutor)
     );

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -236,11 +236,10 @@ public class SingularityScheduler {
     AtomicInteger heldForScheduledActiveTask = new AtomicInteger(0);
     AtomicInteger obsoleteRequests = new AtomicInteger(0);
 
-    deployKeyToPendingRequests.entrySet().parallelStream()
-        .forEach((deployKeyToPendingRequest) -> {
+    deployKeyToPendingRequests.forEach((deployKey, pendingRequestsForDeployKey) -> {
           lock.runWithRequestLock(
-              () -> handlePendingRequestsForDeployKey(obsoleteRequests, heldForScheduledActiveTask, totalNewScheduledTasks, deployKeyToPendingRequest.getKey(), deployKeyToPendingRequest.getValue()),
-              deployKeyToPendingRequest.getKey().getRequestId(),
+              () -> handlePendingRequestsForDeployKey(obsoleteRequests, heldForScheduledActiveTask, totalNewScheduledTasks, deployKey, pendingRequestsForDeployKey),
+              deployKey.getRequestId(),
               String.format("%s#%s", getClass().getSimpleName(), "drainPendingQueue"));
         });
 


### PR DESCRIPTION
There was an extra line here processing the status update in duplicate outside of the lock. A few layers down, this can call `scheduleTasks` in the scheduler, resulting in a few possible duplicate taskIds