### PR TITLE
Periodically flush the queue to make sure batch work does not get stuck

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/async/AsyncSemaphore.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/async/AsyncSemaphore.java
@@ -16,6 +16,8 @@ import java.util.function.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * AsyncSemaphore guarantees that at most N executions
  * of an underlying completablefuture exeuction are occuring
@@ -226,6 +228,7 @@ public class AsyncSemaphore<T> {
       return responseFuture;
     }
 
+    @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION") // https://github.com/findbugsproject/findbugs/issues/79
     private CompletableFuture<Void> execute() {
       if (!EXECUTED_UPDATER.compareAndSet(this, 0, 1)) {
         return CompletableFuture.completedFuture(null);

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
@@ -120,7 +120,7 @@ public class SingularityMesosOfferScheduler {
     this.normalizedDiskFreeWeight = getNormalizedWeight(ResourceUsageType.DISK_BYTES_FREE, configuration);
     this.normalizedDiskUsedWeight = getNormalizedWeight(ResourceUsageType.DISK_BYTES_USED, configuration);
 
-    this.offerScoringSemaphore = AsyncSemaphore.newBuilder(mesosConfiguration::getOffersConcurrencyLimit).build();
+    this.offerScoringSemaphore = AsyncSemaphore.newBuilder(mesosConfiguration::getOffersConcurrencyLimit).setFlushQueuePeriodically(true).build();
     this.offerScoringExecutor = Executors.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat("offer-scoring-%d").build());
   }
 


### PR DESCRIPTION
Also adds better polling of the queue when reusing permits.

@baconmania @pschoenfelder 