### PR TITLE
Allow a buffer for tasks near the cpu hard limit

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilder.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilder.java
@@ -564,12 +564,8 @@ class SingularityMesosTaskBuilder {
       Optional<Resources> maybeResources = task.getPendingTask().getResources().or(task.getDeploy().getResources());
       if (maybeResources.isPresent()) {
         double requestedCpus = maybeResources.get().getCpus();
-        if (requestedCpus > configuration.getCpuHardLimit().get()) {
-          Integer newHardLimit = (int) Math.ceil(requestedCpus * configuration.getCpuHardLimitScaleFactor());
-          return Optional.of(newHardLimit);
-        } else {
-          return configuration.getCpuHardLimit();
-        }
+        int scaledLimit = (int) Math.ceil(requestedCpus * configuration.getCpuHardLimitScaleFactor());
+        return Optional.of(Math.max(scaledLimit, configuration.getCpuHardLimit().get()));
       }
     }
     return Optional.absent();


### PR DESCRIPTION
Tasks close to the hard limit would end up with a smaller buffer than those above it. This fixes it so that a task just below the limit will get proportionally the same amount of buffer