### PR TITLE
 Add the ability to shuffle long running tasks when a host is overloaded

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosSlaveMetricsSnapshotObject.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosSlaveMetricsSnapshotObject.java
@@ -399,4 +399,66 @@ public class MesosSlaveMetricsSnapshotObject {
   public double getContainerizerMesosContainerDestroyErrors() {
     return containerizerMesosContainerDestroyErrors;
   }
+
+  @Override
+  public String toString() {
+    return "MesosSlaveMetricsSnapshotObject{" +
+        "slaveDiskUsed=" + slaveDiskUsed +
+        ", slaveValidStatusUpdates=" + slaveValidStatusUpdates +
+        ", slaveTasksFinished=" + slaveTasksFinished +
+        ", slaveCpusTotal=" + slaveCpusTotal +
+        ", slaveExecutorsPreempted=" + slaveExecutorsPreempted +
+        ", slaveExecutorsTerminated=" + slaveExecutorsTerminated +
+        ", slaveCpusPercent=" + slaveCpusPercent +
+        ", slaveExecutorsRunning=" + slaveExecutorsRunning +
+        ", slaveGpusRevocableUsed=" + slaveGpusRevocableUsed +
+        ", slaveInvalidStatusUpdates=" + slaveInvalidStatusUpdates +
+        ", slaveExecutorsRegistering=" + slaveExecutorsRegistering +
+        ", slaveMemRevocableTotal=" + slaveMemRevocableTotal +
+        ", systemCpusTotal=" + systemCpusTotal +
+        ", slaveFrameworksActive=" + slaveFrameworksActive +
+        ", slaveCpusRevocablePercent=" + slaveCpusRevocablePercent +
+        ", slaveGpusTotal=" + slaveGpusTotal +
+        ", slaveTasksKilled=" + slaveTasksKilled +
+        ", slaveTasksStarting=" + slaveTasksStarting +
+        ", slaveRegistered=" + slaveRegistered +
+        ", slaveGpusRevocableTotal=" + slaveGpusRevocableTotal +
+        ", containerizerMesosProvisionerRemoveContainerErrors=" + containerizerMesosProvisionerRemoveContainerErrors +
+        ", slaveCpusRevocableUsed=" + slaveCpusRevocableUsed +
+        ", slaveDiskTotal=" + slaveDiskTotal +
+        ", slaveTasksStaging=" + slaveTasksStaging +
+        ", slaveGpusUsed=" + slaveGpusUsed +
+        ", systemLoad5Min=" + systemLoad5Min +
+        ", slaveExecutorDirectoryMaxAllowedAgeSecs=" + slaveExecutorDirectoryMaxAllowedAgeSecs +
+        ", slaveDiskRevocablePercent=" + slaveDiskRevocablePercent +
+        ", systemLoad1Min=" + systemLoad1Min +
+        ", slaveMemPercent=" + slaveMemPercent +
+        ", slaveContainerLaunchErrors=" + slaveContainerLaunchErrors +
+        ", slaveMemRevocableUsed=" + slaveMemRevocableUsed +
+        ", slaveTasksRunning=" + slaveTasksRunning +
+        ", slaveInvalidFrameworkMessages=" + slaveInvalidFrameworkMessages +
+        ", slaveValidFrameworkMessages=" + slaveValidFrameworkMessages +
+        ", slaveMemRevocablePercent=" + slaveMemRevocablePercent +
+        ", slaveTasksFailed=" + slaveTasksFailed +
+        ", slaveExecutorsTerminating=" + slaveExecutorsTerminating +
+        ", slaveTasksKilling=" + slaveTasksKilling +
+        ", slaveDiskRevocableTotal=" + slaveDiskRevocableTotal +
+        ", slaveGpusRevocablePercent=" + slaveGpusRevocablePercent +
+        ", slaveDiskRevocableUsed=" + slaveDiskRevocableUsed +
+        ", slaveUptimeSecs=" + slaveUptimeSecs +
+        ", slaveDiskPercent=" + slaveDiskPercent +
+        ", slaveCpusUsed=" + slaveCpusUsed +
+        ", systemMemTotalBytes=" + systemMemTotalBytes +
+        ", containerizerMesosProvisionerBindRemoveRootfsErrors=" + containerizerMesosProvisionerBindRemoveRootfsErrors +
+        ", systemMemFreeBytes=" + systemMemFreeBytes +
+        ", slaveCpusRevocableTotal=" + slaveCpusRevocableTotal +
+        ", slaveTasksLost=" + slaveTasksLost +
+        ", slaveGpusPercent=" + slaveGpusPercent +
+        ", systemLoad15Min=" + systemLoad15Min +
+        ", slaveRecoveryErrors=" + slaveRecoveryErrors +
+        ", slaveMemUsed=" + slaveMemUsed +
+        ", slaveMemTotal=" + slaveMemTotal +
+        ", containerizerMesosContainerDestroyErrors=" + containerizerMesosContainerDestroyErrors +
+        '}';
+  }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/TaskCleanupType.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/TaskCleanupType.java
@@ -5,7 +5,7 @@ public enum TaskCleanupType {
   USER_REQUESTED(true, true), USER_REQUESTED_TASK_BOUNCE(false, false), DECOMISSIONING(false, false), SCALING_DOWN(true, false), BOUNCING(false, false), INCREMENTAL_BOUNCE(false, false),
   DEPLOY_FAILED(true, true), NEW_DEPLOY_SUCCEEDED(true, false), DEPLOY_STEP_FINISHED(true, false), DEPLOY_CANCELED(true, true), TASK_EXCEEDED_TIME_LIMIT(true, true), UNHEALTHY_NEW_TASK(true, true),
   OVERDUE_NEW_TASK(true, true), USER_REQUESTED_DESTROY(true, true), INCREMENTAL_DEPLOY_FAILED(false, true), INCREMENTAL_DEPLOY_CANCELLED(false, true), PRIORITY_KILL(true, true), REBALANCE_RACKS(false, false),
-  PAUSING(false, false), PAUSE(true, true), DECOMMISSION_TIMEOUT(true, true), REQUEST_DELETING(true, true);
+  PAUSING(false, false), PAUSE(true, true), DECOMMISSION_TIMEOUT(true, true), REQUEST_DELETING(true, true), REBALANCE_CPU_USAGE(false, false);
 
   private final boolean killLongRunningTaskInstantly;
   private final boolean killNonLongRunningTaskInstantly;

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -75,6 +75,10 @@ public class SingularityConfiguration extends Configuration {
 
   private int usageIntervalSeconds = 5760; // 15 saved each 5760 seconds (96 min) apart is 1 day of usage
 
+  private boolean shuffleTasksForOverloadedSlaves = false; // recommended 'true' when oversubscribing cpu for larger clusters
+
+  private int maxTasksToShuffleForCpuOverage = 3;
+
   private long cleanUsageEveryMillis = TimeUnit.MINUTES.toMillis(5);
 
   private int numUsageToKeep = 15;
@@ -1477,6 +1481,22 @@ public class SingularityConfiguration extends Configuration {
   public SingularityConfiguration setUsageIntervalSeconds(int usageIntervalSeconds) {
     this.usageIntervalSeconds = usageIntervalSeconds;
     return this;
+  }
+
+  public int getMaxTasksToShuffleForCpuOverage() {
+    return maxTasksToShuffleForCpuOverage;
+  }
+
+  public void setMaxTasksToShuffleForCpuOverage(int maxTasksToShuffleForCpuOverage) {
+    this.maxTasksToShuffleForCpuOverage = maxTasksToShuffleForCpuOverage;
+  }
+
+  public boolean isShuffleTasksForOverloadedSlaves() {
+    return shuffleTasksForOverloadedSlaves;
+  }
+
+  public void setShuffleTasksForOverloadedSlaves(boolean shuffleTasksForOverloadedSlaves) {
+    this.shuffleTasksForOverloadedSlaves = shuffleTasksForOverloadedSlaves;
   }
 
   public long getCleanUsageEveryMillis() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveUsageWithCalculatedScores.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveUsageWithCalculatedScores.java
@@ -73,7 +73,7 @@ class SingularitySlaveUsageWithCalculatedScores {
         break;
       case SPREAD_SYSTEM_USAGE:
       default:
-        double systemCpuFreeScore = Math.max(0, 1 - ((getSystemLoadMetric() + (estimatedAddedCpusUsage / slaveUsage.getCpusTotal().get())) / slaveUsage.getSystemCpusTotal()));
+        double systemCpuFreeScore = Math.max(0, 1 - ((getSystemLoadMetric() + estimatedAddedCpusUsage) / slaveUsage.getSystemCpusTotal()));
         double systemMemFreeScore = 1 - (slaveUsage.getSystemMemTotalBytes() - slaveUsage.getSystemMemFreeBytes() + estimatedAddedMemoryBytesUsage) / slaveUsage.getSystemMemTotalBytes();
         double systemDiskFreeScore = 1 - ((slaveUsage.getSlaveDiskUsed() + estimatedAddedDiskBytesUsage) / slaveUsage.getSlaveDiskTotal());
         setScores(longRunningCpusUsedScore, longRunningMemUsedScore, longRunningDiskUsedScore, systemCpuFreeScore, systemMemFreeScore, systemDiskFreeScore);

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
@@ -221,7 +221,7 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
           if (slaveOverloaded && configuration.isShuffleTasksForOverloadedSlaves() && currentUsage != null && currentUsage.getCpusUsed() > 0) {
             if (isLongRunning(task)) {
               Optional<SingularityTaskHistoryUpdate> maybeCleanupUpdate = taskManager.getTaskHistoryUpdate(task, ExtendedTaskState.TASK_CLEANING);
-              if (maybeCleanupUpdate.isPresent() && isTaskShuffleCleanup(maybeCleanupUpdate.get())) {
+              if (maybeCleanupUpdate.isPresent() && isTaskAlreadyCleanedUpForShuffle(maybeCleanupUpdate.get())) {
                 LOG.trace("Task {} already being cleaned up to spread cpu usage, skipping", taskId);
                 shuffledTasks++;
               } else {
@@ -294,7 +294,7 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
     usageManager.saveClusterUtilization(getClusterUtilization(utilizationPerRequestId, totalMemBytesUsed, totalMemBytesAvailable, totalCpuUsed, totalCpuAvailable, totalDiskBytesUsed, totalDiskBytesAvailable, now));
   }
 
-  private boolean isTaskShuffleCleanup(SingularityTaskHistoryUpdate taskHistoryUpdate) {
+  private boolean isTaskAlreadyCleanedUpForShuffle(SingularityTaskHistoryUpdate taskHistoryUpdate) {
     if (taskHistoryUpdate.getStatusMessage().or("").contains(TaskCleanupType.REBALANCE_CPU_USAGE.name())) {
       return true;
     }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
@@ -148,8 +148,8 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
 
 
 
-        boolean slaveOverloaded = systemLoad > 1.0;
-        double cpuOverage = slaveOverloaded ? (systemLoad - 1.0) * systemCpusTotal : 0.0;
+        boolean slaveOverloaded = systemCpusTotal > 0 && systemLoad / systemCpusTotal > 1.0;
+        double cpuOverage = slaveOverloaded ? systemLoad - systemCpusTotal : 0.0;
         int shuffledTasks = 0;
         List<TaskIdWithUsage> possibleTasksToShuffle = new ArrayList<>();
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -29,10 +30,12 @@ import com.hubspot.singularity.SingularitySlave;
 import com.hubspot.singularity.SingularitySlaveUsage;
 import com.hubspot.singularity.SingularitySlaveUsage.ResourceUsageType;
 import com.hubspot.singularity.SingularityTask;
+import com.hubspot.singularity.SingularityTaskCleanup;
 import com.hubspot.singularity.SingularityTaskCurrentUsage;
 import com.hubspot.singularity.SingularityTaskHistoryUpdate;
 import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.SingularityTaskUsage;
+import com.hubspot.singularity.TaskCleanupType;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.DeployManager;
 import com.hubspot.singularity.data.RequestManager;
@@ -128,7 +131,8 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
 
         boolean slaveOverloaded = systemLoad5Min > 1.0;
         double cpuOverage = slaveOverloaded ? (systemLoad5Min - 1.0) * systemCpusTotal : 0.0;
-        List<TaskIdWithUsage> tasksToShuffle = new ArrayList<>();
+        int shuffledTasks = 0;
+        List<TaskIdWithUsage> possibleTasksToShuffle = new ArrayList<>();
 
         for (MesosTaskMonitorObject taskUsage : allTaskUsage) {
           String taskId = taskUsage.getSource();
@@ -195,14 +199,39 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
             cpusUsedOnSlave += taskCpusUsed;
           }
 
-          if (slaveOverloaded && currentUsage != null) {
-            if (canShuffleTask(task)) {
-              tasksToShuffle.add(new TaskIdWithUsage(task, currentUsage));
+          if (slaveOverloaded && configuration.isShuffleTasksForOverloadedSlaves() && currentUsage != null && currentUsage.getCpusUsed() > 0) {
+            if (isLongRunning(task)) {
+              Optional<SingularityTaskHistoryUpdate> maybeCleanupUpdate = taskManager.getTaskHistoryUpdate(task, ExtendedTaskState.TASK_CLEANING);
+              if (maybeCleanupUpdate.isPresent() && isTaskShuffleCleanup(maybeCleanupUpdate.get())) {
+                LOG.trace("Task {} already being cleaned up to spread cpu usage, skipping", taskId);
+                shuffledTasks++;
+              } else {
+                possibleTasksToShuffle.add(new TaskIdWithUsage(task, currentUsage));
+              }
             }
           }
         }
 
-        TODO // cleanups for overloaded slave
+        if (slaveOverloaded && configuration.isShuffleTasksForOverloadedSlaves()) {
+          possibleTasksToShuffle.sort((u1, u2) -> Double.compare(u2.getUsage().getCpusUsed(), u1.getUsage().getCpusUsed()));
+          for (TaskIdWithUsage taskIdWithUsage : possibleTasksToShuffle) {
+            if (cpuOverage <= 0 || shuffledTasks > configuration.getMaxTasksToShuffleForCpuOverage()) {
+              break;
+            }
+            LOG.debug("Cleaning up task {} to free up cpu on overloaded host (remaining cpu overage: {})", taskIdWithUsage.getTaskId(), cpuOverage);
+            taskManager.createTaskCleanup(
+                new SingularityTaskCleanup(
+                    Optional.absent(),
+                    TaskCleanupType.REBALANCE_CPU_USAGE,
+                    System.currentTimeMillis(),
+                    taskIdWithUsage.getTaskId(),
+                    Optional.of(String.format("Load on slave %s is %s / %s, shuffling task to less busy host", slave.getHost(), systemLoad5Min, systemCpusTotal)),
+                    Optional.of(UUID.randomUUID().toString()),
+                    Optional.absent(), Optional.absent()));
+            cpuOverage -= taskIdWithUsage.getUsage().getCpusUsed();
+            shuffledTasks++;
+          }
+        }
 
         if (!slave.getResources().isPresent() ||
             !slave.getResources().get().getMemoryMegaBytes().isPresent() ||
@@ -243,8 +272,16 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
     usageManager.saveClusterUtilization(getClusterUtilization(utilizationPerRequestId, totalMemBytesUsed, totalMemBytesAvailable, totalCpuUsed, totalCpuAvailable, totalDiskBytesUsed, totalDiskBytesAvailable, now));
   }
 
-  private boolean canShuffleTask(SingularityTaskId taskId) {
-    TODO
+  private boolean isTaskShuffleCleanup(SingularityTaskHistoryUpdate taskHistoryUpdate) {
+    if (taskHistoryUpdate.getStatusMessage().or("").contains(TaskCleanupType.REBALANCE_CPU_USAGE.name())) {
+      return true;
+    }
+    for (SingularityTaskHistoryUpdate previous : taskHistoryUpdate.getPrevious()) {
+      if (previous.getStatusMessage().or("").contains(TaskCleanupType.REBALANCE_CPU_USAGE.name())) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private SingularityTaskUsage getUsage(MesosTaskMonitorObject taskUsage) {
@@ -489,7 +526,7 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
     private final SingularityTaskId taskId;
     private final SingularityTaskCurrentUsage usage;
 
-    public TaskIdWithUsage(SingularityTaskId taskId, SingularityTaskCurrentUsage usage) {
+    TaskIdWithUsage(SingularityTaskId taskId, SingularityTaskCurrentUsage usage) {
       this.taskId = taskId;
       this.usage = usage;
     }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
@@ -539,7 +539,7 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
 
   }
 
-  private class TaskIdWithUsage {
+  private static class TaskIdWithUsage {
     private final SingularityTaskId taskId;
     private final SingularityTaskCurrentUsage usage;
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityUsageTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityUsageTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
+import com.hubspot.mesos.json.MesosSlaveMetricsSnapshotObject;
 import com.hubspot.mesos.json.MesosTaskMonitorObject;
 import com.hubspot.mesos.json.MesosTaskStatisticsObject;
 import com.hubspot.singularity.MachineState;
@@ -20,6 +21,7 @@ import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.SingularityTaskCurrentUsageWithId;
 import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.SingularityTaskUsage;
+import com.hubspot.singularity.TaskCleanupType;
 import com.hubspot.singularity.data.UsageManager;
 
 public class SingularityUsageTest extends SingularitySchedulerTestBase {
@@ -502,6 +504,52 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
     Assert.assertEquals(7, minCpu, 0);
     Assert.assertEquals(850, maxMemBytes);
     Assert.assertEquals(600, minMemBytes);
+  }
+
+  @Test
+  public void itCreatesTaskCleanupsWhenAMachineIsOverloaded() {
+    try {
+      configuration.setShuffleTasksForOverloadedSlaves(true);
+
+      initRequest();
+      initFirstDeploy();
+      saveAndSchedule(requestManager.getRequest(requestId).get().getRequest().toBuilder().setInstances(Optional.of(3)));
+      resourceOffers(1);
+      SingularitySlaveUsage highUsage = new SingularitySlaveUsage(15, 10, Optional.of(10.0), 1, 1, Optional.of(30L), 1, 1, Optional.of(1024L), Collections.emptyMap(), 1, System.currentTimeMillis(), 1, 30000, 10, 1.5, 1.5, 1.5, 0, 107374182);
+      usageManager.saveSpecificSlaveUsageAndSetCurrent("host1", highUsage);
+
+      SingularityTaskId taskId1 = taskManager.getActiveTaskIds().get(0);
+      String t1 = taskId1.getId();
+      SingularityTaskId taskId2 = taskManager.getActiveTaskIds().get(1);
+      String t2 = taskId2.getId();
+      SingularityTaskId taskId3 = taskManager.getActiveTaskIds().get(2);
+      String t3 = taskId3.getId();
+      statusUpdate(taskManager.getTask(taskId1).get(), TaskState.TASK_STARTING, Optional.of(taskId1.getStartedAt()));
+      statusUpdate(taskManager.getTask(taskId2).get(), TaskState.TASK_STARTING, Optional.of(taskId2.getStartedAt()));
+      statusUpdate(taskManager.getTask(taskId3).get(), TaskState.TASK_STARTING, Optional.of(taskId3.getStartedAt()));
+      // task 1 using 3 cpus
+      MesosTaskMonitorObject t1u1 = getTaskMonitor(t1, 15, TimeUnit.MILLISECONDS.toSeconds(taskId1.getStartedAt()) + 5, 1000);
+      // task 2 using 2 cpus
+      MesosTaskMonitorObject t2u1 = getTaskMonitor(t2, 10, TimeUnit.MILLISECONDS.toSeconds(taskId2.getStartedAt()) + 5, 1000);
+      // task 3 using 1 cpus
+      MesosTaskMonitorObject t3u1 = getTaskMonitor(t3, 5, TimeUnit.MILLISECONDS.toSeconds(taskId3.getStartedAt()) + 5, 1000);
+      mesosClient.setSlaveResourceUsage("host1", Arrays.asList(t1u1, t2u1, t3u1));
+      mesosClient.setSlaveMetricsSnapshot(
+          "host1",
+          new MesosSlaveMetricsSnapshotObject(0, 0, 0, 10.0, 0, 0, 0, 0, 0, 0, 0, 0, 10.0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1.5, 0, 0, 1.5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 15, 0, 0, 0, 0, 0, 0, 1.5, 0, 0, 0, 0)
+      );
+
+      usagePoller.runActionOnPoll();
+
+      // First task is cleaned up
+      Assert.assertEquals(taskManager.getTaskCleanup(taskId1.getId()).get().getCleanupType(), TaskCleanupType.REBALANCE_CPU_USAGE);
+      // Second task is cleaned up, which brings the cpu overage back down to 0
+      Assert.assertEquals(taskManager.getTaskCleanup(taskId2.getId()).get().getCleanupType(), TaskCleanupType.REBALANCE_CPU_USAGE);
+      // Third task doesn't get cleaned up due to cpu overage being satisfied
+      Assert.assertFalse(taskManager.getTaskCleanup(taskId3.getId()).isPresent());
+    } finally {
+      configuration.setShuffleTasksForOverloadedSlaves(false);
+    }
   }
 
   private MesosTaskStatisticsObject getStatistics(double cpuSecs, double timestamp, long memBytes) {

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityUsageTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityUsageTest.java
@@ -13,7 +13,6 @@ import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.hubspot.mesos.json.MesosSlaveMetricsSnapshotObject;
 import com.hubspot.mesos.json.MesosTaskMonitorObject;
-import com.hubspot.mesos.json.MesosTaskStatisticsObject;
 import com.hubspot.singularity.MachineState;
 import com.hubspot.singularity.SingularityClusterUtilization;
 import com.hubspot.singularity.SingularitySlaveUsage;
@@ -515,7 +514,7 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
       initFirstDeploy();
       saveAndSchedule(requestManager.getRequest(requestId).get().getRequest().toBuilder().setInstances(Optional.of(3)));
       resourceOffers(1);
-      SingularitySlaveUsage highUsage = new SingularitySlaveUsage(15, 10, Optional.of(10.0), 1, 1, Optional.of(30L), 1, 1, Optional.of(1024L), Collections.emptyMap(), 1, System.currentTimeMillis(), 1, 30000, 10, 1.5, 1.5, 1.5, 0, 107374182);
+      SingularitySlaveUsage highUsage = new SingularitySlaveUsage(15, 10, Optional.of(10.0), 1, 1, Optional.of(30L), 1, 1, Optional.of(1024L), Collections.emptyMap(), 1, System.currentTimeMillis(), 1, 30000, 10, 15, 15, 15, 0, 107374182);
       usageManager.saveSpecificSlaveUsageAndSetCurrent("host1", highUsage);
 
       SingularityTaskId taskId1 = taskManager.getActiveTaskIds().get(0);
@@ -536,7 +535,7 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
       mesosClient.setSlaveResourceUsage("host1", Arrays.asList(t1u1, t2u1, t3u1));
       mesosClient.setSlaveMetricsSnapshot(
           "host1",
-          new MesosSlaveMetricsSnapshotObject(0, 0, 0, 10.0, 0, 0, 0, 0, 0, 0, 0, 0, 10.0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1.5, 0, 0, 1.5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 15, 0, 0, 0, 0, 0, 0, 1.5, 0, 0, 0, 0)
+          new MesosSlaveMetricsSnapshotObject(0, 0, 0, 10.0, 0, 0, 0, 0, 0, 0, 0, 0, 10.0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 15, 0, 0, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 15, 0, 0, 0, 0, 0, 0, 15, 0, 0, 0, 0)
       );
 
       usagePoller.runActionOnPoll();

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/TestingMesosClient.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/TestingMesosClient.java
@@ -15,13 +15,19 @@ import com.hubspot.mesos.json.MesosTaskMonitorObject;
 public class TestingMesosClient implements MesosClient {
 
   private Map<String, List<MesosTaskMonitorObject>> slaveResourceUsage;
+  private Map<String, MesosSlaveMetricsSnapshotObject> slaveMetrics;
 
   public TestingMesosClient() {
     this.slaveResourceUsage = new HashMap<>();
+    this.slaveMetrics = new HashMap<>();
   }
 
   public void setSlaveResourceUsage(String hostname, List<MesosTaskMonitorObject> taskMonitorObjects) {
     slaveResourceUsage.put(hostname, taskMonitorObjects);
+  }
+
+  public void setSlaveMetricsSnapshot(String hostname, MesosSlaveMetricsSnapshotObject snapshotObject) {
+    slaveMetrics.put(hostname, snapshotObject);
   }
 
   @Override
@@ -46,7 +52,7 @@ public class TestingMesosClient implements MesosClient {
 
   @Override
   public MesosSlaveMetricsSnapshotObject getSlaveMetricsSnapshot(String hostname) {
-    return null;
+    return slaveMetrics.get(hostname);
   }
 
   @Override
@@ -61,10 +67,7 @@ public class TestingMesosClient implements MesosClient {
 
   @Override
   public List<MesosTaskMonitorObject> getSlaveResourceUsage(String hostname) {
-    if (!slaveResourceUsage.containsKey(hostname)) {
-      return Collections.emptyList();
-    }
-    return slaveResourceUsage.get(hostname);
+    return slaveResourceUsage.getOrDefault(hostname, Collections.emptyList());
   }
 
 }


### PR DESCRIPTION
It is very common to oversubscribe on resources to use fewer large hosts more efficiently. Unfortunately that can have unintended consequences like overloading a host's cpu or oom-ing if memory is oversubscribed too much. This PR tackles the first of those cases (cpu). During our usage polling, we will check the system load on the machine (as reported by the mesos slave api). If it is > 1.0, this is indicative of the machine being overloaded and we will attempt to create cleanups on high cpu usage long running tasks on the host in order to disperse the load to hosts with more free resources. We will only allow up to 3 cleaning tasks per host by default, and will stop creating cleanups if we hit that limit or believe the usage of the cleaned tasks accounts for enough of the cpu to get the host back to acceptable levels

This is akin to mesos' revocable resources, however fully integrating those into Singularity would be a much larger lift for similar functionality