### PR TITLE
Create task cleanups for scale down at request update time

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -4,6 +4,7 @@ import static com.hubspot.singularity.WebExceptions.checkBadRequest;
 import static com.hubspot.singularity.WebExceptions.checkConflict;
 import static com.hubspot.singularity.WebExceptions.checkNotNullBadRequest;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -28,7 +29,9 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
+import com.google.common.collect.HashMultiset;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Multiset;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.hubspot.jackson.jaxrs.PropertyFiltering;
@@ -46,6 +49,7 @@ import com.hubspot.singularity.SingularityPendingRequest.PendingType;
 import com.hubspot.singularity.SingularityPendingRequestParent;
 import com.hubspot.singularity.SingularityRequest;
 import com.hubspot.singularity.SingularityRequestCleanup;
+import com.hubspot.singularity.SingularityRequestDeployState;
 import com.hubspot.singularity.SingularityRequestHistory.RequestHistoryType;
 import com.hubspot.singularity.SingularityRequestParent;
 import com.hubspot.singularity.SingularityRequestWithState;
@@ -68,7 +72,9 @@ import com.hubspot.singularity.api.SingularityUnpauseRequest;
 import com.hubspot.singularity.api.SingularityUpdateGroupsRequest;
 import com.hubspot.singularity.auth.SingularityAuthorizationHelper;
 import com.hubspot.singularity.config.ApiPaths;
+import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.DeployManager;
+import com.hubspot.singularity.data.RackManager;
 import com.hubspot.singularity.data.RequestManager;
 import com.hubspot.singularity.data.SingularityValidator;
 import com.hubspot.singularity.data.SlaveManager;
@@ -103,16 +109,21 @@ public class RequestResource extends AbstractRequestResource {
   private final TaskManager taskManager;
   private final RequestHelper requestHelper;
   private final SlaveManager slaveManager;
+  private final RackManager rackManager;
+  private final SingularityConfiguration configuration;
 
   @Inject
   public RequestResource(SingularityValidator validator, DeployManager deployManager, TaskManager taskManager, RequestManager requestManager, SingularityMailer mailer,
                          SingularityAuthorizationHelper authorizationHelper, RequestHelper requestHelper, LeaderLatch leaderLatch,
-                         SlaveManager slaveManager, AsyncHttpClient httpClient, ObjectMapper objectMapper, RequestHistoryHelper requestHistoryHelper) {
+                         SlaveManager slaveManager, AsyncHttpClient httpClient, ObjectMapper objectMapper, RequestHistoryHelper requestHistoryHelper,
+                         RackManager rackManager, SingularityConfiguration configuration) {
     super(requestManager, deployManager, validator, authorizationHelper, httpClient, leaderLatch, objectMapper, requestHelper, requestHistoryHelper);
     this.mailer = mailer;
     this.taskManager = taskManager;
     this.requestHelper = requestHelper;
     this.slaveManager = slaveManager;
+    this.rackManager = rackManager;
+    this.configuration = configuration;
   }
 
   private void submitRequest(SingularityRequest request, Optional<SingularityRequestWithState> oldRequestWithState, Optional<RequestHistoryType> historyType,
@@ -154,19 +165,42 @@ public class RequestResource extends AbstractRequestResource {
     if (oldRequest.isPresent() && request.getInstancesSafe() < oldRequest.get().getInstancesSafe()) {
       // Trigger cleanups for scale down
       int newInstances = request.getInstancesSafe();
-      taskManager.getActiveTaskIdsForRequest(request.getId()).forEach((taskId) -> {
-        if (taskId.getInstanceNo() > newInstances) {
-          taskManager.createTaskCleanup(new SingularityTaskCleanup(
-              Optional.of(user.getId()),
-              TaskCleanupType.SCALING_DOWN,
-              System.currentTimeMillis(),
-              taskId,
-              message,
-              Optional.of(UUID.randomUUID().toString()),
-              Optional.absent()
-          ));
+      Optional<SingularityRequestDeployState> maybeDeployState = deployManager.getRequestDeployState(request.getId());
+      if (maybeDeployState.isPresent() && maybeDeployState.get().getActiveDeploy().isPresent()) {
+        List<SingularityTaskId> remainingActiveTasks = new ArrayList<>();
+        taskManager.getActiveTaskIdsForDeploy(request.getId(), maybeDeployState.get().getActiveDeploy().get().getDeployId()).forEach((taskId) -> {
+          if (taskId.getInstanceNo() > newInstances) {
+            taskManager.createTaskCleanup(new SingularityTaskCleanup(
+                Optional.of(user.getId()),
+                TaskCleanupType.SCALING_DOWN,
+                System.currentTimeMillis(),
+                taskId,
+                message,
+                Optional.of(UUID.randomUUID().toString()),
+                Optional.absent()
+            ));
+          } else {
+            remainingActiveTasks.add(taskId);
+          }
+        });
+
+        if (request.isRackSensitive() && configuration.isRebalanceRacksOnScaleDown()) {
+          List<SingularityTaskId> extraCleanedTasks = new ArrayList<>();
+          int numActiveRacks = rackManager.getNumActive();
+          double perRack = request.getInstancesSafe() / (double) numActiveRacks;
+
+          Multiset<String> countPerRack = HashMultiset.create();
+          for (SingularityTaskId taskId : remainingActiveTasks) {
+            countPerRack.add(taskId.getSanitizedRackId());
+            LOG.info("{} - {} - {} - {}", countPerRack, perRack, extraCleanedTasks.size(), taskId);
+            if (countPerRack.count(taskId.getSanitizedRackId()) > perRack && extraCleanedTasks.size() < numActiveRacks / 2) {
+              extraCleanedTasks.add(taskId);
+              LOG.info("Cleaning up task {} to evenly distribute tasks among racks", taskId);
+              taskManager.createTaskCleanup(new SingularityTaskCleanup(user.getEmail(), TaskCleanupType.REBALANCE_RACKS, System.currentTimeMillis(), taskId, Optional.<String>absent(), Optional.<String>absent(), Optional.absent()));
+            }
+          }
         }
-      });
+      }
     }
 
     requestHelper.updateRequest(request, oldRequest, requestState, historyType, user.getEmail(), skipHealthchecks, message, maybeBounceRequest);

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -151,7 +151,7 @@ public class RequestResource extends AbstractRequestResource {
       requestState = oldRequestWithState.get().getState();
     }
 
-    if (oldRequest.isPresent() && oldRequest.get().getInstancesSafe() < request.getInstancesSafe()) {
+    if (oldRequest.isPresent() && request.getInstancesSafe() < oldRequest.get().getInstancesSafe()) {
       // Trigger cleanups for scale down
       int newInstances = request.getInstancesSafe();
       taskManager.getActiveTaskIdsForRequest(request.getId()).forEach((taskId) -> {

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -50,10 +50,12 @@ import com.hubspot.singularity.SingularityRequestHistory.RequestHistoryType;
 import com.hubspot.singularity.SingularityRequestParent;
 import com.hubspot.singularity.SingularityRequestWithState;
 import com.hubspot.singularity.SingularityShellCommand;
+import com.hubspot.singularity.SingularityTaskCleanup;
 import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.SingularityTransformHelpers;
 import com.hubspot.singularity.SingularityUser;
 import com.hubspot.singularity.SlavePlacement;
+import com.hubspot.singularity.TaskCleanupType;
 import com.hubspot.singularity.WebExceptions;
 import com.hubspot.singularity.api.SingularityBounceRequest;
 import com.hubspot.singularity.api.SingularityDeleteRequestRequest;
@@ -138,7 +140,7 @@ public class RequestResource extends AbstractRequestResource {
     }
 
     if (!oldRequest.isPresent() || !(oldRequest.get().getInstancesSafe() == request.getInstancesSafe())) {
-      validator.checkScale(request, Optional.<Integer>absent());
+      validator.checkScale(request, Optional.absent());
     }
 
     authorizationHelper.checkForAuthorization(request, user, SingularityAuthorizationScope.WRITE);
@@ -150,6 +152,24 @@ public class RequestResource extends AbstractRequestResource {
     }
 
     requestHelper.updateRequest(request, oldRequest, requestState, historyType, user.getEmail(), skipHealthchecks, message, maybeBounceRequest);
+
+    if (oldRequest.isPresent() && oldRequest.get().getInstancesSafe() < request.getInstancesSafe()) {
+      // Trigger cleanups for scale down
+      int newInstances = request.getInstancesSafe();
+      taskManager.getActiveTaskIdsForRequest(request.getId()).forEach((taskId) -> {
+        if (taskId.getInstanceNo() > newInstances) {
+          taskManager.createTaskCleanup(new SingularityTaskCleanup(
+              Optional.of(user.getId()),
+              TaskCleanupType.SCALING_DOWN,
+              System.currentTimeMillis(),
+              taskId,
+              message,
+              Optional.of(UUID.randomUUID().toString()),
+              Optional.absent()
+          ));
+        }
+      });
+    }
   }
 
   @POST

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -151,8 +151,6 @@ public class RequestResource extends AbstractRequestResource {
       requestState = oldRequestWithState.get().getState();
     }
 
-    requestHelper.updateRequest(request, oldRequest, requestState, historyType, user.getEmail(), skipHealthchecks, message, maybeBounceRequest);
-
     if (oldRequest.isPresent() && oldRequest.get().getInstancesSafe() < request.getInstancesSafe()) {
       // Trigger cleanups for scale down
       int newInstances = request.getInstancesSafe();
@@ -170,6 +168,8 @@ public class RequestResource extends AbstractRequestResource {
         }
       });
     }
+
+    requestHelper.updateRequest(request, oldRequest, requestState, historyType, user.getEmail(), skipHealthchecks, message, maybeBounceRequest);
   }
 
   @POST

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -19,9 +19,7 @@ import org.apache.mesos.v1.Protos.TaskState;
 import org.apache.mesos.v1.Protos.TaskStatus;
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
@@ -2373,5 +2371,23 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     resourceOffers();
 
     Assert.assertEquals(1, taskManager.getActiveTaskIds().size());
+  }
+
+  @Test
+  public void testCleanupsCreatedOnScaleDown() {
+    initRequest();
+    SingularityRequestBuilder bldr = request.toBuilder();
+    bldr.setInstances(Optional.of(2));
+    requestResource.postRequest(bldr.build(), singularityUser);
+    initFirstDeploy();
+
+    SingularityTask firstTask = launchTask(request, firstDeploy, 1, TaskState.TASK_RUNNING);
+    SingularityTask secondTask = launchTask(request, firstDeploy, 2, TaskState.TASK_RUNNING);
+    Assert.assertEquals(0, taskManager.getNumCleanupTasks());
+
+    bldr.setInstances(Optional.of(1));
+    requestResource.postRequest(bldr.build(), singularityUser);
+    Assert.assertEquals(1, taskManager.getNumCleanupTasks());
+    Assert.assertEquals(taskManager.getCleanupTaskIds().get(0), secondTask.getTaskId());
   }
 }

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySlavePlacementTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySlavePlacementTest.java
@@ -311,7 +311,7 @@ public class SingularitySlavePlacementTest extends SingularitySchedulerTestBase 
 
       scheduler.drainPendingQueue();
 
-      Assert.assertEquals(3, taskManager.getNumCleanupTasks());
+      Assert.assertEquals(4, taskManager.getNumCleanupTasks());
 
       int rebalanceRackCleanups = 0;
       for (SingularityTaskCleanup cleanup : taskManager.getCleanupTasks()) {

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySlavePlacementTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySlavePlacementTest.java
@@ -311,7 +311,7 @@ public class SingularitySlavePlacementTest extends SingularitySchedulerTestBase 
 
       scheduler.drainPendingQueue();
 
-      Assert.assertEquals(4, taskManager.getNumCleanupTasks());
+      Assert.assertEquals(3, taskManager.getNumCleanupTasks());
 
       int rebalanceRackCleanups = 0;
       for (SingularityTaskCleanup cleanup : taskManager.getCleanupTasks()) {


### PR DESCRIPTION
We can run into a certain sate where consistent continuous instance numbers are not kept. If a cleanup is created between a request scaling down and the scheduler processing the pending request update, this can occur. This PR creates the task cleanups for the specific instances that need to be cleaned up at request update time to avoid that possible window.