### PR TITLE
Don't operate directly on pending tasks during statusUpdate

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -603,16 +603,14 @@ public class SingularityScheduler {
     if (state.isSuccess() && requestState == RequestState.SYSTEM_COOLDOWN) {
       // TODO send not cooldown anymore email
       LOG.info("Request {} succeeded a task, removing from cooldown", request.getId());
-      requestState = RequestState.ACTIVE;
       requestManager.exitCooldown(request, System.currentTimeMillis(), Optional.<String>absent(), Optional.<String>absent());
     }
 
     SingularityPendingRequest pendingRequest = new SingularityPendingRequest(request.getId(), requestDeployState.get().getActiveDeploy().get().getDeployId(),
-      System.currentTimeMillis(), Optional.<String>absent(), pendingType, cmdLineArgsList, Optional.<String>absent(), Optional.<Boolean>absent(), Optional.<String>absent(),
-      Optional.<String>absent());
+        System.currentTimeMillis(), Optional.absent(), pendingType, cmdLineArgsList, Optional.absent(), Optional.absent(), Optional.absent(),
+        Optional.absent());
 
-    SingularityDeployKey deployKey = new SingularityDeployKey(taskId.getRequestId(), taskId.getDeployId());
-    scheduleTasks(request, requestState, deployStatistics, pendingRequest, getMatchingTaskIds(request, deployKey), maybePendingDeploy);
+    requestManager.addToPendingQueue(pendingRequest);
 
     return Optional.of(pendingType);
   }

--- a/SingularityService/src/test/java/com/hubspot/singularity/data/StateManagerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/data/StateManagerTest.java
@@ -39,6 +39,8 @@ public class StateManagerTest extends SingularitySchedulerTestBase{
 
     SingularityTask task = taskManager.getActiveTasks().get(0);
     statusUpdate(task, TaskState.TASK_KILLED);
+    scheduler.drainPendingQueue();
+
     taskManager.createTaskCleanup(new SingularityTaskCleanup(Optional.absent(), TaskCleanupType.BOUNCING, 1L, task.getTaskId(), Optional.absent(), Optional.absent(), Optional.absent()));
     Assert.assertEquals(2, taskManager.getActiveTaskIds().size());
     Assert.assertEquals(0, stateManager.getState(true, false).getOverProvisionedRequests());

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityDeploysTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityDeploysTest.java
@@ -61,6 +61,7 @@ public class SingularityDeploysTest extends SingularitySchedulerTestBase {
 
     statusUpdate(secondTask, TaskState.TASK_FAILED);
     statusUpdate(firstTask, TaskState.TASK_FAILED);
+    scheduler.drainPendingQueue();
 
     deployChecker.checkDeploys();
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTestBase.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTestBase.java
@@ -393,6 +393,7 @@ public class SingularitySchedulerTestBase extends SingularityCuratorTestBase {
     for (SingularityKilledTaskIdRecord killed : taskManager.getKilledTaskIdRecords()) {
       statusUpdate(taskManager.getTask(killed.getTaskId()).get(), TaskState.TASK_KILLED);
     }
+    scheduler.drainPendingQueue();
   }
 
   protected void finishNewTaskChecksAndCleanup() {


### PR DESCRIPTION
This was causing a race condition with the new locking setup where a pending task could be selected for offer scheduling, then deleted by statusUpdate while it was still being processed for offers. This PR updates the code to:
- Save the pending request to the queue instead of directly calling scheduleTasks
- Update tests that check pending tasks to call `scheduler.drainPendingQueue()` after calling `statusUpdate`

/cc @baconmania 