### PR TITLE
Grab the request lock when persisting request/deploy history

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityRequestHistoryPersister.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityRequestHistoryPersister.java
@@ -130,7 +130,7 @@ public class SingularityRequestHistoryPersister extends SingularityHistoryPersis
       AtomicInteger i = new AtomicInteger();
       for (SingularityRequestHistoryParent requestHistoryParent : requestHistoryParents) {
         lock.runWithRequestLock(() -> {
-          if (moveToHistoryOrCheckForPurge(requestHistoryParent, i.incrementAndGet())) {
+          if (moveToHistoryOrCheckForPurge(requestHistoryParent, i.getAndIncrement())) {
             numHistoryTransferred.getAndAdd(requestHistoryParent.history.size());
           }
         }, requestHistoryParent.requestId, "request history purger");


### PR DESCRIPTION
Otherwise we can end up with race conditions where something can end up without an active deploy