### PR TITLE
Better check for finish of a bounce

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskCleanup.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskCleanup.java
@@ -17,8 +17,8 @@ public class SingularityTaskCleanup {
 
   @JsonCreator
   public SingularityTaskCleanup(@JsonProperty("user") Optional<String> user, @JsonProperty("cleanupType") TaskCleanupType cleanupType, @JsonProperty("timestamp") long timestamp,
-      @JsonProperty("taskId") SingularityTaskId taskId, @JsonProperty("message") Optional<String> message, @JsonProperty("actionId") Optional<String> actionId,
-      @JsonProperty("runBeforeKillId") Optional<SingularityTaskShellCommandRequestId> runBeforeKillId,
+                                @JsonProperty("taskId") SingularityTaskId taskId, @JsonProperty("message") Optional<String> message, @JsonProperty("actionId") Optional<String> actionId,
+                                @JsonProperty("runBeforeKillId") Optional<SingularityTaskShellCommandRequestId> runBeforeKillId,
                                 @JsonProperty("removeFromLoadBalancer") Optional<Boolean> removeFromLoadBalancer
   ) {
     this.user = user;

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
@@ -497,6 +497,10 @@ public class RequestManager extends CuratorAsyncManager {
     return create(getIsBouncingPath(requestId));
   }
 
+  public boolean isBouncing(String requestId) {
+    return exists(getIsBouncingPath(requestId));
+  }
+
   public SingularityDeleteResult markBounceComplete(String requestId) {
     return delete(getIsBouncingPath(requestId));
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
@@ -657,18 +657,6 @@ public class SingularityCleaner {
 
       cleanupRequestIfNoRemainingTasks(cleanupTask, taskIdsForDeletedRequest, isRequestDeleting);
     }
-
-    for (SingularityDeployKey bounceSucceeded : isBouncing) {
-      Optional<SingularityExpiringBounce> expiringBounce = requestManager.getExpiringBounce(bounceSucceeded.getRequestId());
-
-      if (expiringBounce.isPresent() && expiringBounce.get().getDeployId().equals(bounceSucceeded.getDeployId())) {
-        LOG.info("Bounce succeeded for {}, deleting expiring bounce {}", bounceSucceeded.getRequestId(), expiringBounce.get());
-
-        requestManager.deleteExpiringObject(SingularityExpiringBounce.class, bounceSucceeded.getRequestId());
-      }
-      requestManager.markBounceComplete(bounceSucceeded.getRequestId());
-    }
-
   }
 
   private void cleanupRequestIfNoRemainingTasks(SingularityTaskCleanup cleanupTask, List<String> taskIdsForDeletedRequest, boolean isRequestDeleting) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
@@ -616,7 +616,6 @@ public class SingularityCleaner {
 
   private void processTaskCleanupsForRequest(String requestId, List<SingularityTaskCleanup> cleanupTasks, AtomicInteger killedTasks) {
     final Multiset<SingularityDeployKey> incrementalCleaningTasks = HashMultiset.create(cleanupTasks.size());
-    final Set<SingularityDeployKey> isBouncing = new HashSet<>(cleanupTasks.size());
     final List<String> taskIdsForDeletedRequest = new ArrayList<>();
     boolean isRequestDeleting = false;
 
@@ -626,9 +625,6 @@ public class SingularityCleaner {
       cleaningTasks.add(cleanupTask.getTaskId());
       if (isIncrementalDeployCleanup(cleanupTask) || cleanupTask.getCleanupType() == TaskCleanupType.INCREMENTAL_BOUNCE) {
         incrementalCleaningTasks.add(SingularityDeployKey.fromTaskId(cleanupTask.getTaskId()));
-      }
-      if (cleanupTask.getCleanupType() == TaskCleanupType.BOUNCING || cleanupTask.getCleanupType() == TaskCleanupType.INCREMENTAL_BOUNCE) {
-        isBouncing.add(SingularityDeployKey.fromTaskId(cleanupTask.getTaskId()));
       }
       if (cleanupTask.getCleanupType() == TaskCleanupType.REQUEST_DELETING) {
         taskIdsForDeletedRequest.add(cleanupTask.getTaskId().getId());
@@ -651,8 +647,6 @@ public class SingularityCleaner {
         taskManager.deleteCleanupTask(taskId.getId());
 
         killedTasks.getAndIncrement();
-      } else if (cleanupTask.getCleanupType() == TaskCleanupType.BOUNCING || cleanupTask.getCleanupType() == TaskCleanupType.INCREMENTAL_BOUNCE) {
-        isBouncing.remove(SingularityDeployKey.fromTaskId(taskId));
       }
 
       cleanupRequestIfNoRemainingTasks(cleanupTask, taskIdsForDeletedRequest, isRequestDeleting);

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -75,6 +75,7 @@ import com.hubspot.singularity.data.RequestManager;
 import com.hubspot.singularity.data.SlaveManager;
 import com.hubspot.singularity.data.TaskManager;
 import com.hubspot.singularity.data.TaskRequestManager;
+import com.hubspot.singularity.expiring.SingularityExpiringBounce;
 import com.hubspot.singularity.helpers.RFC5545Schedule;
 import com.hubspot.singularity.mesos.SingularitySchedulerLock;
 import com.hubspot.singularity.smtp.SingularityMailer;
@@ -636,6 +637,38 @@ public class SingularityScheduler {
 
     if (!task.isPresent() || task.get().getTaskRequest().getRequest().isLoadBalanced()) {
       taskManager.createLBCleanupTask(taskId);
+    }
+
+    if (requestManager.isBouncing(taskId.getRequestId())) {
+      List<SingularityTaskId> activeTaskIds = taskManager.getActiveTaskIdsForRequest(taskId.getRequestId());
+      boolean foundBouncingTask = false;
+      for (SingularityTaskId activeTaskId : activeTaskIds) {
+        Optional<SingularityTaskHistoryUpdate> maybeCleaningUpdate = taskManager.getTaskHistoryUpdate(activeTaskId, ExtendedTaskState.TASK_CLEANING);
+        if (maybeCleaningUpdate.isPresent()) {
+          if (maybeCleaningUpdate.get().getStatusReason().or("").contains("BOUNCE")) { // TaskCleanupType enum is included in status message
+            LOG.debug("Found task {} still waiting for bounce to complete", activeTaskId);
+            foundBouncingTask = true;
+            break;
+          } else if (!maybeCleaningUpdate.get().getPrevious().isEmpty()) {
+            for (SingularityTaskHistoryUpdate previousUpdate : maybeCleaningUpdate.get().getPrevious()) {
+              if (previousUpdate.getStatusMessage().or("").contains("BOUNCE")) {
+                LOG.debug("Found task {} still waiting for bounce to complete", activeTaskId);
+                foundBouncingTask = true;
+                break;
+              }
+            }
+          }
+        }
+      }
+      if (!foundBouncingTask) {
+        LOG.info("Bounce completed for request {}, no cleaning tasks due to bounce found", taskId.getRequestId());
+        Optional<SingularityExpiringBounce> expiringBounce = requestManager.getExpiringBounce(taskId.getRequestId());
+
+        if (expiringBounce.isPresent() && expiringBounce.get().getDeployId().equals(taskId.getDeployId())) {
+          requestManager.deleteExpiringObject(SingularityExpiringBounce.class, taskId.getRequestId());
+        }
+        requestManager.markBounceComplete(taskId.getRequestId());
+      }
     }
 
     final Optional<PendingType> scheduleResult = handleCompletedTaskWithStatistics(task, taskId, timestamp, state, deployStatistics, taskHistoryUpdateCreateResult, status);

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -1234,6 +1234,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     Assert.assertEquals(1, taskManager.getActiveTaskIds().size());
 
     requestResource.bounce(requestId, Optional.of(new SingularityBounceRequest(Optional.absent(), Optional.of(true), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent())), singularityUser);
+    Assert.assertTrue(requestManager.isBouncing(requestId));
     cleaner.drainCleanupQueue();
 
     // It acquires a lock on the bounce
@@ -1247,8 +1248,10 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     }
 
     Assert.assertTrue("Need to start at least 1 instance to begin killing old instances", taskManager.getActiveTaskIds().size() >= 2);
+    Assert.assertTrue(requestManager.isBouncing(requestId));
     cleaner.drainCleanupQueue();
     killKilledTasks();
+    Assert.assertFalse(requestManager.isBouncing(requestId));
 
 
     // It finishes with one task running and the bounce released


### PR DESCRIPTION
Check if a bounce is complete during statusUpdate instead of during cleanup runs. Previously if the cleanup type got overriden or the task exited in an unexpected way, the cleanup could be deleted in such a way that we never check the bounce status again. By checking in the status update, if the request is bouncing we can always determine if the bounce is finished by checking the list of active task ids for any remaining active tasks in cleaning status due to a bounce.