### PR TITLE
Make requestUtilization map thread safe.

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/data/NotificationsManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/NotificationsManager.java
@@ -5,7 +5,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.utils.ZKPaths;
-import org.jetbrains.annotations.NotNull;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.cache.CacheBuilder;
@@ -49,7 +48,7 @@ public class NotificationsManager extends CuratorManager {
     return cache.getUnchecked(BLACKLIST_ROOT);
   }
 
-  @NotNull private String getEmailPath(String email) {
+  private String getEmailPath(String email) {
     return ZKPaths.makePath(BLACKLIST_ROOT, email);
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCache.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCache.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -47,7 +48,7 @@ public class SingularityLeaderCache {
   private Map<String, SingularitySlave> slaves;
   private Map<String, SingularityRack> racks;
   private Set<SingularityPendingTaskId> pendingTaskIdsToDelete;
-  private Map<String, RequestUtilization> requestUtilizations;
+  private ConcurrentMap<String, RequestUtilization> requestUtilizations;
 
   private volatile boolean active;
 
@@ -117,7 +118,7 @@ public class SingularityLeaderCache {
   }
 
   public void cacheRequestUtilizations(Map<String, RequestUtilization> requestUtilizations) {
-    this.requestUtilizations = new HashMap<>(requestUtilizations);
+    this.requestUtilizations = new ConcurrentHashMap<>(requestUtilizations);
   }
 
   public boolean active() {


### PR DESCRIPTION
The `requestUtilizations` map is iterated over when it gets loaded into a new `HashMap` here:
https://github.com/HubSpot/Singularity/blob/2c77825acf1cd5929029cb678ecb71172ac8e566/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCache.java#L460

Because `requestUtilizations` wasn't previously threadsafe, we'd get occasional `ConcurrentModificationException`s here.