### PR TITLE
Auto expand Healthcheck section when healthcheck link is clicked

### DIFF
--- a/SingularityUI/app/components/common/CollapsableSection.jsx
+++ b/SingularityUI/app/components/common/CollapsableSection.jsx
@@ -4,6 +4,7 @@ export default class CollapsableSection extends React.Component {
 
   static propTypes = {
     defaultExpanded: PropTypes.bool,
+    expanded: PropTypes.bool,
     title: PropTypes.string,
     subtitle: PropTypes.string,
     children: PropTypes.node,
@@ -11,10 +12,16 @@ export default class CollapsableSection extends React.Component {
   };
 
   constructor(props) {
-    super();
+    super(props);
     this.state = {
-      expanded: props.defaultExpanded
+      expanded: props.defaultExpanded || props.expanded,
     };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.expanded !== nextProps.expanded) {
+      this.setState({ expanded: nextProps.expanded });
+    }
   }
 
   toggle() {

--- a/SingularityUI/app/components/taskDetail/TaskAlerts.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskAlerts.jsx
@@ -178,7 +178,7 @@ const TaskAlerts = (props) => {
         </p>
         {respondedMessage}
         <p><li>
-          <a href="#healthchecks">View all healthchecks</a>
+          <a onClick={props.onViewHealthchecks} href="#healthchecks">View all healthchecks</a>
         </li>
         <li>
           <a href="#logs">View service logs</a>
@@ -253,6 +253,8 @@ TaskAlerts.propTypes = {
     }).isRequired,
     currentDeployState: PropTypes.string
   })),
+
+  onViewHealthchecks: PropTypes.func.isRequired,
 };
 
 export default TaskAlerts;

--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -130,7 +130,8 @@ class TaskDetail extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      previousUsage: null
+      previousUsage: null,
+      expandedHealthchecks: false,
     };
   }
 
@@ -477,7 +478,12 @@ class TaskDetail extends Component {
     return (
       <div className="task-detail detail-view">
         {this.renderHeader(cleanup)}
-        <TaskAlerts task={this.props.task} deploy={this.props.deploy} pendingDeploys={this.props.pendingDeploys} />
+        <TaskAlerts
+          task={this.props.task}
+          deploy={this.props.deploy}
+          pendingDeploys={this.props.pendingDeploys}
+          onViewHealthchecks={() => this.setState({ expandedHealthchecks: true })}
+        />
         <TaskMetadataAlerts task={this.props.task} />
         <TaskHistory taskUpdates={this.props.task.taskUpdates} />
         <TaskLatestLog taskId={this.props.taskId} status={this.props.task.status} files={filesToDisplay} available={filesAvailable} />
@@ -487,7 +493,12 @@ class TaskDetail extends Component {
         <TaskInfo task={this.props.task.task} ports={this.props.task.ports} directory={this.props.task.directory} />
         {this.renderResourceUsage()}
         <TaskEnvVars executor={this.props.task.task.mesosTask.executor} />
-        <TaskHealthchecks task={this.props.task.task} healthcheckResults={this.props.task.healthcheckResults} ports={this.props.task.ports} />
+        <TaskHealthchecks
+          task={this.props.task.task}
+          healthcheckResults={this.props.task.healthcheckResults}
+          ports={this.props.task.ports}
+          expanded={this.state.expandedHealthchecks}
+        />
         {this.renderShellCommands()}
       </div>
     );

--- a/SingularityUI/app/components/taskDetail/TaskHealthchecks.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskHealthchecks.jsx
@@ -36,7 +36,7 @@ function TaskHealthchecks (props) {
   }
 
   return (healthchecks && healthcheckOptions.uri && (
-    <CollapsableSection title="Healthchecks" id="healthchecks">
+    <CollapsableSection title="Healthchecks" id="healthchecks" expanded={props.expanded}>
       <div className="well">
         <p>
           Beginning {beginningOnMessage}, wait a max of <strong>{healthcheckOptions.startupTimeoutSeconds || config.defaultStartupTimeoutSeconds}s</strong> for app to start responding, then hit
@@ -127,7 +127,8 @@ TaskHealthchecks.propTypes = {
     errorMessage: PropTypes.string,
     responseBody: PropTypes.string
   })),
-  ports: PropTypes.arrayOf(PropTypes.number)
+  ports: PropTypes.arrayOf(PropTypes.number),
+  expanded: PropTypes.bool,
 };
 
 export default TaskHealthchecks;


### PR DESCRIPTION
This will only auto expand it the first time it's clicked because the `CollapsableSection` component handles it's own internal state. We're overriding it once, but since we're not controlling it from a parent component, I didn't want to disable the expand/collapse feature of the component.