### PR TITLE
Log the full list of healthy task ids when killing a task

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
@@ -215,7 +215,7 @@ public class SingularityCleaner {
           }
         }
 
-        LOG.debug("Killing a task {}, all replacement tasks are healthy", taskCleanup);
+        LOG.debug("Killing a task {}, at least {} replacement tasks are healthy [{}]", taskCleanup, request.getInstancesSafe(), matchingTasks);
         return true;
       case WAITING:
       case UNHEALTHY:


### PR DESCRIPTION
This is to help figure out a possible race condition in pending tasks / bug with pending task creation