### PR TITLE
Account for expected usage when scoring offers

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
@@ -23,9 +23,9 @@ import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.hubspot.mesos.Resources;
 import com.hubspot.singularity.RequestType;
+import com.hubspot.singularity.RequestUtilization;
 import com.hubspot.singularity.SingularityDeployStatistics;
 import com.hubspot.singularity.SingularityPendingTaskId;
-import com.hubspot.singularity.SingularitySlaveUsage;
 import com.hubspot.singularity.SingularitySlaveUsage.ResourceUsageType;
 import com.hubspot.singularity.SingularitySlaveUsageWithId;
 import com.hubspot.singularity.SingularityTask;
@@ -188,10 +188,13 @@ public class SingularityMesosOfferScheduler {
         .parallelStream()
         .collect(Collectors.toMap(
             SingularitySlaveUsageWithId::getSlaveId,
-            this::buildSlaveUsageWithScores
+            (usageWithId) -> new SingularitySlaveUsageWithCalculatedScores(usageWithId, configuration.getMesosConfiguration().getScoringStrategy())
         ));
 
     LOG.trace("Found slave usages {}", currentSlaveUsagesBySlaveId);
+
+    Map<String, RequestUtilization> requestUtilizations = usageManager.getRequestUtilizations();
+
 
     Map<String, Integer> tasksPerOfferHost = new ConcurrentHashMap<>();
 
@@ -220,6 +223,7 @@ public class SingularityMesosOfferScheduler {
           SingularityMesosTaskHolder taskHolder = acceptTask(bestOffer, tasksPerOfferHost, taskRequestHolder);
           tasksScheduled.getAndIncrement();
           bestOffer.addMatchedTask(taskHolder);
+          updateSlaveUsageScores(taskRequestHolder, currentSlaveUsagesBySlaveId, bestOffer.getSlaveId(), requestUtilizations);
         }
       }, taskRequestHolder.getTaskRequest().getRequest().getId(), String.format("%s#%s", getClass().getSimpleName(), "checkOffers"));
     }
@@ -229,44 +233,25 @@ public class SingularityMesosOfferScheduler {
     return offerHolders.values();
   }
 
-  SingularitySlaveUsageWithCalculatedScores buildSlaveUsageWithScores(SingularitySlaveUsage slaveUsage) {
-    if (SingularitySlaveUsageWithCalculatedScores.missingUsageData(slaveUsage)) {
-      return new SingularitySlaveUsageWithCalculatedScores(slaveUsage, true, 0, 0, 0, 0, 0, 0, 0);
-    }
-    double longRunningCpusUsedScore = slaveUsage.getLongRunningTasksUsage().get(ResourceUsageType.CPU_USED).doubleValue() / slaveUsage.getCpusTotal().get();
-    double longRunningMemUsedScore = ((double) slaveUsage.getLongRunningTasksUsage().get(ResourceUsageType.MEMORY_BYTES_USED).longValue() / slaveUsage.getMemoryBytesTotal().get());
-    double longRunningDiskUsedScore = ((double) slaveUsage.getLongRunningTasksUsage().get(ResourceUsageType.DISK_BYTES_USED).longValue() / slaveUsage.getDiskBytesTotal().get());
-    switch (configuration.getMesosConfiguration().getScoringStrategy()) {
-      case SPREAD_TASK_USAGE:
-        double cpusFreeScore = 1 - (slaveUsage.getCpusReserved() / slaveUsage.getCpusTotal().get());
-        double memFreeScore = 1 - ((double) slaveUsage.getMemoryMbReserved() / slaveUsage.getMemoryMbTotal().get());
-        double diskFreeScore = 1 - ((double) slaveUsage.getDiskMbReserved() / slaveUsage.getDiskMbTotal().get());
-        return new SingularitySlaveUsageWithCalculatedScores(
-            slaveUsage, false, longRunningCpusUsedScore, longRunningMemUsedScore, longRunningDiskUsedScore, cpusFreeScore, memFreeScore, diskFreeScore,
-            scoreLongRunningTask(longRunningMemUsedScore, memFreeScore, longRunningCpusUsedScore, cpusFreeScore, longRunningDiskUsedScore, diskFreeScore)
-        );
-      case SPREAD_SYSTEM_USAGE:
-      default:
-        double systemCpuFreeScore = Math.max(0, 1 - (slaveUsage.getSystemLoad15Min() / slaveUsage.getSystemCpusTotal()));
-        double systemMemFreeScore = 1 - (slaveUsage.getSystemMemTotalBytes() - slaveUsage.getSystemMemFreeBytes()) / slaveUsage.getSystemMemTotalBytes();
-        double systemDiskFreeScore = 1 - (slaveUsage.getSlaveDiskUsed() / slaveUsage.getSlaveDiskTotal());
-        return new SingularitySlaveUsageWithCalculatedScores(
-            slaveUsage,
-            false,
-            longRunningCpusUsedScore,
-            longRunningMemUsedScore,
-            longRunningDiskUsedScore,
-            systemCpuFreeScore,
-            systemMemFreeScore,
-            systemDiskFreeScore,
-            scoreLongRunningTask(longRunningMemUsedScore, systemMemFreeScore, longRunningCpusUsedScore, systemCpuFreeScore, longRunningDiskUsedScore, systemDiskFreeScore)
-        );
-    }
-
-  }
-
   private boolean isOfferFull(SingularityOfferHolder offerHolder) {
     return configuration.getMaxTasksPerOffer() > 0 && offerHolder.getAcceptedTasks().size() >= configuration.getMaxTasksPerOffer();
+  }
+
+  private void updateSlaveUsageScores(SingularityTaskRequestHolder taskHolder, Map<String, SingularitySlaveUsageWithCalculatedScores> currentSlaveUsagesBySlaveId, String slaveId, Map<String, RequestUtilization> requestUtilizations) {
+    Optional<SingularitySlaveUsageWithCalculatedScores> maybeUsage = Optional.fromNullable(currentSlaveUsagesBySlaveId.get(slaveId));
+    if (maybeUsage.isPresent() && !maybeUsage.get().isMissingUsageData()) {
+      SingularitySlaveUsageWithCalculatedScores usage = maybeUsage.get();
+      usage.addEstimatedCpuReserved(taskHolder.getTotalResources().getCpus());
+      usage.addEstimatedMemoryReserved(taskHolder.getTotalResources().getMemoryMb());
+      usage.addEstimatedDiskReserved(taskHolder.getTotalResources().getDiskMb());
+      if (requestUtilizations.containsKey(taskHolder.getTaskRequest().getRequest().getId())) {
+        RequestUtilization requestUtilization = requestUtilizations.get(taskHolder.getTaskRequest().getRequest().getId());
+        usage.addEstimatedCpuUsage(requestUtilization.getMaxCpuUsed());
+        usage.addEstimatedMemoryBytesUsage(requestUtilization.getMaxMemBytesUsed());
+        usage.addEstimatedDiskBytesUsage(requestUtilization.getMaxDiskBytesUsed());
+      }
+      usage.setScores(configuration.getMesosConfiguration().getScoringStrategy());
+    }
   }
 
   private double calculateScore(SingularityOfferHolder offerHolder, Map<String, SingularitySlaveUsageWithCalculatedScores> currentSlaveUsagesBySlaveId, Map<String, Integer> tasksPerOffer,
@@ -340,7 +325,7 @@ public class SingularityMesosOfferScheduler {
     }
 
     return isLongRunning(taskRequest)
-        ? maybeSlaveUsage.get().getDefaultLongRunningTaskScore()
+        ? scoreLongRunningTask(maybeSlaveUsage.get())
         : scoreNonLongRunningTask(taskRequest, maybeSlaveUsage.get());
   }
 
@@ -348,9 +333,13 @@ public class SingularityMesosOfferScheduler {
     return taskRequest.getRequest().getRequestType().isLongRunning();
   }
 
-  private double scoreLongRunningTask(double longRunningMemUsedScore, double memFreeScore, double longRunningCpusUsedScore, double cpusFreeScore, double longRunningDiskUsedScore, double diskFreeScore) {
+  private double scoreLongRunningTask(SingularitySlaveUsageWithCalculatedScores slaveUsageWithScores) {
     // unused, reserved resources improve score
-    return calculateScore(1 - longRunningMemUsedScore, memFreeScore, 1 - longRunningCpusUsedScore, cpusFreeScore, 1 - longRunningDiskUsedScore, diskFreeScore, 0.50, 0.50);
+    return calculateScore(
+        1 - slaveUsageWithScores.getLongRunningMemUsedScore(), slaveUsageWithScores.getMemFreeScore(),
+        1 - slaveUsageWithScores.getLongRunningCpusUsedScore(), slaveUsageWithScores.getCpusFreeScore(),
+        1 - slaveUsageWithScores.getLongRunningDiskUsedScore(), slaveUsageWithScores.getDiskFreeScore(),
+        0.50, 0.50);
   }
 
   private double scoreNonLongRunningTask(SingularityTaskRequest taskRequest, SingularitySlaveUsageWithCalculatedScores slaveUsageWithScores) {
@@ -365,7 +354,7 @@ public class SingularityMesosOfferScheduler {
       usedResourceWeight = Math.min((double) TimeUnit.MILLISECONDS.toSeconds(statistics.get().getAverageRuntimeMillis().get()) / configuration.getConsiderNonLongRunningTaskLongRunningAfterRunningForSeconds(), 1) * maxNonLongRunningUsedResourceWeight;
 
       if (Math.abs(usedResourceWeight - maxNonLongRunningUsedResourceWeight) < epsilon) {
-        return slaveUsageWithScores.getDefaultLongRunningTaskScore();
+        return scoreLongRunningTask(slaveUsageWithScores);
       }
       freeResourceWeight = 1 - usedResourceWeight;
     }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveUsageWithCalculatedScores.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveUsageWithCalculatedScores.java
@@ -2,40 +2,52 @@ package com.hubspot.singularity.mesos;
 
 import com.hubspot.singularity.SingularitySlaveUsage;
 import com.hubspot.singularity.SingularitySlaveUsage.ResourceUsageType;
+import com.hubspot.singularity.SingularityUsageScoringStrategy;
 
 class SingularitySlaveUsageWithCalculatedScores {
   private final SingularitySlaveUsage slaveUsage;
-  private final boolean missingUsageData;
-  private final double longRunningCpusUsedScore;
-  private final double longRunningMemUsedScore;
-  private final double longRunningDiskUsedScore;
-  private final double cpusFreeScore;
-  private final double memFreeScore;
-  private final double diskFreeScore;
+  private boolean missingUsageData;
+  private double longRunningCpusUsedScore;
+  private double longRunningMemUsedScore;
+  private double longRunningDiskUsedScore;
+  private double cpusFreeScore;
+  private double memFreeScore;
+  private double diskFreeScore;
 
-  private final double defaultLongRunningTaskScore;
+  private double estimatedAddedCpusUsage = 0;
+  private double estimatedAddedMemoryBytesUsage = 0;
+  private double estimatedAddedDiskBytesUsage = 0;
 
-  public SingularitySlaveUsageWithCalculatedScores(SingularitySlaveUsage slaveUsage,
-                                                   boolean missingUsageData,
-                                                   double longRunningCpusUsedScore,
-                                                   double longRunningMemUsedScore,
-                                                   double longRunningDiskUsedScore,
-                                                   double cpusFreeScore,
-                                                   double memFreeScore,
-                                                   double diskFreeScore,
-                                                   double defaultLongRunningTaskScore) {
+  private double estimatedAddedCpusReserved = 0;
+  private double estimatedAddedMemoryBytesReserved = 0;
+  private double estimatedAddedDiskBytesReserved = 0;
+
+  public SingularitySlaveUsageWithCalculatedScores(SingularitySlaveUsage slaveUsage, SingularityUsageScoringStrategy scoringStrategy) {
     this.slaveUsage = slaveUsage;
-    this.missingUsageData = missingUsageData;
+    if (missingUsageData(slaveUsage)) {
+      this.missingUsageData = true;
+      setScores(0, 0, 0, 0, 0, 0);
+    } else {
+      this.missingUsageData = false;
+      setScores(scoringStrategy);
+    }
+  }
+
+  private void setScores(double longRunningCpusUsedScore,
+                 double longRunningMemUsedScore,
+                 double longRunningDiskUsedScore,
+                 double cpusFreeScore,
+                 double memFreeScore,
+                 double diskFreeScore) {
     this.longRunningCpusUsedScore = longRunningCpusUsedScore;
     this.longRunningMemUsedScore = longRunningMemUsedScore;
     this.longRunningDiskUsedScore = longRunningDiskUsedScore;
     this.cpusFreeScore = cpusFreeScore;
     this.memFreeScore = memFreeScore;
     this.diskFreeScore = diskFreeScore;
-    this.defaultLongRunningTaskScore = defaultLongRunningTaskScore;
   }
 
-  static boolean missingUsageData(SingularitySlaveUsage slaveUsage) {
+  private boolean missingUsageData(SingularitySlaveUsage slaveUsage) {
     return !slaveUsage.getCpusTotal().isPresent() ||
         !slaveUsage.getMemoryMbTotal().isPresent() ||
         !slaveUsage.getDiskMbTotal().isPresent() ||
@@ -43,6 +55,26 @@ class SingularitySlaveUsageWithCalculatedScores {
         !slaveUsage.getLongRunningTasksUsage().containsKey(ResourceUsageType.CPU_USED) ||
         !slaveUsage.getLongRunningTasksUsage().containsKey(ResourceUsageType.MEMORY_BYTES_USED) ||
         !slaveUsage.getLongRunningTasksUsage().containsKey(ResourceUsageType.DISK_BYTES_USED);
+  }
+
+  void setScores(SingularityUsageScoringStrategy scoringStrategy) {
+    double longRunningCpusUsedScore = (slaveUsage.getLongRunningTasksUsage().get(ResourceUsageType.CPU_USED).doubleValue() + estimatedAddedCpusUsage) / slaveUsage.getCpusTotal().get();
+    double longRunningMemUsedScore = ((slaveUsage.getLongRunningTasksUsage().get(ResourceUsageType.MEMORY_BYTES_USED).longValue() + estimatedAddedMemoryBytesUsage) / slaveUsage.getMemoryBytesTotal().get());
+    double longRunningDiskUsedScore = ((slaveUsage.getLongRunningTasksUsage().get(ResourceUsageType.DISK_BYTES_USED).longValue() + estimatedAddedDiskBytesUsage) / slaveUsage.getDiskBytesTotal().get());
+    switch (scoringStrategy) {
+      case SPREAD_TASK_USAGE:
+        double cpusFreeScore = 1 - ((slaveUsage.getCpusReserved() + estimatedAddedCpusReserved) / slaveUsage.getCpusTotal().get());
+        double memFreeScore = 1 - ((slaveUsage.getMemoryMbReserved() + estimatedAddedMemoryBytesReserved) / slaveUsage.getMemoryMbTotal().get());
+        double diskFreeScore = 1 - ((slaveUsage.getDiskMbReserved() + estimatedAddedDiskBytesReserved) / slaveUsage.getDiskMbTotal().get());
+        setScores(longRunningCpusUsedScore, longRunningMemUsedScore, longRunningDiskUsedScore, cpusFreeScore, memFreeScore, diskFreeScore);
+        break;
+      case SPREAD_SYSTEM_USAGE:
+      default:
+        double systemCpuFreeScore = Math.max(0, 1 - ((slaveUsage.getSystemLoad15Min() + estimatedAddedCpusUsage) / slaveUsage.getSystemCpusTotal()));
+        double systemMemFreeScore = 1 - (slaveUsage.getSystemMemTotalBytes() - slaveUsage.getSystemMemFreeBytes() + estimatedAddedMemoryBytesUsage) / slaveUsage.getSystemMemTotalBytes();
+        double systemDiskFreeScore = 1 - ((slaveUsage.getSlaveDiskUsed() + estimatedAddedDiskBytesUsage) / slaveUsage.getSlaveDiskTotal());
+        setScores(longRunningCpusUsedScore, longRunningMemUsedScore, longRunningDiskUsedScore, systemCpuFreeScore, systemMemFreeScore, systemDiskFreeScore);
+    }
   }
 
   boolean isMissingUsageData() {
@@ -77,8 +109,28 @@ class SingularitySlaveUsageWithCalculatedScores {
     return diskFreeScore;
   }
 
-  double getDefaultLongRunningTaskScore() {
-    return defaultLongRunningTaskScore;
+  void addEstimatedCpuUsage(double estimatedAddedCpus) {
+    this.estimatedAddedCpusUsage += estimatedAddedCpus;
+  }
+
+  void addEstimatedMemoryBytesUsage(double estimatedAddedMemoryBytes) {
+    this.estimatedAddedMemoryBytesUsage += estimatedAddedMemoryBytes;
+  }
+
+  void addEstimatedDiskBytesUsage(double estimatedAddedDiskBytes) {
+    this.estimatedAddedDiskBytesUsage = estimatedAddedDiskBytes;
+  }
+
+  void addEstimatedCpuReserved(double estimatedAddedCpus) {
+    this.estimatedAddedCpusReserved += estimatedAddedCpus;
+  }
+
+  void addEstimatedMemoryReserved(double estimatedAddedMemoryBytes) {
+    this.estimatedAddedMemoryBytesReserved += estimatedAddedMemoryBytes;
+  }
+
+  void addEstimatedDiskReserved(double estimatedAddedDiskBytes) {
+    this.estimatedAddedDiskBytesReserved = estimatedAddedDiskBytes;
   }
 
   @Override
@@ -92,7 +144,6 @@ class SingularitySlaveUsageWithCalculatedScores {
         ", cpusFreeScore=" + cpusFreeScore +
         ", memFreeScore=" + memFreeScore +
         ", diskFreeScore=" + diskFreeScore +
-        ", defaultLongRunningTaskScore=" + defaultLongRunningTaskScore +
         '}';
   }
 }

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosOfferSchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosOfferSchedulerTest.java
@@ -22,6 +22,7 @@ import com.hubspot.singularity.SingularityRequest;
 import com.hubspot.singularity.SingularitySlaveUsage;
 import com.hubspot.singularity.SingularitySlaveUsage.ResourceUsageType;
 import com.hubspot.singularity.SingularityTaskRequest;
+import com.hubspot.singularity.SingularityUsageScoringStrategy;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.DeployManager;
 
@@ -318,9 +319,10 @@ public class SingularityMesosOfferSchedulerTest extends SingularityCuratorTestBa
   }
 
   private SingularitySlaveUsageWithCalculatedScores getUsage(long memMbReserved, long memMbTotal, double cpusReserved, double cpusTotal, long diskMbReserved, long diskMbTotal, Map<ResourceUsageType, Number> longRunningTasksUsage) {
-    return scheduler.buildSlaveUsageWithScores(new SingularitySlaveUsage(
-            0, cpusReserved, Optional.of(cpusTotal), 0, memMbReserved, Optional.of(memMbTotal), 0, diskMbReserved, Optional.of(diskMbTotal), longRunningTasksUsage, 1, 0L,
-        0, 0, 0, 0, 0, 0, 0 , 0)
+    return new SingularitySlaveUsageWithCalculatedScores(
+        new SingularitySlaveUsage(0, cpusReserved, Optional.of(cpusTotal), 0, memMbReserved, Optional.of(memMbTotal), 0, diskMbReserved, Optional.of(diskMbTotal), longRunningTasksUsage, 1, 0L,
+            0, 0, 0, 0, 0, 0, 0 , 0),
+        SingularityUsageScoringStrategy.SPREAD_TASK_USAGE
     );
   }
 


### PR DESCRIPTION
Right now it's possible for us to easily overload a fairly empty machine if we have lots of tasks to schedule. The way the score is calculated, we don't account for other tasks we may have _just_ scheduled. This adds the reserved and last recorded max usage to factoring into scoring, updating those after each task is added to an offer host.