### PR TITLE
Sort tasks to shuffle by overusage, not usage

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -1,5 +1,6 @@
 package com.hubspot.singularity.config;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -80,6 +81,8 @@ public class SingularityConfiguration extends Configuration {
   private int maxTasksToShuffleTotal = 6; // Do not allow more than this many shuffle cleanups at once cluster-wide
 
   private int maxTasksToShufflePerHost = 2;
+
+  private List<String> doNotShuffleRequests = new ArrayList<>();
 
   private long cleanUsageEveryMillis = TimeUnit.MINUTES.toMillis(5);
 
@@ -1506,6 +1509,14 @@ public class SingularityConfiguration extends Configuration {
 
   public void setMaxTasksToShuffleTotal(int maxTasksToShuffleTotal) {
     this.maxTasksToShuffleTotal = maxTasksToShuffleTotal;
+  }
+
+  public List<String> getDoNotShuffleRequests() {
+    return doNotShuffleRequests;
+  }
+
+  public void setDoNotShuffleRequests(List<String> doNotShuffleRequests) {
+    this.doNotShuffleRequests = doNotShuffleRequests;
   }
 
   public long getCleanUsageEveryMillis() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
@@ -219,7 +219,7 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
           }
 
           if (configuration.isShuffleTasksForOverloadedSlaves() && currentUsage != null && currentUsage.getCpusUsed() > 0) {
-            if (isLongRunning(task)) {
+            if (isLongRunning(task) && !configuration.getDoNotShuffleRequests().contains(task.getRequestId())) {
               Optional<SingularityTaskHistoryUpdate> maybeCleanupUpdate = taskManager.getTaskHistoryUpdate(task, ExtendedTaskState.TASK_CLEANING);
               if (maybeCleanupUpdate.isPresent() && isTaskAlreadyCleanedUpForShuffle(maybeCleanupUpdate.get())) {
                 LOG.trace("Task {} already being cleaned up to spread cpu usage, skipping", taskId);

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityUsageTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityUsageTest.java
@@ -511,7 +511,7 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
       configuration.setShuffleTasksForOverloadedSlaves(true);
 
       initRequest();
-      initFirstDeploy();
+      initFirstDeployWithResources(configuration.getMesosConfiguration().getDefaultCpus(), configuration.getMesosConfiguration().getDefaultMemory());
       saveAndSchedule(requestManager.getRequest(requestId).get().getRequest().toBuilder().setInstances(Optional.of(3)));
       resourceOffers(1);
       SingularitySlaveUsage highUsage = new SingularitySlaveUsage(15, 10, Optional.of(10.0), 1, 1, Optional.of(30L), 1, 1, Optional.of(1024L), Collections.emptyMap(), 1, System.currentTimeMillis(), 1, 30000, 10, 15, 15, 15, 0, 107374182);
@@ -556,7 +556,7 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
       configuration.setMaxTasksToShuffleTotal(1);
 
       initRequest();
-      initFirstDeploy();
+      initFirstDeployWithResources(configuration.getMesosConfiguration().getDefaultCpus(), configuration.getMesosConfiguration().getDefaultMemory());
       saveAndSchedule(requestManager.getRequest(requestId).get().getRequest().toBuilder().setInstances(Optional.of(3)));
       resourceOffers(1);
       SingularitySlaveUsage highUsage = new SingularitySlaveUsage(15, 10, Optional.of(10.0), 1, 1, Optional.of(30L), 1, 1, Optional.of(1024L), Collections.emptyMap(), 1, System.currentTimeMillis(), 1, 30000, 10, 15, 15, 15, 0, 107374182);


### PR DESCRIPTION
This updates the choice of which task to shuffle to focus on those that are using far more than their requested resources. For example, a worker that requested 1 resource and is using 2 will be chosen over another worker that requested 10 and is using 11.