### PR TITLE
Simplify offer scoring

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularitySlaveUsage.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularitySlaveUsage.java
@@ -1,17 +1,10 @@
 package com.hubspot.singularity;
 
-import java.util.Map;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
 
 public class SingularitySlaveUsage {
-
-  public enum ResourceUsageType {
-    CPU_USED, MEMORY_BYTES_USED, DISK_BYTES_USED, CPU_FREE, MEMORY_BYTES_FREE, DISK_BYTES_FREE
-  }
-
   public static final long BYTES_PER_MEGABYTE = 1024L * 1024L;
 
   private final double cpusUsed;
@@ -23,7 +16,6 @@ public class SingularitySlaveUsage {
   private final long diskBytesUsed;
   private final long diskMbReserved;
   private final Optional<Long> diskMbTotal;
-  private final Map<ResourceUsageType, Number> longRunningTasksUsage;
   private final int numTasks;
   private final long timestamp;
   private final double systemMemTotalBytes;
@@ -45,7 +37,6 @@ public class SingularitySlaveUsage {
                                @JsonProperty("diskBytesUsed") long diskBytesUsed,
                                @JsonProperty("diskMbReserved") long diskMbReserved,
                                @JsonProperty("diskMbTotal") Optional<Long> diskMbTotal,
-                               @JsonProperty("longRunningTasksUsage") Map<ResourceUsageType, Number> longRunningTasksUsage,
                                @JsonProperty("numTasks") int numTasks,
                                @JsonProperty("timestamp") long timestamp,
                                @JsonProperty("systemMemTotalBytes") double systemMemTotalBytes,
@@ -65,7 +56,6 @@ public class SingularitySlaveUsage {
     this.diskBytesUsed = diskBytesUsed;
     this.diskMbReserved = diskMbReserved;
     this.diskMbTotal = diskMbTotal;
-    this.longRunningTasksUsage = longRunningTasksUsage;
     this.numTasks = numTasks;
     this.timestamp = timestamp;
     this.systemMemTotalBytes = systemMemTotalBytes;
@@ -122,10 +112,6 @@ public class SingularitySlaveUsage {
     return diskMbTotal.isPresent() ? Optional.of(diskMbTotal.get() * BYTES_PER_MEGABYTE) : Optional.absent();
   }
 
-  public Map<ResourceUsageType, Number> getLongRunningTasksUsage() {
-    return longRunningTasksUsage;
-  }
-
   public int getNumTasks() {
     return numTasks;
   }
@@ -178,7 +164,6 @@ public class SingularitySlaveUsage {
         ", diskBytesUsed=" + diskBytesUsed +
         ", diskMbReserved=" + diskMbReserved +
         ", diskMbTotal=" + diskMbTotal +
-        ", longRunningTasksUsage=" + longRunningTasksUsage +
         ", numTasks=" + numTasks +
         ", timestamp=" + timestamp +
         ", systemMemTotalBytes=" + systemMemTotalBytes +

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularitySlaveUsageWithId.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularitySlaveUsageWithId.java
@@ -18,7 +18,6 @@ public class SingularitySlaveUsageWithId extends SingularitySlaveUsage {
         usage.getDiskBytesUsed(),
         usage.getDiskMbReserved(),
         usage.getDiskMbTotal(),
-        usage.getLongRunningTasksUsage(),
         usage.getNumTasks(),
         usage.getTimestamp(),
         usage.getSystemMemTotalBytes(),

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityUsageScoringStrategy.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityUsageScoringStrategy.java
@@ -1,5 +1,0 @@
-package com.hubspot.singularity;
-
-public enum  SingularityUsageScoringStrategy {
-  SPREAD_TASK_USAGE, SPREAD_SYSTEM_USAGE, PROBABLE_MAX_USAGE
-}

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/MesosConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/MesosConfiguration.java
@@ -5,7 +5,6 @@ import javax.validation.constraints.NotNull;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.common.base.Optional;
 import com.hubspot.singularity.MachineLoadMetric;
-import com.hubspot.singularity.SingularityUsageScoringStrategy;
 
 @JsonIgnoreProperties( ignoreUnknown = true )
 public class MesosConfiguration {
@@ -60,12 +59,12 @@ public class MesosConfiguration {
   private int statusUpdateConcurrencyLimit = 500;
   private int maxStatusUpdateQueueSize = 5000;
   private int offersConcurrencyLimit = 100;
-  private SingularityUsageScoringStrategy scoringStrategy = SingularityUsageScoringStrategy.SPREAD_TASK_USAGE;
   private MachineLoadMetric scoreUsingSystemLoad = MachineLoadMetric.LOAD_5;
-  private double longRunningFreeResourceWeight = 0.5;
-  private double longRunningUsedResourceWeight = 0.5;
-  private double nonLonRunningFreeResourceWeight = 0.75;
-  private double nonLongRunningUsedResourceWeight = 0.25;
+  private double allocatedResourceWeight = 0.5;
+  private double inUseResourceWeight = 0.5;
+  private double cpuWeight = 0.4;
+  private double memWeight = 0.4;
+  private double diskWeight = 0.2;
   private boolean omitOverloadedHosts = false;
   private double load5OverloadedThreshold = 1.0;
   private double load1OverloadedThreshold = 1.5;
@@ -302,52 +301,12 @@ public class MesosConfiguration {
     this.offersConcurrencyLimit = offersConcurrencyLimit;
   }
 
-  public SingularityUsageScoringStrategy getScoringStrategy() {
-    return scoringStrategy;
-  }
-
-  public void setScoringStrategy(SingularityUsageScoringStrategy scoringStrategy) {
-    this.scoringStrategy = scoringStrategy;
-  }
-
   public MachineLoadMetric getScoreUsingSystemLoad() {
     return scoreUsingSystemLoad;
   }
 
   public void setScoreUsingSystemLoad(MachineLoadMetric scoreUsingSystemLoad) {
     this.scoreUsingSystemLoad = scoreUsingSystemLoad;
-  }
-
-  public double getLongRunningFreeResourceWeight() {
-    return longRunningFreeResourceWeight;
-  }
-
-  public void setLongRunningFreeResourceWeight(double longRunningFreeResourceWeight) {
-    this.longRunningFreeResourceWeight = longRunningFreeResourceWeight;
-  }
-
-  public double getLongRunningUsedResourceWeight() {
-    return longRunningUsedResourceWeight;
-  }
-
-  public void setLongRunningUsedResourceWeight(double longRunningUsedResourceWeight) {
-    this.longRunningUsedResourceWeight = longRunningUsedResourceWeight;
-  }
-
-  public double getNonLonRunningFreeResourceWeight() {
-    return nonLonRunningFreeResourceWeight;
-  }
-
-  public void setNonLonRunningFreeResourceWeight(double nonLonRunningFreeResourceWeight) {
-    this.nonLonRunningFreeResourceWeight = nonLonRunningFreeResourceWeight;
-  }
-
-  public double getNonLongRunningUsedResourceWeight() {
-    return nonLongRunningUsedResourceWeight;
-  }
-
-  public void setNonLongRunningUsedResourceWeight(double nonLongRunningUsedResourceWeight) {
-    this.nonLongRunningUsedResourceWeight = nonLongRunningUsedResourceWeight;
   }
 
   public boolean isOmitOverloadedHosts() {
@@ -372,5 +331,45 @@ public class MesosConfiguration {
 
   public void setLoad1OverloadedThreshold(double load1OverloadedThreshold) {
     this.load1OverloadedThreshold = load1OverloadedThreshold;
+  }
+
+  public double getAllocatedResourceWeight() {
+    return allocatedResourceWeight;
+  }
+
+  public void setAllocatedResourceWeight(double allocatedResourceWeight) {
+    this.allocatedResourceWeight = allocatedResourceWeight;
+  }
+
+  public double getInUseResourceWeight() {
+    return inUseResourceWeight;
+  }
+
+  public void setInUseResourceWeight(double inUseResourceWeight) {
+    this.inUseResourceWeight = inUseResourceWeight;
+  }
+
+  public double getCpuWeight() {
+    return cpuWeight;
+  }
+
+  public void setCpuWeight(double cpuWeight) {
+    this.cpuWeight = cpuWeight;
+  }
+
+  public double getMemWeight() {
+    return memWeight;
+  }
+
+  public void setMemWeight(double memWeight) {
+    this.memWeight = memWeight;
+  }
+
+  public double getDiskWeight() {
+    return diskWeight;
+  }
+
+  public void setDiskWeight(double diskWeight) {
+    this.diskWeight = diskWeight;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -221,24 +221,6 @@ public class SingularityConfiguration extends Configuration {
 
   private int maxTasksPerOfferPerRequest = 0;
 
-  private double longRunningUsedCpuWeightForOffer = 0.25;
-
-  private double longRunningUsedMemWeightForOffer = 0.65;
-
-  private double longRunningUsedDiskWeightForOffer = 0.10;
-
-  private double freeCpuWeightForOffer = 0.25;
-
-  private double freeMemWeightForOffer = 0.65;
-
-  private double freeDiskWeightForOffer = 0.10;
-
-  private double defaultOfferScoreForMissingUsage = 0.30;
-
-  private long considerNonLongRunningTaskLongRunningAfterRunningForSeconds = TimeUnit.HOURS.toSeconds(6);
-
-  private double maxNonLongRunningUsedResourceWeight = 0.50;
-
   private int maxRequestIdSize = 100;
 
   private int maxUserIdSize = 100;
@@ -731,41 +713,6 @@ public class SingularityConfiguration extends Configuration {
     return maxTasksPerOfferPerRequest;
   }
 
-  public double getLongRunningUsedCpuWeightForOffer() {
-    return longRunningUsedCpuWeightForOffer;
-  }
-
-  public double getLongRunningUsedMemWeightForOffer() {
-    return longRunningUsedMemWeightForOffer;
-  }
-
-  public double getLongRunningUsedDiskWeightForOffer() {
-    return longRunningUsedDiskWeightForOffer;
-  }
-
-  public double getFreeCpuWeightForOffer() {
-    return freeCpuWeightForOffer;
-  }
-
-  public double getFreeMemWeightForOffer() {
-    return freeMemWeightForOffer;
-  }
-
-  public double getFreeDiskWeightForOffer() {
-    return freeDiskWeightForOffer;
-  }
-
-  public double getDefaultOfferScoreForMissingUsage() {
-    return defaultOfferScoreForMissingUsage;
-  }
-
-  public long getConsiderNonLongRunningTaskLongRunningAfterRunningForSeconds() {
-    return considerNonLongRunningTaskLongRunningAfterRunningForSeconds;
-  }
-
-  public double getMaxNonLongRunningUsedResourceWeight() {
-    return maxNonLongRunningUsedResourceWeight;
-  }
   public MesosConfiguration getMesosConfiguration() {
     return mesosConfiguration;
   }
@@ -1136,50 +1083,6 @@ public class SingularityConfiguration extends Configuration {
     this.maxTasksPerOfferPerRequest = maxTasksPerOfferPerRequest;
   }
 
-  public SingularityConfiguration setLongRunningUsedCpuWeightForOffer(double longRunningUsedCpuWeightForOffer) {
-    this.longRunningUsedCpuWeightForOffer = longRunningUsedCpuWeightForOffer;
-    return this;
-  }
-
-  public SingularityConfiguration setLongRunningUsedMemWeightForOffer(double longRunningUsedMemWeightForOffer) {
-    this.longRunningUsedMemWeightForOffer = longRunningUsedMemWeightForOffer;
-    return this;
-  }
-
-  public SingularityConfiguration setLongRunningUsedDiskWeightForOffer(double longRunningUsedDiskWeightForOffer) {
-    this.longRunningUsedDiskWeightForOffer = longRunningUsedDiskWeightForOffer;
-    return this;
-  }
-
-  public SingularityConfiguration setFreeCpuWeightForOffer(double freeCpuWeightForOffer) {
-    this.freeCpuWeightForOffer = freeCpuWeightForOffer;
-    return this;
-  }
-
-  public SingularityConfiguration setFreeMemWeightForOffer(double freeMemWeightForOffer) {
-    this.freeMemWeightForOffer = freeMemWeightForOffer;
-    return this;
-  }
-
-  public SingularityConfiguration setFreeDiskWeightForOffer(double freeDiskWeightForOffer) {
-    this.freeDiskWeightForOffer = freeDiskWeightForOffer;
-    return this;
-  }
-
-  public SingularityConfiguration setDefaultOfferScoreForMissingUsage(double defaultOfferScoreForMissingUsage) {
-    this.defaultOfferScoreForMissingUsage = defaultOfferScoreForMissingUsage;
-    return this;
-  }
-
-  public SingularityConfiguration setConsiderNonLongRunningTaskLongRunningAfterRunningForSeconds(long considerNonLongRunningTaskLongRunningAfterRunningForSeconds) {
-    this.considerNonLongRunningTaskLongRunningAfterRunningForSeconds = considerNonLongRunningTaskLongRunningAfterRunningForSeconds;
-    return this;
-  }
-
-  public SingularityConfiguration setMaxNonLongRunningUsedResourceWeight(double maxNonLongRunningUsedResourceWeight) {
-    this.maxNonLongRunningUsedResourceWeight = maxNonLongRunningUsedResourceWeight;
-    return this;
-  }
   public void setMesosConfiguration(MesosConfiguration mesosConfiguration) {
     this.mesosConfiguration = mesosConfiguration;
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
@@ -27,6 +27,7 @@ import com.google.inject.Inject;
 import com.hubspot.mesos.Resources;
 import com.hubspot.singularity.RequestType;
 import com.hubspot.singularity.RequestUtilization;
+import com.hubspot.singularity.SingularityDeployStatistics;
 import com.hubspot.singularity.SingularityPendingTaskId;
 import com.hubspot.singularity.SingularitySlaveUsage;
 import com.hubspot.singularity.SingularitySlaveUsageWithId;
@@ -39,6 +40,7 @@ import com.hubspot.singularity.async.CompletableFutures;
 import com.hubspot.singularity.config.CustomExecutorConfiguration;
 import com.hubspot.singularity.config.MesosConfiguration;
 import com.hubspot.singularity.config.SingularityConfiguration;
+import com.hubspot.singularity.data.DeployManager;
 import com.hubspot.singularity.data.TaskManager;
 import com.hubspot.singularity.data.UsageManager;
 import com.hubspot.singularity.helpers.MesosUtils;
@@ -64,6 +66,7 @@ public class SingularityMesosOfferScheduler {
   private final SingularitySlaveAndRackHelper slaveAndRackHelper;
   private final SingularityTaskSizeOptimizer taskSizeOptimizer;
   private final UsageManager usageManager;
+  private final DeployManager deployManager;
   private final SingularitySchedulerLock lock;
   private final SingularityLeaderCache leaderCache;
 
@@ -87,6 +90,7 @@ public class SingularityMesosOfferScheduler {
                                         SingularitySlaveAndRackHelper slaveAndRackHelper,
                                         SingularityLeaderCache leaderCache,
                                         UsageManager usageManager,
+                                        DeployManager deployManager,
                                         SingularitySchedulerLock lock) {
     this.defaultResources = new Resources(mesosConfiguration.getDefaultCpus(), mesosConfiguration.getDefaultMemory(), 0, mesosConfiguration.getDefaultDisk());
     this.defaultCustomExecutorResources = new Resources(customExecutorConfiguration.getNumCpus(), customExecutorConfiguration.getMemoryMb(), 0, customExecutorConfiguration.getDiskMb());
@@ -101,6 +105,7 @@ public class SingularityMesosOfferScheduler {
     this.slaveAndRackHelper = slaveAndRackHelper;
     this.taskPrioritizer = taskPrioritizer;
     this.usageManager = usageManager;
+    this.deployManager = deployManager;
     this.lock = lock;
 
     double cpuWeight = mesosConfiguration.getCpuWeight();

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
@@ -253,7 +253,7 @@ public class SingularityMesosOfferScheduler {
                 .or(maybeTask.get().getTaskRequest().getDeploy().getResources())
                 .or(defaultResources);
             cpu += resources.getCpus();
-            memBytes += resources.getDiskMb() * SingularitySlaveUsage.BYTES_PER_MEGABYTE;
+            memBytes += resources.getMemoryMb() * SingularitySlaveUsage.BYTES_PER_MEGABYTE;
             diskBytes += resources.getDiskMb() * SingularitySlaveUsage.BYTES_PER_MEGABYTE;
           }
         }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
@@ -337,10 +337,11 @@ public class SingularityMesosOfferScheduler {
       estimatedCpusToAdd = getEstimatedCpuUsageForRequest(requestUtilization);
     }
     if (mesosConfiguration.isOmitOverloadedHosts() && maybeSlaveUsage.isPresent() && maybeSlaveUsage.get().isCpuOverloaded(estimatedCpusToAdd)) {
-      LOG.debug("Slave {} is overloaded (load5 {}/{}, load1 {}/{}), ignoring offer",
+      LOG.debug("Slave {} is overloaded (load5 {}/{}, load1 {}/{}, estimated cpus to add: {}), ignoring offer",
           offerHolder.getHostname(),
           maybeSlaveUsage.get().getSlaveUsage().getSystemLoad5Min(), maybeSlaveUsage.get().getSlaveUsage().getSystemCpusTotal(),
-          maybeSlaveUsage.get().getSlaveUsage().getSystemLoad1Min(), maybeSlaveUsage.get().getSlaveUsage().getSystemCpusTotal());
+          maybeSlaveUsage.get().getSlaveUsage().getSystemLoad1Min(), maybeSlaveUsage.get().getSlaveUsage().getSystemCpusTotal(),
+          estimatedCpusToAdd);
       return 0;
     }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
@@ -9,7 +9,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -28,10 +27,8 @@ import com.google.inject.Inject;
 import com.hubspot.mesos.Resources;
 import com.hubspot.singularity.RequestType;
 import com.hubspot.singularity.RequestUtilization;
-import com.hubspot.singularity.SingularityDeployStatistics;
 import com.hubspot.singularity.SingularityPendingTaskId;
 import com.hubspot.singularity.SingularitySlaveUsage;
-import com.hubspot.singularity.SingularitySlaveUsage.ResourceUsageType;
 import com.hubspot.singularity.SingularitySlaveUsageWithId;
 import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.SingularityTaskId;
@@ -42,7 +39,6 @@ import com.hubspot.singularity.async.CompletableFutures;
 import com.hubspot.singularity.config.CustomExecutorConfiguration;
 import com.hubspot.singularity.config.MesosConfiguration;
 import com.hubspot.singularity.config.SingularityConfiguration;
-import com.hubspot.singularity.data.DeployManager;
 import com.hubspot.singularity.data.TaskManager;
 import com.hubspot.singularity.data.UsageManager;
 import com.hubspot.singularity.helpers.MesosUtils;
@@ -68,16 +64,12 @@ public class SingularityMesosOfferScheduler {
   private final SingularitySlaveAndRackHelper slaveAndRackHelper;
   private final SingularityTaskSizeOptimizer taskSizeOptimizer;
   private final UsageManager usageManager;
-  private final DeployManager deployManager;
   private final SingularitySchedulerLock lock;
   private final SingularityLeaderCache leaderCache;
 
-  private final double normalizedCpuFreeWeight;
-  private final double normalizedCpuUsedWeight;
-  private final double normalizedMemFreeWeight;
-  private final double normalizedMemUsedWeight;
-  private final double normalizedDiskFreeWeight;
-  private final double normalizedDiskUsedWeight;
+  private final double normalizedCpuWeight;
+  private final double normalizedMemWeight;
+  private final double normalizedDiskWeight;
 
   private final AsyncSemaphore<Void> offerScoringSemaphore;
   private final ExecutorService offerScoringExecutor;
@@ -95,7 +87,6 @@ public class SingularityMesosOfferScheduler {
                                         SingularitySlaveAndRackHelper slaveAndRackHelper,
                                         SingularityLeaderCache leaderCache,
                                         UsageManager usageManager,
-                                        DeployManager deployManager,
                                         SingularitySchedulerLock lock) {
     this.defaultResources = new Resources(mesosConfiguration.getDefaultCpus(), mesosConfiguration.getDefaultMemory(), 0, mesosConfiguration.getDefaultDisk());
     this.defaultCustomExecutorResources = new Resources(customExecutorConfiguration.getNumCpus(), customExecutorConfiguration.getMemoryMb(), 0, customExecutorConfiguration.getDiskMb());
@@ -110,45 +101,23 @@ public class SingularityMesosOfferScheduler {
     this.slaveAndRackHelper = slaveAndRackHelper;
     this.taskPrioritizer = taskPrioritizer;
     this.usageManager = usageManager;
-    this.deployManager = deployManager;
     this.lock = lock;
 
-    this.normalizedCpuFreeWeight = getNormalizedWeight(ResourceUsageType.CPU_FREE, configuration);
-    this.normalizedCpuUsedWeight = getNormalizedWeight(ResourceUsageType.CPU_USED, configuration);
-    this.normalizedMemFreeWeight = getNormalizedWeight(ResourceUsageType.MEMORY_BYTES_FREE, configuration);
-    this.normalizedMemUsedWeight = getNormalizedWeight(ResourceUsageType.MEMORY_BYTES_USED, configuration);
-    this.normalizedDiskFreeWeight = getNormalizedWeight(ResourceUsageType.DISK_BYTES_FREE, configuration);
-    this.normalizedDiskUsedWeight = getNormalizedWeight(ResourceUsageType.DISK_BYTES_USED, configuration);
+    double cpuWeight = mesosConfiguration.getCpuWeight();
+    double memWeight = mesosConfiguration.getMemWeight();
+    double diskWeight = mesosConfiguration.getDiskWeight();
+    if (cpuWeight + memWeight + diskWeight != 1) {
+      this.normalizedCpuWeight = cpuWeight / (cpuWeight + memWeight + diskWeight);
+      this.normalizedMemWeight = memWeight / (cpuWeight + memWeight + diskWeight);
+      this.normalizedDiskWeight = diskWeight / (cpuWeight + memWeight + diskWeight);
+    } else {
+      this.normalizedCpuWeight = cpuWeight;
+      this.normalizedMemWeight = memWeight;
+      this.normalizedDiskWeight = diskWeight;
+    }
 
     this.offerScoringSemaphore = AsyncSemaphore.newBuilder(mesosConfiguration::getOffersConcurrencyLimit).setFlushQueuePeriodically(true).build();
     this.offerScoringExecutor = Executors.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat("offer-scoring-%d").build());
-  }
-
-  private static double getNormalizedWeight(ResourceUsageType type, SingularityConfiguration configuration) {
-    double freeCpuWeight = configuration.getFreeCpuWeightForOffer();
-    double freeMemWeight = configuration.getFreeMemWeightForOffer();
-    double freeDiskWeight = configuration.getFreeDiskWeightForOffer();
-    double usedCpuWeight = configuration.getLongRunningUsedCpuWeightForOffer();
-    double usedMemWeight = configuration.getLongRunningUsedMemWeightForOffer();
-    double usedDiskWeight = configuration.getLongRunningUsedDiskWeightForOffer();
-
-    switch (type) {
-      case CPU_FREE:
-        return freeCpuWeight + freeMemWeight + freeDiskWeight != 1 ? freeCpuWeight / (freeCpuWeight + freeMemWeight + freeDiskWeight) : freeCpuWeight;
-      case MEMORY_BYTES_FREE:
-        return freeCpuWeight + freeMemWeight + freeDiskWeight != 1 ? freeMemWeight / (freeCpuWeight + freeMemWeight + freeDiskWeight) : freeMemWeight;
-      case DISK_BYTES_FREE:
-        return freeCpuWeight + freeMemWeight + freeDiskWeight != 1 ? freeDiskWeight / (freeCpuWeight + freeMemWeight + freeDiskWeight) : freeDiskWeight;
-      case CPU_USED:
-        return usedCpuWeight + usedMemWeight + usedDiskWeight != 1 ? usedCpuWeight / (usedCpuWeight + usedMemWeight + usedDiskWeight) : usedCpuWeight;
-      case MEMORY_BYTES_USED:
-        return usedCpuWeight + usedMemWeight + usedDiskWeight != 1 ? usedMemWeight / (usedCpuWeight + usedMemWeight + usedDiskWeight) : usedMemWeight;
-      case DISK_BYTES_USED:
-        return usedCpuWeight + usedMemWeight + usedDiskWeight != 1 ? usedDiskWeight / (usedCpuWeight + usedMemWeight + usedDiskWeight) : usedDiskWeight;
-      default:
-        LOG.error("Invalid ResourceUsageType {}", type);
-        return 0;
-    }
   }
 
   public Collection<SingularityOfferHolder> checkOffers(final Collection<Offer> offers) {
@@ -203,7 +172,6 @@ public class SingularityMesosOfferScheduler {
             SingularitySlaveUsageWithId::getSlaveId,
             (usageWithId) -> new SingularitySlaveUsageWithCalculatedScores(
                 usageWithId,
-                mesosConfiguration.getScoringStrategy(),
                 mesosConfiguration.getScoreUsingSystemLoad(),
                 getMaxProbableUsageForSlave(activeTaskIds, requestUtilizations, offerHolders.get(usageWithId.getSlaveId()).getSanitizedHost()),
                 mesosConfiguration.getLoad5OverloadedThreshold(),
@@ -315,7 +283,7 @@ public class SingularityMesosOfferScheduler {
         usage.addEstimatedMemoryBytesUsage(taskHolder.getTotalResources().getMemoryMb() * SingularitySlaveUsage.BYTES_PER_MEGABYTE);
         usage.addEstimatedDiskBytesUsage(taskHolder.getTotalResources().getDiskMb() * SingularitySlaveUsage.BYTES_PER_MEGABYTE);
       }
-      usage.setScores(configuration.getMesosConfiguration().getScoringStrategy());
+      usage.recalculateScores();
     }
   }
 
@@ -388,7 +356,7 @@ public class SingularityMesosOfferScheduler {
     final SlaveMatchState slaveMatchState = slaveAndRackManager.doesOfferMatch(offerHolder, taskRequest, activeTaskIdsForRequest);
 
     if (slaveMatchState.isMatchAllowed()) {
-      return score(offerHolder.getHostname(), taskRequest, maybeSlaveUsage);
+      return score(offerHolder.getHostname(), maybeSlaveUsage);
     } else if (LOG.isTraceEnabled()) {
       LOG.trace("Ignoring offer on host {} with roles {} on {} for task {}; matched resources: {}, slave match state: {}", offerHolder.getHostname(),
           offerHolder.getRoles(), offerHolder.getHostname(), pendingTaskId, matchesResources, slaveMatchState);
@@ -398,65 +366,31 @@ public class SingularityMesosOfferScheduler {
   }
 
   @VisibleForTesting
-  double score(String hostname, SingularityTaskRequest taskRequest, Optional<SingularitySlaveUsageWithCalculatedScores> maybeSlaveUsage) {
+  double score(String hostname, Optional<SingularitySlaveUsageWithCalculatedScores> maybeSlaveUsage) {
     if (!maybeSlaveUsage.isPresent() || maybeSlaveUsage.get().isMissingUsageData()) {
-      LOG.info("Slave {} has missing usage data ({}). Will default to {}", hostname, maybeSlaveUsage, configuration.getDefaultOfferScoreForMissingUsage());
-      return configuration.getDefaultOfferScoreForMissingUsage();
+      LOG.info("Slave {} has missing usage data ({}). Will default to {}", hostname, maybeSlaveUsage, 0.5);
+      return 0.5;
     }
 
-    return isLongRunning(taskRequest)
-        ? scoreLongRunningTask(maybeSlaveUsage.get())
-        : scoreNonLongRunningTask(taskRequest, maybeSlaveUsage.get());
-  }
+    SingularitySlaveUsageWithCalculatedScores slaveUsageWithScores = maybeSlaveUsage.get();
 
-  private boolean isLongRunning(SingularityTaskRequest taskRequest) {
-    return taskRequest.getRequest().getRequestType().isLongRunning();
-  }
-
-  private double scoreLongRunningTask(SingularitySlaveUsageWithCalculatedScores slaveUsageWithScores) {
-    // unused, reserved resources improve score
     return calculateScore(
-        1 - slaveUsageWithScores.getLongRunningMemUsedScore(), slaveUsageWithScores.getMemFreeScore(),
-        1 - slaveUsageWithScores.getLongRunningCpusUsedScore(), slaveUsageWithScores.getCpusFreeScore(),
-        1 - slaveUsageWithScores.getLongRunningDiskUsedScore(), slaveUsageWithScores.getDiskFreeScore(),
-        mesosConfiguration.getLongRunningFreeResourceWeight(), mesosConfiguration.getLongRunningUsedResourceWeight());
+        1 - slaveUsageWithScores.getMemAllocatedScore(), slaveUsageWithScores.getMemInUseScore(),
+        1 - slaveUsageWithScores.getCpusAllocatedScore(), slaveUsageWithScores.getCpusInUseScore(),
+        1 - slaveUsageWithScores.getDiskAllocatedScore(), slaveUsageWithScores.getDiskInUseScore(),
+        mesosConfiguration.getInUseResourceWeight(), mesosConfiguration.getAllocatedResourceWeight());
   }
 
-  private double scoreNonLongRunningTask(SingularityTaskRequest taskRequest, SingularitySlaveUsageWithCalculatedScores slaveUsageWithScores) {
-    Optional<SingularityDeployStatistics> statistics = deployManager.getDeployStatistics(taskRequest.getRequest().getId(), taskRequest.getDeploy().getId());
-    final double epsilon = 0.0001;
-
-    double freeResourceWeight = mesosConfiguration.getNonLonRunningFreeResourceWeight();
-    double usedResourceWeight = mesosConfiguration.getNonLongRunningUsedResourceWeight();
-
-    if (statistics.isPresent() && statistics.get().getAverageRuntimeMillis().isPresent()) {
-      final double maxNonLongRunningUsedResourceWeight = configuration.getMaxNonLongRunningUsedResourceWeight();
-      usedResourceWeight = Math.min((double) TimeUnit.MILLISECONDS.toSeconds(statistics.get().getAverageRuntimeMillis().get()) / configuration.getConsiderNonLongRunningTaskLongRunningAfterRunningForSeconds(), 1) * maxNonLongRunningUsedResourceWeight;
-
-      if (Math.abs(usedResourceWeight - maxNonLongRunningUsedResourceWeight) < epsilon) {
-        return scoreLongRunningTask(slaveUsageWithScores);
-      }
-      freeResourceWeight = 1 - usedResourceWeight;
-    }
-
-    // usage reduces score
-    return calculateScore(
-        slaveUsageWithScores.getLongRunningMemUsedScore(), slaveUsageWithScores.getMemFreeScore(),
-        slaveUsageWithScores.getLongRunningCpusUsedScore(), slaveUsageWithScores.getCpusFreeScore(),
-        slaveUsageWithScores.getLongRunningDiskUsedScore(), slaveUsageWithScores.getDiskFreeScore(),
-        freeResourceWeight, usedResourceWeight * -1);
-  }
-
-  private double calculateScore(double longRunningMemUsedScore, double memFreeScore, double longRunningCpusUsedScore, double cpusFreeScore, double longRunningDiskUsedScore, double diskFreeScore, double freeResourceWeight, double usedResourceWeight) {
+  private double calculateScore(double memAllocatedScore, double memInUseScore, double cpusAllocatedScore, double cpusInUseScore, double diskAllocatedScore, double diskInUseScore, double inUseResourceWeight, double allocatedResourceWeight) {
     double score = 0;
 
-    score += (normalizedCpuUsedWeight * usedResourceWeight) * longRunningCpusUsedScore;
-    score += (normalizedMemUsedWeight * usedResourceWeight) * longRunningMemUsedScore;
-    score += (normalizedDiskUsedWeight * usedResourceWeight) * longRunningDiskUsedScore;
+    score += (normalizedCpuWeight * allocatedResourceWeight) * cpusAllocatedScore;
+    score += (normalizedMemWeight * allocatedResourceWeight) * memAllocatedScore;
+    score += (normalizedDiskWeight * allocatedResourceWeight) * diskAllocatedScore;
 
-    score += (normalizedCpuFreeWeight * freeResourceWeight) * cpusFreeScore;
-    score += (normalizedMemFreeWeight * freeResourceWeight) * memFreeScore;
-    score += (normalizedDiskFreeWeight * freeResourceWeight) * diskFreeScore;
+    score += (normalizedCpuWeight * inUseResourceWeight) * cpusInUseScore;
+    score += (normalizedMemWeight * inUseResourceWeight) * memInUseScore;
+    score += (normalizedDiskWeight * inUseResourceWeight) * diskInUseScore;
 
     return score;
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveUsageWithCalculatedScores.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveUsageWithCalculatedScores.java
@@ -43,8 +43,9 @@ class SingularitySlaveUsageWithCalculatedScores {
     this.load1Threshold = load1Threshold;
   }
 
-  public boolean isOverloaded() {
-    return  (slaveUsage.getSystemLoad5Min() / slaveUsage.getSystemCpusTotal()) > load5Threshold || (slaveUsage.getSystemLoad1Min() / slaveUsage.getSystemCpusTotal()) > load1Threshold;
+  public boolean isCpuOverloaded(double estimatedNumCpusToAdd) {
+    return  ((slaveUsage.getSystemLoad5Min() + estimatedNumCpusToAdd) / slaveUsage.getSystemCpusTotal()) > load5Threshold
+        || ((slaveUsage.getSystemLoad1Min() + estimatedNumCpusToAdd) / slaveUsage.getSystemCpusTotal()) > load1Threshold;
   }
 
   private void setScores(double longRunningCpusUsedScore,

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveUsageWithCalculatedScores.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveUsageWithCalculatedScores.java
@@ -2,20 +2,18 @@ package com.hubspot.singularity.mesos;
 
 import com.hubspot.singularity.MachineLoadMetric;
 import com.hubspot.singularity.SingularitySlaveUsage;
-import com.hubspot.singularity.SingularitySlaveUsage.ResourceUsageType;
-import com.hubspot.singularity.SingularityUsageScoringStrategy;
 
 class SingularitySlaveUsageWithCalculatedScores {
   private final SingularitySlaveUsage slaveUsage;
   private final MachineLoadMetric systemLoadMetric;
   private final MaxProbableUsage maxProbableTaskUsage;
   private boolean missingUsageData;
-  private double longRunningCpusUsedScore;
-  private double longRunningMemUsedScore;
-  private double longRunningDiskUsedScore;
-  private double cpusFreeScore;
-  private double memFreeScore;
-  private double diskFreeScore;
+  private double cpusAllocatedScore;
+  private double memAllocatedScore;
+  private double diskAllocatedScore;
+  private double cpusInUseScore;
+  private double memInUseScore;
+  private double diskInUseScore;
 
   private double estimatedAddedCpusUsage = 0;
   private double estimatedAddedMemoryBytesUsage = 0;
@@ -28,7 +26,7 @@ class SingularitySlaveUsageWithCalculatedScores {
   private final double load5Threshold;
   private final double load1Threshold;
 
-  public SingularitySlaveUsageWithCalculatedScores(SingularitySlaveUsage slaveUsage, SingularityUsageScoringStrategy scoringStrategy, MachineLoadMetric systemLoadMetric, MaxProbableUsage maxProbableTaskUsage, double load5Threshold, double load1Threshold) {
+  SingularitySlaveUsageWithCalculatedScores(SingularitySlaveUsage slaveUsage, MachineLoadMetric systemLoadMetric, MaxProbableUsage maxProbableTaskUsage, double load5Threshold, double load1Threshold) {
     this.slaveUsage = slaveUsage;
     this.systemLoadMetric = systemLoadMetric;
     this.maxProbableTaskUsage = maxProbableTaskUsage;
@@ -37,68 +35,46 @@ class SingularitySlaveUsageWithCalculatedScores {
       setScores(0, 0, 0, 0, 0, 0);
     } else {
       this.missingUsageData = false;
-      setScores(scoringStrategy);
+      recalculateScores();
     }
     this.load5Threshold = load5Threshold;
     this.load1Threshold = load1Threshold;
   }
 
-  public boolean isCpuOverloaded(double estimatedNumCpusToAdd) {
+  boolean isCpuOverloaded(double estimatedNumCpusToAdd) {
     return  ((slaveUsage.getSystemLoad5Min() + estimatedNumCpusToAdd) / slaveUsage.getSystemCpusTotal()) > load5Threshold
         || ((slaveUsage.getSystemLoad1Min() + estimatedNumCpusToAdd) / slaveUsage.getSystemCpusTotal()) > load1Threshold;
   }
 
-  private void setScores(double longRunningCpusUsedScore,
-                 double longRunningMemUsedScore,
-                 double longRunningDiskUsedScore,
-                 double cpusFreeScore,
-                 double memFreeScore,
-                 double diskFreeScore) {
-    this.longRunningCpusUsedScore = longRunningCpusUsedScore;
-    this.longRunningMemUsedScore = longRunningMemUsedScore;
-    this.longRunningDiskUsedScore = longRunningDiskUsedScore;
-    this.cpusFreeScore = cpusFreeScore;
-    this.memFreeScore = memFreeScore;
-    this.diskFreeScore = diskFreeScore;
+  private void setScores(double cpusAllocatedScore,
+                 double memAllocatedScore,
+                 double diskAllocatedScore,
+                 double cpusInUseScore,
+                 double memInUseScore,
+                 double diskInUseScore) {
+    this.cpusAllocatedScore = cpusAllocatedScore;
+    this.memAllocatedScore = memAllocatedScore;
+    this.diskAllocatedScore = diskAllocatedScore;
+    this.cpusInUseScore = cpusInUseScore;
+    this.memInUseScore = memInUseScore;
+    this.diskInUseScore = diskInUseScore;
   }
 
   private boolean missingUsageData(SingularitySlaveUsage slaveUsage) {
     return !slaveUsage.getCpusTotal().isPresent() ||
         !slaveUsage.getMemoryMbTotal().isPresent() ||
-        !slaveUsage.getDiskMbTotal().isPresent() ||
-        slaveUsage.getLongRunningTasksUsage() == null ||
-        !slaveUsage.getLongRunningTasksUsage().containsKey(ResourceUsageType.CPU_USED) ||
-        !slaveUsage.getLongRunningTasksUsage().containsKey(ResourceUsageType.MEMORY_BYTES_USED) ||
-        !slaveUsage.getLongRunningTasksUsage().containsKey(ResourceUsageType.DISK_BYTES_USED);
+        !slaveUsage.getDiskMbTotal().isPresent();
   }
 
-  void setScores(SingularityUsageScoringStrategy scoringStrategy) {
-    double longRunningCpusUsedScore = (slaveUsage.getLongRunningTasksUsage().get(ResourceUsageType.CPU_USED).doubleValue() + estimatedAddedCpusUsage) / slaveUsage.getCpusTotal().get();
-    double longRunningMemUsedScore = ((slaveUsage.getLongRunningTasksUsage().get(ResourceUsageType.MEMORY_BYTES_USED).longValue() + estimatedAddedMemoryBytesUsage) / slaveUsage.getMemoryBytesTotal().get());
-    double longRunningDiskUsedScore = ((slaveUsage.getLongRunningTasksUsage().get(ResourceUsageType.DISK_BYTES_USED).longValue() + estimatedAddedDiskBytesUsage) / slaveUsage.getDiskBytesTotal().get());
-    switch (scoringStrategy) {
-      case SPREAD_TASK_USAGE:
-        double cpusFreeScore = 1 - ((slaveUsage.getCpusReserved() + estimatedAddedCpusReserved) / slaveUsage.getCpusTotal().get());
-        double memFreeScore = 1 - ((slaveUsage.getMemoryMbReserved() + (estimatedAddedMemoryBytesReserved / SingularitySlaveUsage.BYTES_PER_MEGABYTE)) / slaveUsage.getMemoryMbTotal().get());
-        double diskFreeScore = 1 - ((slaveUsage.getDiskMbReserved() + (estimatedAddedDiskBytesReserved / SingularitySlaveUsage.BYTES_PER_MEGABYTE)) / slaveUsage.getDiskMbTotal().get());
-        setScores(longRunningCpusUsedScore, longRunningMemUsedScore, longRunningDiskUsedScore, cpusFreeScore, memFreeScore, diskFreeScore);
-        break;
-      case PROBABLE_MAX_USAGE:
-        double probableMaxCpuFreeScore = Math.max(
-            0,
-            1 - (getMaxProbableCpuWithEstimatedUsage() / slaveUsage.getSystemCpusTotal())
-        );
-        double probableMaxMemFreeScore = 1 - (getMaxProbableMemBytesWithEstimatedUsage() / slaveUsage.getSystemMemTotalBytes());
-        double probableMaxDiskFreeScore = 1 - (getMaxProbableDiskBytesWithEstimatedUsage() / slaveUsage.getSlaveDiskTotal());
-        setScores(longRunningCpusUsedScore, longRunningMemUsedScore, longRunningDiskUsedScore, probableMaxCpuFreeScore, probableMaxMemFreeScore, probableMaxDiskFreeScore);
-        break;
-      case SPREAD_SYSTEM_USAGE:
-      default:
-        double systemCpuFreeScore = Math.max(0, 1 - ((getSystemLoadMetric() + estimatedAddedCpusUsage) / slaveUsage.getSystemCpusTotal()));
-        double systemMemFreeScore = 1 - (slaveUsage.getSystemMemTotalBytes() - slaveUsage.getSystemMemFreeBytes() + estimatedAddedMemoryBytesUsage) / slaveUsage.getSystemMemTotalBytes();
-        double systemDiskFreeScore = 1 - ((slaveUsage.getSlaveDiskUsed() + estimatedAddedDiskBytesUsage) / slaveUsage.getSlaveDiskTotal());
-        setScores(longRunningCpusUsedScore, longRunningMemUsedScore, longRunningDiskUsedScore, systemCpuFreeScore, systemMemFreeScore, systemDiskFreeScore);
-    }
+  void recalculateScores() {
+    setScores(
+        (slaveUsage.getCpusReserved() + estimatedAddedCpusUsage) / slaveUsage.getCpusTotal().get(),
+        ((slaveUsage.getMemoryMbReserved() * SingularitySlaveUsage.BYTES_PER_MEGABYTE) + estimatedAddedMemoryBytesUsage) / slaveUsage.getMemoryBytesTotal().get(),
+        ((slaveUsage.getDiskMbReserved() * SingularitySlaveUsage.BYTES_PER_MEGABYTE) + estimatedAddedDiskBytesUsage) / slaveUsage.getDiskBytesTotal().get(),
+        Math.max(0, 1 - (getMaxProbableCpuWithEstimatedUsage() / slaveUsage.getSystemCpusTotal())),
+        1 - (getMaxProbableMemBytesWithEstimatedUsage() / slaveUsage.getSystemMemTotalBytes()),
+        1 - (getMaxProbableDiskBytesWithEstimatedUsage() / slaveUsage.getSlaveDiskTotal())
+    );
   }
 
   private double getMaxProbableCpuWithEstimatedUsage() {
@@ -121,28 +97,28 @@ class SingularitySlaveUsageWithCalculatedScores {
     return slaveUsage;
   }
 
-  double getLongRunningCpusUsedScore() {
-    return longRunningCpusUsedScore;
+  double getCpusAllocatedScore() {
+    return cpusAllocatedScore;
   }
 
-  double getLongRunningMemUsedScore() {
-    return longRunningMemUsedScore;
+  double getMemAllocatedScore() {
+    return memAllocatedScore;
   }
 
-  double getLongRunningDiskUsedScore() {
-    return longRunningDiskUsedScore;
+  double getDiskAllocatedScore() {
+    return diskAllocatedScore;
   }
 
-  double getCpusFreeScore() {
-    return cpusFreeScore;
+  double getCpusInUseScore() {
+    return cpusInUseScore;
   }
 
-  double getMemFreeScore() {
-    return memFreeScore;
+  double getMemInUseScore() {
+    return memInUseScore;
   }
 
-  double getDiskFreeScore() {
-    return diskFreeScore;
+  double getDiskInUseScore() {
+    return diskInUseScore;
   }
 
   void addEstimatedCpuUsage(double estimatedAddedCpus) {
@@ -210,12 +186,12 @@ class SingularitySlaveUsageWithCalculatedScores {
     return "SingularitySlaveUsageWithCalculatedScores{" +
         "slaveUsage=" + slaveUsage +
         ", missingUsageData=" + missingUsageData +
-        ", longRunningCpusUsedScore=" + longRunningCpusUsedScore +
-        ", longRunningMemUsedScore=" + longRunningMemUsedScore +
-        ", longRunningDiskUsedScore=" + longRunningDiskUsedScore +
-        ", cpusFreeScore=" + cpusFreeScore +
-        ", memFreeScore=" + memFreeScore +
-        ", diskFreeScore=" + diskFreeScore +
+        ", cpusAllocatedScore=" + cpusAllocatedScore +
+        ", memAllocatedScore=" + memAllocatedScore +
+        ", diskAllocatedScore=" + diskAllocatedScore +
+        ", cpusInUseScore=" + cpusInUseScore +
+        ", memInUseScore=" + memInUseScore +
+        ", diskInUseScore=" + diskInUseScore +
         ", estimatedAddedCpusUsage=" + estimatedAddedCpusUsage +
         ", estimatedAddedMemoryBytesUsage=" + estimatedAddedMemoryBytesUsage +
         ", estimatedAddedDiskBytesUsage=" + estimatedAddedDiskBytesUsage +

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveUsageWithCalculatedScores.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveUsageWithCalculatedScores.java
@@ -42,8 +42,8 @@ class SingularitySlaveUsageWithCalculatedScores {
   }
 
   boolean isCpuOverloaded(double estimatedNumCpusToAdd) {
-    return  ((slaveUsage.getSystemLoad5Min() + estimatedNumCpusToAdd) / slaveUsage.getSystemCpusTotal()) > load5Threshold
-        || ((slaveUsage.getSystemLoad1Min() + estimatedNumCpusToAdd) / slaveUsage.getSystemCpusTotal()) > load1Threshold;
+    return  ((slaveUsage.getSystemLoad5Min() + estimatedAddedCpusUsage + estimatedNumCpusToAdd) / slaveUsage.getSystemCpusTotal()) > load5Threshold
+        || ((slaveUsage.getSystemLoad1Min() + estimatedAddedCpusUsage + estimatedNumCpusToAdd) / slaveUsage.getSystemCpusTotal()) > load1Threshold;
   }
 
   private void setScores(double cpusAllocatedScore,

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityUsageTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityUsageTest.java
@@ -515,7 +515,7 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
       initFirstDeployWithResources(configuration.getMesosConfiguration().getDefaultCpus(), configuration.getMesosConfiguration().getDefaultMemory());
       saveAndSchedule(requestManager.getRequest(requestId).get().getRequest().toBuilder().setInstances(Optional.of(3)));
       resourceOffers(1);
-      SingularitySlaveUsage highUsage = new SingularitySlaveUsage(15, 10, Optional.of(10.0), 1, 1, Optional.of(30L), 1, 1, Optional.of(1024L), Collections.emptyMap(), 1, System.currentTimeMillis(), 1, 30000, 10, 15, 15, 15, 0, 107374182);
+      SingularitySlaveUsage highUsage = new SingularitySlaveUsage(15, 10, Optional.of(10.0), 1, 1, Optional.of(30L), 1, 1, Optional.of(1024L), 1, System.currentTimeMillis(), 1, 30000, 10, 15, 15, 15, 0, 107374182);
       usageManager.saveSpecificSlaveUsageAndSetCurrent("host1", highUsage);
 
       SingularityTaskId taskId1 = taskManager.getActiveTaskIds().get(0);
@@ -566,7 +566,7 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
       initFirstDeployWithResources(configuration.getMesosConfiguration().getDefaultCpus(), configuration.getMesosConfiguration().getDefaultMemory());
       saveAndSchedule(requestManager.getRequest(requestId).get().getRequest().toBuilder().setInstances(Optional.of(3)));
       resourceOffers(1);
-      SingularitySlaveUsage highUsage = new SingularitySlaveUsage(15, 10, Optional.of(10.0), 1, 1, Optional.of(30L), 1, 1, Optional.of(1024L), Collections.emptyMap(), 1, System.currentTimeMillis(), 1, 30000, 10, 15, 15, 15, 0, 107374182);
+      SingularitySlaveUsage highUsage = new SingularitySlaveUsage(15, 10, Optional.of(10.0), 1, 1, Optional.of(30L), 1, 1, Optional.of(1024L), 1, System.currentTimeMillis(), 1, 30000, 10, 15, 15, 15, 0, 107374182);
       usageManager.saveSpecificSlaveUsageAndSetCurrent("host1", highUsage);
 
       SingularityTaskId taskId1 = taskManager.getActiveTaskIds().get(0);
@@ -612,7 +612,7 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
       initFirstDeployWithResources(configuration.getMesosConfiguration().getDefaultCpus(), configuration.getMesosConfiguration().getDefaultMemory());
       saveAndSchedule(requestManager.getRequest(requestId).get().getRequest().toBuilder().setInstances(Optional.of(3)));
       resourceOffers(1);
-      SingularitySlaveUsage highUsage = new SingularitySlaveUsage(15, 10, Optional.of(10.0), 1, 1, Optional.of(30L), 1, 1, Optional.of(1024L), Collections.emptyMap(), 1, System.currentTimeMillis(), 1, 30000, 10, 15, 15, 15, 0, 107374182);
+      SingularitySlaveUsage highUsage = new SingularitySlaveUsage(15, 10, Optional.of(10.0), 1, 1, Optional.of(30L), 1, 1, Optional.of(1024L), 1, System.currentTimeMillis(), 1, 30000, 10, 15, 15, 15, 0, 107374182);
       usageManager.saveSpecificSlaveUsageAndSetCurrent("host1", highUsage);
 
       SingularityTaskId taskId1 = taskManager.getActiveTaskIds().get(0);


### PR DESCRIPTION
- Consolidate on a single strategy for offer scoring that will account for usage if it is available, using allocated resource values if not
- Stop treating long running, non-long running separately in offer scoring
- Consolidate configurable values
```
mesos:
  allocatedResourceWeight: 0.5
  inUseResourceWeight: 0.5
  cpuWeight: 0.4
  memWeight: 0.4
  diskWeight: 0.2
```
- rename of used/free to allocated/inUse

cc @baconmania @pschoenfelder 