### PR TITLE
Fixed a logging statement

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityDeployHealthHelper.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityDeployHealthHelper.java
@@ -154,8 +154,9 @@ public class SingularityDeployHealthHelper {
     Optional<SingularityTaskHistoryUpdate> runningUpdate = SingularityTaskHistoryUpdate.getUpdate(updates, ExtendedTaskState.TASK_RUNNING);
     long taskDuration = System.currentTimeMillis() - runningUpdate.get().getTimestamp();
 
-    if (taskDuration < TimeUnit.SECONDS.toMillis(runningThreshold)) {
-      LOG.debug("Task {} has been running for {}, has not yet reached running threshold of {}", taskId, JavaUtils.durationFromMillis(taskDuration), JavaUtils.durationFromMillis(runningThreshold));
+    long runningThresholdMillis = TimeUnit.SECONDS.toMillis(runningThreshold);
+    if (taskDuration < runningThresholdMillis) {
+      LOG.debug("Task {} has been running for {}, has not yet reached running threshold of {}", taskId, JavaUtils.durationFromMillis(taskDuration), JavaUtils.durationFromMillis(runningThresholdMillis));
       return false;
     }
     return true;


### PR DESCRIPTION
```
DEBUG [2018-03-21 14:56:31,242] com.hubspot.singularity.scheduler.SingularityDeployHealthHelper: Task task-1-1521644025943-1-10.38.0.0-DEFAULT has been running for 00:27.903, has not yet reached running threshold of 00:00.030
```
`00:00.030` looks wrong. should've been `00:30.000` instead.