### PR TITLE
Catch exceptions in offer scoring

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/async/AsyncSemaphore.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/async/AsyncSemaphore.java
@@ -210,7 +210,7 @@ public class AsyncSemaphore<T> {
     }
   }
 
-  int getQueueSize() {
+  public int getQueueSize() {
     long stamp = stampedLock.tryOptimisticRead();
     int queueSize = requestQueue.size();
     if (!stampedLock.validate(stamp)) {
@@ -224,7 +224,7 @@ public class AsyncSemaphore<T> {
     return queueSize;
   }
 
-  int getConcurrentRequests() {
+  public int getConcurrentRequests() {
     return concurrentRequests.get();
   }
 }


### PR DESCRIPTION
We are seeing a few instances where we are getting stuck on the `allOf(...).join()`. Best guess is that async semaphore isn't completing properly for this case. This adds exception handling within each future, setting a reference to the throwable that will then be thrown back up, causing singularity to abort (as it would normally do for uncaught exceptions in scoring). This isn't a fix for the underlying bug yet, but I'm hoping this can tease out the root cause of the exception, since we are currently swallowing these exceptions

cc @baconmania 