### PR TITLE
Faster refresh for request and task detail pages

### DIFF
--- a/SingularityUI/app/actions/ui/requestDetail.es6
+++ b/SingularityUI/app/actions/ui/requestDetail.es6
@@ -14,7 +14,7 @@ export const refresh = (requestId) => (dispatch, getState) => {
     dispatch(FetchRequestHistory.trigger(requestId, 5, 1))
   ])
 
-  dispatch(FetchActiveTasksForRequest.trigger(requestId, 5, 1));
+  dispatch(FetchActiveTasksForRequest.trigger(requestId));
   dispatch(FetchTaskCleanups.trigger());
   dispatch(FetchTaskHistoryForRequest.trigger(requestId, 5, 1));
   dispatch(FetchDeploysForRequest.trigger(requestId, 5, 1));

--- a/SingularityUI/app/components/requestDetail/RequestDetailPage.jsx
+++ b/SingularityUI/app/components/requestDetail/RequestDetailPage.jsx
@@ -83,14 +83,16 @@ const mapStateToProps = (state, ownProps) => {
 const mapDispatchToProps = (dispatch, ownProps) => {
   const refreshActions = [
     FetchRequest.trigger(ownProps.params.requestId, true),
-    FetchTaskCleanups.trigger()
+    FetchTaskCleanups.trigger(),
+    FetchActiveTasksForRequest.trigger(ownProps.params.requestId),
+    FetchScheduledTasksForRequest.trigger(ownProps.params.requestId)
   ];
   return {
     refresh: () => {
       dispatch(RefreshActions.BeginAutoRefresh(
         `RequestDetailPage-${ownProps.index}`,
         refreshActions,
-        5000
+        4000
       ));
     },
     cancelRefresh: () => dispatch(
@@ -107,4 +109,4 @@ const mapDispatchToProps = (dispatch, ownProps) => {
 export default connect(
   mapStateToProps,
   mapDispatchToProps
-)(rootComponent(RequestDetailPage, (props) => refresh(props.params.requestId), false));
+)(rootComponent(RequestDetailPage, (props) => refresh(props.params.requestId), true));

--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -126,7 +126,8 @@ class TaskDetail extends Component {
     fetchTaskStatistics: PropTypes.func.isRequired,
     fetchTaskFiles: PropTypes.func.isRequired,
     runCommandOnTask: PropTypes.func.isRequired,
-    group: PropTypes.object
+    group: PropTypes.object,
+    cancelRefresh: PropTypes.func.isRequired
   };
 
   constructor(props) {
@@ -590,6 +591,9 @@ function mapDispatchToProps(dispatch, ownProps) {
         4000
       ));
     },
+    cancelRefresh: () => dispatch(
+      RefreshActions.CancelAutoRefresh(`TaskDetailPage-${ownProps.params.taskId}`)
+    ),
     runCommandOnTask: (taskId, commandName) => dispatch(RunCommandOnTask.trigger(taskId, commandName)),
     fetchTaskHistory: (taskId) => dispatch(FetchTaskHistory.trigger(taskId, true)),
     fetchTaskStatistics: (taskId) => dispatch(FetchTaskStatistics.trigger(taskId, [404, 500])),

--- a/SingularityUI/app/components/taskDetail/TaskDetail.jsx
+++ b/SingularityUI/app/components/taskDetail/TaskDetail.jsx
@@ -4,6 +4,8 @@ import { withRouter } from 'react-router';
 import rootComponent from '../../rootComponent';
 import Utils from '../../utils';
 
+import * as RefreshActions from '../../actions/ui/refresh';
+
 import { FetchTaskFiles } from '../../actions/api/sandbox';
 import {
   FetchTaskStatistics,
@@ -135,6 +137,7 @@ class TaskDetail extends Component {
   }
 
   componentDidMount() {
+    this.props.refresh();
     if (!this.props.task) return;
     // Get a second sample for CPU usage right away
     if (this.props.task.isStillRunning) {
@@ -153,6 +156,7 @@ class TaskDetail extends Component {
   }
 
   componentWillUnmount() {
+    this.props.cancelRefresh();
     clearInterval(this.statisticsRefreshInterval);
   }
 
@@ -573,8 +577,19 @@ function mapStateToProps(state, ownProps) {
   };
 }
 
-function mapDispatchToProps(dispatch) {
+function mapDispatchToProps(dispatch, ownProps) {
+  const refreshActions = [
+    FetchTaskHistory.trigger(ownProps.params.taskId, true),
+    FetchTaskCleanups.trigger()
+  ];
   return {
+    refresh: () => {
+      dispatch(RefreshActions.BeginAutoRefresh(
+        `TaskDetailPage-${ownProps.params.taskId}`,
+        refreshActions,
+        4000
+      ));
+    },
     runCommandOnTask: (taskId, commandName) => dispatch(RunCommandOnTask.trigger(taskId, commandName)),
     fetchTaskHistory: (taskId) => dispatch(FetchTaskHistory.trigger(taskId, true)),
     fetchTaskStatistics: (taskId) => dispatch(FetchTaskStatistics.trigger(taskId, [404, 500])),


### PR DESCRIPTION
The request refresher should also refresh active tasks and scheduled tasks so things like watching a bounce don't require a refresh of the whole page. Similar for task detail, watching a launching task shouldn't require a page refresh. Shortened the refresh time on these as well

cc @kwm4385 