### PR TITLE
Only require read authorization to view list of slaves

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAuthorizationHelper.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAuthorizationHelper.java
@@ -82,6 +82,24 @@ public class SingularityAuthorizationHelper {
     }
   }
 
+  public void checkReadAuthorization(SingularityUser user) {
+    if (authEnabled) {
+      checkForbidden(user.isAuthenticated(), "Not Authenticated!");
+      if (!adminGroups.isEmpty()) {
+        final Set<String> userGroups = user.getGroups();
+        final boolean userIsAdmin = !adminGroups.isEmpty() && groupsIntersect(userGroups, adminGroups);
+        final boolean userIsJITA = !jitaGroups.isEmpty() && groupsIntersect(userGroups, jitaGroups);
+        final boolean userIsReadOnlyUser = (!globalReadOnlyGroups.isEmpty() && groupsIntersect(userGroups, globalReadOnlyGroups));
+        final boolean userIsPartOfRequiredGroups = requiredGroups.isEmpty() || groupsIntersect(userGroups, requiredGroups);
+        if (!userIsAdmin) {
+          checkForbidden(
+              (userIsJITA || userIsReadOnlyUser) && userIsPartOfRequiredGroups,
+              "%s must be part of one or more read only or jita groups: %s,%s", user.getId(), JavaUtils.COMMA_JOINER.join(jitaGroups), JavaUtils.COMMA_JOINER.join(globalReadOnlyGroups));
+        }
+      }
+    }
+  }
+
   public void checkForAuthorizationByTaskId(String taskId, SingularityUser user, SingularityAuthorizationScope scope) {
     if (authEnabled) {
       checkForbidden(user.isAuthenticated(), "Not Authenticated!");

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAuthorizationHelper.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAuthorizationHelper.java
@@ -89,7 +89,7 @@ public class SingularityAuthorizationHelper {
         final Set<String> userGroups = user.getGroups();
         final boolean userIsAdmin = !adminGroups.isEmpty() && groupsIntersect(userGroups, adminGroups);
         final boolean userIsJITA = !jitaGroups.isEmpty() && groupsIntersect(userGroups, jitaGroups);
-        final boolean userIsReadOnlyUser = (!globalReadOnlyGroups.isEmpty() && groupsIntersect(userGroups, globalReadOnlyGroups));
+        final boolean userIsReadOnlyUser = !globalReadOnlyGroups.isEmpty() && groupsIntersect(userGroups, globalReadOnlyGroups);
         final boolean userIsPartOfRequiredGroups = requiredGroups.isEmpty() || groupsIntersect(userGroups, requiredGroups);
         if (!userIsAdmin) {
           checkForbidden(

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractMachineResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractMachineResource.java
@@ -45,7 +45,7 @@ public abstract class AbstractMachineResource<T extends SingularityMachineAbstra
   }
 
   protected List<SingularityExpiringMachineState> getExpiringStateChanges(SingularityUser user) {
-    authorizationHelper.checkAdminAuthorization(user);
+    authorizationHelper.checkReadAuthorization(user);
     return manager.getExpiringObjects();
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RackResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RackResource.java
@@ -55,7 +55,7 @@ public class RackResource extends AbstractMachineResource<SingularityRack> {
   public List<SingularityRack> getRacks(
       @Parameter(hidden = true) @Auth SingularityUser user,
       @Parameter(description = "Optionally specify a particular state to filter racks by") @QueryParam("state") Optional<MachineState> filterState) {
-    authorizationHelper.checkAdminAuthorization(user);
+    authorizationHelper.checkReadAuthorization(user);
     return manager.getObjectsFiltered(filterState);
   }
 
@@ -65,7 +65,7 @@ public class RackResource extends AbstractMachineResource<SingularityRack> {
   public List<SingularityMachineStateHistoryUpdate> getRackHistory(
       @Parameter(hidden = true) @Auth SingularityUser user,
       @Parameter(required = true, description = "Rack ID") @PathParam("rackId") String rackId) {
-    authorizationHelper.checkAdminAuthorization(user);
+    authorizationHelper.checkReadAuthorization(user);
     return manager.getHistory(rackId);
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/SlaveResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/SlaveResource.java
@@ -55,7 +55,7 @@ public class SlaveResource extends AbstractMachineResource<SingularitySlave> {
   public List<SingularitySlave> getSlaves(
       @Parameter(hidden = true) @Auth SingularityUser user,
       @Parameter(description = "Optionally specify a particular state to filter slaves by") @QueryParam("state") Optional<MachineState> filterState) {
-    authorizationHelper.checkAdminAuthorization(user);
+    authorizationHelper.checkReadAuthorization(user);
     return manager.getObjectsFiltered(filterState);
   }
 
@@ -65,7 +65,7 @@ public class SlaveResource extends AbstractMachineResource<SingularitySlave> {
   public List<SingularityMachineStateHistoryUpdate> getSlaveHistory(
       @Parameter(hidden = true) @Auth SingularityUser user,
       @Parameter(required = true, description = "Slave ID") @PathParam("slaveId") String slaveId) {
-    authorizationHelper.checkAdminAuthorization(user);
+    authorizationHelper.checkReadAuthorization(user);
     return manager.getHistory(slaveId);
   }
 
@@ -75,7 +75,7 @@ public class SlaveResource extends AbstractMachineResource<SingularitySlave> {
   public Optional<SingularitySlave> getSlave(
       @Parameter(hidden = true) @Auth SingularityUser user,
       @Parameter(required = true, description = "Slave ID") @PathParam("slaveId") String slaveId) {
-    authorizationHelper.checkAdminAuthorization(user);
+    authorizationHelper.checkReadAuthorization(user);
     return manager.getObject(slaveId);
   }
 


### PR DESCRIPTION
This updates the GETs on the slaves and racks endpoints to only require read auth instead of admin. This way components like the SingularityExecutorCleanup don't need to be given admin privileges to function properly

cc @pschoenfelder 