### PR TITLE
Remove second declaration of defaultProps in UITable in SingaularityUI.

### DIFF
--- a/SingularityUI/app/components/common/table/UITable.jsx
+++ b/SingularityUI/app/components/common/table/UITable.jsx
@@ -67,7 +67,8 @@ class UITable extends Component {
     defaultSortDirection: UITable.SortDirection.DESC,
     asyncSort: false,
     maxPaginationButtons: 10,
-    triggerOnDataSizeChange: undefined
+    triggerOnDataSizeChange: undefined,
+    initialPageNumber: 1
   };
 
   state;
@@ -460,10 +461,6 @@ class UITable extends Component {
     );
   }
 }
-
-UITable.defaultProps = {
-  initialPageNumber: 1
-};
 
 UITable.propTypes = {
   data: PropTypes.arrayOf(PropTypes.object).isRequired,


### PR DESCRIPTION
Resolves issue that caused the requests table not to show up at `singularity/ui/requests/`.