### PR TITLE
Customizable bash in startup script

### DIFF
--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
@@ -228,6 +228,10 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
 
   private int defaultCfsPeriod = 100000;
 
+  private String extraScriptContent = "";
+
+  private String extraDockerScriptContent = "";
+
   public SingularityExecutorConfiguration() {
     super(Optional.of("singularity-executor.log"));
   }
@@ -664,6 +668,22 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
   public SingularityExecutorConfiguration setDefaultCfsPeriod(int defaultCfsPeriod) {
     this.defaultCfsPeriod = defaultCfsPeriod;
     return this;
+  }
+
+  public String getExtraScriptContent() {
+    return extraScriptContent;
+  }
+
+  public void setExtraScriptContent(String extraScriptContent) {
+    this.extraScriptContent = extraScriptContent;
+  }
+
+  public String getExtraDockerScriptContent() {
+    return extraDockerScriptContent;
+  }
+
+  public void setExtraDockerScriptContent(String extraDockerScriptContent) {
+    this.extraDockerScriptContent = extraDockerScriptContent;
   }
 
   @Override

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/models/RunnerContext.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/models/RunnerContext.java
@@ -22,6 +22,7 @@ public class RunnerContext {
   private final boolean useFileAttributes;
   private final Integer cfsQuota;
   private final Integer cfsPeriod;
+  private final String extraScriptContent;
 
   public RunnerContext(String cmd,
                        String taskAppDirectory,
@@ -36,7 +37,8 @@ public class RunnerContext {
                        String switchUserCommand,
                        boolean useFileAttributes,
                        Integer cfsQuota,
-                       Integer cfsPeriod) {
+                       Integer cfsPeriod,
+                       String extraScriptContent) {
     this.cmd = cmd;
     this.taskAppDirectory = taskAppDirectory;
     this.logDir = logDir;
@@ -52,6 +54,7 @@ public class RunnerContext {
     this.useFileAttributes = useFileAttributes;
     this.cfsQuota = cfsQuota;
     this.cfsPeriod = cfsPeriod;
+    this.extraScriptContent = extraScriptContent;
   }
 
   public String getCmd() {
@@ -110,6 +113,10 @@ public class RunnerContext {
     return cfsPeriod;
   }
 
+  public String getExtraScriptContent() {
+    return extraScriptContent;
+  }
+
   @Override
   public String toString() {
     return "RunnerContext{" +
@@ -127,6 +134,7 @@ public class RunnerContext {
         ", useFileAttributes=" + useFileAttributes +
         ", cfsQuota=" + cfsQuota +
         ", cfsPeriod=" + cfsPeriod +
+        ", extraScriptContent=" + extraScriptContent +
         '}';
   }
 }

--- a/SingularityExecutor/src/main/resources/docker.sh.hbs
+++ b/SingularityExecutor/src/main/resources/docker.sh.hbs
@@ -166,6 +166,8 @@ sudo chown "$user" {{{ runContext.logFile }}}
 setfattr -n user.logstart -v "$(($(date +%s%N)/1000000))" {{{ runContext.logFile }}}
 {{/if}}
 
+{{{ runContext.extraScriptContent }}}
+
 # Start up the container
 env_args=({{#each envContext.env}}{{#ifHasNewLinesOrBackticks value}}-e {{#shellQuote name}}{{/shellQuote}}={{#shellQuote value}}{{/shellQuote}} {{/ifHasNewLinesOrBackticks}}{{/each}})
 cmd=(sudo -E -H -u "$user" docker create "${DOCKER_OPTIONS[@]}" "${env_args[@]}" "$DOCKER_IMAGE" {{{ runContext.cmd }}})

--- a/SingularityExecutor/src/main/resources/runner.sh.hbs
+++ b/SingularityExecutor/src/main/resources/runner.sh.hbs
@@ -116,6 +116,8 @@ sudo chown {{{ user }}} {{{ logFilePath }}}
 setfattr -n user.logstart -v "$(($(date +%s%N)/1000000))" {{{ logFilePath }}}
 {{/if}}
 
+{{{ extraScriptContent }}}
+
 # execute command
 {{#if shouldChangeUser}}
 echo "Executing: {{{ switchUserCommand }}} {{#if maxOpenFiles}}/bin/bash -c 'ulimit -Sn {{{maxOpenFiles}}} && {{/if}}{{{ cmd }}}{{#if maxOpenFiles}}'{{/if}} >> {{{ logFilePath }}} 2>&1"


### PR DESCRIPTION
@jonathanwgoodwin this should allow us to shell out on startup for tasks to do things like set environment variables. There are separate fields for the docker/non-docker ones since the scripts are slightly different