### PR TITLE
Fix cached offer checkin in resourceOffers

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
@@ -209,7 +209,7 @@ public class SingularityMesosSchedulerImpl extends SingularityMesosScheduler {
         for (SingularityOfferHolder offerHolder : offerHolders) {
           if (!offerHolder.getAcceptedTasks().isEmpty()) {
             List<Offer> leftoverOffers = offerHolder.launchTasksAndGetUnusedOffers(mesosSchedulerClient);
-            LOG.debug("Leftover offers: {}", leftoverOffers.stream().map(Offer::getId));
+            LOG.debug("Leftover offers: {}", leftoverOffers.stream().map(Offer::getId).collect(Collectors.toList()));
 
             leftoverOffers.forEach((o) -> {
               if (cachedOffers.containsKey(o.getId().getValue())) {
@@ -221,6 +221,7 @@ public class SingularityMesosSchedulerImpl extends SingularityMesosScheduler {
 
             List<Offer> offersAcceptedFromSlave = offerHolder.getOffers();
             offersAcceptedFromSlave.removeAll(leftoverOffers);
+            LOG.trace("Accepted offers {}", offersAcceptedFromSlave.stream().map(Offer::getId).collect(Collectors.toList()));
             offersAcceptedFromSlave.stream()
                 .filter((offer) -> cachedOffers.containsKey(offer.getId().getValue()))
                 .map((o) -> cachedOffers.get(o.getId().getValue()))

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
@@ -209,6 +209,7 @@ public class SingularityMesosSchedulerImpl extends SingularityMesosScheduler {
         for (SingularityOfferHolder offerHolder : offerHolders) {
           if (!offerHolder.getAcceptedTasks().isEmpty()) {
             List<Offer> leftoverOffers = offerHolder.launchTasksAndGetUnusedOffers(mesosSchedulerClient);
+            LOG.debug("Leftover offers: {}", leftoverOffers.stream().map(Offer::getId));
 
             leftoverOffers.forEach((o) -> {
               if (cachedOffers.containsKey(o.getId().getValue())) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityOfferCache.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityOfferCache.java
@@ -75,11 +75,13 @@ public class SingularityOfferCache implements OfferCache, RemovalListener<String
 
   @Override
   public void rescindOffer(OfferID offerId) {
+    LOG.trace("Offer {} rescinded, removing from cache", offerId.getValue());
     offerCache.invalidate(offerId.getValue());
   }
 
   @Override
   public void useOffer(CachedOffer cachedOffer) {
+    LOG.trace("Using cached offer {}", cachedOffer.getOfferId());
     offerCache.invalidate(cachedOffer.offerId);
   }
 
@@ -94,6 +96,7 @@ public class SingularityOfferCache implements OfferCache, RemovalListener<String
 
     List<CachedOffer> offers = new ArrayList<>((int) offerCache.size());
     for (CachedOffer cachedOffer : offerCache.asMap().values()) {
+      LOG.trace("Checking out offer {}", cachedOffer.getOfferId());
       cachedOffer.checkOut();
       offers.add(cachedOffer);
     }
@@ -116,8 +119,10 @@ public class SingularityOfferCache implements OfferCache, RemovalListener<String
   public void returnOffer(CachedOffer cachedOffer) {
     synchronized (offerCache) {
       if (cachedOffer.offerState == OfferState.EXPIRED) {
+        LOG.trace("Declining returned offer {}", cachedOffer.getOfferId());
         declineOffer(cachedOffer);
       } else {
+        LOG.trace("Returning offer {} to cache", cachedOffer.getOfferId());
         cachedOffer.checkIn();
       }
     }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityOfferCache.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityOfferCache.java
@@ -116,10 +116,8 @@ public class SingularityOfferCache implements OfferCache, RemovalListener<String
   public void returnOffer(CachedOffer cachedOffer) {
     synchronized (offerCache) {
       if (cachedOffer.offerState == OfferState.EXPIRED) {
-        LOG.trace("Declining returned offer {}", cachedOffer.getOfferId());
         declineOffer(cachedOffer);
       } else {
-        LOG.trace("Returning offer {} to cache", cachedOffer.getOfferId());
         cachedOffer.checkIn();
       }
     }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityOfferCache.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityOfferCache.java
@@ -75,13 +75,11 @@ public class SingularityOfferCache implements OfferCache, RemovalListener<String
 
   @Override
   public void rescindOffer(OfferID offerId) {
-    LOG.trace("Offer {} rescinded, removing from cache", offerId.getValue());
     offerCache.invalidate(offerId.getValue());
   }
 
   @Override
   public void useOffer(CachedOffer cachedOffer) {
-    LOG.trace("Using cached offer {}", cachedOffer.getOfferId());
     offerCache.invalidate(cachedOffer.offerId);
   }
 
@@ -96,7 +94,6 @@ public class SingularityOfferCache implements OfferCache, RemovalListener<String
 
     List<CachedOffer> offers = new ArrayList<>((int) offerCache.size());
     for (CachedOffer cachedOffer : offerCache.asMap().values()) {
-      LOG.trace("Checking out offer {}", cachedOffer.getOfferId());
       cachedOffer.checkOut();
       offers.add(cachedOffer);
     }


### PR DESCRIPTION
Need to add this in a traditional for loop so we are using the original object in the cache. Otherwise, when we call checkIn, we don't actually check in the original object in the cache and it can no longer be checked out again