### PR TITLE
Allow user to configure which load metric is used for offer scoring

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/MachineLoadMetric.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/MachineLoadMetric.java
@@ -1,0 +1,5 @@
+package com.hubspot.singularity;
+
+public enum MachineLoadMetric {
+  LOAD_1, LOAD_5, LOAD_15
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/MesosConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/MesosConfiguration.java
@@ -4,6 +4,7 @@ import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.common.base.Optional;
+import com.hubspot.singularity.MachineLoadMetric;
 import com.hubspot.singularity.SingularityUsageScoringStrategy;
 
 @JsonIgnoreProperties( ignoreUnknown = true )
@@ -57,6 +58,7 @@ public class MesosConfiguration {
   private int maxStatusUpdateQueueSize = 5000;
   private int offersConcurrencyLimit = 100;
   private SingularityUsageScoringStrategy scoringStrategy = SingularityUsageScoringStrategy.SPREAD_TASK_USAGE;
+  private MachineLoadMetric scoreUsingSystemLoad = MachineLoadMetric.LOAD_5;
 
   public int getMaxNumInstancesPerRequest() {
     return maxNumInstancesPerRequest;
@@ -276,5 +278,17 @@ public class MesosConfiguration {
 
   public SingularityUsageScoringStrategy getScoringStrategy() {
     return scoringStrategy;
+  }
+
+  public void setScoringStrategy(SingularityUsageScoringStrategy scoringStrategy) {
+    this.scoringStrategy = scoringStrategy;
+  }
+
+  public MachineLoadMetric getScoreUsingSystemLoad() {
+    return scoreUsingSystemLoad;
+  }
+
+  public void setScoreUsingSystemLoad(MachineLoadMetric scoreUsingSystemLoad) {
+    this.scoreUsingSystemLoad = scoreUsingSystemLoad;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
@@ -268,9 +268,9 @@ public class SingularityMesosOfferScheduler {
     switch (configuration.getMesosConfiguration().getScoreUsingSystemLoad()) {
       case LOAD_1:
         return slaveUsage.getSystemLoad1Min();
-      case LOAD_5:
-        return slaveUsage.getSystemLoad5Min();
       case LOAD_15:
+        return slaveUsage.getSystemLoad5Min();
+      case LOAD_5:
       default:
         return slaveUsage.getSystemLoad15Min();
     }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
@@ -247,7 +247,7 @@ public class SingularityMesosOfferScheduler {
         );
       case SPREAD_SYSTEM_USAGE:
       default:
-        double systemCpuFreeScore = Math.max(0, 1 - (slaveUsage.getSystemLoad15Min() / slaveUsage.getSystemCpusTotal()));
+        double systemCpuFreeScore = Math.max(0, 1 - (getSystemLoadMetric(slaveUsage) / slaveUsage.getSystemCpusTotal()));
         double systemMemFreeScore = 1 - (slaveUsage.getSystemMemTotalBytes() - slaveUsage.getSystemMemFreeBytes()) / slaveUsage.getSystemMemTotalBytes();
         double systemDiskFreeScore = 1 - (slaveUsage.getSlaveDiskUsed() / slaveUsage.getSlaveDiskTotal());
         return new SingularitySlaveUsageWithCalculatedScores(
@@ -262,7 +262,18 @@ public class SingularityMesosOfferScheduler {
             scoreLongRunningTask(longRunningMemUsedScore, systemMemFreeScore, longRunningCpusUsedScore, systemCpuFreeScore, longRunningDiskUsedScore, systemDiskFreeScore)
         );
     }
+  }
 
+  private double getSystemLoadMetric(SingularitySlaveUsage slaveUsage) {
+    switch (configuration.getMesosConfiguration().getScoreUsingSystemLoad()) {
+      case LOAD_1:
+        return slaveUsage.getSystemLoad1Min();
+      case LOAD_5:
+        return slaveUsage.getSystemLoad5Min();
+      case LOAD_15:
+      default:
+        return slaveUsage.getSystemLoad15Min();
+    }
   }
 
   private boolean isOfferFull(SingularityOfferHolder offerHolder) {


### PR DESCRIPTION
We collect the 1, 5, and 15 minute load. Right now it just uses 15 by default. This allows the user to configure which is used and changes the default to 5 minute