### PR TITLE
Remove sort in getPortByIndex

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTask.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTask.java
@@ -102,7 +102,6 @@ public class SingularityTask extends SingularityTaskIdHolder {
     if (index >= ports.size() || index < 0) {
       return Optional.absent();
     } else {
-      Collections.sort(ports); // ports are always in ascending order
       return Optional.of(ports.get(index));
     }
   }

--- a/SingularityExecutor/src/main/resources/docker.sh.hbs
+++ b/SingularityExecutor/src/main/resources/docker.sh.hbs
@@ -153,7 +153,7 @@ DOCKER_OPTIONS+=(--privileged)
 {{/if}}
 
 {{#each envContext.dockerParameters}}
-DOCKER_OPTIONS+=({{this}})
+DOCKER_OPTIONS+=({{this}})g
 {{/each}}
 
 echo "Ensuring {{{ runContext.taskAppDirectory }}} is owned by $user"

--- a/SingularityExecutor/src/main/resources/docker.sh.hbs
+++ b/SingularityExecutor/src/main/resources/docker.sh.hbs
@@ -153,7 +153,7 @@ DOCKER_OPTIONS+=(--privileged)
 {{/if}}
 
 {{#each envContext.dockerParameters}}
-DOCKER_OPTIONS+=({{this}})g
+DOCKER_OPTIONS+=({{this}})
 {{/each}}
 
 echo "Ensuring {{{ runContext.taskAppDirectory }}} is owned by $user"

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilderTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilderTest.java
@@ -299,7 +299,7 @@ public class SingularityMesosTaskBuilderTest {
         .build();
     final SingularityTaskRequest taskRequest = new SingularityTaskRequest(request, deploy, pendingTask);
     final SingularityMesosTaskHolder task = builder.buildTask(offerHolder, Collections.singletonList(portsResource), taskRequest, taskResources, executorResources);
-    assertEquals(31003L, task.getTask().getPortByIndex(2).get().longValue());
+    assertEquals(31000L, task.getTask().getPortByIndex(2).get().longValue());
   }
 
   @Test

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilderTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosTaskBuilderTest.java
@@ -284,12 +284,10 @@ public class SingularityMesosTaskBuilderTest {
         .setName("ports")
         .setType(Protos.Value.Type.RANGES)
         .setRanges(Protos.Value.Ranges.newBuilder()
-            .addRange(Protos.Value.Range.newBuilder()
-                .setBegin(31003)
-                .setEnd(31004).build())
-            .addRange(Protos.Value.Range.newBuilder()
-                .setBegin(31000)
-                .setEnd(31001).build())
+            .addRange(
+                Protos.Value.Range.newBuilder()
+                    .setBegin(31003)
+                    .setEnd(31006).build())
             .build()).build();
 
     final SingularityRequest request = new SingularityRequestBuilder("test", RequestType.WORKER).build();
@@ -299,7 +297,7 @@ public class SingularityMesosTaskBuilderTest {
         .build();
     final SingularityTaskRequest taskRequest = new SingularityTaskRequest(request, deploy, pendingTask);
     final SingularityMesosTaskHolder task = builder.buildTask(offerHolder, Collections.singletonList(portsResource), taskRequest, taskResources, executorResources);
-    assertEquals(31000L, task.getTask().getPortByIndex(2).get().longValue());
+    assertEquals(31005L, task.getTask().getPortByIndex(2).get().longValue());
   }
 
   @Test


### PR DESCRIPTION
Need to verify tests and things all pass with this. We should be getting/using these in the same order we initially receive them from mesos

/fixes https://github.com/HubSpot/Singularity/issues/1827