### PR TITLE
Improve order of search results

### DIFF
--- a/SingularityUI/app/utils.es6
+++ b/SingularityUI/app/utils.es6
@@ -142,6 +142,7 @@ const Utils = {
       } else if (fuzzyObject.string.toLowerCase().indexOf(filter.toLowerCase()) > -1) {
         fuzzyObject.score = fuzzyObject.score * 5;
       }
+      fuzzyObject.score = fuzzyObject.score * (1 + (filter.length/fuzzyObject.string.length));
       return fuzzyObject;
     });
     return _.uniq(


### PR DESCRIPTION
**Original Issue**
> I feel like my search should have caused `janus-web` to be the first entry in this search:
![image](https://user-images.githubusercontent.com/15708264/40846546-e87ae81e-6587-11e8-981c-5e747b1ff08f.png)

---
**Fix**
Before:
![image](https://user-images.githubusercontent.com/15708264/40846901-df89f848-6588-11e8-834e-d80dbcfe1b19.png)

After:
![image](https://user-images.githubusercontent.com/15708264/40846909-e4bae2c8-6588-11e8-9141-56de1bc4e5c8.png)


