### PR TITLE
Configurably omit offers from hosts that are overloaded

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularitySlaveUsage.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularitySlaveUsage.java
@@ -2,10 +2,9 @@ package com.hubspot.singularity;
 
 import java.util.Map;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.google.common.base.Optional;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Optional;
 
 public class SingularitySlaveUsage {
 
@@ -77,12 +76,6 @@ public class SingularitySlaveUsage {
     this.systemLoad15Min = systemLoad15Min;
     this.slaveDiskUsed = slaveDiskUsed;
     this.slaveDiskTotal = slaveDiskTotal;
-  }
-
-  @JsonIgnore
-  public boolean isOverloaded() {
-    // Any host where load5 is > 1 is overloaded. Also consider a higher threshold for load1 to take into account spikes large enough to be disruptive
-    return  systemLoad5Min > 1.0 || systemLoad1Min > 1.5;
   }
 
   public double getCpusUsed() {

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularitySlaveUsage.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularitySlaveUsage.java
@@ -2,6 +2,7 @@ package com.hubspot.singularity;
 
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Optional;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -76,6 +77,12 @@ public class SingularitySlaveUsage {
     this.systemLoad15Min = systemLoad15Min;
     this.slaveDiskUsed = slaveDiskUsed;
     this.slaveDiskTotal = slaveDiskTotal;
+  }
+
+  @JsonIgnore
+  public boolean isOverloaded() {
+    // Any host where load5 is > 1 is overloaded. Also consider a higher threshold for load1 to take into account spikes large enough to be disruptive
+    return  systemLoad5Min > 1.0 || systemLoad1Min > 1.5;
   }
 
   public double getCpusUsed() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/MesosConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/MesosConfiguration.java
@@ -67,6 +67,8 @@ public class MesosConfiguration {
   private double nonLonRunningFreeResourceWeight = 0.75;
   private double nonLongRunningUsedResourceWeight = 0.25;
   private boolean omitOverloadedHosts = false;
+  private double load5OverloadedThreshold = 1.0;
+  private double load1OverloadedThreshold = 1.5;
 
   public int getMaxNumInstancesPerRequest() {
     return maxNumInstancesPerRequest;
@@ -354,5 +356,21 @@ public class MesosConfiguration {
 
   public void setOmitOverloadedHosts(boolean omitOverloadedHosts) {
     this.omitOverloadedHosts = omitOverloadedHosts;
+  }
+
+  public double getLoad5OverloadedThreshold() {
+    return load5OverloadedThreshold;
+  }
+
+  public void setLoad5OverloadedThreshold(double load5OverloadedThreshold) {
+    this.load5OverloadedThreshold = load5OverloadedThreshold;
+  }
+
+  public double getLoad1OverloadedThreshold() {
+    return load1OverloadedThreshold;
+  }
+
+  public void setLoad1OverloadedThreshold(double load1OverloadedThreshold) {
+    this.load1OverloadedThreshold = load1OverloadedThreshold;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/MesosConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/MesosConfiguration.java
@@ -66,6 +66,7 @@ public class MesosConfiguration {
   private double longRunningUsedResourceWeight = 0.5;
   private double nonLonRunningFreeResourceWeight = 0.75;
   private double nonLongRunningUsedResourceWeight = 0.25;
+  private boolean omitOverloadedHosts = false;
 
   public int getMaxNumInstancesPerRequest() {
     return maxNumInstancesPerRequest;
@@ -345,5 +346,13 @@ public class MesosConfiguration {
 
   public void setNonLongRunningUsedResourceWeight(double nonLongRunningUsedResourceWeight) {
     this.nonLongRunningUsedResourceWeight = nonLongRunningUsedResourceWeight;
+  }
+
+  public boolean isOmitOverloadedHosts() {
+    return omitOverloadedHosts;
+  }
+
+  public void setOmitOverloadedHosts(boolean omitOverloadedHosts) {
+    this.omitOverloadedHosts = omitOverloadedHosts;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
@@ -353,6 +353,11 @@ public class SingularityMesosOfferScheduler {
       return 0;
     }
 
+    if (mesosConfiguration.isOmitOverloadedHosts() && maybeSlaveUsage.isPresent() && maybeSlaveUsage.get().getSlaveUsage().isOverloaded()) {
+      LOG.debug("Slave {} is overloaded (), ignoring offer");
+      return 0;
+    }
+
     if (LOG.isTraceEnabled()) {
       LOG.trace("Attempting to match task {} resources {} with required role '{}' ({} for task + {} for executor) with remaining offer resources {}",
           pendingTaskId, taskRequestHolder.getTotalResources(), taskRequest.getRequest().getRequiredRole().or("*"),

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
@@ -202,10 +202,12 @@ public class SingularityMesosOfferScheduler {
         .collect(Collectors.toMap(
             SingularitySlaveUsageWithId::getSlaveId,
             (usageWithId) -> new SingularitySlaveUsageWithCalculatedScores(
-                  usageWithId,
-                  configuration.getMesosConfiguration().getScoringStrategy(),
-                  configuration.getMesosConfiguration().getScoreUsingSystemLoad(),
-                  getMaxProbableUsageForSlave(activeTaskIds, requestUtilizations, offerHolders.get(usageWithId.getSlaveId()).getSanitizedHost())
+                usageWithId,
+                mesosConfiguration.getScoringStrategy(),
+                mesosConfiguration.getScoreUsingSystemLoad(),
+                getMaxProbableUsageForSlave(activeTaskIds, requestUtilizations, offerHolders.get(usageWithId.getSlaveId()).getSanitizedHost()),
+                mesosConfiguration.getLoad5OverloadedThreshold(),
+                mesosConfiguration.getLoad1OverloadedThreshold()
             )
         ));
 
@@ -353,7 +355,7 @@ public class SingularityMesosOfferScheduler {
       return 0;
     }
 
-    if (mesosConfiguration.isOmitOverloadedHosts() && maybeSlaveUsage.isPresent() && maybeSlaveUsage.get().getSlaveUsage().isOverloaded()) {
+    if (mesosConfiguration.isOmitOverloadedHosts() && maybeSlaveUsage.isPresent() && maybeSlaveUsage.get().isOverloaded()) {
       LOG.debug("Slave {} is overloaded (), ignoring offer");
       return 0;
     }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveUsageWithCalculatedScores.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveUsageWithCalculatedScores.java
@@ -25,7 +25,10 @@ class SingularitySlaveUsageWithCalculatedScores {
   private double estimatedAddedMemoryBytesReserved = 0;
   private double estimatedAddedDiskBytesReserved = 0;
 
-  public SingularitySlaveUsageWithCalculatedScores(SingularitySlaveUsage slaveUsage, SingularityUsageScoringStrategy scoringStrategy, MachineLoadMetric systemLoadMetric, MaxProbableUsage maxProbableTaskUsage) {
+  private final double load5Threshold;
+  private final double load1Threshold;
+
+  public SingularitySlaveUsageWithCalculatedScores(SingularitySlaveUsage slaveUsage, SingularityUsageScoringStrategy scoringStrategy, MachineLoadMetric systemLoadMetric, MaxProbableUsage maxProbableTaskUsage, double load5Threshold, double load1Threshold) {
     this.slaveUsage = slaveUsage;
     this.systemLoadMetric = systemLoadMetric;
     this.maxProbableTaskUsage = maxProbableTaskUsage;
@@ -36,6 +39,12 @@ class SingularitySlaveUsageWithCalculatedScores {
       this.missingUsageData = false;
       setScores(scoringStrategy);
     }
+    this.load5Threshold = load5Threshold;
+    this.load1Threshold = load1Threshold;
+  }
+
+  public boolean isOverloaded() {
+    return  slaveUsage.getSystemLoad5Min() > load5Threshold || slaveUsage.getSystemLoad1Min() > load1Threshold;
   }
 
   private void setScores(double longRunningCpusUsedScore,

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveUsageWithCalculatedScores.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveUsageWithCalculatedScores.java
@@ -44,7 +44,7 @@ class SingularitySlaveUsageWithCalculatedScores {
   }
 
   public boolean isOverloaded() {
-    return  slaveUsage.getSystemLoad5Min() > load5Threshold || slaveUsage.getSystemLoad1Min() > load1Threshold;
+    return  (slaveUsage.getSystemLoad5Min() / slaveUsage.getSystemCpusTotal()) > load5Threshold || (slaveUsage.getSystemLoad1Min() / slaveUsage.getSystemCpusTotal()) > load1Threshold;
   }
 
   private void setScores(double longRunningCpusUsedScore,

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosOfferSchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosOfferSchedulerTest.java
@@ -452,6 +452,7 @@ public class SingularityMesosOfferSchedulerTest extends SingularitySchedulerTest
         new SingularitySlaveUsage(0, cpusReserved, Optional.of(cpusTotal), 0, memMbReserved, Optional.of(memMbTotal), 0, diskMbReserved, Optional.of(diskMbTotal), longRunningTasksUsage, 1, 0L,
             0, 0, 0, 0, 0, 0, 0 , 0),
         SingularityUsageScoringStrategy.SPREAD_TASK_USAGE, MachineLoadMetric.LOAD_5, new MaxProbableUsage(0, 0, 0)
+        0, 0
     );
   }
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosOfferSchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosOfferSchedulerTest.java
@@ -451,7 +451,7 @@ public class SingularityMesosOfferSchedulerTest extends SingularitySchedulerTest
     return new SingularitySlaveUsageWithCalculatedScores(
         new SingularitySlaveUsage(0, cpusReserved, Optional.of(cpusTotal), 0, memMbReserved, Optional.of(memMbTotal), 0, diskMbReserved, Optional.of(diskMbTotal), longRunningTasksUsage, 1, 0L,
             0, 0, 0, 0, 0, 0, 0 , 0),
-        SingularityUsageScoringStrategy.SPREAD_TASK_USAGE, MachineLoadMetric.LOAD_5, new MaxProbableUsage(0, 0, 0)
+        SingularityUsageScoringStrategy.SPREAD_TASK_USAGE, MachineLoadMetric.LOAD_5, new MaxProbableUsage(0, 0, 0),
         0, 0
     );
   }


### PR DESCRIPTION
If, according to the metrics collected from the slave metrics endpoint, a slave is overloaded, omit these offers from scoring and do not schedule tasks there. This feature is configurable via `omitOverloadedHosts` under the `mesos` config, and defaults to `false`/off

Overloaded is currently defined as a load5 > 1.0 to catch ongoing load, or a load1 > 1.5 to catch shorter spikes large enough to be disruptive to tasks on the host.