### PR TITLE
Permalink request within group

### DIFF
--- a/SingularityUI/app/components/groupDetail/GroupDetail.jsx
+++ b/SingularityUI/app/components/groupDetail/GroupDetail.jsx
@@ -1,6 +1,6 @@
-import React, {PropTypes, Component} from 'react';
+import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { LinkContainer } from 'react-router-bootstrap';
+import { withRouter, routerShape } from 'react-router';
 import rootComponent from '../../rootComponent';
 
 import { Row, Col, Nav, NavItem, Label } from 'react-bootstrap';
@@ -9,68 +9,68 @@ import MetadataButton from '../common/MetadataButton';
 import { refresh } from '../../actions/ui/groupDetail';
 import ActionDropdown from './ActionDropdown';
 
-class GroupDetail extends Component {
+const GroupDetail = (props) => {
+  const { group, location, params, requestsNotFound, router } = props;
+  const showRequestId = params.requestId || _.first(group.requestIds);
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      showRequestId: props.params.requestId || _.first(props.group.requestIds),
-    };
-    _.bindAll(this, 'handleRequestSelect');
-  }
+  const handleRequestSelect = (eventKey) => {
+    router.push(`/group/${group.id}/${eventKey}`);
+  };
 
-  handleRequestSelect(eventkey) {
-    this.setState({
-      showRequestId: eventkey
-    });
-  }
+  const metadata = !_.isEmpty(group.metadata) && (
+    <MetadataButton title={group.id} metadata={group.metadata}>View Metadata</MetadataButton>
+  );
 
-  render() {
-    const {group, location, requestsNotFound} = this.props;
-    const metadata = !_.isEmpty(group.metadata) && (
-      <MetadataButton title={group.id} metadata={group.metadata}>View Metadata</MetadataButton>
+  const requestPages = {};
+  group.requestIds.forEach((requestId, index) => {
+    requestPages[requestId] = (
+      <RequestDetailPage
+        index={index}
+        key={requestId}
+        params={{requestId}}
+        location={location}
+        showBreadcrumbs={false}
+      />
     );
-    const requestPages = {};
-    group.requestIds.forEach((requestId, index) => {
-      requestPages[requestId] = <RequestDetailPage key={index} index={index} params={{requestId}} location={location} showBreadcrumbs={false} />
-    });
+  });
 
-    return (
-      <div className="tabbed-page">
-        <Row className="clearfix">
-          <Col className="tab-col" sm={4} md={2}>
-            <h3>Request Group</h3>
-            <Row className="detail-header">
-              <Col xs={10}>
-                <h4>{group.id}</h4>
-              </Col>
-              <Col xs={2}>
-                <ActionDropdown group={group} metadata={metadata} />
-              </Col>
-            </Row>
-
-            <Nav bsStyle="pills" stacked={true} activeKey={this.state.showRequestId} onSelect={this.handleRequestSelect}>
-              {group.requestIds.map((requestId, index) =>
-                <LinkContainer
-                  eventKey={requestId}
-                  key={index}
-                  to={`/group/${group.id}/${requestId}`}
-                >
-                  <NavItem className="request-group-navitem">
-                    {requestId} {requestsNotFound.includes(requestId) && <Label bsStyle="danger">Deleted</Label>}
-                  </NavItem>
-                </LinkContainer>
-              )}
-            </Nav>
-          </Col>
-          <Col sm={8} md={10}>
-            {requestPages[this.state.showRequestId]}
-          </Col>
-        </Row>
-      </div>
-    );
-  }
-}
+  return (
+    <div className="tabbed-page">
+      <Row className="clearfix">
+        <Col className="tab-col" sm={4} md={2}>
+          <h3>Request Group</h3>
+          <Row className="detail-header">
+            <Col xs={10}>
+              <h4>{group.id}</h4>
+            </Col>
+            <Col xs={2}>
+              <ActionDropdown group={group} metadata={metadata} />
+            </Col>
+          </Row>
+          <Nav
+            activeKey={showRequestId}
+            bsStyle="pills"
+            onSelect={handleRequestSelect}
+            stacked={true}
+          >
+            {group.requestIds.map(requestId =>
+              <NavItem
+                className="request-group-navitem"
+                eventKey={requestId}
+                key={requestId}
+              >
+                {requestId} {requestsNotFound.includes(requestId) && <Label bsStyle="danger">Deleted</Label>}
+              </NavItem>
+            )}
+          </Nav>
+        </Col>
+        <Col sm={8} md={10}>
+          {requestPages[showRequestId]}
+        </Col>
+      </Row>
+    </div>
+  );
+};
 
 GroupDetail.propTypes = {
   group: PropTypes.object,
@@ -78,7 +78,8 @@ GroupDetail.propTypes = {
   params: PropTypes.shape({
     requestId: PropTypes.string,
   }),
-  requestsNotFound: PropTypes.array
+  requestsNotFound: PropTypes.array,
+  router: routerShape,
 };
 
 const mapStateToProps = (state, ownProps) => {
@@ -91,4 +92,6 @@ const mapStateToProps = (state, ownProps) => {
   });
 };
 
-export default connect(mapStateToProps)(rootComponent(GroupDetail, refresh, false, false));
+export default withRouter(
+  connect(mapStateToProps)(rootComponent(GroupDetail, refresh, false, false))
+);

--- a/SingularityUI/app/components/groupDetail/GroupDetail.jsx
+++ b/SingularityUI/app/components/groupDetail/GroupDetail.jsx
@@ -1,5 +1,6 @@
 import React, {PropTypes, Component} from 'react';
 import { connect } from 'react-redux';
+import { LinkContainer } from 'react-router-bootstrap';
 import rootComponent from '../../rootComponent';
 
 import { Row, Col, Nav, NavItem, Label } from 'react-bootstrap';
@@ -13,7 +14,7 @@ class GroupDetail extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      showRequestId: _.first(props.group.requestIds)
+      showRequestId: props.params.requestId || _.first(props.group.requestIds),
     };
     _.bindAll(this, 'handleRequestSelect');
   }
@@ -50,9 +51,15 @@ class GroupDetail extends Component {
 
             <Nav bsStyle="pills" stacked={true} activeKey={this.state.showRequestId} onSelect={this.handleRequestSelect}>
               {group.requestIds.map((requestId, index) =>
-                <NavItem className="request-group-navitem" key={index} eventKey={requestId}>
-                  {requestId} {requestsNotFound.includes(requestId) && <Label bsStyle="danger">Deleted</Label>}
-                </NavItem>
+                <LinkContainer
+                  eventKey={requestId}
+                  key={index}
+                  to={`/group/${group.id}/${requestId}`}
+                >
+                  <NavItem className="request-group-navitem">
+                    {requestId} {requestsNotFound.includes(requestId) && <Label bsStyle="danger">Deleted</Label>}
+                  </NavItem>
+                </LinkContainer>
               )}
             </Nav>
           </Col>
@@ -68,7 +75,9 @@ class GroupDetail extends Component {
 GroupDetail.propTypes = {
   group: PropTypes.object,
   location: PropTypes.object,
-  requests: PropTypes.object,
+  params: PropTypes.shape({
+    requestId: PropTypes.string,
+  }),
   requestsNotFound: PropTypes.array
 };
 

--- a/SingularityUI/app/router.jsx
+++ b/SingularityUI/app/router.jsx
@@ -37,7 +37,7 @@ const routes = (
     <Route path="requests/new" component={RequestForm} title="New Request" />
     <Route path="requests/edit/:requestId" component={RequestForm} title="New or Edit Request" />
     <Route path="requests(/:group)(/:state)(/:subFilter)(/:searchFilter)" component={RequestsPage} title="Requests" />
-    <Route path="group/:groupId" component={Group} title={(params) => `Group ${params.groupId}`} />
+    <Route path="group/:groupId(/:requestId)" component={Group} title={(params) => `Group ${params.groupId}`} />
     <Route path="request">
       <Route path=":requestId" component={RequestDetailPage} title={(params) => params.requestId} />
       <Route path=":requestId/task-search" component={TaskSearch} title="Task Search" />

--- a/SingularityUI/package.json
+++ b/SingularityUI/package.json
@@ -51,7 +51,6 @@
     "react-json-tree": "^0.10.9",
     "react-redux": "^5.0.5",
     "react-router": "^2.5.2",
-    "react-router-bootstrap": "^0.23.3",
     "react-router-redux": "^4.0.5",
     "react-select": "^1.0.0-rc.5",
     "react-tagsinput": "^3.13.0",

--- a/SingularityUI/package.json
+++ b/SingularityUI/package.json
@@ -51,6 +51,7 @@
     "react-json-tree": "^0.10.9",
     "react-redux": "^5.0.5",
     "react-router": "^2.5.2",
+    "react-router-bootstrap": "^0.23.3",
     "react-router-redux": "^4.0.5",
     "react-select": "^1.0.0-rc.5",
     "react-tagsinput": "^3.13.0",


### PR DESCRIPTION
Previously, request groups didn't support permalinks for requests within the group. It would simply select the first request and display that.

You'd have link that looked like this:
```
localhost/singularity/ui/group/RequestGroup1
```

Which would contain some requests: RequestGroup1-foo1, RequestGroup1-foo2, RequestGroup1-foo3

Now you can link them directly:
```
localhost/singularity/ui/group/RequestGroup1/RequestGroup1-foo1
localhost/singularity/ui/group/RequestGroup1/RequestGroup1-foo2
localhost/singularity/ui/group/RequestGroup1/RequestGroup1-foo3
```

The default behavior is maintained, no request ID means display the first request. Incorrect request ID will still load the selected group page, but the request data will not be displayed since there is none.