### PR TITLE
Simplify mesos master uri parsing

### DIFF
--- a/Docs/reference/configuration.md
+++ b/Docs/reference/configuration.md
@@ -163,9 +163,7 @@ These settings should live under the "mesos" field inside the root configuration
 #### Framework ####
 | Parameter | Default | Description | Type |
 |-----------|---------|-------------|------|
-| master | null | A comma separated list of mesos master `host:port` | String |
-| mesosUsername | | Username to authenticate with the mesos master when using basic auth | String |
-| mesosPassword | | Password to authenticate with the mesos master when using basic auth | String |
+| master | null | A comma separated list of mesos master `http(s)://user:password@host:port` user and password are optional, http is used if no protocol is provided | String |
 | frameworkName | null | | String |
 | frameworkId | null | | String |
 | frameworkFailoverTimeout | 0.0 | | double |

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/MesosConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/MesosConfiguration.java
@@ -13,8 +13,6 @@ public class MesosConfiguration {
   @NotNull
   private String master;
   @NotNull
-  private String masterProtocol = "http";
-  @NotNull
   private String frameworkName;
   @NotNull
   private String frameworkId;
@@ -53,8 +51,6 @@ public class MesosConfiguration {
   private int maxDiskMbPerRequest = 3000000;
 
   private Optional<String> credentialPrincipal = Optional.absent();
-  private Optional<String> mesosUsername = Optional.absent();
-  private Optional<String> mesosPassword = Optional.absent();
 
   private long rxEventBufferSize = 10000;
   private int statusUpdateConcurrencyLimit = 500;
@@ -146,14 +142,6 @@ public class MesosConfiguration {
     return master;
   }
 
-  public String getMasterProtocol() {
-    return masterProtocol;
-  }
-
-  public void setMasterProtocol(String masterProtocol) {
-    this.masterProtocol = masterProtocol;
-  }
-
   public String getFrameworkId() {
     return frameworkId;
   }
@@ -236,22 +224,6 @@ public class MesosConfiguration {
 
   public void setCredentialPrincipal(Optional<String> credentialPrincipal) {
     this.credentialPrincipal = credentialPrincipal;
-  }
-
-  public Optional<String> getMesosUsername() {
-    return mesosUsername;
-  }
-
-  public void setMesosUsername(Optional<String> mesosUsername) {
-    this.mesosUsername = mesosUsername;
-  }
-
-  public Optional<String> getMesosPassword() {
-    return mesosPassword;
-  }
-
-  public void setMesosPassword(Optional<String> mesosPassword) {
-    this.mesosPassword = mesosPassword;
   }
 
   public int getDefaultDisk() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerClient.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerClient.java
@@ -81,11 +81,11 @@ public class SingularityMesosSchedulerClient {
    *
    * @throws URISyntaxException if the URL provided was not a syntactically correct URL.
    */
-  public void subscribe(String mesosMasterURI, SingularityMesosScheduler scheduler) throws URISyntaxException {
+  public void subscribe(URI mesosMasterURI, SingularityMesosScheduler scheduler) throws URISyntaxException {
 
     FrameworkInfo frameworkInfo = buildFrameworkInfo();
 
-    if (mesosMasterURI == null || mesosMasterURI.contains("zk:")) {
+    if (mesosMasterURI == null || mesosMasterURI.getScheme().contains("zk")) {
       throw new IllegalArgumentException(String.format("Must use master address for http api (e.g. http://localhost:5050/api/v1/scheduler) was %s", mesosMasterURI));
     }
 
@@ -99,7 +99,7 @@ public class SingularityMesosSchedulerClient {
       subscriberThread = new Thread() {
         public void run() {
           try {
-            connect(URI.create(mesosMasterURI), frameworkInfo, scheduler);
+            connect(mesosMasterURI, frameworkInfo, scheduler);
           } catch (RuntimeException|URISyntaxException e) {
             LOG.error("Could not connect: ", e);
             scheduler.onConnectException(e);

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
@@ -370,12 +370,9 @@ public class SingularityMesosSchedulerImpl extends SingularityMesosScheduler {
     MesosConfiguration mesosConfiguration = configuration.getMesosConfiguration();
     // If more than one host is provided choose at random, we will be redirected if the host is not the master
     List<String> masters = Arrays.asList(mesosConfiguration.getMaster().split(","));
-    String masterUrl;
-    if (mesosConfiguration.getMesosUsername().isPresent() && mesosConfiguration.getMesosPassword().isPresent()) {
-      masterUrl = String.format(SCHEDULER_API_URL_CREDENTIALS_FORMAT, mesosConfiguration.getMasterProtocol(), mesosConfiguration.getMesosUsername().get(),
-          mesosConfiguration.getMesosPassword().get(), masters.get(new Random().nextInt(masters.size())));
-    } else {
-      masterUrl = String.format(SCHEDULER_API_URL_FORMAT, mesosConfiguration.getMasterProtocol(), masters.get(new Random().nextInt(masters.size())));
+    String masterUrl = masters.get(new Random().nextInt(masters.size()));
+    if (!masterUrl.startsWith("http")) {
+      masterUrl = "http://" + masterUrl;
     }
     mesosSchedulerClient.subscribe(masterUrl, this);
   }


### PR DESCRIPTION
Instead of building url ourselves, this allows the user to specify a full http(s)://user:password@host:post/path. Singularity will add the http:// if it is missing, but will not change the uri beyond that

/cc https://github.com/HubSpot/Singularity/issues/1756