### PR TITLE
lsof alternative for open files check

### DIFF
--- a/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/shared/SimpleProcessManager.java
+++ b/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/shared/SimpleProcessManager.java
@@ -42,6 +42,20 @@ public class SimpleProcessManager extends SafeProcessManager {
     return runCommand(command, redirectOutput, Sets.newHashSet(0));
   }
 
+  public int getExitCode(final List<String> command) {
+    final ProcessBuilder processBuilder = new ProcessBuilder(command);
+    Optional<Integer> exitCode = Optional.absent();
+    try {
+      final Process process = startProcess(processBuilder);
+      return process.waitFor();
+    } catch (Throwable t) {
+      signalKillToProcessIfActive();
+      throw new RuntimeException(t);
+    } finally {
+      processFinished(exitCode);
+    }
+  }
+
   public List<String> runCommand(final List<String> command, final Redirect redirectOutput, final Set<Integer> acceptableExitCodes) throws InterruptedException, ProcessFailedException {
     final ProcessBuilder processBuilder = new ProcessBuilder(command);
 

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityUploader.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityUploader.java
@@ -171,14 +171,21 @@ public abstract class SingularityUploader {
     return found;
   }
 
-  static boolean isFileOpen(Path path) {
+  static boolean isFileOpen(Path path, boolean useFuser) {
     try {
-      SimpleProcessManager lsof = new SimpleProcessManager(LOG);
-      List<String> cmd = ImmutableList.of("lsof", path.toAbsolutePath().toString());
-      List<String> output = lsof.runCommandWithOutput(cmd, Sets.newHashSet(0, 1));
-      for (String line : output) {
-        if (line.contains(path.toAbsolutePath().toString())) {
-          return true;
+      if (useFuser) {
+        SimpleProcessManager fuser = new SimpleProcessManager(LOG);
+        List<String> cmd = ImmutableList.of("fuser", path.toAbsolutePath().toString());
+        int exitCode = fuser.getExitCode(cmd);
+        return exitCode == 0;
+      } else {
+        SimpleProcessManager lsof = new SimpleProcessManager(LOG);
+        List<String> cmd = ImmutableList.of("lsof", path.toAbsolutePath().toString());
+        List<String> output = lsof.runCommandWithOutput(cmd, Sets.newHashSet(0, 1));
+        for (String line : output) {
+          if (line.contains(path.toAbsolutePath().toString())) {
+            return true;
+          }
         }
       }
     } catch (Exception e) {

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityUploader.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityUploader.java
@@ -81,7 +81,7 @@ public abstract class SingularityUploader {
     for (int i = 0; i < toUpload.size(); i++) {
       final Context context = metrics.getUploadTimer().time();
       final Path file = toUpload.get(i);
-      if (!configuration.isCheckForOpenFiles() || !isFileOpen(file)) {
+      if (!configuration.isCheckForOpenFiles() || !isFileOpen(file, configuration.isCheckOpenFilesViaFuser())) {
         try {
           uploadSingle(i, file);
           metrics.upload();

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/config/SingularityS3UploaderConfiguration.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/config/SingularityS3UploaderConfiguration.java
@@ -64,6 +64,9 @@ public class SingularityS3UploaderConfiguration extends BaseRunnerConfiguration 
   @JsonProperty
   private boolean checkForOpenFiles = true;
 
+  @JsonProperty
+  private boolean checkOpenFilesViaFuser = false;
+
   @NotNull
   @JsonProperty
   private Map<String, SingularityS3Credentials> s3BucketCredentials = new HashMap<>();
@@ -165,6 +168,14 @@ public class SingularityS3UploaderConfiguration extends BaseRunnerConfiguration 
     this.checkForOpenFiles = checkForOpenFiles;
   }
 
+  public boolean isCheckOpenFilesViaFuser() {
+    return checkOpenFilesViaFuser;
+  }
+
+  public void setCheckOpenFilesViaFuser(boolean checkOpenFilesViaFuser) {
+    this.checkOpenFilesViaFuser = checkOpenFilesViaFuser;
+  }
+
   public Map<String, SingularityS3Credentials> getS3BucketCredentials() {
     return s3BucketCredentials;
   }
@@ -195,6 +206,7 @@ public class SingularityS3UploaderConfiguration extends BaseRunnerConfiguration 
         ", retryWaitMs=" + retryWaitMs +
         ", retryCount=" + retryCount +
         ", checkForOpenFiles=" + checkForOpenFiles +
+        ", checkOpenFilesViaFuser=" + checkOpenFilesViaFuser +
         ", s3BucketCredentials=" + s3BucketCredentials +
         ", s3ContentHeaders=" + s3ContentHeaders +
         "} " + super.toString();


### PR DESCRIPTION
We have found that with high process counts this lsof call can be very inefficient and cause spurts of high load. This adds an option of using fuser which, while not a perfect replacement, is a faster alternative for this specific use case