### PR TITLE
Add a new scoring mode accounting for max historical usage of all tasks

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/RequestUtilization.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/RequestUtilization.java
@@ -40,8 +40,8 @@ public class RequestUtilization {
     return this;
   }
 
-  public RequestUtilization addCpuUsed(double cpu) {
-    this.cpuUsed += cpu;
+  public RequestUtilization setCpuUsed(double cpu) {
+    this.cpuUsed = cpu;
     return this;
   }
 
@@ -173,13 +173,21 @@ public class RequestUtilization {
   @Override
   public String toString() {
     return "RequestUtilization{" +
-        "requestId=" + requestId +
-        ", deployId=" + deployId +
+        "requestId='" + requestId + '\'' +
+        ", deployId='" + deployId + '\'' +
         ", memBytesUsed=" + memBytesUsed +
         ", memBytesReserved=" + memBytesReserved +
         ", cpuUsed=" + cpuUsed +
         ", cpuReserved=" + cpuReserved +
+        ", diskBytesUsed=" + diskBytesUsed +
+        ", diskBytesReserved=" + diskBytesReserved +
         ", numTasks=" + numTasks +
+        ", maxMemBytesUsed=" + maxMemBytesUsed +
+        ", minMemBytesUsed=" + minMemBytesUsed +
+        ", maxCpuUsed=" + maxCpuUsed +
+        ", minCpuUsed=" + minCpuUsed +
+        ", maxDiskBytesUsed=" + maxDiskBytesUsed +
+        ", minDiskBytesUsed=" + minDiskBytesUsed +
         '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/RequestUtilization.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/RequestUtilization.java
@@ -40,8 +40,9 @@ public class RequestUtilization {
     return this;
   }
 
-  public RequestUtilization setCpuUsed(double cpu) {
-    this.cpuUsed = cpu;
+  // This is a running total, not the current usage
+  public RequestUtilization addCpuUsed(double cpu) {
+    this.cpuUsed += cpu;
     return this;
   }
 

--- a/SingularityBase/src/main/java/com/hubspot/singularity/RequestUtilization.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/RequestUtilization.java
@@ -23,6 +23,8 @@ public class RequestUtilization {
   private long maxDiskBytesUsed = 0;
   private long minDiskBytesUsed = 0;
 
+  private double cpuBurstRating = 0;
+
   @JsonCreator
   public RequestUtilization(@JsonProperty("requestId") String requestId,
                             @JsonProperty("deployId") String deployId) {
@@ -92,6 +94,11 @@ public class RequestUtilization {
 
   public int getNumTasks() {
     return numTasks;
+  }
+
+  // 0 -> 1, where 0 is never over-utilized, or only short bursts and 1 is consistently overutilized
+  public double getCpuBurstRating() {
+    return cpuBurstRating;
   }
 
   @JsonIgnore
@@ -171,6 +178,11 @@ public class RequestUtilization {
     return this;
   }
 
+  public RequestUtilization setCpuBurstRating(double cpuBurstRating) {
+    this.cpuBurstRating = cpuBurstRating;
+    return this;
+  }
+
   @Override
   public String toString() {
     return "RequestUtilization{" +
@@ -189,6 +201,7 @@ public class RequestUtilization {
         ", minCpuUsed=" + minCpuUsed +
         ", maxDiskBytesUsed=" + maxDiskBytesUsed +
         ", minDiskBytesUsed=" + minDiskBytesUsed +
+        ", cpuBurstRating=" + cpuBurstRating +
         '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularitySlaveUsage.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularitySlaveUsage.java
@@ -12,7 +12,7 @@ public class SingularitySlaveUsage {
     CPU_USED, MEMORY_BYTES_USED, DISK_BYTES_USED, CPU_FREE, MEMORY_BYTES_FREE, DISK_BYTES_FREE
   }
 
-  public static final long BYTES_PER_MEGABYTE = 1000L * 1000L;
+  public static final long BYTES_PER_MEGABYTE = 1024L * 1024L;
 
   private final double cpusUsed;
   private final double cpusReserved;

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityUsageScoringStrategy.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityUsageScoringStrategy.java
@@ -1,5 +1,5 @@
 package com.hubspot.singularity;
 
 public enum  SingularityUsageScoringStrategy {
-  SPREAD_TASK_USAGE, SPREAD_SYSTEM_USAGE
+  SPREAD_TASK_USAGE, SPREAD_SYSTEM_USAGE, PROBABLE_MAX_USAGE
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/MesosConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/MesosConfiguration.java
@@ -59,6 +59,10 @@ public class MesosConfiguration {
   private int offersConcurrencyLimit = 100;
   private SingularityUsageScoringStrategy scoringStrategy = SingularityUsageScoringStrategy.SPREAD_TASK_USAGE;
   private MachineLoadMetric scoreUsingSystemLoad = MachineLoadMetric.LOAD_5;
+  private double longRunningFreeResourceWeight = 0.5;
+  private double longRunningUsedResourceWeight = 0.5;
+  private double nonLonRunningFreeResourceWeight = 0.75;
+  private double nonLongRunningUsedResourceWeight = 0.25;
 
   public int getMaxNumInstancesPerRequest() {
     return maxNumInstancesPerRequest;
@@ -290,5 +294,37 @@ public class MesosConfiguration {
 
   public void setScoreUsingSystemLoad(MachineLoadMetric scoreUsingSystemLoad) {
     this.scoreUsingSystemLoad = scoreUsingSystemLoad;
+  }
+
+  public double getLongRunningFreeResourceWeight() {
+    return longRunningFreeResourceWeight;
+  }
+
+  public void setLongRunningFreeResourceWeight(double longRunningFreeResourceWeight) {
+    this.longRunningFreeResourceWeight = longRunningFreeResourceWeight;
+  }
+
+  public double getLongRunningUsedResourceWeight() {
+    return longRunningUsedResourceWeight;
+  }
+
+  public void setLongRunningUsedResourceWeight(double longRunningUsedResourceWeight) {
+    this.longRunningUsedResourceWeight = longRunningUsedResourceWeight;
+  }
+
+  public double getNonLonRunningFreeResourceWeight() {
+    return nonLonRunningFreeResourceWeight;
+  }
+
+  public void setNonLonRunningFreeResourceWeight(double nonLonRunningFreeResourceWeight) {
+    this.nonLonRunningFreeResourceWeight = nonLonRunningFreeResourceWeight;
+  }
+
+  public double getNonLongRunningUsedResourceWeight() {
+    return nonLongRunningUsedResourceWeight;
+  }
+
+  public void setNonLongRunningUsedResourceWeight(double nonLongRunningUsedResourceWeight) {
+    this.nonLongRunningUsedResourceWeight = nonLongRunningUsedResourceWeight;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
@@ -26,6 +26,7 @@ import com.hubspot.singularity.RequestType;
 import com.hubspot.singularity.RequestUtilization;
 import com.hubspot.singularity.SingularityDeployStatistics;
 import com.hubspot.singularity.SingularityPendingTaskId;
+import com.hubspot.singularity.SingularitySlaveUsage;
 import com.hubspot.singularity.SingularitySlaveUsage.ResourceUsageType;
 import com.hubspot.singularity.SingularitySlaveUsageWithId;
 import com.hubspot.singularity.SingularityTask;
@@ -258,8 +259,8 @@ public class SingularityMesosOfferScheduler {
                 .or(maybeTask.get().getTaskRequest().getDeploy().getResources())
                 .or(defaultResources);
             cpu += resources.getCpus();
-            memBytes += resources.getDiskMb() * 1024 * 1024;
-            diskBytes += resources.getDiskMb() * 1024 * 1024;
+            memBytes += resources.getDiskMb() * SingularitySlaveUsage.BYTES_PER_MEGABYTE;
+            diskBytes += resources.getDiskMb() * SingularitySlaveUsage.BYTES_PER_MEGABYTE;
           }
         }
       }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveUsageWithCalculatedScores.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveUsageWithCalculatedScores.java
@@ -81,6 +81,7 @@ class SingularitySlaveUsageWithCalculatedScores {
         double probableMaxMemFreeScore = 1 - (getMaxProbableMemBytesWithEstimatedUsage() / slaveUsage.getSystemMemTotalBytes());
         double probableMaxDiskFreeScore = 1 - (getMaxProbableDiskBytesWithEstimatedUsage() / slaveUsage.getSlaveDiskTotal());
         setScores(longRunningCpusUsedScore, longRunningMemUsedScore, longRunningDiskUsedScore, probableMaxCpuFreeScore, probableMaxMemFreeScore, probableMaxDiskFreeScore);
+        break;
       case SPREAD_SYSTEM_USAGE:
       default:
         double systemCpuFreeScore = Math.max(0, 1 - ((getSystemLoadMetric() + estimatedAddedCpusUsage) / slaveUsage.getSystemCpusTotal()));

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveUsageWithCalculatedScores.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveUsageWithCalculatedScores.java
@@ -8,6 +8,7 @@ import com.hubspot.singularity.SingularityUsageScoringStrategy;
 class SingularitySlaveUsageWithCalculatedScores {
   private final SingularitySlaveUsage slaveUsage;
   private final MachineLoadMetric systemLoadMetric;
+  private final MaxProbableUsage maxProbableTaskUsage;
   private boolean missingUsageData;
   private double longRunningCpusUsedScore;
   private double longRunningMemUsedScore;
@@ -24,9 +25,10 @@ class SingularitySlaveUsageWithCalculatedScores {
   private double estimatedAddedMemoryBytesReserved = 0;
   private double estimatedAddedDiskBytesReserved = 0;
 
-  public SingularitySlaveUsageWithCalculatedScores(SingularitySlaveUsage slaveUsage, SingularityUsageScoringStrategy scoringStrategy, MachineLoadMetric systemLoadMetric) {
+  public SingularitySlaveUsageWithCalculatedScores(SingularitySlaveUsage slaveUsage, SingularityUsageScoringStrategy scoringStrategy, MachineLoadMetric systemLoadMetric, MaxProbableUsage maxProbableTaskUsage) {
     this.slaveUsage = slaveUsage;
     this.systemLoadMetric = systemLoadMetric;
+    this.maxProbableTaskUsage = maxProbableTaskUsage;
     if (missingUsageData(slaveUsage)) {
       this.missingUsageData = true;
       setScores(0, 0, 0, 0, 0, 0);
@@ -71,6 +73,14 @@ class SingularitySlaveUsageWithCalculatedScores {
         double diskFreeScore = 1 - ((slaveUsage.getDiskMbReserved() + (estimatedAddedDiskBytesReserved / SingularitySlaveUsage.BYTES_PER_MEGABYTE)) / slaveUsage.getDiskMbTotal().get());
         setScores(longRunningCpusUsedScore, longRunningMemUsedScore, longRunningDiskUsedScore, cpusFreeScore, memFreeScore, diskFreeScore);
         break;
+      case PROBABLE_MAX_USAGE:
+        double probableMaxCpuFreeScore = Math.max(
+            0,
+            1 - (getMaxProbableCpuWithEstimatedUsage() / slaveUsage.getSystemCpusTotal())
+        );
+        double probableMaxMemFreeScore = 1 - (getMaxProbableMemBytesWithEstimatedUsage() / slaveUsage.getSystemMemTotalBytes());
+        double probableMaxDiskFreeScore = 1 - (getMaxProbableDiskBytesWithEstimatedUsage() / slaveUsage.getSlaveDiskTotal());
+        setScores(longRunningCpusUsedScore, longRunningMemUsedScore, longRunningDiskUsedScore, probableMaxCpuFreeScore, probableMaxMemFreeScore, probableMaxDiskFreeScore);
       case SPREAD_SYSTEM_USAGE:
       default:
         double systemCpuFreeScore = Math.max(0, 1 - ((getSystemLoadMetric() + estimatedAddedCpusUsage) / slaveUsage.getSystemCpusTotal()));
@@ -78,6 +88,18 @@ class SingularitySlaveUsageWithCalculatedScores {
         double systemDiskFreeScore = 1 - ((slaveUsage.getSlaveDiskUsed() + estimatedAddedDiskBytesUsage) / slaveUsage.getSlaveDiskTotal());
         setScores(longRunningCpusUsedScore, longRunningMemUsedScore, longRunningDiskUsedScore, systemCpuFreeScore, systemMemFreeScore, systemDiskFreeScore);
     }
+  }
+
+  private double getMaxProbableCpuWithEstimatedUsage() {
+    return Math.max(getSystemLoadMetric(), maxProbableTaskUsage.getCpu()) + estimatedAddedCpusUsage;
+  }
+
+  private double getMaxProbableMemBytesWithEstimatedUsage() {
+    return Math.max(slaveUsage.getSystemMemTotalBytes() - slaveUsage.getSystemMemFreeBytes(), maxProbableTaskUsage.getMemBytes()) + estimatedAddedMemoryBytesUsage;
+  }
+
+  private double getMaxProbableDiskBytesWithEstimatedUsage() {
+    return Math.max(slaveUsage.getSlaveDiskUsed(), maxProbableTaskUsage.getDiskBytes()) + estimatedAddedDiskBytesUsage;
   }
 
   boolean isMissingUsageData() {
@@ -145,6 +167,30 @@ class SingularitySlaveUsageWithCalculatedScores {
       case LOAD_5:
       default:
         return slaveUsage.getSystemLoad5Min();
+    }
+  }
+
+  static class MaxProbableUsage {
+    private final double cpu;
+    private final double memBytes;
+    private final double diskBytes;
+
+    public MaxProbableUsage(double cpu, double memBytes, double diskBytes) {
+      this.cpu = cpu;
+      this.memBytes = memBytes;
+      this.diskBytes = diskBytes;
+    }
+
+    public double getCpu() {
+      return cpu;
+    }
+
+    public double getMemBytes() {
+      return memBytes;
+    }
+
+    public double getDiskBytes() {
+      return diskBytes;
     }
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
@@ -1,6 +1,7 @@
 package com.hubspot.singularity.scheduler;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -202,6 +203,7 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
               cpusUsedOnSlave += usedCpusSinceStart;
             }
           } else {
+            System.out.println(pastTaskUsages.get(pastTaskUsages.size() - 1));
             SingularityTaskUsage lastUsage = pastTaskUsages.get(pastTaskUsages.size() - 1);
 
             double taskCpusUsed = ((latestUsage.getCpuSeconds() - lastUsage.getCpuSeconds()) / (latestUsage.getTimestamp() - lastUsage.getTimestamp()));
@@ -414,6 +416,7 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
     }
 
     List<SingularityTaskUsage> pastTaskUsagesCopy = copyUsages(pastTaskUsages, latestUsage, task);
+    pastTaskUsagesCopy.sort(Comparator.comparingDouble(SingularityTaskUsage::getTimestamp));
     int numTasks = pastTaskUsagesCopy.size() - 1;
 
     for (int i = 0; i < numTasks; i++) {
@@ -429,7 +432,7 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
       curMinDiskBytesUsed = Math.min(newerUsage.getDiskTotalBytes(), curMinDiskBytesUsed);
 
       requestUtilization
-          .addCpuUsed(cpusUsed)
+          .setCpuUsed(cpusUsed)
           .addMemBytesUsed(newerUsage.getMemoryTotalBytes())
           .addDiskBytesUsed(newerUsage.getDiskTotalBytes())
           .incrementTaskCount();

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
@@ -203,7 +203,6 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
               cpusUsedOnSlave += usedCpusSinceStart;
             }
           } else {
-            System.out.println(pastTaskUsages.get(pastTaskUsages.size() - 1));
             SingularityTaskUsage lastUsage = pastTaskUsages.get(pastTaskUsages.size() - 1);
 
             double taskCpusUsed = ((latestUsage.getCpuSeconds() - lastUsage.getCpuSeconds()) / (latestUsage.getTimestamp() - lastUsage.getTimestamp()));
@@ -417,6 +416,7 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
 
     List<SingularityTaskUsage> pastTaskUsagesCopy = copyUsages(pastTaskUsages, latestUsage, task);
     pastTaskUsagesCopy.sort(Comparator.comparingDouble(SingularityTaskUsage::getTimestamp));
+    System.out.println(pastTaskUsagesCopy);
     int numTasks = pastTaskUsagesCopy.size() - 1;
 
     for (int i = 0; i < numTasks; i++) {
@@ -432,7 +432,7 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
       curMinDiskBytesUsed = Math.min(newerUsage.getDiskTotalBytes(), curMinDiskBytesUsed);
 
       requestUtilization
-          .setCpuUsed(cpusUsed)
+          .addCpuUsed(cpusUsed)
           .addMemBytesUsed(newerUsage.getMemoryTotalBytes())
           .addDiskBytesUsed(newerUsage.getDiskTotalBytes())
           .incrementTaskCount();
@@ -551,7 +551,7 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
     }
 
     double avgUnderUtilizedCpu = numRequestsWithUnderUtilizedCpu != 0 ? totalUnderUtilizedCpu / numRequestsWithUnderUtilizedCpu : 0;
-    double avgOverUtilizedCpu = numRequestsWithOverUtilizedCpu != 0? totalOverUtilizedCpu / numRequestsWithOverUtilizedCpu : 0;
+    double avgOverUtilizedCpu = numRequestsWithOverUtilizedCpu != 0 ? totalOverUtilizedCpu / numRequestsWithOverUtilizedCpu : 0;
     long avgUnderUtilizedMemBytes = numRequestsWithUnderUtilizedMemBytes != 0 ? totalUnderUtilizedMemBytes / numRequestsWithUnderUtilizedMemBytes : 0;
     long avgUnderUtilizedDiskBytes = numRequestsWithUnderUtilizedDiskBytes != 0 ? totalUnderUtilizedDiskBytes / numRequestsWithUnderUtilizedDiskBytes : 0;
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosOfferSchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosOfferSchedulerTest.java
@@ -34,6 +34,7 @@ import com.hubspot.singularity.api.SingularityScaleRequest;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.DeployManager;
 import com.hubspot.singularity.data.UsageManager;
+import com.hubspot.singularity.mesos.SingularitySlaveUsageWithCalculatedScores.MaxProbableUsage;
 import com.hubspot.singularity.scheduler.SingularitySchedulerTestBase;
 import com.hubspot.singularity.scheduler.SingularityUsagePoller;
 import com.hubspot.singularity.scheduler.TestingMesosClient;
@@ -394,7 +395,7 @@ public class SingularityMesosOfferSchedulerTest extends SingularitySchedulerTest
     return new SingularitySlaveUsageWithCalculatedScores(
         new SingularitySlaveUsage(0, cpusReserved, Optional.of(cpusTotal), 0, memMbReserved, Optional.of(memMbTotal), 0, diskMbReserved, Optional.of(diskMbTotal), longRunningTasksUsage, 1, 0L,
             0, 0, 0, 0, 0, 0, 0 , 0),
-        SingularityUsageScoringStrategy.SPREAD_TASK_USAGE, MachineLoadMetric.LOAD_5
+        SingularityUsageScoringStrategy.SPREAD_TASK_USAGE, MachineLoadMetric.LOAD_5, new MaxProbableUsage(0, 0, 0)
     );
   }
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosOfferSchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosOfferSchedulerTest.java
@@ -420,7 +420,7 @@ public class SingularityMesosOfferSchedulerTest extends SingularitySchedulerTest
           .absent()), SingularityUser.DEFAULT_USER);
       System.out.println(usageManager.getRequestUtilizations());
 
-      Assert.assertEquals(1.0, usageManager.getRequestUtilizations().get(requestId).getCpuUsed(), 0.001);
+      Assert.assertEquals(3.0, usageManager.getRequestUtilizations().get(requestId).getCpuUsed(), 0.001);
 
       Offer host2Offer = createOffer(6, 30000, 107374182, "host2", "host2");
       slaveAndRackManager.checkOffer(host2Offer);
@@ -445,7 +445,7 @@ public class SingularityMesosOfferSchedulerTest extends SingularitySchedulerTest
   }
 
   private long mbToBytes(long memMb) {
-    return memMb * 1000L * 1000L;
+    return memMb * SingularitySlaveUsage.BYTES_PER_MEGABYTE;
   }
 
   private SingularitySlaveUsageWithCalculatedScores getUsage(long memMbReserved, long memMbTotal, double cpusReserved, double cpusTotal, long diskMbReserved, long diskMbTotal, Map<ResourceUsageType, Number> longRunningTasksUsage) {

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosOfferSchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosOfferSchedulerTest.java
@@ -418,7 +418,6 @@ public class SingularityMesosOfferSchedulerTest extends SingularitySchedulerTest
 
       requestResource.scale(requestId, new SingularityScaleRequest(Optional.of(3), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional
           .absent()), SingularityUser.DEFAULT_USER);
-      System.out.println(usageManager.getRequestUtilizations());
 
       Assert.assertEquals(3.0, usageManager.getRequestUtilizations().get(requestId).getCpuUsed(), 0.001);
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityUsageTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityUsageTest.java
@@ -140,7 +140,7 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
     String host = slaveManager.getObjects().get(0).getHost();
 
     MesosTaskMonitorObject t1u1 = getTaskMonitor(t1, 2, 5, 100);
-    MesosTaskMonitorObject t2u1 = getTaskMonitor(t2, 10, 5, 1000);
+    MesosTaskMonitorObject t2u1 = getTaskMonitor(t2, 10, 5, 1024);
 
     mesosClient.setSlaveResourceUsage(host, Arrays.asList(t1u1, t2u1));
 
@@ -171,7 +171,7 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
     Thread.sleep(2);
 
     MesosTaskMonitorObject t1u3 = getTaskMonitor(t1, 8, 11, 125);
-    MesosTaskMonitorObject t2u3 = getTaskMonitor(t2, 23.5, 11, 1000);
+    MesosTaskMonitorObject t2u3 = getTaskMonitor(t2, 23.5, 11, 1024);
 
     mesosClient.setSlaveResourceUsage(host, Arrays.asList(t1u3, t2u3));
 
@@ -188,10 +188,10 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
     Assert.assertEquals(23.5, usageManager.getTaskUsage(t2).get(1).getCpuSeconds(), 0);
 
     Assert.assertEquals(875, usageManager.getSlaveUsage(slaveId).get(0).getMemoryBytesUsed(), 0);
-    Assert.assertEquals(1125, usageManager.getSlaveUsage(slaveId).get(1).getMemoryBytesUsed(), 0);
+    Assert.assertEquals(1149, usageManager.getSlaveUsage(slaveId).get(1).getMemoryBytesUsed(), 0);
 
     Assert.assertEquals(slaveId, usageManager.getAllCurrentSlaveUsage().get(0).getSlaveId());
-    Assert.assertEquals(1125, usageManager.getAllCurrentSlaveUsage().get(0).getMemoryBytesUsed());
+    Assert.assertEquals(1149, usageManager.getAllCurrentSlaveUsage().get(0).getMemoryBytesUsed());
 
     List<SingularityTaskCurrentUsageWithId> taskCurrentUsages = usageManager.getTaskCurrentUsages(taskManager.getActiveTaskIds());
 
@@ -236,9 +236,9 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
     int taskUsages = usageManager.getTaskUsage(t1).size();
     testUtilization(utilization, 2, taskUsages, cpuReserved, memMbReserved,
         0, 1, 1,
-        0, 2, 175,
-        0, 2, 175,
-        0, 2, 175);
+        0, 2, 223,
+        0, 2, 223,
+        0, 2, 223);
 
     Assert.assertEquals(requestId, utilization.getMaxUnderUtilizedCpuRequestId());
     Assert.assertEquals(requestId, utilization.getMaxUnderUtilizedMemBytesRequestId());
@@ -258,7 +258,7 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
     String host = slaveManager.getObjects().get(0).getHost();
 
     // 2 cpus used
-    MesosTaskMonitorObject t1u1 = getTaskMonitor(t1, 10, getTimestampSeconds(taskId, 5), 1000);
+    MesosTaskMonitorObject t1u1 = getTaskMonitor(t1, 10, getTimestampSeconds(taskId, 5), 1024);
     mesosClient.setSlaveResourceUsage(host, Collections.singletonList(t1u1));
     usagePoller.runActionOnPoll();
 
@@ -274,9 +274,9 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
     int taskUsages = usageManager.getTaskUsage(t1).size();
     testUtilization(utilization, 2, taskUsages, cpuReserved, memMbReserved,
         0, 0, 1,
-        0, 0, 50,
-        0, 0, 50,
-        0, 0, 50);
+        0, 0, 86,
+        0, 0, 86,
+        0, 0, 86);
 
     Assert.assertEquals(requestId, utilization.getMaxUnderUtilizedMemBytesRequestId());
   }
@@ -285,7 +285,7 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
   public void itTracksOverusedCpuInClusterUtilization() {
     initRequest();
     double cpuReserved = 2;
-    double memMbReserved = .001;
+    double memMbReserved = .0009;
     initFirstDeployWithResources(cpuReserved, memMbReserved);
     saveAndSchedule(request.toBuilder().setInstances(Optional.of(1)));
     resourceOffers(1);
@@ -295,12 +295,12 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
     String host = slaveManager.getObjects().get(0).getHost();
 
     // 4 cpus used
-    MesosTaskMonitorObject t1u1 = getTaskMonitor(t1, 20, getTimestampSeconds(taskId, 5), 1000);
+    MesosTaskMonitorObject t1u1 = getTaskMonitor(t1, 20, getTimestampSeconds(taskId, 5), 1024);
     mesosClient.setSlaveResourceUsage(host, Collections.singletonList(t1u1));
     usagePoller.runActionOnPoll();
 
     // 4 cpus used
-    MesosTaskMonitorObject t1u2 = getTaskMonitor(t1, 40, getTimestampSeconds(taskId, 10), 1000);
+    MesosTaskMonitorObject t1u2 = getTaskMonitor(t1, 40, getTimestampSeconds(taskId, 10), 1024);
     mesosClient.setSlaveResourceUsage(host, Collections.singletonList(t1u2));
     usagePoller.runActionOnPoll();
 
@@ -373,7 +373,7 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
   public void itCorrectlyDeterminesResourcesReservedForRequestsWithMultipleTasks() {
     initRequest();
     double cpuReserved = 10;
-    double memMbReserved = .001;
+    double memMbReserved = .0009;
     initFirstDeployWithResources(cpuReserved, memMbReserved);
     saveAndSchedule(request.toBuilder().setInstances(Optional.of(2)));
     resourceOffers(1);
@@ -408,7 +408,7 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
 
     Assert.assertEquals(1, utilization.getRequestUtilizations().size());
     Assert.assertEquals(cpuReserved * (t1TaskUsages + t2TaskUsages), utilization.getRequestUtilizations().get(0).getCpuReserved(), 0);
-    Assert.assertEquals(memMbReserved * SingularitySlaveUsage.BYTES_PER_MEGABYTE * (t1TaskUsages + t2TaskUsages), utilization.getRequestUtilizations().get(0).getMemBytesReserved(), 0);
+    Assert.assertEquals(Math.round(memMbReserved * SingularitySlaveUsage.BYTES_PER_MEGABYTE * (t1TaskUsages + t2TaskUsages)), utilization.getRequestUtilizations().get(0).getMemBytesReserved(), 1);
   }
 
   @Test
@@ -527,11 +527,11 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
       statusUpdate(taskManager.getTask(taskId2).get(), TaskState.TASK_STARTING, Optional.of(taskId2.getStartedAt()));
       statusUpdate(taskManager.getTask(taskId3).get(), TaskState.TASK_STARTING, Optional.of(taskId3.getStartedAt()));
       // task 1 using 3 cpus
-      MesosTaskMonitorObject t1u1 = getTaskMonitor(t1, 15, TimeUnit.MILLISECONDS.toSeconds(taskId1.getStartedAt()) + 5, 1000);
+      MesosTaskMonitorObject t1u1 = getTaskMonitor(t1, 15, TimeUnit.MILLISECONDS.toSeconds(taskId1.getStartedAt()) + 5, 1024);
       // task 2 using 2 cpus
-      MesosTaskMonitorObject t2u1 = getTaskMonitor(t2, 10, TimeUnit.MILLISECONDS.toSeconds(taskId2.getStartedAt()) + 5, 1000);
+      MesosTaskMonitorObject t2u1 = getTaskMonitor(t2, 10, TimeUnit.MILLISECONDS.toSeconds(taskId2.getStartedAt()) + 5, 1024);
       // task 3 using 1 cpus
-      MesosTaskMonitorObject t3u1 = getTaskMonitor(t3, 5, TimeUnit.MILLISECONDS.toSeconds(taskId3.getStartedAt()) + 5, 1000);
+      MesosTaskMonitorObject t3u1 = getTaskMonitor(t3, 5, TimeUnit.MILLISECONDS.toSeconds(taskId3.getStartedAt()) + 5, 1024);
       mesosClient.setSlaveResourceUsage("host1", Arrays.asList(t1u1, t2u1, t3u1));
       mesosClient.setSlaveMetricsSnapshot(
           "host1",
@@ -569,9 +569,9 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
       statusUpdate(taskManager.getTask(taskId1).get(), TaskState.TASK_STARTING, Optional.of(taskId1.getStartedAt()));
       statusUpdate(taskManager.getTask(taskId2).get(), TaskState.TASK_STARTING, Optional.of(taskId2.getStartedAt()));
       // task 1 using 3 cpus
-      MesosTaskMonitorObject t1u1 = getTaskMonitor(t1, 15, TimeUnit.MILLISECONDS.toSeconds(taskId1.getStartedAt()) + 5, 1000);
+      MesosTaskMonitorObject t1u1 = getTaskMonitor(t1, 15, TimeUnit.MILLISECONDS.toSeconds(taskId1.getStartedAt()) + 5, 1024);
       // task 2 using 2 cpus
-      MesosTaskMonitorObject t2u1 = getTaskMonitor(t2, 10, TimeUnit.MILLISECONDS.toSeconds(taskId2.getStartedAt()) + 5, 1000);
+      MesosTaskMonitorObject t2u1 = getTaskMonitor(t2, 10, TimeUnit.MILLISECONDS.toSeconds(taskId2.getStartedAt()) + 5, 1024);
       mesosClient.setSlaveResourceUsage("host1", Arrays.asList(t1u1, t2u1));
       mesosClient.setSlaveMetricsSnapshot(
           "host1",
@@ -626,7 +626,7 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
 
     Assert.assertEquals("Expected 1 request", 1, utilization.getRequestUtilizations().size());
     Assert.assertEquals("Incorrect cpu reserved", cpuReserved * actualTaskUsages, utilization.getRequestUtilizations().get(0).getCpuReserved(), 0);
-    Assert.assertEquals("Incorrect mem reserved", memMbReserved * SingularitySlaveUsage.BYTES_PER_MEGABYTE * actualTaskUsages, utilization.getRequestUtilizations().get(0).getMemBytesReserved(), 0);
+    Assert.assertEquals("Incorrect mem reserved", memMbReserved * SingularitySlaveUsage.BYTES_PER_MEGABYTE * actualTaskUsages, utilization.getRequestUtilizations().get(0).getMemBytesReserved(), 0.5);
 
     Assert.assertEquals(expectedRequestsWithOverUtilizedCpu, utilization.getNumRequestsWithOverUtilizedCpu());
     Assert.assertEquals(expectedRequestsWithUnderUtilizedCpu, utilization.getNumRequestsWithUnderUtilizedCpu());


### PR DESCRIPTION
This adds a new strategy for offer scoring that will additionally take into account:
- the max historical recorded usage for all active tasks currently on a slave
- the system load if it is higher than the predicted maximum
- the estimated max usage of tasks about to be added to the host

It also makes the free/used resource weights for long/non-long running tasks configurable in the yaml