### PR TITLE
Limit the number of tasks that can shuffle for cpu rebalance at once

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -77,7 +77,9 @@ public class SingularityConfiguration extends Configuration {
 
   private boolean shuffleTasksForOverloadedSlaves = false; // recommended 'true' when oversubscribing cpu for larger clusters
 
-  private int maxTasksToShuffleForCpuOverage = 3;
+  private int maxTasksToShuffleTotal = 6; // Do not allow more than this many shuffle cleanups at once cluster-wide
+
+  private int maxTasksToShufflePerHost = 2;
 
   private long cleanUsageEveryMillis = TimeUnit.MINUTES.toMillis(5);
 
@@ -1478,17 +1480,16 @@ public class SingularityConfiguration extends Configuration {
     return usageIntervalSeconds;
   }
 
-  public SingularityConfiguration setUsageIntervalSeconds(int usageIntervalSeconds) {
+  public void setUsageIntervalSeconds(int usageIntervalSeconds) {
     this.usageIntervalSeconds = usageIntervalSeconds;
-    return this;
   }
 
-  public int getMaxTasksToShuffleForCpuOverage() {
-    return maxTasksToShuffleForCpuOverage;
+  public int getMaxTasksToShufflePerHost() {
+    return maxTasksToShufflePerHost;
   }
 
-  public void setMaxTasksToShuffleForCpuOverage(int maxTasksToShuffleForCpuOverage) {
-    this.maxTasksToShuffleForCpuOverage = maxTasksToShuffleForCpuOverage;
+  public void setMaxTasksToShufflePerHost(int maxTasksToShufflePerHost) {
+    this.maxTasksToShufflePerHost = maxTasksToShufflePerHost;
   }
 
   public boolean isShuffleTasksForOverloadedSlaves() {
@@ -1497,6 +1498,14 @@ public class SingularityConfiguration extends Configuration {
 
   public void setShuffleTasksForOverloadedSlaves(boolean shuffleTasksForOverloadedSlaves) {
     this.shuffleTasksForOverloadedSlaves = shuffleTasksForOverloadedSlaves;
+  }
+
+  public int getMaxTasksToShuffleTotal() {
+    return maxTasksToShuffleTotal;
+  }
+
+  public void setMaxTasksToShuffleTotal(int maxTasksToShuffleTotal) {
+    this.maxTasksToShuffleTotal = maxTasksToShuffleTotal;
   }
 
   public long getCleanUsageEveryMillis() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
@@ -247,7 +247,7 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
           possibleTasksToShuffle.sort((u1, u2) -> Double.compare(u2.getUsage().getCpusUsed(), u1.getUsage().getCpusUsed()));
           for (TaskIdWithUsage taskIdWithUsage : possibleTasksToShuffle) {
             if (requestsWithShuffledTasks.contains(taskIdWithUsage.getTaskId().getRequestId())) {
-              LOG.debug("Request {} laready has a shuffling task, skipping", taskIdWithUsage.getTaskId().getRequestId());
+              LOG.debug("Request {} already has a shuffling task, skipping", taskIdWithUsage.getTaskId().getRequestId());
               continue;
             }
             if (cpuOverage <= 0 || shuffledTasks > configuration.getMaxTasksToShufflePerHost() || currentShuffleCleanupsTotal >= configuration.getMaxTasksToShuffleTotal()) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
@@ -94,14 +94,16 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
     long totalDiskBytesAvailable = 0;
 
     long currentShuffleCleanupsTotal = 0;
-    if (configuration.isShuffleTasksForOverloadedSlaves()) {
-      currentShuffleCleanupsTotal = taskManager.getCleanupTasks()
-          .stream()
-          .filter((taskCleanup) -> taskCleanup.getCleanupType() == TaskCleanupType.REBALANCE_CPU_USAGE)
-          .count();
-    }
 
     Set<String> requestsWithShuffledTasks = new HashSet<>();
+    if (configuration.isShuffleTasksForOverloadedSlaves()) {
+      List<SingularityTaskCleanup> shuffleCleanups = taskManager.getCleanupTasks()
+          .stream()
+          .filter((taskCleanup) -> taskCleanup.getCleanupType() == TaskCleanupType.REBALANCE_CPU_USAGE)
+          .collect(Collectors.toList());
+      currentShuffleCleanupsTotal = shuffleCleanups.size();
+      shuffleCleanups.forEach((taskCleanup) -> requestsWithShuffledTasks.add(taskCleanup.getTaskId().getRequestId()));
+    }
 
     for (SingularitySlave slave : usageHelper.getSlavesToTrackUsageFor()) {
       Map<ResourceUsageType, Number> longRunningTasksUsage = new HashMap<>();

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
@@ -243,6 +243,7 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
           possibleTasksToShuffle.sort((u1, u2) -> Double.compare(u2.getUsage().getCpusUsed(), u1.getUsage().getCpusUsed()));
           for (TaskIdWithUsage taskIdWithUsage : possibleTasksToShuffle) {
             if (cpuOverage <= 0 || shuffledTasks > configuration.getMaxTasksToShufflePerHost() || currentShuffleCleanupsTotal >= configuration.getMaxTasksToShuffleTotal()) {
+              LOG.debug("Not shuffling any more tasks (overage: {}, shuffledOnHost: {}, totalShuffleCleanups: {})", cpuOverage, shuffledTasks, currentShuffleCleanupsTotal);
               break;
             }
             LOG.debug("Cleaning up task {} to free up cpu on overloaded host (remaining cpu overage: {})", taskIdWithUsage.getTaskId(), cpuOverage);

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
@@ -2,7 +2,6 @@ package com.hubspot.singularity.scheduler;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -93,17 +92,7 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
     long totalDiskBytesUsed = 0;
     long totalDiskBytesAvailable = 0;
 
-    long currentShuffleCleanupsTotal = 0;
-
-    Set<String> requestsWithShuffledTasks = new HashSet<>();
-    if (configuration.isShuffleTasksForOverloadedSlaves()) {
-      List<SingularityTaskCleanup> shuffleCleanups = taskManager.getCleanupTasks()
-          .stream()
-          .filter((taskCleanup) -> taskCleanup.getCleanupType() == TaskCleanupType.REBALANCE_CPU_USAGE)
-          .collect(Collectors.toList());
-      currentShuffleCleanupsTotal = shuffleCleanups.size();
-      shuffleCleanups.forEach((taskCleanup) -> requestsWithShuffledTasks.add(taskCleanup.getTaskId().getRequestId()));
-    }
+    Map<SingularitySlaveUsage, List<TaskIdWithUsage>> overLoadedHosts = new HashMap<>();
 
     for (SingularitySlave slave : usageHelper.getSlavesToTrackUsageFor()) {
       Map<ResourceUsageType, Number> longRunningTasksUsage = new HashMap<>();
@@ -146,7 +135,6 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
         }
 
         double systemLoad;
-
         switch (configuration.getMesosConfiguration().getScoreUsingSystemLoad()) {
           case LOAD_1:
             systemLoad = systemLoad1Min;
@@ -160,11 +148,7 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
             break;
         }
 
-
-
         boolean slaveOverloaded = systemCpusTotal > 0 && systemLoad / systemCpusTotal > 1.0;
-        double cpuOverage = slaveOverloaded ? systemLoad - systemCpusTotal : 0.0;
-        int shuffledTasks = 0;
         List<TaskIdWithUsage> possibleTasksToShuffle = new ArrayList<>();
 
         for (MesosTaskMonitorObject taskUsage : allTaskUsage) {
@@ -232,47 +216,15 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
             cpusUsedOnSlave += taskCpusUsed;
           }
 
-          if (slaveOverloaded && configuration.isShuffleTasksForOverloadedSlaves() && currentUsage != null && currentUsage.getCpusUsed() > 0) {
+          if (configuration.isShuffleTasksForOverloadedSlaves() && currentUsage != null && currentUsage.getCpusUsed() > 0) {
             if (isLongRunning(task)) {
               Optional<SingularityTaskHistoryUpdate> maybeCleanupUpdate = taskManager.getTaskHistoryUpdate(task, ExtendedTaskState.TASK_CLEANING);
               if (maybeCleanupUpdate.isPresent() && isTaskAlreadyCleanedUpForShuffle(maybeCleanupUpdate.get())) {
                 LOG.trace("Task {} already being cleaned up to spread cpu usage, skipping", taskId);
-                shuffledTasks++;
               } else {
                 possibleTasksToShuffle.add(new TaskIdWithUsage(task, currentUsage));
               }
             }
-          }
-        }
-
-        if (slaveOverloaded && configuration.isShuffleTasksForOverloadedSlaves()) {
-          possibleTasksToShuffle.sort((u1, u2) -> Double.compare(u2.getUsage().getCpusUsed(), u1.getUsage().getCpusUsed()));
-          for (TaskIdWithUsage taskIdWithUsage : possibleTasksToShuffle) {
-            if (requestsWithShuffledTasks.contains(taskIdWithUsage.getTaskId().getRequestId())) {
-              LOG.debug("Request {} already has a shuffling task, skipping", taskIdWithUsage.getTaskId().getRequestId());
-              continue;
-            }
-            if (cpuOverage <= 0 || shuffledTasks > configuration.getMaxTasksToShufflePerHost() || currentShuffleCleanupsTotal >= configuration.getMaxTasksToShuffleTotal()) {
-              LOG.debug("Not shuffling any more tasks (overage: {}, shuffledOnHost: {}, totalShuffleCleanups: {})", cpuOverage, shuffledTasks, currentShuffleCleanupsTotal);
-              break;
-            }
-            LOG.debug("Cleaning up task {} to free up cpu on overloaded host (remaining cpu overage: {})", taskIdWithUsage.getTaskId(), cpuOverage);
-            Optional<String> message = Optional.of(String.format("Load on slave %s is %s / %s, shuffling task to less busy host", slave.getHost(), systemLoad, systemCpusTotal));
-            taskManager.createTaskCleanup(
-                new SingularityTaskCleanup(
-                    Optional.absent(),
-                    TaskCleanupType.REBALANCE_CPU_USAGE,
-                    System.currentTimeMillis(),
-                    taskIdWithUsage.getTaskId(),
-                    message,
-                    Optional.of(UUID.randomUUID().toString()),
-                    Optional.absent(), Optional.absent()));
-            requestManager.addToPendingQueue(new SingularityPendingRequest(taskIdWithUsage.getTaskId().getRequestId(), taskIdWithUsage.getTaskId().getDeployId(), now, Optional.absent(),
-                PendingType.TASK_BOUNCE, Optional.absent(), Optional.absent(), Optional.absent(), message, Optional.of(UUID.randomUUID().toString())));
-            cpuOverage -= taskIdWithUsage.getUsage().getCpusUsed();
-            shuffledTasks++;
-            currentShuffleCleanupsTotal++;
-            requestsWithShuffledTasks.add(taskIdWithUsage.getTaskId().getRequestId());
           }
         }
 
@@ -289,6 +241,11 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
         SingularitySlaveUsage slaveUsage = new SingularitySlaveUsage(cpusUsedOnSlave, cpuReservedOnSlave, cpusTotal, memoryBytesUsedOnSlave, memoryMbReservedOnSlave,
             memoryMbTotal, diskMbUsedOnSlave, diskMbReservedOnSlave, diskMbTotal, longRunningTasksUsage, allTaskUsage.size(), now,
             systemMemTotalBytes, systemMemFreeBytes, systemCpusTotal, systemLoad1Min, systemLoad5Min, systemLoad15Min, slaveDiskUsed, slaveDiskTotal);
+
+        if (slaveOverloaded) {
+          overLoadedHosts.put(slaveUsage, possibleTasksToShuffle);
+        }
+
         List<Long> slaveTimestamps = usageManager.getSlaveUsageTimestamps(slave.getId());
         if (slaveTimestamps.size() + 1 > configuration.getNumUsageToKeep()) {
           usageManager.deleteSpecificSlaveUsage(slave.getId(), slaveTimestamps.get(0));
@@ -313,6 +270,81 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
       }
     }
     usageManager.saveClusterUtilization(getClusterUtilization(utilizationPerRequestId, totalMemBytesUsed, totalMemBytesAvailable, totalCpuUsed, totalCpuAvailable, totalDiskBytesUsed, totalDiskBytesAvailable, now));
+
+    if (configuration.isShuffleTasksForOverloadedSlaves()) {
+      shuffleTasksOnOverloadedHosts(overLoadedHosts);
+    }
+  }
+
+  private void shuffleTasksOnOverloadedHosts(Map<SingularitySlaveUsage, List<TaskIdWithUsage>> overLoadedHosts) {
+    List<SingularityTaskCleanup> shuffleCleanups = taskManager.getCleanupTasks()
+        .stream()
+        .filter((taskCleanup) -> taskCleanup.getCleanupType() == TaskCleanupType.REBALANCE_CPU_USAGE)
+        .collect(Collectors.toList());
+    long currentShuffleCleanupsTotal = shuffleCleanups.size();
+    Set<String> requestsWithShuffledTasks = shuffleCleanups
+        .stream()
+        .map((taskCleanup) -> taskCleanup.getTaskId().getRequestId())
+        .collect(Collectors.toSet());
+
+    List<SingularitySlaveUsage> overLoadedSlavesByUsage = overLoadedHosts.keySet().stream()
+        .sorted((usage1, usage2) -> Double.compare(
+            getSystemLoadForShuffle(usage2),
+            getSystemLoadForShuffle(usage1)
+        ))
+        .collect(Collectors.toList());
+    for (SingularitySlaveUsage overloadedSlave : overLoadedSlavesByUsage) {
+      if (currentShuffleCleanupsTotal >= configuration.getMaxTasksToShuffleTotal()) {
+        LOG.debug("Not shuffling any more tasks (totalShuffleCleanups: {})", currentShuffleCleanupsTotal);
+        break;
+      }
+      int shuffledTasksOnSlave = 0;
+      List<TaskIdWithUsage> possibleTasksToShuffle = overLoadedHosts.get(overloadedSlave);
+      possibleTasksToShuffle.sort((u1, u2) -> Double.compare(u2.getUsage().getCpusUsed(), u1.getUsage().getCpusUsed()));
+
+      double systemLoad = getSystemLoadForShuffle(overloadedSlave);
+      double cpuOverage = systemLoad - overloadedSlave.getSystemCpusTotal();
+
+      for (TaskIdWithUsage taskIdWithUsage : possibleTasksToShuffle) {
+        if (requestsWithShuffledTasks.contains(taskIdWithUsage.getTaskId().getRequestId())) {
+          LOG.debug("Request {} already has a shuffling task, skipping", taskIdWithUsage.getTaskId().getRequestId());
+          continue;
+        }
+        if (cpuOverage <= 0 || shuffledTasksOnSlave > configuration.getMaxTasksToShufflePerHost() || currentShuffleCleanupsTotal >= configuration.getMaxTasksToShuffleTotal()) {
+          LOG.debug("Not shuffling any more tasks (overage: {}, shuffledOnHost: {}, totalShuffleCleanups: {})", cpuOverage, shuffledTasksOnSlave, currentShuffleCleanupsTotal);
+          break;
+        }
+        LOG.debug("Cleaning up task {} to free up cpu on overloaded host (remaining cpu overage: {})", taskIdWithUsage.getTaskId(), cpuOverage);
+        Optional<String> message = Optional.of(String.format("Load on slave is %s / %s, shuffling task to less busy host", systemLoad, overloadedSlave.getSystemCpusTotal()));
+        taskManager.createTaskCleanup(
+            new SingularityTaskCleanup(
+                Optional.absent(),
+                TaskCleanupType.REBALANCE_CPU_USAGE,
+                System.currentTimeMillis(),
+                taskIdWithUsage.getTaskId(),
+                message,
+                Optional.of(UUID.randomUUID().toString()),
+                Optional.absent(), Optional.absent()));
+        requestManager.addToPendingQueue(new SingularityPendingRequest(taskIdWithUsage.getTaskId().getRequestId(), taskIdWithUsage.getTaskId().getDeployId(), System.currentTimeMillis(), Optional.absent(),
+            PendingType.TASK_BOUNCE, Optional.absent(), Optional.absent(), Optional.absent(), message, Optional.of(UUID.randomUUID().toString())));
+        cpuOverage -= taskIdWithUsage.getUsage().getCpusUsed();
+        shuffledTasksOnSlave++;
+        currentShuffleCleanupsTotal++;
+        requestsWithShuffledTasks.add(taskIdWithUsage.getTaskId().getRequestId());
+      }
+    }
+  }
+
+  private double getSystemLoadForShuffle(SingularitySlaveUsage usage) {
+    switch (configuration.getMesosConfiguration().getScoreUsingSystemLoad()) {
+      case LOAD_1:
+        return usage.getSystemLoad15Min();
+      case LOAD_15:
+        return usage.getSystemLoad15Min();
+      case LOAD_5:
+      default:
+        return usage.getSystemLoad5Min();
+    }
   }
 
   private boolean isTaskAlreadyCleanedUpForShuffle(SingularityTaskHistoryUpdate taskHistoryUpdate) {

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityUsageTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityUsageTest.java
@@ -551,6 +551,47 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
     }
   }
 
+  @Test
+  public void itLimitsTheNumberOfTaskCleanupsToCreate() {
+    try {
+      configuration.setShuffleTasksForOverloadedSlaves(true);
+      configuration.setMaxTasksToShuffleTotal(1);
+
+      initRequest();
+      initFirstDeploy();
+      saveAndSchedule(requestManager.getRequest(requestId).get().getRequest().toBuilder().setInstances(Optional.of(3)));
+      resourceOffers(1);
+      SingularitySlaveUsage highUsage = new SingularitySlaveUsage(15, 10, Optional.of(10.0), 1, 1, Optional.of(30L), 1, 1, Optional.of(1024L), Collections.emptyMap(), 1, System.currentTimeMillis(), 1, 30000, 10, 15, 15, 15, 0, 107374182);
+      usageManager.saveSpecificSlaveUsageAndSetCurrent("host1", highUsage);
+
+      SingularityTaskId taskId1 = taskManager.getActiveTaskIds().get(0);
+      String t1 = taskId1.getId();
+      SingularityTaskId taskId2 = taskManager.getActiveTaskIds().get(1);
+      String t2 = taskId2.getId();
+      statusUpdate(taskManager.getTask(taskId1).get(), TaskState.TASK_STARTING, Optional.of(taskId1.getStartedAt()));
+      statusUpdate(taskManager.getTask(taskId2).get(), TaskState.TASK_STARTING, Optional.of(taskId2.getStartedAt()));
+      // task 1 using 3 cpus
+      MesosTaskMonitorObject t1u1 = getTaskMonitor(t1, 15, TimeUnit.MILLISECONDS.toSeconds(taskId1.getStartedAt()) + 5, 1000);
+      // task 2 using 2 cpus
+      MesosTaskMonitorObject t2u1 = getTaskMonitor(t2, 10, TimeUnit.MILLISECONDS.toSeconds(taskId2.getStartedAt()) + 5, 1000);
+      mesosClient.setSlaveResourceUsage("host1", Arrays.asList(t1u1, t2u1));
+      mesosClient.setSlaveMetricsSnapshot(
+          "host1",
+          new MesosSlaveMetricsSnapshotObject(0, 0, 0, 10.0, 0, 0, 0, 0, 0, 0, 0, 0, 10.0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 15, 0, 0, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 15, 0, 0, 0, 0, 0, 0, 15, 0, 0, 0, 0)
+      );
+
+      usagePoller.runActionOnPoll();
+
+      // First task is cleaned up
+      Assert.assertEquals(taskManager.getTaskCleanup(taskId1.getId()).get().getCleanupType(), TaskCleanupType.REBALANCE_CPU_USAGE);
+      // Second task doesn't get cleaned up dur to cluster wide limit
+      Assert.assertFalse(taskManager.getTaskCleanup(taskId2.getId()).isPresent());
+    } finally {
+      configuration.setShuffleTasksForOverloadedSlaves(false);
+      configuration.setMaxTasksToShuffleTotal(6);
+    }
+  }
+
   private long getTimestampSeconds(SingularityTaskId taskId, long seconds) {
     return TimeUnit.MILLISECONDS.toSeconds(taskId.getStartedAt()) + seconds;
   }

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityUsageTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityUsageTest.java
@@ -542,10 +542,8 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
 
       // First task is cleaned up
       Assert.assertEquals(taskManager.getTaskCleanup(taskId1.getId()).get().getCleanupType(), TaskCleanupType.REBALANCE_CPU_USAGE);
-      // Second task is cleaned up, which brings the cpu overage back down to 0
-      Assert.assertEquals(taskManager.getTaskCleanup(taskId2.getId()).get().getCleanupType(), TaskCleanupType.REBALANCE_CPU_USAGE);
-      // Third task doesn't get cleaned up due to cpu overage being satisfied
-      Assert.assertFalse(taskManager.getTaskCleanup(taskId3.getId()).isPresent());
+      // Second task is not cleaned up because it is from the same request as task 1
+      Assert.assertFalse(taskManager.getTaskCleanup(taskId2.getId()).isPresent());
     } finally {
       configuration.setShuffleTasksForOverloadedSlaves(false);
     }


### PR DESCRIPTION
Add a cluster-wide limit as well as a per-slave limit for how many tasks we can shuffle around at once