### PR TITLE
Enable framework auth over http api

### DIFF
--- a/Docs/reference/configuration.md
+++ b/Docs/reference/configuration.md
@@ -162,14 +162,15 @@ These settings should live under the "mesos" field inside the root configuration
 #### Framework ####
 | Parameter | Default | Description | Type |
 |-----------|---------|-------------|------|
-| master | null | A comma separated list of mesos master `host:port` | string |
-| frameworkName | null | | string |
-| frameworkId | null | | string |
+| master | null | A comma separated list of mesos master `host:port` | String |
+| mesosUsername | | Username to authenticate with the mesos master when using basic auth | String |
+| mesosPassword | | Password to authenticate with the mesos master when using basic auth | String |
+| frameworkName | null | | String |
+| frameworkId | null | | String |
 | frameworkFailoverTimeout | 0.0 | | double |
 | frameworkRole | null | Specify framework's desired role when Singularity registers with the master | String |
 | checkpoint | true | | boolean |
-| credentialPrincipal | | Enable framework auth by setting both this and credentialSecret | String |
-| credentialSecret | | Enable framework auth by setting both this and credentialPrincipal | String |
+| credentialPrincipal | | Used to enable authorization based on the authenticated principal | String |
 
 #### Resource Limits ####
 | Parameter | Default | Description | Type |

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/MesosConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/MesosConfiguration.java
@@ -13,6 +13,8 @@ public class MesosConfiguration {
   @NotNull
   private String master;
   @NotNull
+  private String masterProtocol = "http";
+  @NotNull
   private String frameworkName;
   @NotNull
   private String frameworkId;
@@ -51,7 +53,8 @@ public class MesosConfiguration {
   private int maxDiskMbPerRequest = 3000000;
 
   private Optional<String> credentialPrincipal = Optional.absent();
-  private Optional<String> credentialSecret = Optional.absent();
+  private Optional<String> mesosUsername = Optional.absent();
+  private Optional<String> mesosPassword = Optional.absent();
 
   private long rxEventBufferSize = 10000;
   private int statusUpdateConcurrencyLimit = 500;
@@ -140,6 +143,14 @@ public class MesosConfiguration {
     return master;
   }
 
+  public String getMasterProtocol() {
+    return masterProtocol;
+  }
+
+  public void setMasterProtocol(String masterProtocol) {
+    this.masterProtocol = masterProtocol;
+  }
+
   public String getFrameworkId() {
     return frameworkId;
   }
@@ -224,12 +235,20 @@ public class MesosConfiguration {
     this.credentialPrincipal = credentialPrincipal;
   }
 
-  public Optional<String> getCredentialSecret() {
-    return credentialSecret;
+  public Optional<String> getMesosUsername() {
+    return mesosUsername;
   }
 
-  public void setCredentialSecret(Optional<String> credentialSecret) {
-    this.credentialSecret = credentialSecret;
+  public void setMesosUsername(Optional<String> mesosUsername) {
+    this.mesosUsername = mesosUsername;
+  }
+
+  public Optional<String> getMesosPassword() {
+    return mesosPassword;
+  }
+
+  public void setMesosPassword(Optional<String> mesosPassword) {
+    this.mesosPassword = mesosPassword;
   }
 
   public int getDefaultDisk() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerClient.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerClient.java
@@ -119,6 +119,10 @@ public class SingularityMesosSchedulerClient {
         .setId(FrameworkID.newBuilder().setValue(mesosConfiguration.getFrameworkId()))
         .setUser(mesosConfiguration.getFrameworkUser()); // https://issues.apache.org/jira/browse/MESOS-3747
 
+    if (configuration.getMesosConfiguration().getCredentialPrincipal().isPresent()) {
+      frameworkInfoBuilder.setPrincipal(configuration.getMesosConfiguration().getCredentialPrincipal().get());
+    }
+
     if (configuration.getHostname().isPresent()) {
       frameworkInfoBuilder.setHostname(configuration.getHostname().get());
     }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
@@ -369,10 +369,10 @@ public class SingularityMesosSchedulerImpl extends SingularityMesosScheduler {
     List<String> masters = Arrays.asList(mesosConfiguration.getMaster().split(","));
     String masterUrl;
     if (mesosConfiguration.getMesosUsername().isPresent() && mesosConfiguration.getMesosPassword().isPresent()) {
-      masterUrl = String.format(SCHEDULER_API_URL_FORMAT, mesosConfiguration.getMasterProtocol(), masters.get(new Random().nextInt(masters.size())));
-    } else {
       masterUrl = String.format(SCHEDULER_API_URL_CREDENTIALS_FORMAT, mesosConfiguration.getMasterProtocol(), mesosConfiguration.getMesosUsername().get(),
           mesosConfiguration.getMesosPassword().get(), masters.get(new Random().nextInt(masters.size())));
+    } else {
+      masterUrl = String.format(SCHEDULER_API_URL_FORMAT, mesosConfiguration.getMasterProtocol(), masters.get(new Random().nextInt(masters.size())));
     }
     mesosSchedulerClient.subscribe(masterUrl, this);
   }


### PR DESCRIPTION
We were missing a few extra things to authenticate over the http api as compared with the older scheduler driver. mesos rxjava looks like it only supports [basic auth](https://github.com/mesosphere/mesos-rxjava/blob/master/mesos-rxjava-client/src/main/java/com/mesosphere/mesos/rx/java/MesosClient.java#L422-L423) at the moment, so that is now wired up to the `mesosUsername` and `mesosPassword` parameters. `credentialPrincipal` is wired up properly to FrameworkInfo for those that want to use it for authorization as well.