### PR TITLE
Add ability to set attributes that mark slave for only preemptible tasks

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -390,6 +390,10 @@ public class SingularityConfiguration extends Configuration {
   // If cpuHardLimit is specified and a task is requesting a base cpu of > cpuHardLimit, that task's new  hard limit is requested cpus * cpuHardLimitScaleFactor
   private double cpuHardLimitScaleFactor = 1.25;
 
+  private Map<String, String> preemptableTasksOnlyMachineAttributes = Collections.emptyMap();
+
+  private long preemptableTaskMaxExpectedRuntimeMs = 900000; // 15 minutes
+
   public long getAskDriverToKillTasksAgainAfterMillis() {
     return askDriverToKillTasksAgainAfterMillis;
   }
@@ -1669,5 +1673,21 @@ public class SingularityConfiguration extends Configuration {
   public SingularityConfiguration setCpuHardLimitScaleFactor(double cpuHardLimitScaleFactor) {
     this.cpuHardLimitScaleFactor = cpuHardLimitScaleFactor;
     return this;
+  }
+
+  public Map<String, String> getPreemptableTasksOnlyMachineAttributes() {
+    return preemptableTasksOnlyMachineAttributes;
+  }
+
+  public void setPreemptableTasksOnlyMachineAttributes(Map<String, String> preemptableTasksOnlyMachineAttributes) {
+    this.preemptableTasksOnlyMachineAttributes = preemptableTasksOnlyMachineAttributes;
+  }
+
+  public long getPreemptableTaskMaxExpectedRuntimeMs() {
+    return preemptableTaskMaxExpectedRuntimeMs;
+  }
+
+  public void setPreemptableTaskMaxExpectedRuntimeMs(long preemptableTaskMaxExpectedRuntimeMs) {
+    this.preemptableTaskMaxExpectedRuntimeMs = preemptableTaskMaxExpectedRuntimeMs;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -390,9 +390,9 @@ public class SingularityConfiguration extends Configuration {
   // If cpuHardLimit is specified and a task is requesting a base cpu of > cpuHardLimit, that task's new  hard limit is requested cpus * cpuHardLimitScaleFactor
   private double cpuHardLimitScaleFactor = 1.25;
 
-  private Map<String, String> preemptableTasksOnlyMachineAttributes = Collections.emptyMap();
+  private Map<String, String> preemptibleTasksOnlyMachineAttributes = Collections.emptyMap();
 
-  private long preemptableTaskMaxExpectedRuntimeMs = 900000; // 15 minutes
+  private long preemptibleTaskMaxExpectedRuntimeMs = 900000; // 15 minutes
 
   public long getAskDriverToKillTasksAgainAfterMillis() {
     return askDriverToKillTasksAgainAfterMillis;
@@ -1675,19 +1675,19 @@ public class SingularityConfiguration extends Configuration {
     return this;
   }
 
-  public Map<String, String> getPreemptableTasksOnlyMachineAttributes() {
-    return preemptableTasksOnlyMachineAttributes;
+  public Map<String, String> getPreemptibleTasksOnlyMachineAttributes() {
+    return preemptibleTasksOnlyMachineAttributes;
   }
 
-  public void setPreemptableTasksOnlyMachineAttributes(Map<String, String> preemptableTasksOnlyMachineAttributes) {
-    this.preemptableTasksOnlyMachineAttributes = preemptableTasksOnlyMachineAttributes;
+  public void setPreemptibleTasksOnlyMachineAttributes(Map<String, String> preemptibleTasksOnlyMachineAttributes) {
+    this.preemptibleTasksOnlyMachineAttributes = preemptibleTasksOnlyMachineAttributes;
   }
 
-  public long getPreemptableTaskMaxExpectedRuntimeMs() {
-    return preemptableTaskMaxExpectedRuntimeMs;
+  public long getPreemptibleTaskMaxExpectedRuntimeMs() {
+    return preemptibleTaskMaxExpectedRuntimeMs;
   }
 
-  public void setPreemptableTaskMaxExpectedRuntimeMs(long preemptableTaskMaxExpectedRuntimeMs) {
-    this.preemptableTaskMaxExpectedRuntimeMs = preemptableTaskMaxExpectedRuntimeMs;
+  public void setPreemptibleTaskMaxExpectedRuntimeMs(long preemptibleTaskMaxExpectedRuntimeMs) {
+    this.preemptibleTaskMaxExpectedRuntimeMs = preemptibleTaskMaxExpectedRuntimeMs;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
@@ -374,8 +374,7 @@ public class SingularityMesosOfferScheduler {
     if (!matchesResources) {
       return 0;
     }
-
-    final SlaveMatchState slaveMatchState = slaveAndRackManager.doesOfferMatch(offerHolder, taskRequest, activeTaskIdsForRequest);
+    final SlaveMatchState slaveMatchState = slaveAndRackManager.doesOfferMatch(offerHolder, taskRequest, activeTaskIdsForRequest, isPreemtableTask(taskRequest));
 
     if (slaveMatchState.isMatchAllowed()) {
       return score(offerHolder.getHostname(), taskRequest, maybeSlaveUsage);
@@ -385,6 +384,19 @@ public class SingularityMesosOfferScheduler {
     }
 
     return 0;
+  }
+
+  private boolean isPreemtableTask(SingularityTaskRequest taskRequest) {
+    // A long running task can be replaced + killed easily
+    if (taskRequest.getRequest().getRequestType().isLongRunning()) {
+      return true;
+    }
+
+    // A short, non-long-running task
+    Optional<SingularityDeployStatistics> deployStatistics = deployManager.getDeployStatistics(taskRequest.getRequest().getId(), taskRequest.getDeploy().getId());
+    return deployStatistics.isPresent()
+        && deployStatistics.get().getAverageRuntimeMillis().isPresent()
+        && deployStatistics.get().getAverageRuntimeMillis().get() < configuration.getPreemptableTaskMaxExpectedRuntimeMs();
   }
 
   @VisibleForTesting

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
@@ -374,7 +374,7 @@ public class SingularityMesosOfferScheduler {
     if (!matchesResources) {
       return 0;
     }
-    final SlaveMatchState slaveMatchState = slaveAndRackManager.doesOfferMatch(offerHolder, taskRequest, activeTaskIdsForRequest, isPreemtibleTask(taskRequest));
+    final SlaveMatchState slaveMatchState = slaveAndRackManager.doesOfferMatch(offerHolder, taskRequest, activeTaskIdsForRequest, isPreemptibleTask(taskRequest));
 
     if (slaveMatchState.isMatchAllowed()) {
       return score(offerHolder.getHostname(), taskRequest, maybeSlaveUsage);
@@ -386,7 +386,7 @@ public class SingularityMesosOfferScheduler {
     return 0;
   }
 
-  private boolean isPreemtibleTask(SingularityTaskRequest taskRequest) {
+  private boolean isPreemptibleTask(SingularityTaskRequest taskRequest) {
     // A long running task can be replaced + killed easily
     if (taskRequest.getRequest().getRequestType().isLongRunning()) {
       return true;

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
@@ -396,7 +396,7 @@ public class SingularityMesosOfferScheduler {
     Optional<SingularityDeployStatistics> deployStatistics = deployManager.getDeployStatistics(taskRequest.getRequest().getId(), taskRequest.getDeploy().getId());
     return deployStatistics.isPresent()
         && deployStatistics.get().getAverageRuntimeMillis().isPresent()
-        && deployStatistics.get().getAverageRuntimeMillis().get() < configuration.getPreemptableTaskMaxExpectedRuntimeMs();
+        && deployStatistics.get().getAverageRuntimeMillis().get() < configuration.getPreemptibleTaskMaxExpectedRuntimeMs();
   }
 
   @VisibleForTesting

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
@@ -374,7 +374,7 @@ public class SingularityMesosOfferScheduler {
     if (!matchesResources) {
       return 0;
     }
-    final SlaveMatchState slaveMatchState = slaveAndRackManager.doesOfferMatch(offerHolder, taskRequest, activeTaskIdsForRequest, isPreemtableTask(taskRequest));
+    final SlaveMatchState slaveMatchState = slaveAndRackManager.doesOfferMatch(offerHolder, taskRequest, activeTaskIdsForRequest, isPreemtibleTask(taskRequest));
 
     if (slaveMatchState.isMatchAllowed()) {
       return score(offerHolder.getHostname(), taskRequest, maybeSlaveUsage);
@@ -386,7 +386,7 @@ public class SingularityMesosOfferScheduler {
     return 0;
   }
 
-  private boolean isPreemtableTask(SingularityTaskRequest taskRequest) {
+  private boolean isPreemtibleTask(SingularityTaskRequest taskRequest) {
     // A long running task can be replaced + killed easily
     if (taskRequest.getRequest().getRequestType().isLongRunning()) {
       return true;

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
@@ -81,7 +81,7 @@ public class SingularitySlaveAndRackManager {
     this.leaderCache = leaderCache;
   }
 
-  SlaveMatchState doesOfferMatch(SingularityOfferHolder offerHolder, SingularityTaskRequest taskRequest, List<SingularityTaskId> activeTaskIdsForRequest, boolean isPreemtibleTask) {
+  SlaveMatchState doesOfferMatch(SingularityOfferHolder offerHolder, SingularityTaskRequest taskRequest, List<SingularityTaskId> activeTaskIdsForRequest, boolean isPreemptibleTask) {
     final String host = offerHolder.getHostname();
     final String rackId = offerHolder.getRackId();
     final String slaveId = offerHolder.getSlaveId();
@@ -113,7 +113,7 @@ public class SingularitySlaveAndRackManager {
       }
     }
 
-    if (!isSlaveAttributesMatch(offerHolder, taskRequest, isPreemtibleTask)) {
+    if (!isSlaveAttributesMatch(offerHolder, taskRequest, isPreemptibleTask)) {
       return SlaveMatchState.SLAVE_ATTRIBUTES_DO_NOT_MATCH;
     }
 
@@ -241,7 +241,7 @@ public class SingularitySlaveAndRackManager {
     return SlaveMatchState.OK;
   }
 
-  private boolean isSlaveAttributesMatch(SingularityOfferHolder offer, SingularityTaskRequest taskRequest, boolean isPreemtibleTask) {
+  private boolean isSlaveAttributesMatch(SingularityOfferHolder offer, SingularityTaskRequest taskRequest, boolean isPreemptibleTask) {
     if (offer.hasReservedSlaveAttributes()) {
       Map<String, String> reservedSlaveAttributes = offer.getReservedSlaveAttributes();
 
@@ -262,7 +262,7 @@ public class SingularitySlaveAndRackManager {
 
     if (!configuration.getPreemptibleTasksOnlyMachineAttributes().isEmpty()) {
       if (slaveAndRackHelper.hasRequiredAttributes(offer.getTextAttributes(), configuration.getPreemptibleTasksOnlyMachineAttributes())
-          && !isPreemtibleTask) {
+          && !isPreemptibleTask) {
         LOG.debug("Host {} is reserved for preemptible tasks", offer.getHostname());
         return false;
       }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
@@ -260,8 +260,8 @@ public class SingularitySlaveAndRackManager {
       }
     }
 
-    if (!configuration.getPreemptableTasksOnlyMachineAttributes().isEmpty()) {
-      if (slaveAndRackHelper.hasRequiredAttributes(offer.getTextAttributes(), configuration.getPreemptableTasksOnlyMachineAttributes())
+    if (!configuration.getPreemptibleTasksOnlyMachineAttributes().isEmpty()) {
+      if (slaveAndRackHelper.hasRequiredAttributes(offer.getTextAttributes(), configuration.getPreemptibleTasksOnlyMachineAttributes())
           && !isPreemtibleTask) {
         LOG.debug("Host {} is reserved for preemptible tasks", offer.getHostname());
         return false;

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
@@ -81,7 +81,7 @@ public class SingularitySlaveAndRackManager {
     this.leaderCache = leaderCache;
   }
 
-  SlaveMatchState doesOfferMatch(SingularityOfferHolder offerHolder, SingularityTaskRequest taskRequest, List<SingularityTaskId> activeTaskIdsForRequest) {
+  SlaveMatchState doesOfferMatch(SingularityOfferHolder offerHolder, SingularityTaskRequest taskRequest, List<SingularityTaskId> activeTaskIdsForRequest, boolean isPreemtibleTask) {
     final String host = offerHolder.getHostname();
     final String rackId = offerHolder.getRackId();
     final String slaveId = offerHolder.getSlaveId();
@@ -113,7 +113,7 @@ public class SingularitySlaveAndRackManager {
       }
     }
 
-    if (!isSlaveAttributesMatch(offerHolder, taskRequest)) {
+    if (!isSlaveAttributesMatch(offerHolder, taskRequest, isPreemtibleTask)) {
       return SlaveMatchState.SLAVE_ATTRIBUTES_DO_NOT_MATCH;
     }
 
@@ -241,7 +241,7 @@ public class SingularitySlaveAndRackManager {
     return SlaveMatchState.OK;
   }
 
-  private boolean isSlaveAttributesMatch(SingularityOfferHolder offer, SingularityTaskRequest taskRequest) {
+  private boolean isSlaveAttributesMatch(SingularityOfferHolder offer, SingularityTaskRequest taskRequest, boolean isPreemtibleTask) {
     if (offer.hasReservedSlaveAttributes()) {
       Map<String, String> reservedSlaveAttributes = offer.getReservedSlaveAttributes();
 
@@ -256,6 +256,14 @@ public class SingularitySlaveAndRackManager {
         }
       } else {
         LOG.trace("Slaves with attributes {} are reserved for matching tasks. No attributes specified for task {}", reservedSlaveAttributes, taskRequest.getPendingTask().getPendingTaskId().getId());
+        return false;
+      }
+    }
+
+    if (!configuration.getPreemptableTasksOnlyMachineAttributes().isEmpty()) {
+      if (slaveAndRackHelper.hasRequiredAttributes(offer.getTextAttributes(), configuration.getPreemptableTasksOnlyMachineAttributes())
+          && !isPreemtibleTask) {
+        LOG.debug("Host {} is reserved for preemptible tasks", offer.getHostname());
         return false;
       }
     }


### PR DESCRIPTION
For example, set:
```yaml
preemptibleTasksOnlyMachineAttributes:
  preemptibleOnly: "true"
```

And only long-running (worker/service) or shorter non-long-running (`avgRunTime` < `preemptibleTaskMaxExpectedRuntimeMs`) will be placed on those slaves. As a result they are easier to shut down and replace if a portion of the mesos cluster is rotated out frequently