### PR TITLE
Add an optional cpu hard limit

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/deploy/ExecutorData.java
+++ b/SingularityBase/src/main/java/com/hubspot/deploy/ExecutorData.java
@@ -33,6 +33,7 @@ public class ExecutorData {
   private final Optional<Boolean> skipLogrotateAndCompress;
   private final Optional<List<S3ArtifactSignature>> s3ArtifactSignatures;
   private final Optional<SingularityExecutorLogrotateFrequency> logrotateFrequency;
+  private final Optional<Integer> cpuHardLimit;
 
   @JsonCreator
   public ExecutorData(@JsonProperty("cmd") String cmd, @JsonProperty("embeddedArtifacts") List<EmbeddedArtifact> embeddedArtifacts, @JsonProperty("externalArtifacts") List<ExternalArtifact> externalArtifacts,
@@ -41,7 +42,7 @@ public class ExecutorData {
       @JsonProperty("loggingExtraFields") Map<String, String> loggingExtraFields, @JsonProperty("sigKillProcessesAfterMillis") Optional<Long> sigKillProcessesAfterMillis,
       @JsonProperty("maxTaskThreads") Optional<Integer> maxTaskThreads, @JsonProperty("preserveTaskSandboxAfterFinish") Optional<Boolean> preserveTaskSandboxAfterFinish, @JsonProperty("maxOpenFiles") Optional<Integer> maxOpenFiles,
       @JsonProperty("skipLogrotateAndCompress") Optional<Boolean> skipLogrotateAndCompress, @JsonProperty("s3ArtifactSignatures") Optional<List<S3ArtifactSignature>> s3ArtifactSignatures,
-      @JsonProperty("logrotateFrequency") Optional<SingularityExecutorLogrotateFrequency> logrotateFrequency) {
+      @JsonProperty("logrotateFrequency") Optional<SingularityExecutorLogrotateFrequency> logrotateFrequency, @JsonProperty("cpuHardLimit") Optional<Integer> cpuHardLimit) {
     this.cmd = cmd;
     this.embeddedArtifacts = JavaUtils.nonNullImmutable(embeddedArtifacts);
     this.externalArtifacts = JavaUtils.nonNullImmutable(externalArtifacts);
@@ -59,11 +60,13 @@ public class ExecutorData {
     this.skipLogrotateAndCompress = skipLogrotateAndCompress;
     this.s3ArtifactSignatures = s3ArtifactSignatures;
     this.logrotateFrequency = logrotateFrequency;
+    this.cpuHardLimit = cpuHardLimit;
   }
 
   public ExecutorDataBuilder toBuilder() {
     return new ExecutorDataBuilder(cmd, embeddedArtifacts, externalArtifacts, s3Artifacts, successfulExitCodes, runningSentinel, user, extraCmdLineArgs, loggingTag,
-        loggingExtraFields, sigKillProcessesAfterMillis, maxTaskThreads, preserveTaskSandboxAfterFinish, maxOpenFiles, skipLogrotateAndCompress, s3ArtifactSignatures, logrotateFrequency);
+        loggingExtraFields, sigKillProcessesAfterMillis, maxTaskThreads, preserveTaskSandboxAfterFinish, maxOpenFiles, skipLogrotateAndCompress, s3ArtifactSignatures,
+        logrotateFrequency, cpuHardLimit);
   }
 
   @ApiModelProperty(required=true, value="Command for the custom executor to run")
@@ -154,6 +157,11 @@ public class ExecutorData {
   @ApiModelProperty(required=false, value="Run logrotate this often. Can be HOURLY, DAILY, WEEKLY, MONTHLY")
   public Optional<SingularityExecutorLogrotateFrequency> getLogrotateFrequency() {
     return logrotateFrequency;
+  }
+
+  @ApiModelProperty(required = false, value = "An optional hard limit for cpu. If set this will be used to set the cgroup cpu.cfs_quota_us")
+  public Optional<Integer> getCpuHardLimit() {
+    return cpuHardLimit;
   }
 
   @Override

--- a/SingularityBase/src/main/java/com/hubspot/deploy/ExecutorData.java
+++ b/SingularityBase/src/main/java/com/hubspot/deploy/ExecutorData.java
@@ -33,7 +33,6 @@ public class ExecutorData {
   private final Optional<Boolean> skipLogrotateAndCompress;
   private final Optional<List<S3ArtifactSignature>> s3ArtifactSignatures;
   private final Optional<SingularityExecutorLogrotateFrequency> logrotateFrequency;
-  private final Optional<Integer> cpuHardLimit;
 
   @JsonCreator
   public ExecutorData(@JsonProperty("cmd") String cmd, @JsonProperty("embeddedArtifacts") List<EmbeddedArtifact> embeddedArtifacts, @JsonProperty("externalArtifacts") List<ExternalArtifact> externalArtifacts,
@@ -42,7 +41,7 @@ public class ExecutorData {
       @JsonProperty("loggingExtraFields") Map<String, String> loggingExtraFields, @JsonProperty("sigKillProcessesAfterMillis") Optional<Long> sigKillProcessesAfterMillis,
       @JsonProperty("maxTaskThreads") Optional<Integer> maxTaskThreads, @JsonProperty("preserveTaskSandboxAfterFinish") Optional<Boolean> preserveTaskSandboxAfterFinish, @JsonProperty("maxOpenFiles") Optional<Integer> maxOpenFiles,
       @JsonProperty("skipLogrotateAndCompress") Optional<Boolean> skipLogrotateAndCompress, @JsonProperty("s3ArtifactSignatures") Optional<List<S3ArtifactSignature>> s3ArtifactSignatures,
-      @JsonProperty("logrotateFrequency") Optional<SingularityExecutorLogrotateFrequency> logrotateFrequency, @JsonProperty("cpuHardLimit") Optional<Integer> cpuHardLimit) {
+      @JsonProperty("logrotateFrequency") Optional<SingularityExecutorLogrotateFrequency> logrotateFrequency) {
     this.cmd = cmd;
     this.embeddedArtifacts = JavaUtils.nonNullImmutable(embeddedArtifacts);
     this.externalArtifacts = JavaUtils.nonNullImmutable(externalArtifacts);
@@ -60,13 +59,12 @@ public class ExecutorData {
     this.skipLogrotateAndCompress = skipLogrotateAndCompress;
     this.s3ArtifactSignatures = s3ArtifactSignatures;
     this.logrotateFrequency = logrotateFrequency;
-    this.cpuHardLimit = cpuHardLimit;
   }
 
   public ExecutorDataBuilder toBuilder() {
     return new ExecutorDataBuilder(cmd, embeddedArtifacts, externalArtifacts, s3Artifacts, successfulExitCodes, runningSentinel, user, extraCmdLineArgs, loggingTag,
         loggingExtraFields, sigKillProcessesAfterMillis, maxTaskThreads, preserveTaskSandboxAfterFinish, maxOpenFiles, skipLogrotateAndCompress, s3ArtifactSignatures,
-        logrotateFrequency, cpuHardLimit);
+        logrotateFrequency);
   }
 
   @ApiModelProperty(required=true, value="Command for the custom executor to run")
@@ -157,11 +155,6 @@ public class ExecutorData {
   @ApiModelProperty(required=false, value="Run logrotate this often. Can be HOURLY, DAILY, WEEKLY, MONTHLY")
   public Optional<SingularityExecutorLogrotateFrequency> getLogrotateFrequency() {
     return logrotateFrequency;
-  }
-
-  @ApiModelProperty(required = false, value = "An optional hard limit for cpu. If set this will be used to set the cgroup cpu.cfs_quota_us")
-  public Optional<Integer> getCpuHardLimit() {
-    return cpuHardLimit;
   }
 
   @Override

--- a/SingularityBase/src/main/java/com/hubspot/deploy/ExecutorDataBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/deploy/ExecutorDataBuilder.java
@@ -25,13 +25,12 @@ public class ExecutorDataBuilder {
   private Optional<Boolean> skipLogrotateAndCompress;
   private Optional<List<S3ArtifactSignature>> s3ArtifactSignatures;
   private Optional<SingularityExecutorLogrotateFrequency> logrotateFrequency;
-  private Optional<Integer> cpuHardLimit;
 
   public ExecutorDataBuilder(String cmd, List<EmbeddedArtifact> embeddedArtifacts, List<ExternalArtifact> externalArtifacts, List<S3Artifact> s3Artifacts, List<Integer> successfulExitCodes,
       Optional<String> runningSentinel, Optional<String> user, List<String> extraCmdLineArgs, Optional<String> loggingTag, Map<String, String> loggingExtraFields,
       Optional<Long> sigKillProcessesAfterMillis, Optional<Integer> maxTaskThreads, Optional<Boolean> preserveTaskSandboxAfterFinish,
       Optional<Integer> maxOpenFiles, Optional<Boolean> skipLogrotateAndCompress, Optional<List<S3ArtifactSignature>> s3ArtifactSignatures,
-      Optional<SingularityExecutorLogrotateFrequency> logrotateFrequency, Optional<Integer> cpuHardLimit) {
+      Optional<SingularityExecutorLogrotateFrequency> logrotateFrequency) {
     this.cmd = cmd;
     this.embeddedArtifacts = embeddedArtifacts;
     this.externalArtifacts = externalArtifacts;
@@ -49,7 +48,6 @@ public class ExecutorDataBuilder {
     this.skipLogrotateAndCompress = skipLogrotateAndCompress;
     this.s3ArtifactSignatures = s3ArtifactSignatures;
     this.logrotateFrequency = logrotateFrequency;
-    this.cpuHardLimit = cpuHardLimit;
   }
 
   public ExecutorDataBuilder() {
@@ -58,7 +56,7 @@ public class ExecutorDataBuilder {
 
   public ExecutorData build() {
     return new ExecutorData(cmd, embeddedArtifacts, externalArtifacts, s3Artifacts, successfulExitCodes, user, runningSentinel, extraCmdLineArgs, loggingTag, loggingExtraFields,
-        sigKillProcessesAfterMillis, maxTaskThreads, preserveTaskSandboxAfterFinish, maxOpenFiles, skipLogrotateAndCompress, s3ArtifactSignatures, logrotateFrequency, cpuHardLimit);
+        sigKillProcessesAfterMillis, maxTaskThreads, preserveTaskSandboxAfterFinish, maxOpenFiles, skipLogrotateAndCompress, s3ArtifactSignatures, logrotateFrequency);
   }
 
   public Optional<String> getLoggingTag() {
@@ -214,15 +212,6 @@ public class ExecutorDataBuilder {
     return this;
   }
 
-  public Optional<Integer> getCpuHardLimit() {
-    return cpuHardLimit;
-  }
-
-  public ExecutorDataBuilder setCpuHardLimit(Optional<Integer> cpuHardLimit) {
-    this.cpuHardLimit = cpuHardLimit;
-    return this;
-  }
-
   @Override
   public String toString() {
     return "ExecutorDataBuilder{" +
@@ -243,7 +232,6 @@ public class ExecutorDataBuilder {
         ", skipLogrotateAndCompress=" + skipLogrotateAndCompress +
         ", s3ArtifactSignatures=" + s3ArtifactSignatures +
         ", logrotateFrequency=" + logrotateFrequency +
-        ", cpuHardLimit=" + cpuHardLimit +
         '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/deploy/ExecutorDataBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/deploy/ExecutorDataBuilder.java
@@ -25,11 +25,13 @@ public class ExecutorDataBuilder {
   private Optional<Boolean> skipLogrotateAndCompress;
   private Optional<List<S3ArtifactSignature>> s3ArtifactSignatures;
   private Optional<SingularityExecutorLogrotateFrequency> logrotateFrequency;
+  private Optional<Integer> cpuHardLimit;
 
   public ExecutorDataBuilder(String cmd, List<EmbeddedArtifact> embeddedArtifacts, List<ExternalArtifact> externalArtifacts, List<S3Artifact> s3Artifacts, List<Integer> successfulExitCodes,
       Optional<String> runningSentinel, Optional<String> user, List<String> extraCmdLineArgs, Optional<String> loggingTag, Map<String, String> loggingExtraFields,
       Optional<Long> sigKillProcessesAfterMillis, Optional<Integer> maxTaskThreads, Optional<Boolean> preserveTaskSandboxAfterFinish,
-      Optional<Integer> maxOpenFiles, Optional<Boolean> skipLogrotateAndCompress, Optional<List<S3ArtifactSignature>> s3ArtifactSignatures, Optional<SingularityExecutorLogrotateFrequency> logrotateFrequency) {
+      Optional<Integer> maxOpenFiles, Optional<Boolean> skipLogrotateAndCompress, Optional<List<S3ArtifactSignature>> s3ArtifactSignatures,
+      Optional<SingularityExecutorLogrotateFrequency> logrotateFrequency, Optional<Integer> cpuHardLimit) {
     this.cmd = cmd;
     this.embeddedArtifacts = embeddedArtifacts;
     this.externalArtifacts = externalArtifacts;
@@ -47,6 +49,7 @@ public class ExecutorDataBuilder {
     this.skipLogrotateAndCompress = skipLogrotateAndCompress;
     this.s3ArtifactSignatures = s3ArtifactSignatures;
     this.logrotateFrequency = logrotateFrequency;
+    this.cpuHardLimit = cpuHardLimit;
   }
 
   public ExecutorDataBuilder() {
@@ -55,7 +58,7 @@ public class ExecutorDataBuilder {
 
   public ExecutorData build() {
     return new ExecutorData(cmd, embeddedArtifacts, externalArtifacts, s3Artifacts, successfulExitCodes, user, runningSentinel, extraCmdLineArgs, loggingTag, loggingExtraFields,
-        sigKillProcessesAfterMillis, maxTaskThreads, preserveTaskSandboxAfterFinish, maxOpenFiles, skipLogrotateAndCompress, s3ArtifactSignatures, logrotateFrequency);
+        sigKillProcessesAfterMillis, maxTaskThreads, preserveTaskSandboxAfterFinish, maxOpenFiles, skipLogrotateAndCompress, s3ArtifactSignatures, logrotateFrequency, cpuHardLimit);
   }
 
   public Optional<String> getLoggingTag() {
@@ -211,6 +214,15 @@ public class ExecutorDataBuilder {
     return this;
   }
 
+  public Optional<Integer> getCpuHardLimit() {
+    return cpuHardLimit;
+  }
+
+  public ExecutorDataBuilder setCpuHardLimit(Optional<Integer> cpuHardLimit) {
+    this.cpuHardLimit = cpuHardLimit;
+    return this;
+  }
+
   @Override
   public String toString() {
     return "ExecutorDataBuilder{" +
@@ -231,6 +243,7 @@ public class ExecutorDataBuilder {
         ", skipLogrotateAndCompress=" + skipLogrotateAndCompress +
         ", s3ArtifactSignatures=" + s3ArtifactSignatures +
         ", logrotateFrequency=" + logrotateFrequency +
+        ", cpuHardLimit=" + cpuHardLimit +
         '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosTaskStatisticsObject.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/json/MesosTaskStatisticsObject.java
@@ -18,7 +18,7 @@ public class MesosTaskStatisticsObject {
   private final long memTotalBytes;
   private final long diskLimitBytes;
   private final long diskUsedBytes;
-  private final double timestampSeconds;
+  private final double timestamp;
 
   @JsonCreator
   public MesosTaskStatisticsObject(@JsonProperty("cpus_limit") int cpusLimit,
@@ -35,7 +35,7 @@ public class MesosTaskStatisticsObject {
                                    @JsonProperty("mem_total_bytes") long memTotalBytes,
                                    @JsonProperty("disk_limit_bytes") long diskLimitBytes,
                                    @JsonProperty("disk_used_bytes") long diskUsedBytes,
-                                   @JsonProperty("timestamp") double timestampSeconds) {
+                                   @JsonProperty("timestamp") double timestamp) {
     this.cpusLimit = cpusLimit;
     this.cpusNrPeriods = cpusNrPeriods;
     this.cpusNrThrottled = cpusNrThrottled;
@@ -50,7 +50,7 @@ public class MesosTaskStatisticsObject {
     this.memTotalBytes = memTotalBytes;
     this.diskLimitBytes = diskLimitBytes;
     this.diskUsedBytes = diskUsedBytes;
-    this.timestampSeconds = timestampSeconds;
+    this.timestamp = timestamp;
   }
 
   public int getCpusLimit() {
@@ -109,8 +109,8 @@ public class MesosTaskStatisticsObject {
     return diskUsedBytes;
   }
 
-  public double getTimestampSeconds() {
-    return timestampSeconds;
+  public double getTimestamp() {
+    return timestamp;
   }
 
   @Override
@@ -128,7 +128,7 @@ public class MesosTaskStatisticsObject {
         ", memMappedFileBytes=" + memMappedFileBytes +
         ", memRssBytes=" + memRssBytes +
         ", memTotalBytes=" + memTotalBytes +
-        ", timestampSeconds=" + timestampSeconds +
+        ", timestamp=" + timestamp +
         '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/RequestUtilization.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/RequestUtilization.java
@@ -24,6 +24,7 @@ public class RequestUtilization {
   private long minDiskBytesUsed = 0;
 
   private double cpuBurstRating = 0;
+  private double percentCpuTimeThrottledForAllTasks = 0;
 
   @JsonCreator
   public RequestUtilization(@JsonProperty("requestId") String requestId,
@@ -60,6 +61,11 @@ public class RequestUtilization {
 
   public RequestUtilization addDiskBytesReserved(long diskBytes) {
     this.diskBytesReserved += diskBytes;
+    return this;
+  }
+
+  public RequestUtilization addPercentCpuTimeThrottled(double percentCpuTimeThrottled) {
+    this.percentCpuTimeThrottledForAllTasks += percentCpuTimeThrottled;
     return this;
   }
 
@@ -114,6 +120,10 @@ public class RequestUtilization {
   @JsonIgnore
   public double getAvgDiskBytesUsed() {
     return diskBytesUsed / (double) numTasks;
+  }
+
+  public double getAvgPercentCpuTimeThrottled() {
+    return percentCpuTimeThrottledForAllTasks / numTasks;
   }
 
   public String getDeployId() {

--- a/SingularityBase/src/main/java/com/hubspot/singularity/RequestUtilization.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/RequestUtilization.java
@@ -24,7 +24,10 @@ public class RequestUtilization {
   private long minDiskBytesUsed = 0;
 
   private double cpuBurstRating = 0;
-  private double percentCpuTimeThrottledForAllTasks = 0;
+
+  private double percentCpuTimeThrottled = 0;
+  private double maxPercentCpuTimeThrottled = 0;
+  private double minPercentCpuTimeThrottled = 0;
 
   @JsonCreator
   public RequestUtilization(@JsonProperty("requestId") String requestId,
@@ -65,7 +68,7 @@ public class RequestUtilization {
   }
 
   public RequestUtilization addPercentCpuTimeThrottled(double percentCpuTimeThrottled) {
-    this.percentCpuTimeThrottledForAllTasks += percentCpuTimeThrottled;
+    this.percentCpuTimeThrottled += percentCpuTimeThrottled;
     return this;
   }
 
@@ -98,6 +101,10 @@ public class RequestUtilization {
     return diskBytesReserved;
   }
 
+  public double getPercentCpuTimeThrottled() {
+    return percentCpuTimeThrottled;
+  }
+
   public int getNumTasks() {
     return numTasks;
   }
@@ -122,8 +129,9 @@ public class RequestUtilization {
     return diskBytesUsed / (double) numTasks;
   }
 
+  @JsonIgnore
   public double getAvgPercentCpuTimeThrottled() {
-    return percentCpuTimeThrottledForAllTasks / numTasks;
+    return percentCpuTimeThrottled / numTasks;
   }
 
   public String getDeployId() {
@@ -193,6 +201,24 @@ public class RequestUtilization {
     return this;
   }
 
+  public double getMaxPercentCpuTimeThrottled() {
+    return maxPercentCpuTimeThrottled;
+  }
+
+  public RequestUtilization setMaxPercentCpuTimeThrottled(double maxPercentCpuTimeThrottled) {
+    this.maxPercentCpuTimeThrottled = maxPercentCpuTimeThrottled;
+    return this;
+  }
+
+  public double getMinPercentCpuTimeThrottled() {
+    return minPercentCpuTimeThrottled;
+  }
+
+  public RequestUtilization setMinPercentCpuTimeThrottled(double minPercentCpuTimeThrottled) {
+    this.minPercentCpuTimeThrottled = minPercentCpuTimeThrottled;
+    return this;
+  }
+
   @Override
   public String toString() {
     return "RequestUtilization{" +
@@ -212,6 +238,9 @@ public class RequestUtilization {
         ", maxDiskBytesUsed=" + maxDiskBytesUsed +
         ", minDiskBytesUsed=" + minDiskBytesUsed +
         ", cpuBurstRating=" + cpuBurstRating +
+        ", percentCpuTimeThrottled=" + percentCpuTimeThrottled +
+        ", maxPercentCpuTimeThrottled=" + maxPercentCpuTimeThrottled +
+        ", minPercentCpuTimeThrottled=" + minPercentCpuTimeThrottled +
         '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/RequestUtilization.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/RequestUtilization.java
@@ -17,17 +17,25 @@ public class RequestUtilization {
   private int numTasks = 0;
 
   private long maxMemBytesUsed = 0;
+  private double maxMemTimestamp = 0;
   private long minMemBytesUsed = Long.MAX_VALUE;
+  private double minMemTimestamp = 0;
   private double maxCpuUsed = 0;
+  private double maxCpusTimestamp = 0;
   private double minCpuUsed = Double.MAX_VALUE;
+  private double minCpusTimestamp = 0;
   private long maxDiskBytesUsed = 0;
-  private long minDiskBytesUsed = 0;
+  private double maxDiskTimestamp = 0;
+  private long minDiskBytesUsed = Long.MAX_VALUE;
+  private double minDiskTimestamp = 0;
 
   private double cpuBurstRating = 0;
 
   private double percentCpuTimeThrottled = 0;
   private double maxPercentCpuTimeThrottled = 0;
-  private double minPercentCpuTimeThrottled = 0;
+  private double maxCpuThrottledTimestamp = 0;
+  private double minPercentCpuTimeThrottled = Double.MAX_VALUE;
+  private double minCpuThrottledTimestamp = 0;
 
   @JsonCreator
   public RequestUtilization(@JsonProperty("requestId") String requestId,
@@ -216,6 +224,78 @@ public class RequestUtilization {
 
   public RequestUtilization setMinPercentCpuTimeThrottled(double minPercentCpuTimeThrottled) {
     this.minPercentCpuTimeThrottled = minPercentCpuTimeThrottled;
+    return this;
+  }
+
+  public double getMaxMemTimestamp() {
+    return maxMemTimestamp;
+  }
+
+  public RequestUtilization setMaxMemTimestamp(double maxMemTimestamp) {
+    this.maxMemTimestamp = maxMemTimestamp;
+    return this;
+  }
+
+  public double getMinMemTimestamp() {
+    return minMemTimestamp;
+  }
+
+  public RequestUtilization setMinMemTimestamp(double minMemTimestamp) {
+    this.minMemTimestamp = minMemTimestamp;
+    return this;
+  }
+
+  public double getMaxCpusTimestamp() {
+    return maxCpusTimestamp;
+  }
+
+  public RequestUtilization setMaxCpusTimestamp(double maxCpusTimestamp) {
+    this.maxCpusTimestamp = maxCpusTimestamp;
+    return this;
+  }
+
+  public double getMinCpusTimestamp() {
+    return minCpusTimestamp;
+  }
+
+  public RequestUtilization setMinCpusTimestamp(double minCpusTimestamp) {
+    this.minCpusTimestamp = minCpusTimestamp;
+    return this;
+  }
+
+  public double getMaxDiskTimestamp() {
+    return maxDiskTimestamp;
+  }
+
+  public RequestUtilization setMaxDiskTimestamp(double maxDiskTimestamp) {
+    this.maxDiskTimestamp = maxDiskTimestamp;
+    return this;
+  }
+
+  public double getMinDiskTimestamp() {
+    return minDiskTimestamp;
+  }
+
+  public RequestUtilization setMinDiskTimestamp(double minDiskTimestamp) {
+    this.minDiskTimestamp = minDiskTimestamp;
+    return this;
+  }
+
+  public double getMaxCpuThrottledTimestamp() {
+    return maxCpuThrottledTimestamp;
+  }
+
+  public RequestUtilization setMaxCpuThrottledTimestamp(double maxCpuThrottledTimestamp) {
+    this.maxCpuThrottledTimestamp = maxCpuThrottledTimestamp;
+    return this;
+  }
+
+  public double getMinCpuThrottledTimestamp() {
+    return minCpuThrottledTimestamp;
+  }
+
+  public RequestUtilization setMinCpuThrottledTimestamp(double minCpuThrottledTimestamp) {
+    this.minCpuThrottledTimestamp = minCpuThrottledTimestamp;
     return this;
   }
 

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityClusterUtilization.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityClusterUtilization.java
@@ -1,13 +1,9 @@
 package com.hubspot.singularity;
 
-import java.util.List;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class SingularityClusterUtilization {
-  private final List<RequestUtilization> requestUtilizations;
-
   private final int numRequestsWithUnderUtilizedCpu;
   private final int numRequestsWithOverUtilizedCpu;
   private final int numRequestsWithUnderUtilizedMemBytes;
@@ -50,8 +46,7 @@ public class SingularityClusterUtilization {
   private final long timestamp;
 
   @JsonCreator
-  public SingularityClusterUtilization(@JsonProperty("requestUtilizations") List<RequestUtilization> requestUtilizations,
-                                       @JsonProperty("numRequestsWithUnderUtilizedCpu") int numRequestsWithUnderUtilizedCpu,
+  public SingularityClusterUtilization(@JsonProperty("numRequestsWithUnderUtilizedCpu") int numRequestsWithUnderUtilizedCpu,
                                        @JsonProperty("numRequestsWithOverUtilizedCpu") int numRequestsWithOverUtilizedCpu,
                                        @JsonProperty("numRequestsWithUnderUtilizedMemBytes") int numRequestsWithUnderUtilizedMemBytes,
                                        @JsonProperty("numRequestsWithUnderUtilizedDiskBytes") int numRequestsWithUnderUtilizedDiskBytes,
@@ -82,7 +77,6 @@ public class SingularityClusterUtilization {
                                        @JsonProperty("totalCpuUsed") double totalCpuUsed,
                                        @JsonProperty("totalCpuAvailable") double totalCpuAvailable,
                                        @JsonProperty("timestamp") long timestamp) {
-    this.requestUtilizations = requestUtilizations;
     this.numRequestsWithUnderUtilizedCpu = numRequestsWithUnderUtilizedCpu;
     this.numRequestsWithOverUtilizedCpu = numRequestsWithOverUtilizedCpu;
     this.numRequestsWithUnderUtilizedMemBytes = numRequestsWithUnderUtilizedMemBytes;
@@ -114,10 +108,6 @@ public class SingularityClusterUtilization {
     this.totalCpuUsed = totalCpuUsed;
     this.totalCpuAvailable = totalCpuAvailable;
     this.timestamp = timestamp;
-  }
-
-  public List<RequestUtilization> getRequestUtilizations() {
-    return requestUtilizations;
   }
 
   public int getNumRequestsWithUnderUtilizedCpu() {
@@ -247,7 +237,6 @@ public class SingularityClusterUtilization {
   @Override
   public String toString() {
     return "SingularityClusterUtilization [" +
-        ", requestUtilizations=" + requestUtilizations +
         ", numRequestsWithUnderUtilizedCpu=" + numRequestsWithUnderUtilizedCpu +
         ", numRequestsWithOverUtilizedCpu=" + numRequestsWithOverUtilizedCpu +
         ", numRequestsWithUnderUtilizedMemBytes=" + numRequestsWithUnderUtilizedMemBytes +

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskExecutorData.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskExecutorData.java
@@ -22,9 +22,10 @@ public class SingularityTaskExecutorData extends ExecutorData {
   private final Optional<String> requestGroup;
   private final Optional<String> s3StorageClass;
   private final Optional<Long> applyS3StorageClassAfterBytes;
+  private final Optional<Integer> cpuHardLimit;
 
   public SingularityTaskExecutorData(ExecutorData executorData, List<SingularityS3UploaderFile> s3UploaderAdditionalFiles, String defaultS3Bucket, String s3UploaderKeyPattern,
-       String serviceLog, String serviceFinishedTailLog, Optional<String> requestGroup, Optional<String> s3StorageClass, Optional<Long> applyS3StorageClassAfterBytes) {
+       String serviceLog, String serviceFinishedTailLog, Optional<String> requestGroup, Optional<String> s3StorageClass, Optional<Long> applyS3StorageClassAfterBytes, Optional<Integer> cpuHardLimit) {
     this(executorData.getCmd(),
         executorData.getEmbeddedArtifacts(),
         executorData.getExternalArtifacts(),
@@ -42,7 +43,6 @@ public class SingularityTaskExecutorData extends ExecutorData {
         executorData.getSkipLogrotateAndCompress(),
         executorData.getS3ArtifactSignatures(),
         executorData.getLogrotateFrequency(),
-        executorData.getCpuHardLimit(),
         s3UploaderAdditionalFiles,
         defaultS3Bucket,
         s3UploaderKeyPattern,
@@ -50,7 +50,8 @@ public class SingularityTaskExecutorData extends ExecutorData {
         serviceFinishedTailLog,
         requestGroup,
         s3StorageClass,
-        applyS3StorageClassAfterBytes);
+        applyS3StorageClassAfterBytes,
+        cpuHardLimit);
   }
 
   @JsonCreator
@@ -71,7 +72,6 @@ public class SingularityTaskExecutorData extends ExecutorData {
                                      @JsonProperty("skipLogrotateAndCompress") Optional<Boolean> skipLogrotateAndCompress,
                                      @JsonProperty("s3ArtifactSignatures") Optional<List<S3ArtifactSignature>> s3ArtifactSignatures,
                                      @JsonProperty("logrotateFrequency") Optional<SingularityExecutorLogrotateFrequency> logrotateFrequency,
-                                     @JsonProperty("cpuHardLimit") Optional<Integer> cpuHardLimit,
                                      @JsonProperty("s3UploaderAdditionalFiles") List<SingularityS3UploaderFile> s3UploaderAdditionalFiles,
                                      @JsonProperty("defaultS3Bucket") String defaultS3Bucket,
                                      @JsonProperty("s3UploaderKeyPattern") String s3UploaderKeyPattern,
@@ -79,9 +79,10 @@ public class SingularityTaskExecutorData extends ExecutorData {
                                      @JsonProperty("serviceFinishedTailLog") String serviceFinishedTailLog,
                                      @JsonProperty("requestGroup")  Optional<String> requestGroup,
                                      @JsonProperty("s3StorageClass") Optional<String> s3StorageClass,
-                                     @JsonProperty("applyS3StorageClassAfterBytes") Optional<Long> applyS3StorageClassAfterBytes) {
+                                     @JsonProperty("applyS3StorageClassAfterBytes") Optional<Long> applyS3StorageClassAfterBytes,
+                                     @JsonProperty("cpuHardLimit") Optional<Integer> cpuHardLimit) {
     super(cmd, embeddedArtifacts, externalArtifacts, s3Artifacts, successfulExitCodes, user, runningSentinel, extraCmdLineArgs, loggingTag, loggingExtraFields,
-        sigKillProcessesAfterMillis, maxTaskThreads, preserveTaskSandboxAfterFinish, maxOpenFiles, skipLogrotateAndCompress, s3ArtifactSignatures, logrotateFrequency, cpuHardLimit);
+        sigKillProcessesAfterMillis, maxTaskThreads, preserveTaskSandboxAfterFinish, maxOpenFiles, skipLogrotateAndCompress, s3ArtifactSignatures, logrotateFrequency);
     this.s3UploaderAdditionalFiles = s3UploaderAdditionalFiles;
     this.defaultS3Bucket = defaultS3Bucket;
     this.s3UploaderKeyPattern = s3UploaderKeyPattern;
@@ -90,6 +91,7 @@ public class SingularityTaskExecutorData extends ExecutorData {
     this.requestGroup = requestGroup;
     this.s3StorageClass = s3StorageClass;
     this.applyS3StorageClassAfterBytes = applyS3StorageClassAfterBytes;
+    this.cpuHardLimit = cpuHardLimit;
   }
 
   public List<SingularityS3UploaderFile> getS3UploaderAdditionalFiles() {
@@ -124,6 +126,10 @@ public class SingularityTaskExecutorData extends ExecutorData {
     return applyS3StorageClassAfterBytes;
   }
 
+  public Optional<Integer> getCpuHardLimit() {
+    return cpuHardLimit;
+  }
+
   @Override
   public String toString() {
     return "SingularityTaskExecutorData{" +
@@ -135,6 +141,7 @@ public class SingularityTaskExecutorData extends ExecutorData {
         ", requestGroup=" + requestGroup +
         ", s3StorageClass=" + s3StorageClass +
         ", applyS3StorageClassAfterBytes=" + applyS3StorageClassAfterBytes +
+        ", cpuHardLimit=" + cpuHardLimit +
         "} " + super.toString();
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskExecutorData.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskExecutorData.java
@@ -42,6 +42,7 @@ public class SingularityTaskExecutorData extends ExecutorData {
         executorData.getSkipLogrotateAndCompress(),
         executorData.getS3ArtifactSignatures(),
         executorData.getLogrotateFrequency(),
+        executorData.getCpuHardLimit(),
         s3UploaderAdditionalFiles,
         defaultS3Bucket,
         s3UploaderKeyPattern,
@@ -70,6 +71,7 @@ public class SingularityTaskExecutorData extends ExecutorData {
                                      @JsonProperty("skipLogrotateAndCompress") Optional<Boolean> skipLogrotateAndCompress,
                                      @JsonProperty("s3ArtifactSignatures") Optional<List<S3ArtifactSignature>> s3ArtifactSignatures,
                                      @JsonProperty("logrotateFrequency") Optional<SingularityExecutorLogrotateFrequency> logrotateFrequency,
+                                     @JsonProperty("cpuHardLimit") Optional<Integer> cpuHardLimit,
                                      @JsonProperty("s3UploaderAdditionalFiles") List<SingularityS3UploaderFile> s3UploaderAdditionalFiles,
                                      @JsonProperty("defaultS3Bucket") String defaultS3Bucket,
                                      @JsonProperty("s3UploaderKeyPattern") String s3UploaderKeyPattern,
@@ -79,7 +81,7 @@ public class SingularityTaskExecutorData extends ExecutorData {
                                      @JsonProperty("s3StorageClass") Optional<String> s3StorageClass,
                                      @JsonProperty("applyS3StorageClassAfterBytes") Optional<Long> applyS3StorageClassAfterBytes) {
     super(cmd, embeddedArtifacts, externalArtifacts, s3Artifacts, successfulExitCodes, user, runningSentinel, extraCmdLineArgs, loggingTag, loggingExtraFields,
-        sigKillProcessesAfterMillis, maxTaskThreads, preserveTaskSandboxAfterFinish, maxOpenFiles, skipLogrotateAndCompress, s3ArtifactSignatures, logrotateFrequency);
+        sigKillProcessesAfterMillis, maxTaskThreads, preserveTaskSandboxAfterFinish, maxOpenFiles, skipLogrotateAndCompress, s3ArtifactSignatures, logrotateFrequency, cpuHardLimit);
     this.s3UploaderAdditionalFiles = s3UploaderAdditionalFiles;
     this.defaultS3Bucket = defaultS3Bucket;
     this.s3UploaderKeyPattern = s3UploaderKeyPattern;

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskUsage.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskUsage.java
@@ -9,16 +9,25 @@ public class SingularityTaskUsage {
   private final double timestamp; // seconds
   private final double cpuSeconds;
   private final long diskTotalBytes;
+  private final long cpusNrPeriods;
+  private final long cpusNrThrottled;
+  private final double cpusThrottledTimeSecs;
 
   @JsonCreator
   public SingularityTaskUsage(@JsonProperty("memoryTotalBytes") long memoryTotalBytes,
                               @JsonProperty("timestamp") double timestamp,
                               @JsonProperty("cpuSeconds") double cpuSeconds,
-                              @JsonProperty("diskTotalBytes") long diskTotalBytes) {
+                              @JsonProperty("diskTotalBytes") long diskTotalBytes,
+                              @JsonProperty("cpusNrPeriods") long cpusNrPeriods,
+                              @JsonProperty("cpusNrThrottled") long cpusNrThrottled,
+                              @JsonProperty("cpusThrottledTimeSecs") double cpusThrottledTimeSecs) {
     this.memoryTotalBytes = memoryTotalBytes;
     this.timestamp = timestamp;
     this.cpuSeconds = cpuSeconds;
     this.diskTotalBytes = diskTotalBytes;
+    this.cpusNrPeriods = cpusNrPeriods;
+    this.cpusNrThrottled = cpusNrThrottled;
+    this.cpusThrottledTimeSecs = cpusThrottledTimeSecs;
   }
 
   public long getMemoryTotalBytes() {
@@ -37,9 +46,28 @@ public class SingularityTaskUsage {
     return diskTotalBytes;
   }
 
-  @Override
-  public String toString() {
-    return "SingularityTaskUsage [memoryTotalBytes=" + memoryTotalBytes + ", timestamp=" + timestamp + ", cpuSeconds=" + cpuSeconds + "]";
+  public long getCpusNrPeriods() {
+    return cpusNrPeriods;
   }
 
+  public long getCpusNrThrottled() {
+    return cpusNrThrottled;
+  }
+
+  public double getCpusThrottledTimeSecs() {
+    return cpusThrottledTimeSecs;
+  }
+
+  @Override
+  public String toString() {
+    return "SingularityTaskUsage{" +
+        "memoryTotalBytes=" + memoryTotalBytes +
+        ", timestamp=" + timestamp +
+        ", cpuSeconds=" + cpuSeconds +
+        ", diskTotalBytes=" + diskTotalBytes +
+        ", cpusNrPeriods=" + cpusNrPeriods +
+        ", cpusNrThrottled=" + cpusNrThrottled +
+        ", cpusThrottledTimeSecs=" + cpusThrottledTimeSecs +
+        '}';
+  }
 }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorCgroupCfsChecker.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorCgroupCfsChecker.java
@@ -17,6 +17,8 @@ import com.google.common.collect.ImmutableList;
 import com.hubspot.singularity.executor.task.SingularityExecutorTask;
 import com.hubspot.singularity.runner.base.shared.WatchServiceHelper;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 public class SingularityExecutorCgroupCfsChecker extends WatchServiceHelper {
   private static final Logger LOG = LoggerFactory.getLogger(SingularityExecutorCgroupCfsChecker.class);
 
@@ -46,6 +48,7 @@ public class SingularityExecutorCgroupCfsChecker extends WatchServiceHelper {
     throw new RuntimeException(String.format("Found no cpu cgroup from output %s", cgroups));
   }
 
+  @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
   private static String getBaseCgroupPath() {
     if (Files.isDirectory(Paths.get("/cgroup"))) {
       return "/cgroup";
@@ -60,9 +63,9 @@ public class SingularityExecutorCgroupCfsChecker extends WatchServiceHelper {
       if (filename.toString().endsWith(CGROUP_CFS_QUOTA_FILE)) {
         long cfsQuota = Long.parseLong(new String(Files.readAllBytes(filename), StandardCharsets.US_ASCII));
         if (cfsQuota != desiredCfsQuota) {
-          FileOutputStream overwriteFileStream = new FileOutputStream(filename.toFile(), false);
-          overwriteFileStream.write(Long.toString(desiredCfsQuota).getBytes(StandardCharsets.US_ASCII));
-          overwriteFileStream.close();
+          try (FileOutputStream overwriteFileStream = new FileOutputStream(filename.toFile(), false)) {
+            overwriteFileStream.write(Long.toString(desiredCfsQuota).getBytes(StandardCharsets.US_ASCII));
+          }
           LOG.info("Updated cfsQuota from {} to {} for task {}", cfsQuota, desiredCfsQuota, taskId);
         }
       }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorCgroupCfsChecker.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorCgroupCfsChecker.java
@@ -41,8 +41,9 @@ public class SingularityExecutorCgroupCfsChecker extends WatchServiceHelper {
     for (String cgroup : cgroups) {
       if (cgroup.contains(":cpu:")) {
         String[] segments = cgroup.split(":");
-        String cgroupPath = segments[segments.length - 1];
-        return Paths.get(getBaseCgroupPath() + cgroupPath);
+        String cgroupPath = getBaseCgroupPath() + segments[segments.length - 1];
+        LOG.info("Will start watcher for directory {}", cgroupPath);
+        return Paths.get(cgroupPath);
       }
     }
     throw new RuntimeException(String.format("Found no cpu cgroup from output %s", cgroups));

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorCgroupCfsChecker.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorCgroupCfsChecker.java
@@ -62,18 +62,20 @@ public class SingularityExecutorCgroupCfsChecker extends WatchServiceHelper {
   public boolean processEvent(WatchEvent.Kind<?> kind, Path filename) throws IOException {
     try {
       if (filename.toString().endsWith(CGROUP_CFS_QUOTA_FILE)) {
-        long cfsQuota = Long.parseLong(new String(Files.readAllBytes(filename), StandardCharsets.US_ASCII));
+        Path fullPath = getWatchDirectory().resolve(filename);
+        long cfsQuota = Long.parseLong(new String(Files.readAllBytes(fullPath), StandardCharsets.US_ASCII));
         if (cfsQuota != desiredCfsQuota) {
-          try (FileOutputStream overwriteFileStream = new FileOutputStream(filename.toFile(), false)) {
+          try (FileOutputStream overwriteFileStream = new FileOutputStream(fullPath.toFile(), false)) {
             overwriteFileStream.write(Long.toString(desiredCfsQuota).getBytes(StandardCharsets.US_ASCII));
           }
           LOG.info("Updated cfsQuota from {} to {} for task {}", cfsQuota, desiredCfsQuota, taskId);
         }
       }
       if (filename.toString().endsWith(CGROUP_CFS_PERIOD_FILE)) {
-        long cfsPeriod = Long.parseLong(new String(Files.readAllBytes(filename), StandardCharsets.US_ASCII));
+        Path fullPath = getWatchDirectory().resolve(filename);
+        long cfsPeriod = Long.parseLong(new String(Files.readAllBytes(fullPath), StandardCharsets.US_ASCII));
         if (cfsPeriod != desiredCfsPeriod) {
-          try (FileOutputStream overwriteFileStream = new FileOutputStream(filename.toFile(), false)) {
+          try (FileOutputStream overwriteFileStream = new FileOutputStream(fullPath.toFile(), false)) {
             overwriteFileStream.write(Long.toString(desiredCfsPeriod).getBytes(StandardCharsets.US_ASCII));
           }
           LOG.info("Updated cfsPeriod from {} to {} for task {}", cfsPeriod, desiredCfsPeriod, taskId);

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorCgroupCfsChecker.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorCgroupCfsChecker.java
@@ -45,7 +45,7 @@ public class SingularityExecutorCgroupCfsChecker extends WatchServiceHelper {
     for (String cgroup : cgroups) {
       if (cgroup.contains(":cpu:")) {
         String[] segments = cgroup.split(":");
-        String cgroupPath = getBaseCgroupPath() + "/cpu" + segments[segments.length - 1];
+        String cgroupPath = getBaseCgroupPath() + segments[segments.length - 1];
         LOG.info("Will start watcher for directory {}", cgroupPath);
         return Paths.get(cgroupPath);
       }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorCgroupCfsChecker.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorCgroupCfsChecker.java
@@ -72,9 +72,9 @@ public class SingularityExecutorCgroupCfsChecker extends WatchServiceHelper {
       if (filename.toString().endsWith(CGROUP_CFS_PERIOD_FILE)) {
         long cfsPeriod = Long.parseLong(new String(Files.readAllBytes(filename), StandardCharsets.US_ASCII));
         if (cfsPeriod != desiredCfsPeriod) {
-          FileOutputStream overwriteFileStream = new FileOutputStream(filename.toFile(), false);
-          overwriteFileStream.write(Long.toString(desiredCfsPeriod).getBytes(StandardCharsets.US_ASCII));
-          overwriteFileStream.close();
+          try (FileOutputStream overwriteFileStream = new FileOutputStream(filename.toFile(), false)) {
+            overwriteFileStream.write(Long.toString(desiredCfsPeriod).getBytes(StandardCharsets.US_ASCII));
+          }
           LOG.info("Updated cfsPeriod from {} to {} for task {}", cfsPeriod, desiredCfsPeriod, taskId);
         }
       }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorCgroupCfsChecker.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorCgroupCfsChecker.java
@@ -15,12 +15,16 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
 import com.hubspot.singularity.executor.task.SingularityExecutorTask;
+import com.hubspot.singularity.runner.base.shared.ProcessFailedException;
+import com.hubspot.singularity.runner.base.shared.SimpleProcessManager;
 import com.hubspot.singularity.runner.base.shared.WatchServiceHelper;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class SingularityExecutorCgroupCfsChecker extends WatchServiceHelper {
   private static final Logger LOG = LoggerFactory.getLogger(SingularityExecutorCgroupCfsChecker.class);
+
+  private static final List<String> FIND_BASE_CGROUP_PATH_COMMAND = ImmutableList.of(
+      "findmnt", "--kernel", "--first-only", "--types", "cgroup", "--options", "cpu", "--noheadings", "--output", "TARGET"
+  );
 
   private static final String CGROUP_CFS_QUOTA_FILE = "cpu.cfs_quota_us";
   private static final String CGROUP_CFS_PERIOD_FILE = "cpu.cfs_period_us";
@@ -29,14 +33,14 @@ public class SingularityExecutorCgroupCfsChecker extends WatchServiceHelper {
   private final long desiredCfsQuota;
   private final long desiredCfsPeriod;
 
-  public SingularityExecutorCgroupCfsChecker(SingularityExecutorTask task, int cpuHardLimit, long desiredCfsPeriod) throws IOException {
+  public SingularityExecutorCgroupCfsChecker(SingularityExecutorTask task, int cpuHardLimit, long desiredCfsPeriod) throws IOException, InterruptedException, ProcessFailedException {
     super(1000, getCpuCgroupDirectory(task), ImmutableList.of(StandardWatchEventKinds.ENTRY_MODIFY));
     this.taskId = task.getTaskId();
     this.desiredCfsQuota = cpuHardLimit * desiredCfsPeriod;
     this.desiredCfsPeriod = desiredCfsPeriod;
   }
 
-  private static Path getCpuCgroupDirectory(SingularityExecutorTask task) throws IOException {
+  private static Path getCpuCgroupDirectory(SingularityExecutorTask task) throws IOException, InterruptedException, ProcessFailedException {
     List<String> cgroups = Files.readAllLines(Paths.get(String.format("/proc/%s/cgroup", task.getTaskDefinition().getExecutorPid())));
     for (String cgroup : cgroups) {
       if (cgroup.contains(":cpu:")) {
@@ -49,13 +53,9 @@ public class SingularityExecutorCgroupCfsChecker extends WatchServiceHelper {
     throw new RuntimeException(String.format("Found no cpu cgroup from output %s", cgroups));
   }
 
-  @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
-  private static String getBaseCgroupPath() {
-    if (Files.isDirectory(Paths.get("/cgroup"))) {
-      return "/cgroup";
-    } else {
-      return "/sys/fs/cgroup";
-    }
+  private static String getBaseCgroupPath() throws ProcessFailedException, InterruptedException {
+    SimpleProcessManager simpleProcessManager = new SimpleProcessManager(LOG);
+    return simpleProcessManager.runCommandWithOutput(FIND_BASE_CGROUP_PATH_COMMAND).get(0).trim();
   }
 
   @Override

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorCgroupCfsChecker.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorCgroupCfsChecker.java
@@ -1,0 +1,83 @@
+package com.hubspot.singularity.executor;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableList;
+import com.hubspot.singularity.executor.task.SingularityExecutorTask;
+import com.hubspot.singularity.runner.base.shared.WatchServiceHelper;
+
+public class SingularityExecutorCgroupCfsChecker extends WatchServiceHelper {
+  private static final Logger LOG = LoggerFactory.getLogger(SingularityExecutorCgroupCfsChecker.class);
+
+  private static final String CGROUP_CFS_QUOTA_FILE = "cpu.cfs_quota_us";
+  private static final String CGROUP_CFS_PERIOD_FILE = "cpu.cfs_period_us";
+
+  private final String taskId;
+  private final long desiredCfsQuota;
+  private final long desiredCfsPeriod;
+
+  public SingularityExecutorCgroupCfsChecker(SingularityExecutorTask task, int cpuHardLimit, long desiredCfsPeriod) throws IOException {
+    super(1000, getCpuCgroupDirectory(task), ImmutableList.of(StandardWatchEventKinds.ENTRY_MODIFY));
+    this.taskId = task.getTaskId();
+    this.desiredCfsQuota = cpuHardLimit * desiredCfsPeriod;
+    this.desiredCfsPeriod = desiredCfsPeriod;
+  }
+
+  private static Path getCpuCgroupDirectory(SingularityExecutorTask task) throws IOException {
+    List<String> cgroups = Files.readAllLines(Paths.get(String.format("/proc/%s/cgroup", task.getTaskDefinition().getExecutorPid())));
+    for (String cgroup : cgroups) {
+      if (cgroup.contains(":cpu:")) {
+        String[] segments = cgroup.split(":");
+        String cgroupPath = segments[segments.length - 1];
+        return Paths.get(getBaseCgroupPath() + cgroupPath);
+      }
+    }
+    throw new RuntimeException(String.format("Found no cpu cgroup from output %s", cgroups));
+  }
+
+  private static String getBaseCgroupPath() {
+    if (Files.isDirectory(Paths.get("/cgroup"))) {
+      return "/cgroup";
+    } else {
+      return "/sys/fs/cgroup";
+    }
+  }
+
+  @Override
+  public boolean processEvent(WatchEvent.Kind<?> kind, Path filename) throws IOException {
+    try {
+      if (filename.toString().endsWith(CGROUP_CFS_QUOTA_FILE)) {
+        long cfsQuota = Long.parseLong(new String(Files.readAllBytes(filename), StandardCharsets.US_ASCII));
+        if (cfsQuota != desiredCfsQuota) {
+          FileOutputStream overwriteFileStream = new FileOutputStream(filename.toFile(), false);
+          overwriteFileStream.write(Long.toString(desiredCfsQuota).getBytes(StandardCharsets.US_ASCII));
+          overwriteFileStream.close();
+          LOG.info("Updated cfsQuota from {} to {} for task {}", cfsQuota, desiredCfsQuota, taskId);
+        }
+      }
+      if (filename.toString().endsWith(CGROUP_CFS_PERIOD_FILE)) {
+        long cfsPeriod = Long.parseLong(new String(Files.readAllBytes(filename), StandardCharsets.US_ASCII));
+        if (cfsPeriod != desiredCfsPeriod) {
+          FileOutputStream overwriteFileStream = new FileOutputStream(filename.toFile(), false);
+          overwriteFileStream.write(Long.toString(desiredCfsPeriod).getBytes(StandardCharsets.US_ASCII));
+          overwriteFileStream.close();
+          LOG.info("Updated cfsPeriod from {} to {} for task {}", cfsPeriod, desiredCfsPeriod, taskId);
+        }
+      }
+    } catch (Throwable t) {
+      LOG.error("Unable to update cfs period/quota values for task {}",taskId, t);
+    }
+    return true;
+  }
+}

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorCgroupCfsChecker.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorCgroupCfsChecker.java
@@ -41,7 +41,7 @@ public class SingularityExecutorCgroupCfsChecker extends WatchServiceHelper {
     for (String cgroup : cgroups) {
       if (cgroup.contains(":cpu:")) {
         String[] segments = cgroup.split(":");
-        String cgroupPath = getBaseCgroupPath() + segments[segments.length - 1];
+        String cgroupPath = getBaseCgroupPath() + "/cpu" + segments[segments.length - 1];
         LOG.info("Will start watcher for directory {}", cgroupPath);
         return Paths.get(cgroupPath);
       }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorCgroupCfsChecker.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorCgroupCfsChecker.java
@@ -63,7 +63,7 @@ public class SingularityExecutorCgroupCfsChecker extends WatchServiceHelper {
     try {
       if (filename.toString().endsWith(CGROUP_CFS_QUOTA_FILE)) {
         Path fullPath = getWatchDirectory().resolve(filename);
-        long cfsQuota = Long.parseLong(new String(Files.readAllBytes(fullPath), StandardCharsets.US_ASCII));
+        long cfsQuota = Long.parseLong(new String(Files.readAllBytes(fullPath), StandardCharsets.US_ASCII).trim());
         if (cfsQuota != desiredCfsQuota) {
           try (FileOutputStream overwriteFileStream = new FileOutputStream(fullPath.toFile(), false)) {
             overwriteFileStream.write(Long.toString(desiredCfsQuota).getBytes(StandardCharsets.US_ASCII));
@@ -73,7 +73,7 @@ public class SingularityExecutorCgroupCfsChecker extends WatchServiceHelper {
       }
       if (filename.toString().endsWith(CGROUP_CFS_PERIOD_FILE)) {
         Path fullPath = getWatchDirectory().resolve(filename);
-        long cfsPeriod = Long.parseLong(new String(Files.readAllBytes(fullPath), StandardCharsets.US_ASCII));
+        long cfsPeriod = Long.parseLong(new String(Files.readAllBytes(fullPath), StandardCharsets.US_ASCII).trim());
         if (cfsPeriod != desiredCfsPeriod) {
           try (FileOutputStream overwriteFileStream = new FileOutputStream(fullPath.toFile(), false)) {
             overwriteFileStream.write(Long.toString(desiredCfsPeriod).getBytes(StandardCharsets.US_ASCII));

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorMonitor.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorMonitor.java
@@ -327,7 +327,9 @@ public class SingularityExecutorMonitor {
             SingularityTaskExecutorData taskExecutorData = (SingularityTaskExecutorData) task.getExecutorData();
             if (taskExecutorData.getCpuHardLimit().isPresent()) {
               try {
-                cgroupCheckers.put(task.getTaskId(), new SingularityExecutorCgroupCfsChecker(task, taskExecutorData.getCpuHardLimit().get(), configuration.getDefaultCfsPeriod()));
+                SingularityExecutorCgroupCfsChecker cfsChecker = new SingularityExecutorCgroupCfsChecker(task, taskExecutorData.getCpuHardLimit().get(), configuration.getDefaultCfsPeriod());
+                cfsChecker.watch();
+                cgroupCheckers.put(task.getTaskId(), cfsChecker);
               } catch (Throwable t) {
                 LOG.error("Could not start cgorup checker for task {}", task.getTaskId(), t);
               }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
@@ -222,6 +222,8 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
   @JsonProperty
   private boolean useFileAttributes = false;
 
+  private int defaultCfsPeriod = 100000;
+
   public SingularityExecutorConfiguration() {
     super(Optional.of("singularity-executor.log"));
   }
@@ -647,6 +649,15 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
     this.initialIdleExecutorShutdownWaitMillis = initialIdleExecutorShutdownWaitMillis;
   }
 
+  public int getDefaultCfsPeriod() {
+    return defaultCfsPeriod;
+  }
+
+  public SingularityExecutorConfiguration setDefaultCfsPeriod(int defaultCfsPeriod) {
+    this.defaultCfsPeriod = defaultCfsPeriod;
+    return this;
+  }
+
   @Override
   public String toString() {
     return "SingularityExecutorConfiguration{" +
@@ -701,6 +712,7 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
         ", logrotateFrequency=" + logrotateFrequency +
         ", cronDirectory='" + cronDirectory + '\'' +
         ", useFileAttributes=" + useFileAttributes +
+        ", defaultCfsPeriod=" + defaultCfsPeriod +
         "} " + super.toString();
   }
 }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/models/RunnerContext.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/models/RunnerContext.java
@@ -20,8 +20,23 @@ public class RunnerContext {
   private final Integer maxOpenFiles;
   private final String switchUserCommand;
   private final boolean useFileAttributes;
+  private final Integer cfsQuota;
+  private final Integer cfsPeriod;
 
-  public RunnerContext(String cmd, String taskAppDirectory, String logDir, String user, String logFile, String logFilePath, String taskId, Optional<Integer> maxTaskThreads, boolean shouldChangeUser, Integer maxOpenFiles, String switchUserCommand, boolean useFileAttributes) {
+  public RunnerContext(String cmd,
+                       String taskAppDirectory,
+                       String logDir,
+                       String user,
+                       String logFile,
+                       String logFilePath,
+                       String taskId,
+                       Optional<Integer> maxTaskThreads,
+                       boolean shouldChangeUser,
+                       Integer maxOpenFiles,
+                       String switchUserCommand,
+                       boolean useFileAttributes,
+                       Integer cfsQuota,
+                       Integer cfsPeriod) {
     this.cmd = cmd;
     this.taskAppDirectory = taskAppDirectory;
     this.logDir = logDir;
@@ -35,6 +50,8 @@ public class RunnerContext {
     this.maxOpenFiles = maxOpenFiles;
     this.switchUserCommand = switchUserCommand;
     this.useFileAttributes = useFileAttributes;
+    this.cfsQuota = cfsQuota;
+    this.cfsPeriod = cfsPeriod;
   }
 
   public String getCmd() {
@@ -85,21 +102,31 @@ public class RunnerContext {
     return useFileAttributes;
   }
 
+  public Integer getCfsQuota() {
+    return cfsQuota;
+  }
+
+  public Integer getCfsPeriod() {
+    return cfsPeriod;
+  }
+
   @Override
   public String toString() {
     return "RunnerContext{" +
-            "cmd='" + cmd + '\'' +
-            ", taskAppDirectory='" + taskAppDirectory + '\'' +
-            ", logDir='" + logDir + '\'' +
-            ", user='" + user + '\'' +
-            ", logFile='" + logFile + '\'' +
-            ", logFilePath='" + logFilePath + '\'' +
-            ", taskId='" + taskId + '\'' +
-            ", maxTaskThreads=" + maxTaskThreads +
-            ", shouldChangeUser=" + shouldChangeUser +
-            ", maxOpenFiles=" + maxOpenFiles +
-            ", switchUserCommand='" + switchUserCommand + '\'' +
-            ", useFileAttributes=" + useFileAttributes +
-            '}';
+        "cmd='" + cmd + '\'' +
+        ", taskAppDirectory='" + taskAppDirectory + '\'' +
+        ", logDir='" + logDir + '\'' +
+        ", user='" + user + '\'' +
+        ", logFile='" + logFile + '\'' +
+        ", logFilePath='" + logFilePath + '\'' +
+        ", taskId='" + taskId + '\'' +
+        ", maxTaskThreads=" + maxTaskThreads +
+        ", shouldChangeUser=" + shouldChangeUser +
+        ", maxOpenFiles=" + maxOpenFiles +
+        ", switchUserCommand='" + switchUserCommand + '\'' +
+        ", useFileAttributes=" + useFileAttributes +
+        ", cfsQuota=" + cfsQuota +
+        ", cfsPeriod=" + cfsPeriod +
+        '}';
   }
 }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskProcessBuilder.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskProcessBuilder.java
@@ -21,6 +21,7 @@ import com.hubspot.deploy.ExternalArtifact;
 import com.hubspot.deploy.RemoteArtifact;
 import com.hubspot.deploy.S3Artifact;
 import com.hubspot.deploy.S3ArtifactSignature;
+import com.hubspot.singularity.SingularityTaskExecutorData;
 import com.hubspot.singularity.executor.TemplateManager;
 import com.hubspot.singularity.executor.config.SingularityExecutorConfiguration;
 import com.hubspot.singularity.executor.models.DockerContext;
@@ -43,7 +44,7 @@ public class SingularityExecutorTaskProcessBuilder implements Callable<ProcessBu
 
   private final ExecutorUtils executorUtils;
 
-  private final ExecutorData executorData;
+  private final SingularityTaskExecutorData executorData;
 
   private final SingularityExecutorArtifactFetcher artifactFetcher;
 
@@ -58,7 +59,7 @@ public class SingularityExecutorTaskProcessBuilder implements Callable<ProcessBu
       SingularityExecutorArtifactFetcher artifactFetcher,
       TemplateManager templateManager,
       SingularityExecutorConfiguration configuration,
-      ExecutorData executorData, String executorPid,
+      SingularityTaskExecutorData executorData, String executorPid,
       DockerUtils dockerUtils, ObjectMapper objectMapper) {
     this.executorData = executorData;
     this.objectMapper = objectMapper;
@@ -164,7 +165,7 @@ public class SingularityExecutorTaskProcessBuilder implements Callable<ProcessBu
     return System.getProperty("user.name"); // TODO: better way to do this?
   }
 
-  private ProcessBuilder buildProcessBuilder(TaskInfo taskInfo, ExecutorData executorData, String serviceLog) {
+  private ProcessBuilder buildProcessBuilder(TaskInfo taskInfo, SingularityTaskExecutorData executorData, String serviceLog) {
     final String cmd = getCommand(executorData);
 
     RunnerContext runnerContext = new RunnerContext(
@@ -211,7 +212,7 @@ public class SingularityExecutorTaskProcessBuilder implements Callable<ProcessBu
     return processBuilder;
   }
 
-  private Integer getCfsQuota(ExecutorData executorData) {
+  private Integer getCfsQuota(SingularityTaskExecutorData executorData) {
     if (!executorData.getCpuHardLimit().isPresent()) {
       return null;
     } else {

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskProcessBuilder.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskProcessBuilder.java
@@ -179,7 +179,9 @@ public class SingularityExecutorTaskProcessBuilder implements Callable<ProcessBu
         !getExecutorUser().equals(executorData.getUser().or(configuration.getDefaultRunAsUser())),
         executorData.getMaxOpenFiles().orNull(),
         String.format(configuration.getSwitchUserCommandFormat(), executorData.getUser().or(configuration.getDefaultRunAsUser())),
-        configuration.isUseFileAttributes());
+        configuration.isUseFileAttributes(),
+        getCfsQuota(executorData),
+        configuration.getDefaultCfsPeriod());
 
     EnvironmentContext environmentContext = new EnvironmentContext(taskInfo);
 
@@ -207,6 +209,14 @@ public class SingularityExecutorTaskProcessBuilder implements Callable<ProcessBu
     processBuilder.redirectOutput(task.getTaskDefinition().getExecutorBashOutPath().toFile());
 
     return processBuilder;
+  }
+
+  private Integer getCfsQuota(ExecutorData executorData) {
+    if (!executorData.getCpuHardLimit().isPresent()) {
+      return null;
+    } else {
+      return executorData.getCpuHardLimit().get() * configuration.getDefaultCfsPeriod();
+    }
   }
 
   private String serviceLogOutPath(String serviceLog) {

--- a/SingularityExecutor/src/main/resources/docker.sh.hbs
+++ b/SingularityExecutor/src/main/resources/docker.sh.hbs
@@ -133,10 +133,15 @@ DOCKER_OPTIONS+=(--net=host)
 {{/if}}
 
 PARENT_CGROUP=$(get_deepest_cgroup)
+BASE_CGROUP_DIR=$(get_base_cgroup_directory)"
 
 DOCKER_OPTIONS+=(--name=$CONTAINER_NAME)
 DOCKER_OPTIONS+=(--cgroup-parent=$PARENT_CGROUP)
 DOCKER_OPTIONS+=(--env-file=docker.env)
+{{#if runContext.cfsQuota }}
+DOCKER_OPTIONS+=(--cpu-quota={{{ runContext.cfsQuota }}})
+DOCKER_OPTIONS+=(--cpu-period={{{ runContext.cfsPeriod }}})
+{{/if}}
 
 {{#unless envContext.dockerWorkdirOverriden }}
 DOCKER_OPTIONS+=(-w /mnt/mesos/sandbox/{{{ runContext.taskAppDirectory }}})

--- a/SingularityExecutor/src/main/resources/docker.sh.hbs
+++ b/SingularityExecutor/src/main/resources/docker.sh.hbs
@@ -80,14 +80,6 @@ function get_deepest_cgroup {
    echo "$max_path"
 }
 
-function get_base_cgroup_directory {
-  if [ -d "/cgroup" ]; then
-    echo "/cgroup"
-  else
-    echo "/sys/fs/cgroup"
-  fi
-}
-
 DOCKER_IMAGE={{{ envContext.dockerInfo.image }}}
 
 # load env vars
@@ -141,7 +133,6 @@ DOCKER_OPTIONS+=(--net=host)
 {{/if}}
 
 PARENT_CGROUP=$(get_deepest_cgroup)
-BASE_CGROUP_DIR=$(get_base_cgroup_directory)
 
 DOCKER_OPTIONS+=(--name=$CONTAINER_NAME)
 DOCKER_OPTIONS+=(--cgroup-parent=$PARENT_CGROUP)

--- a/SingularityExecutor/src/main/resources/docker.sh.hbs
+++ b/SingularityExecutor/src/main/resources/docker.sh.hbs
@@ -138,15 +138,8 @@ DOCKER_OPTIONS+=(--name=$CONTAINER_NAME)
 DOCKER_OPTIONS+=(--cgroup-parent=$PARENT_CGROUP)
 DOCKER_OPTIONS+=(--env-file=docker.env)
 {{#if runContext.cfsQuota }}
-function get_base_cgroup_directory {
-  if [ -d "/cgroup" ]; then
-    echo "/cgroup"
-  else
-    echo "/sys/fs/cgroup"
-  fi
-}
-
-CGROUP_CPU_PATH="$(get_base_cgroup_directory)/cpu$PARENT_CGROUP"
+CPU_CGROUP_BASE_DIRECTORY=`findmnt --kernel --first-only --types cgroup --options cpu --noheadings --output TARGET`
+CGROUP_CPU_PATH="$CPU_CGROUP_BASE_DIRECTORY/cpu$PARENT_CGROUP"
 echo {{{ runContext.cfsQuota }}} > "$CGROUP_CPU_PATH/cpu.cfs_quota_us"
 echo {{{ runContext.cfsPeriod }}} > "$CGROUP_CPU_PATH/cpu.cfs_period_us"
 {{/if}}

--- a/SingularityExecutor/src/main/resources/docker.sh.hbs
+++ b/SingularityExecutor/src/main/resources/docker.sh.hbs
@@ -133,7 +133,7 @@ DOCKER_OPTIONS+=(--net=host)
 {{/if}}
 
 PARENT_CGROUP=$(get_deepest_cgroup)
-BASE_CGROUP_DIR=$(get_base_cgroup_directory)"
+BASE_CGROUP_DIR=$(get_base_cgroup_directory)
 
 DOCKER_OPTIONS+=(--name=$CONTAINER_NAME)
 DOCKER_OPTIONS+=(--cgroup-parent=$PARENT_CGROUP)

--- a/SingularityExecutor/src/main/resources/docker.sh.hbs
+++ b/SingularityExecutor/src/main/resources/docker.sh.hbs
@@ -147,8 +147,8 @@ function get_base_cgroup_directory {
 }
 
 CGROUP_CPU_PATH="$(get_base_cgroup_directory)/cpu$PARENT_CGROUP"
-echo {{{ cfsQuota }}} > "$CGROUP_CPU_PATH/cpu.cfs_quota_us"
-echo {{{ cfsPeriod }}} > "$CGROUP_CPU_PATH/cpu.cfs_period_us"
+echo {{{ runContext.cfsQuota }}} > "$CGROUP_CPU_PATH/cpu.cfs_quota_us"
+echo {{{ runContext.cfsPeriod }}} > "$CGROUP_CPU_PATH/cpu.cfs_period_us"
 {{/if}}
 
 {{#unless envContext.dockerWorkdirOverriden }}

--- a/SingularityExecutor/src/main/resources/docker.sh.hbs
+++ b/SingularityExecutor/src/main/resources/docker.sh.hbs
@@ -138,8 +138,17 @@ DOCKER_OPTIONS+=(--name=$CONTAINER_NAME)
 DOCKER_OPTIONS+=(--cgroup-parent=$PARENT_CGROUP)
 DOCKER_OPTIONS+=(--env-file=docker.env)
 {{#if runContext.cfsQuota }}
-DOCKER_OPTIONS+=(--cpu-quota={{{ runContext.cfsQuota }}})
-DOCKER_OPTIONS+=(--cpu-period={{{ runContext.cfsPeriod }}})
+function get_base_cgroup_directory {
+  if [ -d "/cgroup" ]; then
+    echo "/cgroup"
+  else
+    echo "/sys/fs/cgroup"
+  fi
+}
+
+CGROUP_CPU_PATH="$(get_base_cgroup_directory)/cpu$PARENT_CGROUP"
+echo {{{ cfsQuota }}} > "$CGROUP_CPU_PATH/cpu.cfs_quota_us"
+echo {{{ cfsPeriod }}} > "$CGROUP_CPU_PATH/cpu.cfs_period_us"
 {{/if}}
 
 {{#unless envContext.dockerWorkdirOverriden }}

--- a/SingularityExecutor/src/main/resources/docker.sh.hbs
+++ b/SingularityExecutor/src/main/resources/docker.sh.hbs
@@ -80,6 +80,14 @@ function get_deepest_cgroup {
    echo "$max_path"
 }
 
+function get_base_cgroup_directory {
+  if [ -d "/cgroup" ]; then
+    echo "/cgroup"
+  else
+    echo "/sys/fs/cgroup"
+  fi
+}
+
 DOCKER_IMAGE={{{ envContext.dockerInfo.image }}}
 
 # load env vars

--- a/SingularityExecutor/src/main/resources/docker.sh.hbs
+++ b/SingularityExecutor/src/main/resources/docker.sh.hbs
@@ -139,7 +139,7 @@ DOCKER_OPTIONS+=(--cgroup-parent=$PARENT_CGROUP)
 DOCKER_OPTIONS+=(--env-file=docker.env)
 {{#if runContext.cfsQuota }}
 CPU_CGROUP_BASE_DIRECTORY=`findmnt --kernel --first-only --types cgroup --options cpu --noheadings --output TARGET`
-CGROUP_CPU_PATH="$CPU_CGROUP_BASE_DIRECTORY/cpu$PARENT_CGROUP"
+CGROUP_CPU_PATH="$CPU_CGROUP_BASE_DIRECTORY$PARENT_CGROUP"
 echo {{{ runContext.cfsQuota }}} > "$CGROUP_CPU_PATH/cpu.cfs_quota_us"
 echo {{{ runContext.cfsPeriod }}} > "$CGROUP_CPU_PATH/cpu.cfs_period_us"
 {{/if}}

--- a/SingularityExecutor/src/main/resources/runner.sh.hbs
+++ b/SingularityExecutor/src/main/resources/runner.sh.hbs
@@ -6,6 +6,58 @@
 
 export MESOS_TASK_ID={{{bashEscaped taskId}}}  # I can't believe Mesos doesn't expose this.
 
+{{#if cfsQuota }}
+# Outputs the path of the deepest cgroup the current process is in.
+# The output of:
+#   cat /proc/self/cgroup
+# will look like:
+# --------------------
+# 8:net_cls:/
+# 7:memory:/test_cgroup/mesos/4e59173b-e2a7-47a6-bcb8-455b637faa5f
+# 6:freezer:/test_cgroup/mesos/4e59173b-e2a7-47a6-bcb8-455b637faa5f
+# 5:devices:/
+# 4:cpuset:/
+# 3:cpuacct:/test_cgroup/mesos/4e59173b-e2a7-47a6-bcb8-455b637faa5f
+# 2:cpu:/test_cgroup/mesos/4e59173b-e2a7-47a6-bcb8-455b637faa5f
+# 1:blkio:/test_cgroup
+# --------------------
+# This function will return the deepest cgroup path in that output.
+# For this example, it would return:
+#   /test_cgroup/mesos/4e59173b-e2a7-47a6-bcb8-455b637faa5f
+function get_deepest_cgroup {
+   local cgroups=$(</proc/self/cgroup)
+   local max_depth=0
+   local max_path="/"
+
+   for cgroup_spec in $cgroups; do
+     local cg_path=$(echo $cgroup_spec | cut -d: -f3)
+     if [ "$cg_path" == "/" ]; then
+       local depth=0
+     else
+       local depth=$(echo -ne "$cg_path" | tr '/' "\n" | wc -l)
+     fi
+
+     if [ "$depth" -gt "$max_depth" ]; then
+       local max_depth="$depth"
+       local max_path="$cg_path"
+     fi
+   done
+   echo "$max_path"
+}
+
+function get_base_cgroup_directory {
+  if [ -d "/cgroup" ]; then
+    echo "/cgroup"
+  else
+    echo "/sys/fs/cgroup"
+  fi
+}
+
+CGROUP_CPU_PATH="$(get_base_cgroup_directory)/cpu$(get_deepest_cgroup)"
+echo {{{ cfsQuota }}} > "$CGROUP_CPU_PATH/cpu.cfs_quota_us"
+echo {{{ cfsPeriod }}} > "$CGROUP_CPU_PATH/cpu.cfs_period_us"
+{{/if}}
+
 # load system-wide profile.d
 if [[ -d /etc/profile.d ]]; then
   echo "Sourcing files from /etc/profile.d"

--- a/SingularityExecutor/src/main/resources/runner.sh.hbs
+++ b/SingularityExecutor/src/main/resources/runner.sh.hbs
@@ -45,15 +45,9 @@ function get_deepest_cgroup {
    echo "$max_path"
 }
 
-function get_base_cgroup_directory {
-  if [ -d "/cgroup" ]; then
-    echo "/cgroup"
-  else
-    echo "/sys/fs/cgroup"
-  fi
-}
+CPU_CGROUP_BASE_DIRECTORY=`findmnt --kernel --first-only --types cgroup --options cpu --noheadings --output TARGET`
 
-CGROUP_CPU_PATH="$(get_base_cgroup_directory)/cpu$(get_deepest_cgroup)"
+CGROUP_CPU_PATH="$CPU_CGROUP_BASE_DIRECTORY$(get_deepest_cgroup)"
 echo {{{ cfsQuota }}} > "$CGROUP_CPU_PATH/cpu.cfs_quota_us"
 echo {{{ cfsPeriod }}} > "$CGROUP_CPU_PATH/cpu.cfs_period_us"
 {{/if}}

--- a/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/SingularityExecutorCleanup.java
+++ b/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/SingularityExecutorCleanup.java
@@ -213,7 +213,8 @@ public class SingularityExecutorCleanup {
             Strings.isNullOrEmpty(oldDefinition.getExecutorData().getServiceFinishedTailLog()) ? cleanupConfiguration.getDefaultServiceFinishedTailLog() : oldDefinition.getExecutorData().getServiceFinishedTailLog(),
             oldDefinition.getExecutorData().getRequestGroup(),
             oldDefinition.getExecutorData().getS3StorageClass(),
-            oldDefinition.getExecutorData().getApplyS3StorageClassAfterBytes()
+            oldDefinition.getExecutorData().getApplyS3StorageClassAfterBytes(),
+            oldDefinition.getExecutorData().getCpuHardLimit()
         ),
         oldDefinition.getTaskDirectory(),
         oldDefinition.getExecutorPid(),

--- a/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/shared/WatchServiceHelper.java
+++ b/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/shared/WatchServiceHelper.java
@@ -54,6 +54,10 @@ public abstract class WatchServiceHelper implements Closeable {
     this.stopped = stopped;
   }
 
+  protected Path getWatchDirectory() {
+    return watchDirectory;
+  }
+
   @Override
   public void close() {
     try {

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -385,6 +385,11 @@ public class SingularityConfiguration extends Configuration {
 
   private boolean allowDeployOfPausedRequests = false;
 
+  private Optional<Integer> cpuHardLimit = Optional.absent();
+
+  // If cpuHardLimit is specified and a task is requesting a base cpu of > cpuHardLimit, that task's new  hard limit is requested cpus * cpuHardLimitScaleFactor
+  private double cpuHardLimitScaleFactor = 1.25;
+
   public long getAskDriverToKillTasksAgainAfterMillis() {
     return askDriverToKillTasksAgainAfterMillis;
   }
@@ -1647,5 +1652,22 @@ public class SingularityConfiguration extends Configuration {
 
   public void setAllowDeployOfPausedRequests(boolean allowDeployOfPausedRequests) {
     this.allowDeployOfPausedRequests = allowDeployOfPausedRequests;
+  }
+
+  public Optional<Integer> getCpuHardLimit() {
+    return cpuHardLimit;
+  }
+
+  public void setCpuHardLimit(Optional<Integer> cpuHardLimit) {
+    this.cpuHardLimit = cpuHardLimit;
+  }
+
+  public double getCpuHardLimitScaleFactor() {
+    return cpuHardLimitScaleFactor;
+  }
+
+  public SingularityConfiguration setCpuHardLimitScaleFactor(double cpuHardLimitScaleFactor) {
+    this.cpuHardLimitScaleFactor = cpuHardLimitScaleFactor;
+    return this;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -74,8 +74,6 @@ public class SingularityConfiguration extends Configuration {
 
   private long checkUsageEveryMillis = TimeUnit.MINUTES.toMillis(1);
 
-  private int usageIntervalSeconds = 5760; // 15 saved each 5760 seconds (96 min) apart is 1 day of usage
-
   private int maxConcurrentUsageCollections = 15;
 
   private boolean shuffleTasksForOverloadedSlaves = false; // recommended 'true' when oversubscribing cpu for larger clusters
@@ -1496,14 +1494,6 @@ public class SingularityConfiguration extends Configuration {
 
   public void setCheckUsageEveryMillis(long checkUsageEveryMillis) {
     this.checkUsageEveryMillis = checkUsageEveryMillis;
-  }
-
-  public int getUsageIntervalSeconds() {
-    return usageIntervalSeconds;
-  }
-
-  public void setUsageIntervalSeconds(int usageIntervalSeconds) {
-    this.usageIntervalSeconds = usageIntervalSeconds;
   }
 
   public int getMaxConcurrentUsageCollections() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/UsageManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/UsageManager.java
@@ -3,7 +3,6 @@ package com.hubspot.singularity.data;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -37,7 +36,7 @@ public class UsageManager extends CuratorAsyncManager {
 
   private static final String SLAVE_PATH = ROOT_PATH + "/slaves";
   private static final String TASK_PATH = ROOT_PATH + "/tasks";
-  private static final String REQUEST_PATH = ROOT_PATH + "/requests";
+  private static final String REQUESTS_PATH = ROOT_PATH + "/requests";
   private static final String USAGE_SUMMARY_PATH = ROOT_PATH + "/summary";
 
   private static final String USAGE_HISTORY_PATH_KEY = "history";
@@ -120,6 +119,10 @@ public class UsageManager extends CuratorAsyncManager {
     return ZKPaths.makePath(getTaskUsagePath(taskId), CURRENT_USAGE_NODE_KEY);
   }
 
+  private String getRequestPath(String requestId) {
+    return ZKPaths.makePath(REQUESTS_PATH, requestId);
+  }
+
   public SingularityDeleteResult deleteSlaveUsage(String slaveId) {
     return delete(getSlaveUsagePath(slaveId));
   }
@@ -182,16 +185,19 @@ public class UsageManager extends CuratorAsyncManager {
   }
 
   public Map<String, RequestUtilization> getRequestUtilizations() {
-    Optional<SingularityClusterUtilization> clusterUtilization = getClusterUtilization();
-    if (clusterUtilization.isPresent()) {
-      return clusterUtilization.get().getRequestUtilizations().stream()
-          .collect(Collectors.toMap(
-              RequestUtilization::getRequestId,
-              Function.identity(),
-              (r1, r2) -> r1 // Ignore duplicate usages for a single request id
-          ));
-    }
-    return new HashMap<>();
+    return getAsyncChildren(REQUESTS_PATH, requestUtilizationTranscoder).stream()
+        .collect(Collectors.toMap(
+            RequestUtilization::getRequestId,
+            Function.identity()
+        ));
+  }
+
+  public Optional<RequestUtilization> getRequestUtilization(String requestId) {
+    return getData(getRequestPath(requestId), requestUtilizationTranscoder);
+  }
+
+  public SingularityCreateResult saveRequestUtilization(RequestUtilization requestUtilization) {
+    return save(getRequestPath(requestUtilization.getRequestId()), requestUtilization, requestUtilizationTranscoder);
   }
 
   public List<SingularitySlaveUsageWithId> getCurrentSlaveUsages(List<String> slaveIds) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/UsageManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/UsageManager.java
@@ -37,6 +37,7 @@ public class UsageManager extends CuratorAsyncManager {
 
   private static final String SLAVE_PATH = ROOT_PATH + "/slaves";
   private static final String TASK_PATH = ROOT_PATH + "/tasks";
+  private static final String REQUEST_PATH = ROOT_PATH + "/requests";
   private static final String USAGE_SUMMARY_PATH = ROOT_PATH + "/summary";
 
   private static final String USAGE_HISTORY_PATH_KEY = "history";
@@ -46,6 +47,7 @@ public class UsageManager extends CuratorAsyncManager {
   private final Transcoder<SingularityTaskUsage> taskUsageTranscoder;
   private final Transcoder<SingularityTaskCurrentUsage> taskCurrentUsageTranscoder;
   private final Transcoder<SingularityClusterUtilization> clusterUtilizationTranscoder;
+  private final Transcoder<RequestUtilization> requestUtilizationTranscoder;
 
   @Inject
   public UsageManager(CuratorFramework curator,
@@ -54,13 +56,15 @@ public class UsageManager extends CuratorAsyncManager {
                       Transcoder<SingularitySlaveUsage> slaveUsageTranscoder,
                       Transcoder<SingularityTaskUsage> taskUsageTranscoder,
                       Transcoder<SingularityTaskCurrentUsage> taskCurrentUsageTranscoder,
-                      Transcoder<SingularityClusterUtilization> clusterUtilizationTranscoder) {
+                      Transcoder<SingularityClusterUtilization> clusterUtilizationTranscoder,
+                      Transcoder<RequestUtilization> requestUtilizationTranscoder) {
     super(curator, configuration, metricRegistry);
 
     this.slaveUsageTranscoder = slaveUsageTranscoder;
     this.taskUsageTranscoder = taskUsageTranscoder;
     this.taskCurrentUsageTranscoder = taskCurrentUsageTranscoder;
     this.clusterUtilizationTranscoder = clusterUtilizationTranscoder;
+    this.requestUtilizationTranscoder = requestUtilizationTranscoder;
   }
 
   public List<String> getSlavesWithUsage() {
@@ -149,14 +153,7 @@ public class UsageManager extends CuratorAsyncManager {
     return save(getSpecificSlaveUsagePath(slaveId, usage.getTimestamp()), usage, slaveUsageTranscoder);
   }
 
-  private static final Comparator<SingularitySlaveUsage> SLAVE_USAGE_COMPARATOR_TIMESTAMP_ASC = new Comparator<SingularitySlaveUsage>() {
-
-    @Override
-    public int compare(SingularitySlaveUsage o1, SingularitySlaveUsage o2) {
-      return Long.compare(o1.getTimestamp(), o2.getTimestamp());
-    }
-
-  };
+  private static final Comparator<SingularitySlaveUsage> SLAVE_USAGE_COMPARATOR_TIMESTAMP_ASC = Comparator.comparingLong(SingularitySlaveUsage::getTimestamp);
 
   public List<SingularitySlaveUsage> getSlaveUsage(String slaveId) {
     List<SingularitySlaveUsage> children = getAsyncChildren(getSlaveUsageHistoryPath(slaveId), slaveUsageTranscoder);
@@ -164,14 +161,7 @@ public class UsageManager extends CuratorAsyncManager {
     return children;
   }
 
-  private static final Comparator<SingularityTaskUsage> TASK_USAGE_COMPARATOR_TIMESTAMP_ASC = new Comparator<SingularityTaskUsage>() {
-
-    @Override
-    public int compare(SingularityTaskUsage o1, SingularityTaskUsage o2) {
-      return Double.compare(o1.getTimestamp(), o2.getTimestamp());
-    }
-
-  };
+  private static final Comparator<SingularityTaskUsage> TASK_USAGE_COMPARATOR_TIMESTAMP_ASC = Comparator.comparingDouble(SingularityTaskUsage::getTimestamp);
 
   public List<SingularityTaskUsage> getTaskUsage(String taskId) {
     List<SingularityTaskUsage> children = getAsyncChildren(getTaskUsageHistoryPath(taskId), taskUsageTranscoder);

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/transcoders/SingularityTranscoderModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/transcoders/SingularityTranscoderModule.java
@@ -4,6 +4,7 @@ import static com.hubspot.singularity.data.transcoders.SingularityJsonTranscoder
 
 import com.google.inject.Binder;
 import com.google.inject.Module;
+import com.hubspot.singularity.RequestUtilization;
 import com.hubspot.singularity.SingularityClusterUtilization;
 import com.hubspot.singularity.SingularityDeploy;
 import com.hubspot.singularity.SingularityDeployHistory;
@@ -103,6 +104,7 @@ public class SingularityTranscoderModule implements Module {
     bindTranscoder(binder).asJson(SingularityTaskUsage.class);
     bindTranscoder(binder).asJson(SingularityClusterUtilization.class);
     bindTranscoder(binder).asJson(SingularityTaskCurrentUsage.class);
+    bindTranscoder(binder).asJson(RequestUtilization.class);
 
     bindTranscoder(binder).asCompressedJson(SingularityDeployHistory.class);
     bindTranscoder(binder).asCompressedJson(SingularityDeploy.class);

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
@@ -356,7 +356,10 @@ public class SingularityMesosOfferScheduler {
     }
 
     if (mesosConfiguration.isOmitOverloadedHosts() && maybeSlaveUsage.isPresent() && maybeSlaveUsage.get().isOverloaded()) {
-      LOG.debug("Slave {} is overloaded (), ignoring offer");
+      LOG.debug("Slave {} is overloaded (load5 {}/{}, load1 {}/{}), ignoring offer",
+          offerHolder.getHostname(),
+          maybeSlaveUsage.get().getSlaveUsage().getSystemLoad5Min(), maybeSlaveUsage.get().getSlaveUsage().getSystemCpusTotal(),
+          maybeSlaveUsage.get().getSlaveUsage().getSystemLoad1Min(), maybeSlaveUsage.get().getSlaveUsage().getSystemCpusTotal());
       return 0;
     }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/UsageResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/UsageResource.java
@@ -11,6 +11,7 @@ import javax.ws.rs.core.MediaType;
 
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
+import com.hubspot.singularity.RequestUtilization;
 import com.hubspot.singularity.SingularityAuthorizationScope;
 import com.hubspot.singularity.SingularityClusterUtilization;
 import com.hubspot.singularity.SingularityService;
@@ -99,4 +100,18 @@ public class UsageResource {
 
     return usageManager.getClusterUtilization().get();
   }
+
+  @GET
+  @Path("/requests")
+  public List<RequestUtilization> getRequestUtilizations(@Auth SingularityUser user) {
+    return new ArrayList<>(usageManager.getRequestUtilizations().values());
+  }
+
+  @GET
+  @Path("/requests/request/{requestId}")
+  public Optional<RequestUtilization> getRequestUtilization(@Auth SingularityUser user, @PathParam("requestId") String requestId) {
+    authorizationHelper.checkForAuthorizationByRequestId(requestId, user, SingularityAuthorizationScope.READ);
+    return usageManager.getRequestUtilization(requestId);
+  }
+
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
@@ -447,6 +447,8 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
     double curMinCpuUsed = Double.MAX_VALUE;
     long curMaxDiskBytesUsed = 0;
     long curMinDiskBytesUsed = Long.MAX_VALUE;
+    double curMaxPercentCpuTimeThrottled = 0;
+    double curMinPercentCpuTimeThrottled = Long.MAX_VALUE;
 
     if (utilizationPerRequestId.containsKey(requestId)) {
       curMaxMemBytesUsed = requestUtilization.getMaxMemBytesUsed();
@@ -455,6 +457,8 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
       curMinCpuUsed = requestUtilization.getMinCpuUsed();
       curMaxDiskBytesUsed = requestUtilization.getMaxDiskBytesUsed();
       curMinDiskBytesUsed = requestUtilization.getMinDiskBytesUsed();
+      curMaxPercentCpuTimeThrottled = requestUtilization.getMaxPercentCpuTimeThrottled();
+      curMinPercentCpuTimeThrottled = requestUtilization.getMinPercentCpuTimeThrottled();
     }
 
     List<SingularityTaskUsage> pastTaskUsagesCopy = copyUsages(pastTaskUsages, latestUsage, task);
@@ -475,6 +479,8 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
       curMinMemBytesUsed = Math.min(newerUsage.getMemoryTotalBytes(), curMinMemBytesUsed);
       curMaxDiskBytesUsed = Math.max(newerUsage.getDiskTotalBytes(), curMaxDiskBytesUsed);
       curMinDiskBytesUsed = Math.min(newerUsage.getDiskTotalBytes(), curMinDiskBytesUsed);
+      curMaxPercentCpuTimeThrottled = Math.max(percentCpuTimeThrottled, curMaxPercentCpuTimeThrottled);
+      curMinPercentCpuTimeThrottled = Math.min(percentCpuTimeThrottled, curMinPercentCpuTimeThrottled);
 
       if (cpusUsed > cpuReservedForTask) {
         numCpuOverages ++;
@@ -500,6 +506,8 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
         .setMinMemBytesUsed(curMinMemBytesUsed)
         .setMaxDiskBytesUsed(curMaxDiskBytesUsed)
         .setMinDiskBytesUsed(curMinDiskBytesUsed)
+        .setMaxPercentCpuTimeThrottled(curMaxPercentCpuTimeThrottled)
+        .setMinPercentCpuTimeThrottled(curMinPercentCpuTimeThrottled)
         .setCpuBurstRating(cpuBurstRating);
 
     utilizationPerRequestId.put(requestId, requestUtilization);

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
@@ -441,7 +441,7 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
   private SingularityTaskUsage getUsage(MesosTaskMonitorObject taskUsage) {
     return new SingularityTaskUsage(
         taskUsage.getStatistics().getMemTotalBytes(),
-        taskUsage.getStatistics().getTimestampSeconds(),
+        taskUsage.getStatistics().getTimestamp(),
         taskUsage.getStatistics().getCpusSystemTimeSecs() + taskUsage.getStatistics().getCpusUserTimeSecs(),
         taskUsage.getStatistics().getDiskUsedBytes(),
         taskUsage.getStatistics().getCpusNrPeriods(),

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
@@ -59,6 +59,7 @@ import com.hubspot.singularity.sentry.SingularityExceptionNotifier;
 public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
 
   private static final Logger LOG = LoggerFactory.getLogger(SingularityUsagePoller.class);
+  private static final long DAY_IN_SECONDS = TimeUnit.DAYS.toSeconds(1);
 
   private final SingularityConfiguration configuration;
   private final MesosClient mesosClient;
@@ -99,6 +100,7 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
   @Override
   public void runActionOnPoll() {
     Map<String, RequestUtilization> utilizationPerRequestId = new ConcurrentHashMap<>();
+    Map<String, RequestUtilization> previousUtilizations = usageManager.getRequestUtilizations();
     final long now = System.currentTimeMillis();
 
     AtomicLong totalMemBytesUsed = new AtomicLong(0);
@@ -115,9 +117,9 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
     usageHelper.getSlavesToTrackUsageFor().forEach((slave) -> {
       usageFutures.add(usageCollectionSemaphore.call(() ->
           CompletableFuture.runAsync(() -> {
-            collectSlaveUage(slave, now, utilizationPerRequestId, overLoadedHosts, totalMemBytesUsed, totalMemBytesAvailable,
+            collectSlaveUage(slave, now, utilizationPerRequestId, previousUtilizations, overLoadedHosts, totalMemBytesUsed, totalMemBytesAvailable,
                 totalCpuUsed, totalCpuAvailable, totalDiskBytesUsed, totalDiskBytesAvailable);
-          })
+          }, usageExecutor)
       ));
     });
 
@@ -132,7 +134,7 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
     }
   }
 
-  private void collectSlaveUage(SingularitySlave slave, long now, Map<String, RequestUtilization> utilizationPerRequestId, Map<SingularitySlaveUsage, List<TaskIdWithUsage>> overLoadedHosts,
+  private void collectSlaveUage(SingularitySlave slave, long now, Map<String, RequestUtilization> utilizationPerRequestId, Map<String, RequestUtilization> previousUtilizations, Map<SingularitySlaveUsage, List<TaskIdWithUsage>> overLoadedHosts,
                                 AtomicLong totalMemBytesUsed, AtomicLong totalMemBytesAvailable, AtomicDouble totalCpuUsed, AtomicDouble totalCpuAvailable, AtomicLong totalDiskBytesUsed, AtomicLong totalDiskBytesAvailable) {
     Map<ResourceUsageType, Number> longRunningTasksUsage = new HashMap<>();
     longRunningTasksUsage.put(ResourceUsageType.MEMORY_BYTES_USED, 0);
@@ -221,7 +223,7 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
             cpuReservedOnSlave += cpuReservedForTask;
             diskMbReservedOnSlave += diskMbReservedForTask;
 
-            updateRequestUtilization(utilizationPerRequestId, pastTaskUsages, latestUsage, task, memoryMbReservedForTask, cpuReservedForTask, diskMbReservedForTask);
+            updateRequestUtilization(utilizationPerRequestId, previousUtilizations, pastTaskUsages, latestUsage, task, memoryMbReservedForTask, cpuReservedForTask, diskMbReservedForTask);
           }
         }
         memoryBytesUsedOnSlave += latestUsage.getMemoryTotalBytes();
@@ -433,6 +435,7 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
   }
 
   private void updateRequestUtilization(Map<String, RequestUtilization> utilizationPerRequestId,
+                                        Map<String, RequestUtilization> previousUtilizations,
                                         List<SingularityTaskUsage> pastTaskUsages,
                                         SingularityTaskUsage latestUsage,
                                         SingularityTaskId task,
@@ -440,30 +443,47 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
                                         double cpuReservedForTask,
                                         double diskMbReservedForTask) {
     String requestId = task.getRequestId();
-    RequestUtilization requestUtilization = utilizationPerRequestId.getOrDefault(requestId, new RequestUtilization(requestId, task.getDeployId()));
-    long curMaxMemBytesUsed = 0;
-    long curMinMemBytesUsed = Long.MAX_VALUE;
-    double curMaxCpuUsed = 0;
-    double curMinCpuUsed = Double.MAX_VALUE;
-    long curMaxDiskBytesUsed = 0;
-    long curMinDiskBytesUsed = Long.MAX_VALUE;
-    double curMaxPercentCpuTimeThrottled = 0;
-    double curMinPercentCpuTimeThrottled = Long.MAX_VALUE;
-
-    if (utilizationPerRequestId.containsKey(requestId)) {
-      curMaxMemBytesUsed = requestUtilization.getMaxMemBytesUsed();
-      curMinMemBytesUsed = requestUtilization.getMinMemBytesUsed();
-      curMaxCpuUsed = requestUtilization.getMaxCpuUsed();
-      curMinCpuUsed = requestUtilization.getMinCpuUsed();
-      curMaxDiskBytesUsed = requestUtilization.getMaxDiskBytesUsed();
-      curMinDiskBytesUsed = requestUtilization.getMinDiskBytesUsed();
-      curMaxPercentCpuTimeThrottled = requestUtilization.getMaxPercentCpuTimeThrottled();
-      curMinPercentCpuTimeThrottled = requestUtilization.getMinPercentCpuTimeThrottled();
+    RequestUtilization newRequestUtilization = utilizationPerRequestId.getOrDefault(requestId, new RequestUtilization(requestId, task.getDeployId()));
+    RequestUtilization previous = previousUtilizations.get(requestId);
+    // Take the previous request utilization into account to better measure 24 hour max/min values
+    if (previous != null) {
+      if (previous.getMaxMemTimestamp() < DAY_IN_SECONDS) {
+        newRequestUtilization.setMaxMemBytesUsed(previous.getMaxMemBytesUsed());
+        newRequestUtilization.setMaxMemTimestamp(previous.getMaxMemTimestamp());
+      }
+      if (previous.getMinMemTimestamp() < DAY_IN_SECONDS) {
+        newRequestUtilization.setMinMemBytesUsed(previous.getMinMemBytesUsed());
+        newRequestUtilization.setMinMemTimestamp(previous.getMinMemTimestamp());
+      }
+      if (previous.getMaxCpusTimestamp() < DAY_IN_SECONDS) {
+        newRequestUtilization.setMaxCpuUsed(previous.getMaxCpuUsed());
+        newRequestUtilization.setMaxCpusTimestamp(previous.getMaxCpusTimestamp());
+      }
+      if (previous.getMinCpusTimestamp() < DAY_IN_SECONDS) {
+        newRequestUtilization.setMinCpuUsed(previous.getMinCpuUsed());
+        newRequestUtilization.setMinCpusTimestamp(previous.getMinCpusTimestamp());
+      }
+      if (previous.getMaxDiskTimestamp() < DAY_IN_SECONDS) {
+        newRequestUtilization.setMaxDiskBytesUsed(previous.getMaxDiskBytesUsed());
+        newRequestUtilization.setMaxDiskTimestamp(previous.getMaxDiskTimestamp());
+      }
+      if (previous.getMinDiskTimestamp() < DAY_IN_SECONDS) {
+        newRequestUtilization.setMinDiskBytesUsed(previous.getMinDiskBytesUsed());
+        newRequestUtilization.setMinDiskTimestamp(previous.getMinDiskTimestamp());
+      }
+      if (previous.getMaxCpuThrottledTimestamp() < DAY_IN_SECONDS) {
+        newRequestUtilization.setMaxPercentCpuTimeThrottled(previous.getMaxPercentCpuTimeThrottled());
+        newRequestUtilization.setMaxCpuThrottledTimestamp(previous.getMaxCpuThrottledTimestamp());
+      }
+      if (previous.getMinCpuThrottledTimestamp() < DAY_IN_SECONDS) {
+        newRequestUtilization.setMinPercentCpuTimeThrottled(previous.getMinPercentCpuTimeThrottled());
+        newRequestUtilization.setMinCpuThrottledTimestamp(previous.getMinCpuThrottledTimestamp());
+      }
     }
 
-    List<SingularityTaskUsage> pastTaskUsagesCopy = copyUsages(pastTaskUsages, latestUsage, task);
+    List<SingularityTaskUsage> pastTaskUsagesCopy = getFullListOfTaskUsages(pastTaskUsages, latestUsage, task);
     pastTaskUsagesCopy.sort(Comparator.comparingDouble(SingularityTaskUsage::getTimestamp));
-    int numTasks = pastTaskUsagesCopy.size() - 1;
+    int numTasks = pastTaskUsagesCopy.size() - 1; // One usage is a fake 0 usage to calculate first cpu times
 
     int numCpuOverages = 0;
 
@@ -473,20 +493,44 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
       double cpusUsed = (newerUsage.getCpuSeconds() - olderUsage.getCpuSeconds()) / (newerUsage.getTimestamp() - olderUsage.getTimestamp());
       double percentCpuTimeThrottled = (newerUsage.getCpusThrottledTimeSecs() - olderUsage.getCpusThrottledTimeSecs()) / (newerUsage.getTimestamp() - olderUsage.getTimestamp());
 
-      curMaxCpuUsed = Math.max(cpusUsed, curMaxCpuUsed);
-      curMinCpuUsed = Math.min(cpusUsed, curMinCpuUsed);
-      curMaxMemBytesUsed = Math.max(newerUsage.getMemoryTotalBytes(), curMaxMemBytesUsed);
-      curMinMemBytesUsed = Math.min(newerUsage.getMemoryTotalBytes(), curMinMemBytesUsed);
-      curMaxDiskBytesUsed = Math.max(newerUsage.getDiskTotalBytes(), curMaxDiskBytesUsed);
-      curMinDiskBytesUsed = Math.min(newerUsage.getDiskTotalBytes(), curMinDiskBytesUsed);
-      curMaxPercentCpuTimeThrottled = Math.max(percentCpuTimeThrottled, curMaxPercentCpuTimeThrottled);
-      curMinPercentCpuTimeThrottled = Math.min(percentCpuTimeThrottled, curMinPercentCpuTimeThrottled);
+      if (cpusUsed > newRequestUtilization.getMaxCpuUsed()) {
+        newRequestUtilization.setMaxCpuUsed(cpusUsed);
+        newRequestUtilization.setMaxCpusTimestamp(newerUsage.getTimestamp());
+      }
+      if (cpusUsed < newRequestUtilization.getMinCpuUsed()) {
+        newRequestUtilization.setMinCpuUsed(cpusUsed);
+        newRequestUtilization.setMinCpusTimestamp(newerUsage.getTimestamp());
+      }
+      if (newerUsage.getMemoryTotalBytes() > newRequestUtilization.getMaxMemBytesUsed()) {
+        newRequestUtilization.setMaxMemBytesUsed(newerUsage.getMemoryTotalBytes());
+        newRequestUtilization.setMaxMemTimestamp(newerUsage.getTimestamp());
+      }
+      if (newerUsage.getMemoryTotalBytes() < newRequestUtilization.getMinMemBytesUsed()) {
+        newRequestUtilization.setMinMemBytesUsed(newerUsage.getMemoryTotalBytes());
+        newRequestUtilization.setMinMemTimestamp(newerUsage.getTimestamp());
+      }
+      if (newerUsage.getDiskTotalBytes() > newRequestUtilization.getMaxDiskBytesUsed()) {
+        newRequestUtilization.setMaxDiskBytesUsed(newerUsage.getDiskTotalBytes());
+        newRequestUtilization.setMaxDiskTimestamp(newerUsage.getTimestamp());
+      }
+      if (newerUsage.getDiskTotalBytes() < newRequestUtilization.getMinDiskBytesUsed()) {
+        newRequestUtilization.setMinDiskBytesUsed(newerUsage.getDiskTotalBytes());
+        newRequestUtilization.setMaxDiskTimestamp(newerUsage.getTimestamp());
+      }
+      if (percentCpuTimeThrottled > newRequestUtilization.getMaxPercentCpuTimeThrottled()) {
+        newRequestUtilization.setMaxPercentCpuTimeThrottled(percentCpuTimeThrottled);
+        newRequestUtilization.setMaxCpuThrottledTimestamp(newerUsage.getTimestamp());
+      }
+      if (percentCpuTimeThrottled < newRequestUtilization.getMinPercentCpuTimeThrottled()) {
+        newRequestUtilization.setMinPercentCpuTimeThrottled(percentCpuTimeThrottled);
+        newRequestUtilization.setMinCpuThrottledTimestamp(newerUsage.getTimestamp());
+      }
 
       if (cpusUsed > cpuReservedForTask) {
         numCpuOverages ++;
       }
 
-      requestUtilization
+      newRequestUtilization
           .addCpuUsed(cpusUsed)
           .addMemBytesUsed(newerUsage.getMemoryTotalBytes())
           .addPercentCpuTimeThrottled(percentCpuTimeThrottled)
@@ -496,24 +540,16 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
 
     double cpuBurstRating = pastTaskUsagesCopy.size() > 0 ? numCpuOverages / (double) pastTaskUsagesCopy.size() : 1;
 
-    requestUtilization
+    newRequestUtilization
         .addMemBytesReserved((long) (memoryMbReservedForTask * SingularitySlaveUsage.BYTES_PER_MEGABYTE * numTasks))
         .addCpuReserved(cpuReservedForTask * numTasks)
         .addDiskBytesReserved((long) diskMbReservedForTask * SingularitySlaveUsage.BYTES_PER_MEGABYTE  * numTasks)
-        .setMaxCpuUsed(curMaxCpuUsed)
-        .setMinCpuUsed(curMinCpuUsed)
-        .setMaxMemBytesUsed(curMaxMemBytesUsed)
-        .setMinMemBytesUsed(curMinMemBytesUsed)
-        .setMaxDiskBytesUsed(curMaxDiskBytesUsed)
-        .setMinDiskBytesUsed(curMinDiskBytesUsed)
-        .setMaxPercentCpuTimeThrottled(curMaxPercentCpuTimeThrottled)
-        .setMinPercentCpuTimeThrottled(curMinPercentCpuTimeThrottled)
         .setCpuBurstRating(cpuBurstRating);
 
-    utilizationPerRequestId.put(requestId, requestUtilization);
+    utilizationPerRequestId.put(requestId, newRequestUtilization);
   }
 
-  private List<SingularityTaskUsage> copyUsages(List<SingularityTaskUsage> pastTaskUsages, SingularityTaskUsage latestUsage, SingularityTaskId task) {
+  private List<SingularityTaskUsage> getFullListOfTaskUsages(List<SingularityTaskUsage> pastTaskUsages, SingularityTaskUsage latestUsage, SingularityTaskId task) {
     List<SingularityTaskUsage> pastTaskUsagesCopy = new ArrayList<>();
     pastTaskUsagesCopy.add(new SingularityTaskUsage(0, TimeUnit.MILLISECONDS.toSeconds(task.getStartedAt()), 0, 0, 0 , 0, 0)); // to calculate oldest cpu usage
     pastTaskUsagesCopy.addAll(pastTaskUsages);
@@ -633,32 +669,16 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
 
   @VisibleForTesting
   void clearOldUsage(String taskId) {
-    List<Double> pastTaskUsagePaths = usageManager.getTaskUsagePaths(taskId).stream().map(Double::parseDouble).collect(Collectors.toList());
-
-    while (pastTaskUsagePaths.size() + 1 > configuration.getNumUsageToKeep()) {
-      long minSecondsApart = configuration.getUsageIntervalSeconds();
-      boolean deleted = false;
-
-      for (int i = 0; i < pastTaskUsagePaths.size() - 1; i++) {
-        if (pastTaskUsagePaths.get(i + 1) - pastTaskUsagePaths.get(i) < minSecondsApart) {
-          SingularityDeleteResult result = usageManager.deleteSpecificTaskUsage(taskId, pastTaskUsagePaths.get(i + 1));
-
+    usageManager.getTaskUsagePaths(taskId)
+        .stream()
+        .map(Double::parseDouble)
+        .skip(configuration.getNumUsageToKeep())
+        .forEach((pathId) -> {
+          SingularityDeleteResult result = usageManager.deleteSpecificTaskUsage(taskId, pathId);
           if (result.equals(SingularityDeleteResult.DIDNT_EXIST)) {
-            LOG.warn("Didn't delete taskUsage {} for taskId {}", pastTaskUsagePaths.get(i + 1).toString(), taskId);
+            LOG.warn("Didn't delete taskUsage {} for taskId {}", pathId.toString(), taskId);
           }
-
-          deleted = true;
-          pastTaskUsagePaths.remove(pastTaskUsagePaths.get(i + 1));
-          break;
-        }
-      }
-
-      if (!deleted) {
-        usageManager.deleteSpecificTaskUsage(taskId, pastTaskUsagePaths.get(0));
-        pastTaskUsagePaths.remove(pastTaskUsagePaths.get(0));
-      }
-    }
-
+        });
   }
 
   private static class TaskIdWithUsage {

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityUsageTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityUsageTest.java
@@ -596,7 +596,7 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
 
   private void saveTaskUsage(String taskId, long... times) {
     for (long time : times) {
-      usageManager.saveSpecificTaskUsage(taskId, new SingularityTaskUsage(0, time, 0, 0));
+      usageManager.saveSpecificTaskUsage(taskId, new SingularityTaskUsage(0, time, 0, 0, 0, 0, 0));
     }
   }
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityUsageTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityUsageTest.java
@@ -1,5 +1,6 @@
 package com.hubspot.singularity.scheduler;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -14,6 +15,7 @@ import com.google.inject.Inject;
 import com.hubspot.mesos.json.MesosSlaveMetricsSnapshotObject;
 import com.hubspot.mesos.json.MesosTaskMonitorObject;
 import com.hubspot.singularity.MachineState;
+import com.hubspot.singularity.RequestUtilization;
 import com.hubspot.singularity.SingularityClusterUtilization;
 import com.hubspot.singularity.SingularitySlaveUsage;
 import com.hubspot.singularity.SingularityTask;
@@ -121,14 +123,13 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
   }
 
   @Test
-  public void testUsagePollerComplex() throws InterruptedException {
+  public void testUsagePoller() throws InterruptedException {
     initRequest();
     initFirstDeploy();
     saveAndSchedule(request.toBuilder().setInstances(Optional.of(2)));
     resourceOffers(1);
 
     configuration.setNumUsageToKeep(2);
-    configuration.setUsageIntervalSeconds(1);
     configuration.setCheckUsageEveryMillis(1);
 
     List<SingularityTaskId> taskIds = taskManager.getActiveTaskIds();
@@ -181,11 +182,11 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
     //check that there is only 2 usages
 
     Assert.assertEquals(2, usageManager.getSlaveUsage(slaveId).size());
-    Assert.assertEquals(2, usageManager.getTaskUsage(t1).size());
-    Assert.assertEquals(2, usageManager.getTaskUsage(t2).size());
+    Assert.assertEquals(3, usageManager.getTaskUsage(t1).size());
+    Assert.assertEquals(3, usageManager.getTaskUsage(t2).size());
 
-    Assert.assertEquals(22.5, usageManager.getTaskUsage(t2).get(0).getCpuSeconds(), 0);
-    Assert.assertEquals(23.5, usageManager.getTaskUsage(t2).get(1).getCpuSeconds(), 0);
+    Assert.assertEquals(10.0, usageManager.getTaskUsage(t2).get(0).getCpuSeconds(), 0);
+    Assert.assertEquals(22.5, usageManager.getTaskUsage(t2).get(1).getCpuSeconds(), 0);
 
     Assert.assertEquals(875, usageManager.getSlaveUsage(slaveId).get(0).getMemoryBytesUsed(), 0);
     Assert.assertEquals(1149, usageManager.getSlaveUsage(slaveId).get(1).getMemoryBytesUsed(), 0);
@@ -320,8 +321,7 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
 
   @Test
   public void itCorrectlyDeletesOldUsage() {
-    configuration.setNumUsageToKeep(3);
-    configuration.setUsageIntervalSeconds(180);
+    configuration.setNumUsageToKeep(2);
     configuration.setCheckUsageEveryMillis(TimeUnit.MINUTES.toMillis(1));
     long now = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
 
@@ -341,32 +341,13 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
     clearUsages(taskId);
     Assert.assertEquals(2, usageManager.getTaskUsage(taskId).size());
 
-    // x1 (3 min apart) x2 (1 min apart) x3
-    // x3 is deleted
+    // 3 usages, oldest is deleted
     taskId = "threeUsages";
     saveTaskUsage(taskId, now, now + TimeUnit.MINUTES.toSeconds(3), now + TimeUnit.MINUTES.toSeconds(4));
     clearUsages(taskId);
     Assert.assertEquals(2, usageManager.getTaskUsage(taskId).size());
     Assert.assertEquals(now, (long) usageManager.getTaskUsage(taskId).get(0).getTimestamp());
     Assert.assertEquals(now + TimeUnit.MINUTES.toSeconds(3), (long) usageManager.getTaskUsage(taskId).get(1).getTimestamp());
-
-    // x1 (1 min apart) x2 (1 min apart) x3
-    // x2 is deleted
-    taskId = "threeUsages2";
-    saveTaskUsage(taskId, now, now + TimeUnit.MINUTES.toSeconds(1), now + TimeUnit.MINUTES.toSeconds(2));
-    clearUsages(taskId);
-    Assert.assertEquals(2, usageManager.getTaskUsage(taskId).size());
-    Assert.assertEquals(now, (long) usageManager.getTaskUsage(taskId).get(0).getTimestamp());
-    Assert.assertEquals(now + TimeUnit.MINUTES.toSeconds(2), (long) usageManager.getTaskUsage(taskId).get(1).getTimestamp());
-
-    // x1 (3 min apart) x2 (3 min apart) x3
-    // x1 is deleted
-    taskId = "threeUsages3";
-    saveTaskUsage(taskId, now, now + TimeUnit.MINUTES.toSeconds(3), now + TimeUnit.MINUTES.toSeconds(6));
-    clearUsages(taskId);
-    Assert.assertEquals(2, usageManager.getTaskUsage(taskId).size());
-    Assert.assertEquals(now + TimeUnit.MINUTES.toSeconds(3), (long) usageManager.getTaskUsage(taskId).get(0).getTimestamp());
-    Assert.assertEquals(now + TimeUnit.MINUTES.toSeconds(6), (long) usageManager.getTaskUsage(taskId).get(1).getTimestamp());
   }
 
   @Test
@@ -400,15 +381,16 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
     Assert.assertTrue("Couldn't find cluster utilization", usageManager.getClusterUtilization().isPresent());
 
     SingularityClusterUtilization utilization = usageManager.getClusterUtilization().get();
+    List<RequestUtilization> requestUtilizations = new ArrayList<>(usageManager.getRequestUtilizations().values());
 
     int t1TaskUsages = usageManager.getTaskUsage(t1.getId()).size();
     int t2TaskUsages = usageManager.getTaskUsage(t2.getId()).size();
     Assert.assertEquals(2, t1TaskUsages);
     Assert.assertEquals(2, t2TaskUsages);
 
-    Assert.assertEquals(1, utilization.getRequestUtilizations().size());
-    Assert.assertEquals(cpuReserved * (t1TaskUsages + t2TaskUsages), utilization.getRequestUtilizations().get(0).getCpuReserved(), 0);
-    Assert.assertEquals(Math.round(memMbReserved * SingularitySlaveUsage.BYTES_PER_MEGABYTE * (t1TaskUsages + t2TaskUsages)), utilization.getRequestUtilizations().get(0).getMemBytesReserved(), 1);
+    Assert.assertEquals(1, requestUtilizations.size());
+    Assert.assertEquals(cpuReserved * (t1TaskUsages + t2TaskUsages), requestUtilizations.get(0).getCpuReserved(), 0);
+    Assert.assertEquals(Math.round(memMbReserved * SingularitySlaveUsage.BYTES_PER_MEGABYTE * (t1TaskUsages + t2TaskUsages)), requestUtilizations.get(0).getMemBytesReserved(), 1);
   }
 
   @Test
@@ -434,17 +416,18 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
 
     Assert.assertTrue("Couldn't find cluster utilization", usageManager.getClusterUtilization().isPresent());
     SingularityClusterUtilization utilization = usageManager.getClusterUtilization().get();
+    List<RequestUtilization> requestUtilizations = new ArrayList<>(usageManager.getRequestUtilizations().values());
 
     int t1TaskUsages = usageManager.getTaskUsage(t1.getId()).size();
     int t2TaskUsages = usageManager.getTaskUsage(t2.getId()).size();
     Assert.assertEquals(1, t1TaskUsages);
     Assert.assertEquals(1, t2TaskUsages);
-    Assert.assertEquals(1, utilization.getRequestUtilizations().size());
+    Assert.assertEquals(1, requestUtilizations.size());
 
-    double maxCpu = utilization.getRequestUtilizations().get(0).getMaxCpuUsed();
-    double minCpu = utilization.getRequestUtilizations().get(0).getMinCpuUsed();
-    long maxMemBytes = utilization.getRequestUtilizations().get(0).getMaxMemBytesUsed();
-    long minMemBytes = utilization.getRequestUtilizations().get(0).getMinMemBytesUsed();
+    double maxCpu = requestUtilizations.get(0).getMaxCpuUsed();
+    double minCpu = requestUtilizations.get(0).getMinCpuUsed();
+    long maxMemBytes = requestUtilizations.get(0).getMaxMemBytesUsed();
+    long minMemBytes = requestUtilizations.get(0).getMinMemBytesUsed();
     Assert.assertEquals(10, maxCpu, 0);
     Assert.assertEquals(8, minCpu, 0);
     Assert.assertEquals(800, maxMemBytes);
@@ -461,17 +444,18 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
 
     Assert.assertTrue("Couldn't find cluster utilization", usageManager.getClusterUtilization().isPresent());
     utilization = usageManager.getClusterUtilization().get();
+    requestUtilizations = new ArrayList<>(usageManager.getRequestUtilizations().values());
 
     t1TaskUsages = usageManager.getTaskUsage(t1.getId()).size();
     t2TaskUsages = usageManager.getTaskUsage(t2.getId()).size();
     Assert.assertEquals(2, t1TaskUsages);
     Assert.assertEquals(2, t2TaskUsages);
-    Assert.assertEquals(1, utilization.getRequestUtilizations().size());
+    Assert.assertEquals(1, requestUtilizations.size());
 
-    maxCpu = utilization.getRequestUtilizations().get(0).getMaxCpuUsed();
-    minCpu = utilization.getRequestUtilizations().get(0).getMinCpuUsed();
-    maxMemBytes = utilization.getRequestUtilizations().get(0).getMaxMemBytesUsed();
-    minMemBytes = utilization.getRequestUtilizations().get(0).getMinMemBytesUsed();
+    maxCpu = requestUtilizations.get(0).getMaxCpuUsed();
+    minCpu = requestUtilizations.get(0).getMinCpuUsed();
+    maxMemBytes = requestUtilizations.get(0).getMaxMemBytesUsed();
+    minMemBytes = requestUtilizations.get(0).getMinMemBytesUsed();
     Assert.assertEquals(12, maxCpu, 0);
     Assert.assertEquals(7, minCpu, 0);
     Assert.assertEquals(850, maxMemBytes);
@@ -488,17 +472,18 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
 
     Assert.assertTrue("Couldn't find cluster utilization", usageManager.getClusterUtilization().isPresent());
     utilization = usageManager.getClusterUtilization().get();
+    requestUtilizations = new ArrayList<>(usageManager.getRequestUtilizations().values());
 
     t1TaskUsages = usageManager.getTaskUsage(t1.getId()).size();
     t2TaskUsages = usageManager.getTaskUsage(t2.getId()).size();
     Assert.assertEquals(3, t1TaskUsages);
     Assert.assertEquals(3, t2TaskUsages);
-    Assert.assertEquals(1, utilization.getRequestUtilizations().size());
+    Assert.assertEquals(1, requestUtilizations.size());
 
-    maxCpu = utilization.getRequestUtilizations().get(0).getMaxCpuUsed();
-    minCpu = utilization.getRequestUtilizations().get(0).getMinCpuUsed();
-    maxMemBytes = utilization.getRequestUtilizations().get(0).getMaxMemBytesUsed();
-    minMemBytes = utilization.getRequestUtilizations().get(0).getMinMemBytesUsed();
+    maxCpu = requestUtilizations.get(0).getMaxCpuUsed();
+    minCpu = requestUtilizations.get(0).getMinCpuUsed();
+    maxMemBytes = requestUtilizations.get(0).getMaxMemBytesUsed();
+    minMemBytes = requestUtilizations.get(0).getMinMemBytesUsed();
     Assert.assertEquals(12, maxCpu, 0);
     Assert.assertEquals(7, minCpu, 0);
     Assert.assertEquals(850, maxMemBytes);
@@ -623,10 +608,6 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
                                long expectedMinUnderUtilizedMemBytes) {
 
     Assert.assertEquals(expectedTaskUsages, actualTaskUsages);
-
-    Assert.assertEquals("Expected 1 request", 1, utilization.getRequestUtilizations().size());
-    Assert.assertEquals("Incorrect cpu reserved", cpuReserved * actualTaskUsages, utilization.getRequestUtilizations().get(0).getCpuReserved(), 0);
-    Assert.assertEquals("Incorrect mem reserved", memMbReserved * SingularitySlaveUsage.BYTES_PER_MEGABYTE * actualTaskUsages, utilization.getRequestUtilizations().get(0).getMemBytesReserved(), 0.5);
 
     Assert.assertEquals(expectedRequestsWithOverUtilizedCpu, utilization.getNumRequestsWithOverUtilizedCpu());
     Assert.assertEquals(expectedRequestsWithUnderUtilizedCpu, utilization.getNumRequestsWithUnderUtilizedCpu());

--- a/SingularityUI/app/actions/api/utilization.es6
+++ b/SingularityUI/app/actions/api/utilization.es6
@@ -8,3 +8,20 @@ export const FetchUtilization = buildApiAction(
   })
 );
 
+export const FetchRequestUtilizations = buildApiAction(
+  'FETCH_REQUEST_UTILIZATIONS',
+  (catchStatusCodes = null) => ({
+    url: '/usage/requests',
+    catchStatusCodes
+  })
+);
+
+
+export const FetchRequestUtilization = buildApiAction(
+  'FETCH_REQUEST_UTILIZATION',
+  (requestId, catchStatusCodes = null) => ({
+    url: `/usage/requests/request/${requestId}`,
+    catchStatusCodes
+  }),
+  (requestId) => requestId
+);

--- a/SingularityUI/app/actions/ui/requestDetail.es6
+++ b/SingularityUI/app/actions/ui/requestDetail.es6
@@ -6,7 +6,7 @@ import {
   FetchRequestHistory,
 } from '../api/history';
 import { FetchTaskCleanups, FetchScheduledTasksForRequest } from '../api/tasks';
-import { FetchRequestUtilization } from '../api.utilization';
+import { FetchRequestUtilization } from '../api/utilization';
 
 export const refresh = (requestId) => (dispatch, getState) => {
   const requiredPromises = Promise.all([

--- a/SingularityUI/app/actions/ui/requestDetail.es6
+++ b/SingularityUI/app/actions/ui/requestDetail.es6
@@ -6,6 +6,7 @@ import {
   FetchRequestHistory,
 } from '../api/history';
 import { FetchTaskCleanups, FetchScheduledTasksForRequest } from '../api/tasks';
+import { FetchRequestUtilization } from '../api.utilization';
 
 export const refresh = (requestId) => (dispatch, getState) => {
   const requiredPromises = Promise.all([
@@ -18,6 +19,7 @@ export const refresh = (requestId) => (dispatch, getState) => {
   dispatch(FetchTaskHistoryForRequest.trigger(requestId, 5, 1));
   dispatch(FetchDeploysForRequest.trigger(requestId, 5, 1));
   dispatch(FetchScheduledTasksForRequest.trigger(requestId));
+  dispatch(FetchRequestUtilization.trigger(requestId, [404]))
 
   return requiredPromises;
 }

--- a/SingularityUI/app/actions/ui/requests.es6
+++ b/SingularityUI/app/actions/ui/requests.es6
@@ -1,4 +1,9 @@
 import { FetchRequestsInState } from '../../actions/api/requests';
+import { FetchRequestUtilizations } from '../../actions/api/utilization';
 
-export const refresh = (state) => (dispatch) =>
-	dispatch(FetchRequestsInState.trigger(state === 'cleaning' ? 'cleanup' : state, true))
+export const refresh = (state) => (dispatch) => {
+    const promises = []
+	promises.push(dispatch(FetchRequestsInState.trigger(state === 'cleaning' ? 'cleanup' : state, true)));
+	promises.push(dispatch(FetchRequestUtilizations.trigger()));
+	return Promise.all(promises);
+}

--- a/SingularityUI/app/actions/ui/taskDetail.es6
+++ b/SingularityUI/app/actions/ui/taskDetail.es6
@@ -32,9 +32,5 @@ export const refresh = (taskId, splat) => (dispatch, getState) => {
 };
 
 export const onLoad = (taskId) => (dispatch) => {
-  const refreshStatistics = () => {
-    dispatch(FetchTaskStatistics.trigger(taskId, [404, 500]));
-  }
-  setInterval(refreshStatistics, 3000);
   return dispatch(FetchTaskS3Logs.trigger(taskId, [404, 500]));
 };

--- a/SingularityUI/app/actions/ui/taskDetail.es6
+++ b/SingularityUI/app/actions/ui/taskDetail.es6
@@ -32,5 +32,10 @@ export const refresh = (taskId, splat) => (dispatch, getState) => {
 };
 
 export const onLoad = (taskId) => (dispatch) => {
+  console.log('polling stats');
+  const refreshStatistics = () => {
+    dispatch(FetchTaskStatistics.trigger(taskId, [404, 500]));
+  }
+  setInterval(refreshStatistics, 3000);
   return dispatch(FetchTaskS3Logs.trigger(taskId, [404, 500]));
 };

--- a/SingularityUI/app/actions/ui/taskDetail.es6
+++ b/SingularityUI/app/actions/ui/taskDetail.es6
@@ -32,7 +32,6 @@ export const refresh = (taskId, splat) => (dispatch, getState) => {
 };
 
 export const onLoad = (taskId) => (dispatch) => {
-  console.log('polling stats');
   const refreshStatistics = () => {
     dispatch(FetchTaskStatistics.trigger(taskId, [404, 500]));
   }

--- a/SingularityUI/app/components/machines/usage/Utilization.jsx
+++ b/SingularityUI/app/components/machines/usage/Utilization.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import rootComponent from '../../../rootComponent';
 import { FetchSlaveUsages, FetchSlaves } from '../../../actions/api/slaves';
 import { FetchSingularityStatus } from '../../../actions/api/state';
+import { FetchUtilization } from '../../../actions/api/utilization';
 import { STAT_NAMES, WHOLE_NUMBER, HEALTH_SCALE_MAX } from '../Constants';
 import Utils from '../../../utils';
 import ResourceHealthData from './ResourceHealthData';
@@ -105,7 +106,8 @@ const refresh = () => (dispatch) =>
   Promise.all([
     dispatch(FetchSlaves.trigger()),
     dispatch(FetchSlaveUsages.trigger()),
-    dispatch(FetchSingularityStatus.trigger())
+    dispatch(FetchSingularityStatus.trigger()),
+    dispatch(FetchUtilization.trigger())
   ]);
 
 export default connect(mapStateToProps, mapDispatchToProps)(rootComponent(SlaveUsage, refresh, true, true));

--- a/SingularityUI/app/components/requestDetail/RequestUtilization.jsx
+++ b/SingularityUI/app/components/requestDetail/RequestUtilization.jsx
@@ -9,10 +9,10 @@ import Loader from "../common/Loader";
 
 export const HUNDREDTHS_PLACE = 2;
 
-const RequestUtilization = ({isFetching, utilization}) => {
+const RequestUtilization = ({utilization}) => {
   const isCpuOverAllocated = utilization &&
     (utilization.maxCpuUsed > utilization.cpuReserved / utilization.numTasks);
-  const isCpuThrottled = utilization.percentCpuTimeThrottled > 0;
+  const isCpuThrottled = utilization && utilization.percentCpuTimeThrottled > 0;
   const attributes = utilization && (
       <div className="row">
         <div className="col-md-3">
@@ -119,9 +119,10 @@ RequestUtilization.propTypes = {
 
 
 const mapStateToProps = function(state, ownProps) {
+  console.log(state);
   const requestId = ownProps.requestId;
   return {
-    utilization: Utils.maybe(state, ['api', 'requestUtilization', requestId])
+    utilization: Utils.maybe(state, ['api', 'requestUtilization', requestId, 'data'])
   };
 };
 

--- a/SingularityUI/app/components/requestDetail/RequestUtilization.jsx
+++ b/SingularityUI/app/components/requestDetail/RequestUtilization.jsx
@@ -12,6 +12,7 @@ export const HUNDREDTHS_PLACE = 2;
 const RequestUtilization = ({isFetching, utilization}) => {
   const isCpuOverAllocated = utilization &&
     (utilization.maxCpuUsed > utilization.cpuReserved / utilization.numTasks);
+  const isCpuThrottled = utilization.percentCpuTimeThrottled > 0;
   const attributes = utilization && (
       <div className="row">
         <div className="col-md-3">
@@ -31,6 +32,27 @@ const RequestUtilization = ({isFetching, utilization}) => {
                 <tr>
                   <td className={isCpuOverAllocated ? 'danger' : ''}>Max CPU (all tasks)</td>
                   <td className={isCpuOverAllocated ? 'danger' : ''}>{Utils.roundTo(utilization.maxCpuUsed, HUNDREDTHS_PLACE)}</td>
+                </tr>
+              </tbody>
+            </BootstrapTable>
+          </UsageInfo>
+        </div>
+        <div className="col-md-3">
+          <UsageInfo
+            title="Averge % CPU Time Throttled"
+            total={100}
+            used={utilization.percentCpuTimeThrottled / utilization.numTasks}
+            style={isCpuThrottled ? 'danger' : null}
+          >
+            <BootstrapTable responsive={false} striped={true} style={{marginTop: '10px'}}>
+              <tbody>
+                <tr>
+                  <td>Min CPU Time Throttled % (all tasks)</td>
+                  <td>{Utils.roundTo(utilization.minPercentCpuTimeThrottled, HUNDREDTHS_PLACE)}</td>
+                </tr>
+                <tr>
+                  <td className={isCpuThrottled ? 'danger' : ''}>Max CPU Time Throttled % (all tasks)</td>
+                  <td className={isCpuThrottled ? 'danger' : ''}>{Utils.roundTo(utilization.maxPercentCpuTimeThrottled, HUNDREDTHS_PLACE)}</td>
                 </tr>
               </tbody>
             </BootstrapTable>

--- a/SingularityUI/app/components/requestDetail/RequestUtilization.jsx
+++ b/SingularityUI/app/components/requestDetail/RequestUtilization.jsx
@@ -26,11 +26,11 @@ const RequestUtilization = ({isFetching, utilization}) => {
             <BootstrapTable responsive={false} striped={true} style={{marginTop: '10px'}}>
               <tbody>
                 <tr>
-                  <td>Min CPU (all tasks)</td>
+                  <td>Min CPU (24 hour min for all tasks)</td>
                   <td>{Utils.roundTo(utilization.minCpuUsed, HUNDREDTHS_PLACE)}</td>
                 </tr>
                 <tr>
-                  <td className={isCpuOverAllocated ? 'danger' : ''}>Max CPU (all tasks)</td>
+                  <td className={isCpuOverAllocated ? 'danger' : ''}>Max CPU (24 hour max for all tasks)</td>
                   <td className={isCpuOverAllocated ? 'danger' : ''}>{Utils.roundTo(utilization.maxCpuUsed, HUNDREDTHS_PLACE)}</td>
                 </tr>
               </tbody>
@@ -47,11 +47,11 @@ const RequestUtilization = ({isFetching, utilization}) => {
             <BootstrapTable responsive={false} striped={true} style={{marginTop: '10px'}}>
               <tbody>
                 <tr>
-                  <td>Min CPU Time Throttled % (all tasks)</td>
+                  <td>Min CPU Time Throttled % (24 hour min for all tasks)</td>
                   <td>{Utils.roundTo(utilization.minPercentCpuTimeThrottled, HUNDREDTHS_PLACE)}</td>
                 </tr>
                 <tr>
-                  <td className={isCpuThrottled ? 'danger' : ''}>Max CPU Time Throttled % (all tasks)</td>
+                  <td className={isCpuThrottled ? 'danger' : ''}>Max CPU Time Throttled % (24 hour max for all tasks)</td>
                   <td className={isCpuThrottled ? 'danger' : ''}>{Utils.roundTo(utilization.maxPercentCpuTimeThrottled, HUNDREDTHS_PLACE)}</td>
                 </tr>
               </tbody>
@@ -69,11 +69,11 @@ const RequestUtilization = ({isFetching, utilization}) => {
             <BootstrapTable responsive={false} striped={true} style={{marginTop: '10px'}}>
               <tbody>
                 <tr>
-                  <td>Min memory (all tasks)</td>
+                  <td>Min memory (24 hour min for all tasks)</td>
                   <td>{Utils.humanizeFileSize(utilization.minMemBytesUsed)}</td>
                 </tr>
                 <tr>
-                  <td>Max memory (all tasks)</td>
+                  <td>Max memory (24 hour max for all tasks)</td>
                   <td>{Utils.humanizeFileSize(utilization.maxMemBytesUsed)}</td>
                 </tr>
               </tbody>
@@ -105,16 +105,15 @@ const RequestUtilization = ({isFetching, utilization}) => {
     </div>
   );
 
-  return utilization ? (
-    <CollapsableSection id="request-utilization" title="Resource usage" subtitle="(past 24 hours)" defaultExpanded={isCpuOverAllocated}>
-      {isFetching ? <Loader /> : attributes}
+  return (
+    <CollapsableSection id="request-utilization" title="Resource usage" defaultExpanded={isCpuOverAllocated}>
+      {attributes}
     </CollapsableSection>
-  ) : <div></div>;
+  );
 };
 
 RequestUtilization.propTypes = {
   requestId: PropTypes.string.isRequired,
-  isFetching: PropTypes.bool.isRequired,
   utilization: PropTypes.object
 };
 
@@ -122,10 +121,7 @@ RequestUtilization.propTypes = {
 const mapStateToProps = function(state, ownProps) {
   const requestId = ownProps.requestId;
   return {
-    isFetching: state.api.utilization.isFetching,
-    utilization: _.find(state.api.utilization.data.requestUtilizations, (request) => {
-      return request.requestId === requestId;
-    })
+    utilization: Utils.maybe(state, ['api', 'requestUtilization', requestId])
   };
 };
 

--- a/SingularityUI/app/components/requestDetail/RequestUtilization.jsx
+++ b/SingularityUI/app/components/requestDetail/RequestUtilization.jsx
@@ -26,11 +26,11 @@ const RequestUtilization = ({utilization}) => {
             <BootstrapTable responsive={false} striped={true} style={{marginTop: '10px'}}>
               <tbody>
                 <tr>
-                  <td>Min CPU (24 hour min for all tasks)</td>
+                  <td>Min CPU (24 Hr Min)</td>
                   <td>{Utils.roundTo(utilization.minCpuUsed, HUNDREDTHS_PLACE)}</td>
                 </tr>
                 <tr>
-                  <td className={isCpuOverAllocated ? 'danger' : ''}>Max CPU (24 hour max for all tasks)</td>
+                  <td className={isCpuOverAllocated ? 'danger' : ''}>Max CPU (24 Hr Max)</td>
                   <td className={isCpuOverAllocated ? 'danger' : ''}>{Utils.roundTo(utilization.maxCpuUsed, HUNDREDTHS_PLACE)}</td>
                 </tr>
               </tbody>
@@ -47,11 +47,11 @@ const RequestUtilization = ({utilization}) => {
             <BootstrapTable responsive={false} striped={true} style={{marginTop: '10px'}}>
               <tbody>
                 <tr>
-                  <td>Min CPU Time Throttled % (24 hour min for all tasks)</td>
+                  <td>Min CPU Time Throttled % (24 Hr Min)</td>
                   <td>{Utils.roundTo(utilization.minPercentCpuTimeThrottled, HUNDREDTHS_PLACE)}</td>
                 </tr>
                 <tr>
-                  <td className={isCpuThrottled ? 'danger' : ''}>Max CPU Time Throttled % (24 hour max for all tasks)</td>
+                  <td className={isCpuThrottled ? 'danger' : ''}>Max CPU Time Throttled % (24 Hr Max)</td>
                   <td className={isCpuThrottled ? 'danger' : ''}>{Utils.roundTo(utilization.maxPercentCpuTimeThrottled, HUNDREDTHS_PLACE)}</td>
                 </tr>
               </tbody>
@@ -69,11 +69,11 @@ const RequestUtilization = ({utilization}) => {
             <BootstrapTable responsive={false} striped={true} style={{marginTop: '10px'}}>
               <tbody>
                 <tr>
-                  <td>Min memory (24 hour min for all tasks)</td>
+                  <td>Min memory (24 Hr Min)</td>
                   <td>{Utils.humanizeFileSize(utilization.minMemBytesUsed)}</td>
                 </tr>
                 <tr>
-                  <td>Max memory (24 hour max for all tasks)</td>
+                  <td>Max memory (24 Hr Max)</td>
                   <td>{Utils.humanizeFileSize(utilization.maxMemBytesUsed)}</td>
                 </tr>
               </tbody>

--- a/SingularityUI/app/components/requestDetail/RequestUtilization.jsx
+++ b/SingularityUI/app/components/requestDetail/RequestUtilization.jsx
@@ -91,11 +91,11 @@ const RequestUtilization = ({utilization}) => {
             <BootstrapTable responsive={false} striped={true} style={{marginTop: '10px'}}>
               <tbody>
               <tr>
-                <td>Min disk (all tasks)</td>
+                <td>Min disk (24 Hr Min)</td>
                 <td>{Utils.humanizeFileSize(utilization.minDiskBytesUsed)}</td>
               </tr>
               <tr>
-                <td>Max disk (all tasks)</td>
+                <td>Max disk (24 Hr Max)</td>
                 <td>{Utils.humanizeFileSize(utilization.maxDiskBytesUsed)}</td>
               </tr>
               </tbody>

--- a/SingularityUI/app/components/requests/RequestsPage.jsx
+++ b/SingularityUI/app/components/requests/RequestsPage.jsx
@@ -166,7 +166,7 @@ function mapStateToProps(state, ownProps) {
     pathname: ownProps.location.pathname,
     notFound: statusCode === 404,
     requestsInState: modifiedRequests,
-    requestUtilizations: state.api.utilization.data.requestUtilizations,
+    requestUtilizations: state.api.requestUtilizations.data,
     groups: userGroups,
     filter
   };

--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -348,12 +348,14 @@ class TaskDetail extends Component {
     if (!this.props.task.isStillRunning) return null;
     let cpuUsage = 0;
     let cpuUsageExceeding = false;
+    let percentCpuTimeThrottled = 0;
     if (this.state.previousUsage) {
       const currentTime = this.props.resourceUsage.cpusSystemTimeSecs + this.props.resourceUsage.cpusUserTimeSecs;
       const previousTime = this.state.previousUsage.cpusSystemTimeSecs + this.state.previousUsage.cpusUserTimeSecs;
       const timestampDiff = this.props.resourceUsage.timestamp - this.state.previousUsage.timestamp;
       cpuUsage = (currentTime - previousTime) / timestampDiff;
       cpuUsageExceeding = (cpuUsage / this.props.resourceUsage.cpusLimit) > 1.10;
+      percentCpuTimeThrottled = (this.props.resourceUsage.cpusThrottledTimeSecs - this.state.previousUsage.cpusThrottledTimeSecs) / timestampDiff
     }
 
     const exceedingWarning = cpuUsageExceeding && (
@@ -374,7 +376,7 @@ class TaskDetail extends Component {
           title="CPU Usage"
           style={cpuUsageExceeding ? 'danger' : 'success'}
           total={this.props.resourceUsage.cpusLimit}
-          used={cpuUsage.toFixed(3)}
+          used={cpuUsage}
         >
           <span>
             <p>
@@ -387,6 +389,21 @@ class TaskDetail extends Component {
         <Panel header="CPU Usage">
           <p>{cpuUsage.toFixed(3)} shares used</p>
         </Panel>
+      );
+
+      const maybePercentCpuTimeThrottled = (
+         <UsageInfo
+          title="% CPU Time Throttled"
+          style={percentCpuTimeThrottled > 0 ? 'danger' : 'success'}
+          total={100}
+          used={percentCpuTimeThrottled}
+        >
+          <span>
+            <p>
+              {percentCpuTimeThrottled.toFixed(3)}% of CPU Time Throttled
+            </p>
+          </span>
+        </UsageInfo>
       );
       maybeResourceUsage = (
         <div>
@@ -403,6 +420,9 @@ class TaskDetail extends Component {
             </div>
             <div className="col-md-3 col-sm-4">
               {maybeCpuUsage}
+            </div>
+            <div className="col-md-3 col-sm-4">
+              {maybePercentCpuTimeThrottled}
             </div>
             <div className="col-md-3 col-sm-4">
               <UsageInfo

--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -140,7 +140,7 @@ class TaskDetail extends Component {
     if (this.props.task.isStillRunning) {
       this.props.fetchTaskStatistics(this.props.params.taskId);
     }
-    this.statisticsRefreshInterval = setInterval(this.props.fetchTaskStatistics, 3000);
+    this.statisticsRefreshInterval = setInterval(() => this.props.fetchTaskStatistics(this.props.params.taskId), 3000);
   }
 
   componentWillReceiveProps(nextProps) {

--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -140,6 +140,7 @@ class TaskDetail extends Component {
     if (this.props.task.isStillRunning) {
       this.props.fetchTaskStatistics(this.props.params.taskId);
     }
+    this.statisticsRefreshInterval = setInterval(this.props.fetchTaskStatistics, 3000);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -149,6 +150,10 @@ class TaskDetail extends Component {
         previousUsage: this.props.resourceUsage
       });
     }
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.statisticsRefreshInterval);
   }
 
   analyzeFiles(files) {
@@ -572,12 +577,12 @@ function mapDispatchToProps(dispatch) {
   return {
     runCommandOnTask: (taskId, commandName) => dispatch(RunCommandOnTask.trigger(taskId, commandName)),
     fetchTaskHistory: (taskId) => dispatch(FetchTaskHistory.trigger(taskId, true)),
-    fetchTaskStatistics: (taskId) => dispatch(FetchTaskStatistics.trigger(taskId, [404])),
+    fetchTaskStatistics: (taskId) => dispatch(FetchTaskStatistics.trigger(taskId, [404, 500])),
     fetchTaskFiles: (taskId, path, catchStatusCodes = []) => dispatch(FetchTaskFiles.trigger(taskId, path, catchStatusCodes.concat([404]))),
     fetchDeployForRequest: (taskId, deployId) => dispatch(FetchDeployForRequest.trigger(taskId, deployId)),
     fetchTaskCleanups: () => dispatch(FetchTaskCleanups.trigger()),
     fetchPendingDeploys: () => dispatch(FetchPendingDeploys.trigger()),
-    fecthS3Logs: (taskId) => dispatch(FetchTaskS3Logs.trigger(taskId, [404, 500])),
+    fecthS3Logs: (taskId) => dispatch(FetchTaskS3Logs.trigger(taskId, [404, 500]))
   };
 }
 

--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -374,18 +374,18 @@ class TaskDetail extends Component {
           title="CPU Usage"
           style={cpuUsageExceeding ? 'danger' : 'success'}
           total={this.props.resourceUsage.cpusLimit}
-          used={Math.round(cpuUsage * 100) / 100}
+          used={cpuUsage.toFixed(3)}
         >
           <span>
             <p>
-              {Math.round(cpuUsage * 100) / 100} used / {this.props.resourceUsage.cpusLimit} allocated CPUs
+              {cpuUsage.toFixed(3)} used / {this.props.resourceUsage.cpusLimit} allocated CPUs
             </p>
             {exceedingWarning}
           </span>
         </UsageInfo>
       ) : (
         <Panel header="CPU Usage">
-          <p>{Math.round(cpuUsage * 100) / 100} shares used</p>
+          <p>{cpuUsage.toFixed(3)} shares used</p>
         </Panel>
       );
       maybeResourceUsage = (

--- a/SingularityUI/app/initialize.jsx
+++ b/SingularityUI/app/initialize.jsx
@@ -14,7 +14,6 @@ import AppRouter from './router';
 import configureStore from 'store';
 import { FetchUser } from 'actions/api/auth';
 import { FetchGroups } from 'actions/api/requestGroups';
-import { FetchUtilization } from 'actions/api/utilization';
 import { FetchSingularityStatus } from 'actions/api/state';
 import { actions as tailerActions } from 'singularityui-tailer';
 import { AddStarredRequests } from 'actions/api/users';
@@ -90,9 +89,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const globalRefresh = () => {
       // set up request groups
       store.dispatch(FetchGroups.trigger([404, 500]));
-
-      // set up cluster utilization
-      store.dispatch(FetchUtilization.trigger([404, 500]));
 
       // set up state
       store.dispatch(FetchSingularityStatus.trigger());

--- a/SingularityUI/app/reducers/api/index.es6
+++ b/SingularityUI/app/reducers/api/index.es6
@@ -89,7 +89,11 @@ import { FetchGroups } from '../../actions/api/requestGroups';
 
 import { FetchInactiveHosts } from '../../actions/api/inactive';
 
-import { FetchUtilization } from '../../actions/api/utilization';
+import {
+  FetchUtilization,
+  FetchRequestUtilizations,
+  FetchRequestUtilization
+} from '../../actions/api/utilization';
 
 const user = buildApiActionReducer(FetchUser);
 const addStarredRequests = buildApiActionReducer(AddStarredRequests, []);
@@ -145,6 +149,8 @@ const tasks = buildApiActionReducer(FetchTasksInState, []);
 const requestGroups = buildApiActionReducer(FetchGroups, []);
 const inactiveHosts = buildApiActionReducer(FetchInactiveHosts, []);
 const utilization = buildApiActionReducer(FetchUtilization, {});
+const requestUtilizations = buildApiActionReducer(FetchRequestUtilizations, []);
+const requestUtilization = buildKeyedApiActionReducer(FetchRequestUtilizations, []);
 
 export default combineReducers({
   user,
@@ -200,5 +206,7 @@ export default combineReducers({
   taskHistory,
   requestGroups,
   inactiveHosts,
-  utilization
+  utilization,
+  requestUtilizations,
+  requestUtilization
 });

--- a/SingularityUI/app/reducers/api/index.es6
+++ b/SingularityUI/app/reducers/api/index.es6
@@ -150,7 +150,7 @@ const requestGroups = buildApiActionReducer(FetchGroups, []);
 const inactiveHosts = buildApiActionReducer(FetchInactiveHosts, []);
 const utilization = buildApiActionReducer(FetchUtilization, {});
 const requestUtilizations = buildApiActionReducer(FetchRequestUtilizations, []);
-const requestUtilization = buildKeyedApiActionReducer(FetchRequestUtilizations, []);
+const requestUtilization = buildKeyedApiActionReducer(FetchRequestUtilization, []);
 
 export default combineReducers({
   user,


### PR DESCRIPTION
If a hard limit on cpu is not enabled on the mesos slave/agent, cpu usage is only controlled by cpu shares. It can be useful to also add an additional hard limit, such that a single task cannot overwhelm a slave. This adds a `cpuHardLimit` and `cpuHardLimitScaleFactor` configuration parameter in the base SingularityConfiguration, which will:

- propagate a hard limit to ExecutorData for the task. If the hard limit is below the requested task cpus, that task's new hard limit is requested cpus * cpuHardLimitScaleFactor
- triggers the executor to echo a calculated cfs quota and cfs period (defaults to the recommended 100000) to the cgroup settings for the task in runner.sh. For docker tasks, this adds the --cpu-quota/--cpu-period flags to the docker run command