### PR TITLE
Support SSE S3 in SingularityUploader

### DIFF
--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskLogManager.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskLogManager.java
@@ -255,7 +255,7 @@ public class SingularityExecutorTaskLogManager {
     }
 
     S3UploadMetadata s3UploadMetadata = new S3UploadMetadata(pathToS3Directory.toString(), globForS3Files, s3UploaderBucket, getS3KeyPattern(s3KeyPattern.or(taskDefinition.getExecutorData().getS3UploaderKeyPattern())), finished, Optional.<String> absent(),
-        Optional. absent(), Optional. absent(), Optional. absent(), Optional. absent(), s3StorageClass, applyS3StorageClassAfterBytes, Optional.of(finished), Optional.of(checkSubdirectories), Optional.absent(), Collections.emptyMap(), Optional.absent(), Optional.absent());
+        Optional. absent(), Optional. absent(), Optional. absent(), Optional. absent(), s3StorageClass, applyS3StorageClassAfterBytes, Optional.of(finished), Optional.of(checkSubdirectories), Optional.absent(), Collections.emptyMap(), Optional.absent(), Optional.absent(), Optional.absent());
 
     String s3UploadMetadataFileName = String.format("%s-%s%s", taskDefinition.getTaskId(), filenameHint, baseConfiguration.getS3UploaderMetadataSuffix());
 

--- a/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/shared/S3UploadMetadata.java
+++ b/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/shared/S3UploadMetadata.java
@@ -60,6 +60,7 @@ public class S3UploadMetadata {
   private final Map<String, Object> gcsCredentials;
   private final Optional<String> gcsStorageClass;
   private final Optional<String> encryptionKey;
+  private final Optional<Boolean> encryptionS3;
 
   @JsonCreator
   public S3UploadMetadata(@JsonProperty("directory") String directory,
@@ -79,7 +80,8 @@ public class S3UploadMetadata {
                           @JsonProperty("uploaderType") Optional<SingularityUploaderType> uploaderType,
                           @JsonProperty("gcsCredentials") Map<String, Object> gcsCredentials,
                           @JsonProperty("gcsStorageClass") Optional<String> gcsStorageClass,
-                          @JsonProperty("encryptionKey") Optional<String> encryptionKey) {
+                          @JsonProperty("encryptionKey") Optional<String> encryptionKey,
+                          @JsonProperty("encryptionS3") Optional<Boolean> encryptionS3) {
     Preconditions.checkNotNull(directory);
     Preconditions.checkNotNull(fileGlob);
     Preconditions.checkNotNull(s3Bucket);
@@ -103,6 +105,7 @@ public class S3UploadMetadata {
     this.gcsCredentials = gcsCredentials != null ? gcsCredentials : Collections.emptyMap();
     this.gcsStorageClass = gcsStorageClass;
     this.encryptionKey = encryptionKey;
+    this.encryptionS3 = encryptionS3;
   }
 
 
@@ -217,6 +220,10 @@ public class S3UploadMetadata {
     return encryptionKey;
   }
 
+  public boolean isS3ServerSideEncryption() {
+    return encryptionS3.or(false);
+  }
+
   @JsonIgnore
   public boolean isImmediate() {
     return uploadImmediately.or(false);
@@ -242,6 +249,7 @@ public class S3UploadMetadata {
         ", uploaderType=" + uploaderType +
         ", gcsStorageClass=" + gcsStorageClass +
         ", encryptionKey=" + encryptionKey +
+        ", encryptionS3=" + encryptionS3 +
         '}';
   }
 }

--- a/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/shared/S3UploadMetadata.java
+++ b/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/shared/S3UploadMetadata.java
@@ -60,7 +60,7 @@ public class S3UploadMetadata {
   private final Map<String, Object> gcsCredentials;
   private final Optional<String> gcsStorageClass;
   private final Optional<String> encryptionKey;
-  private final Optional<Boolean> encryptionS3;
+  private final Optional<Boolean> s3ServerSideEncryption;
 
   @JsonCreator
   public S3UploadMetadata(@JsonProperty("directory") String directory,
@@ -81,7 +81,7 @@ public class S3UploadMetadata {
                           @JsonProperty("gcsCredentials") Map<String, Object> gcsCredentials,
                           @JsonProperty("gcsStorageClass") Optional<String> gcsStorageClass,
                           @JsonProperty("encryptionKey") Optional<String> encryptionKey,
-                          @JsonProperty("encryptionS3") Optional<Boolean> encryptionS3) {
+                          @JsonProperty("s3ServerSideEncryption") Optional<Boolean> s3ServerSideEncryption) {
     Preconditions.checkNotNull(directory);
     Preconditions.checkNotNull(fileGlob);
     Preconditions.checkNotNull(s3Bucket);
@@ -105,7 +105,7 @@ public class S3UploadMetadata {
     this.gcsCredentials = gcsCredentials != null ? gcsCredentials : Collections.emptyMap();
     this.gcsStorageClass = gcsStorageClass;
     this.encryptionKey = encryptionKey;
-    this.encryptionS3 = encryptionS3;
+    this.s3ServerSideEncryption = s3ServerSideEncryption;
   }
 
 
@@ -221,7 +221,7 @@ public class S3UploadMetadata {
   }
 
   public boolean isS3ServerSideEncryption() {
-    return encryptionS3.or(false);
+    return s3ServerSideEncryption.or(false);
   }
 
   @JsonIgnore
@@ -249,7 +249,7 @@ public class S3UploadMetadata {
         ", uploaderType=" + uploaderType +
         ", gcsStorageClass=" + gcsStorageClass +
         ", encryptionKey=" + encryptionKey +
-        ", encryptionS3=" + encryptionS3 +
+        ", s3ServerSideEncryption=" + s3ServerSideEncryption +
         '}';
   }
 }

--- a/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/shared/S3UploadMetadata.java
+++ b/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/shared/S3UploadMetadata.java
@@ -220,7 +220,7 @@ public class S3UploadMetadata {
     return encryptionKey;
   }
 
-  public boolean getUseS3ServerSideEncryption() {
+  public boolean isUseS3ServerSideEncryption() {
     return useS3ServerSideEncryption.or(false);
   }
 

--- a/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/shared/S3UploadMetadata.java
+++ b/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/shared/S3UploadMetadata.java
@@ -60,7 +60,7 @@ public class S3UploadMetadata {
   private final Map<String, Object> gcsCredentials;
   private final Optional<String> gcsStorageClass;
   private final Optional<String> encryptionKey;
-  private final Optional<Boolean> s3ServerSideEncryption;
+  private final Optional<Boolean> useS3ServerSideEncryption;
 
   @JsonCreator
   public S3UploadMetadata(@JsonProperty("directory") String directory,
@@ -81,7 +81,7 @@ public class S3UploadMetadata {
                           @JsonProperty("gcsCredentials") Map<String, Object> gcsCredentials,
                           @JsonProperty("gcsStorageClass") Optional<String> gcsStorageClass,
                           @JsonProperty("encryptionKey") Optional<String> encryptionKey,
-                          @JsonProperty("s3ServerSideEncryption") Optional<Boolean> s3ServerSideEncryption) {
+                          @JsonProperty("useS3ServerSideEncryption") Optional<Boolean> useS3ServerSideEncryption) {
     Preconditions.checkNotNull(directory);
     Preconditions.checkNotNull(fileGlob);
     Preconditions.checkNotNull(s3Bucket);
@@ -105,7 +105,7 @@ public class S3UploadMetadata {
     this.gcsCredentials = gcsCredentials != null ? gcsCredentials : Collections.emptyMap();
     this.gcsStorageClass = gcsStorageClass;
     this.encryptionKey = encryptionKey;
-    this.s3ServerSideEncryption = s3ServerSideEncryption;
+    this.useS3ServerSideEncryption = useS3ServerSideEncryption;
   }
 
 
@@ -220,8 +220,8 @@ public class S3UploadMetadata {
     return encryptionKey;
   }
 
-  public boolean isS3ServerSideEncryption() {
-    return s3ServerSideEncryption.or(false);
+  public boolean getUseS3ServerSideEncryption() {
+    return useS3ServerSideEncryption.or(false);
   }
 
   @JsonIgnore
@@ -249,7 +249,7 @@ public class S3UploadMetadata {
         ", uploaderType=" + uploaderType +
         ", gcsStorageClass=" + gcsStorageClass +
         ", encryptionKey=" + encryptionKey +
-        ", s3ServerSideEncryption=" + s3ServerSideEncryption +
+        ", useS3ServerSideEncryption=" + useS3ServerSideEncryption +
         '}';
   }
 }

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3Uploader.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3Uploader.java
@@ -112,7 +112,7 @@ public class SingularityS3Uploader extends SingularityUploader {
         if (fileSizeBytes > configuration.getMaxSingleUploadSizeBytes()) {
           multipartUpload(key, file.toFile(), objectMetadata, maybeStorageClass);
         } else {
-          if (uploadMetadata.isS3ServerSideEncryption()) {
+          if (uploadMetadata.getUseS3ServerSideEncryption()) {
             objectMetadata.setSSEAlgorithm(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
           }
           PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, key, file.toFile()).withMetadata(objectMetadata);

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3Uploader.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3Uploader.java
@@ -112,6 +112,9 @@ public class SingularityS3Uploader extends SingularityUploader {
         if (fileSizeBytes > configuration.getMaxSingleUploadSizeBytes()) {
           multipartUpload(key, file.toFile(), objectMetadata, maybeStorageClass);
         } else {
+          if (uploadMetadata.isS3ServerSideEncryption()) {
+            objectMetadata.setSSEAlgorithm(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
+          }
           PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, key, file.toFile()).withMetadata(objectMetadata);
           if (maybeStorageClass.isPresent()) {
             putObjectRequest.setStorageClass(maybeStorageClass.get());

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3Uploader.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3Uploader.java
@@ -112,7 +112,7 @@ public class SingularityS3Uploader extends SingularityUploader {
         if (fileSizeBytes > configuration.getMaxSingleUploadSizeBytes()) {
           multipartUpload(key, file.toFile(), objectMetadata, maybeStorageClass);
         } else {
-          if (uploadMetadata.getUseS3ServerSideEncryption()) {
+          if (uploadMetadata.isUseS3ServerSideEncryption()) {
             objectMetadata.setSSEAlgorithm(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
           }
           PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, key, file.toFile()).withMetadata(objectMetadata);


### PR DESCRIPTION
- This enables a flag to turn on the SSE-S3 which transparently encrypts the data on the server side and is managed by S3.
https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html

- We've tested the object metadata flag to make it indeeds sets SSE-S3 when we inspect the uploaded object on S3. This follows the S3 java-sdk documentation.
https://docs.aws.amazon.com/AmazonS3/latest/dev/SSEUsingJavaSDK.html

- I am unfamiliar with the naming convention for the JSON Values so open to change it to something more suitable for our convention so far.

@baconmania @ssalinas 