### PR TITLE
Clean up logrotate files sooner

### DIFF
--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskCleanup.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskCleanup.java
@@ -82,8 +82,8 @@ public class SingularityExecutorTaskCleanup {
     }
   }
 
-  public void removeLogrotateFiles() {
-    taskLogManager.removeLogrotateFile();
+  public void cleanUpLogs() {
+    taskLogManager.teardown();
   }
 
   private TaskCleanupResult finishTaskCleanup(boolean dockerCleanSuccess) {

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskCleanup.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskCleanup.java
@@ -82,6 +82,10 @@ public class SingularityExecutorTaskCleanup {
     }
   }
 
+  public void removeLogrotateFiles() {
+    taskLogManager.removeLogrotateFile();
+  }
+
   private TaskCleanupResult finishTaskCleanup(boolean dockerCleanSuccess) {
     boolean cleanTaskDefinitionFile = cleanTaskDefinitionFile();
 

--- a/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/SingularityExecutorCleanup.java
+++ b/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/SingularityExecutorCleanup.java
@@ -280,7 +280,7 @@ public class SingularityExecutorCleanup {
 
       if (lastUpdate.isPresent()) {
         if (lastUpdate.get().getTaskState().isDone() && System.currentTimeMillis() - lastUpdate.get().getTimestamp() > TimeUnit.MINUTES.toMillis(15)) {
-          LOG.info("Task {} is done for > 15 minutess, removing logrotate files");
+          LOG.info("Task {} is done for > 15 minutes, removing logrotate files");
           taskCleanup.cleanUpLogs();
         }
         if (lastUpdate.get().getTaskState().isFailed()) {

--- a/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/SingularityExecutorCleanup.java
+++ b/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/SingularityExecutorCleanup.java
@@ -281,7 +281,7 @@ public class SingularityExecutorCleanup {
       if (lastUpdate.isPresent()) {
         if (lastUpdate.get().getTaskState().isDone() && System.currentTimeMillis() - lastUpdate.get().getTimestamp() > TimeUnit.HOURS.toMillis(2)) {
           LOG.info("Task {} is done for > 2 hours, removing logrotate files");
-          taskCleanup.removeLogrotateFiles();
+          taskCleanup.cleanUpLogs();
         }
         if (lastUpdate.get().getTaskState().isFailed()) {
           final long delta = System.currentTimeMillis() - lastUpdate.get().getTimestamp();

--- a/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/SingularityExecutorCleanup.java
+++ b/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/SingularityExecutorCleanup.java
@@ -279,8 +279,8 @@ public class SingularityExecutorCleanup {
       final Optional<SingularityTaskHistoryUpdate> lastUpdate = JavaUtils.getLast(taskHistory.get().getTaskUpdates());
 
       if (lastUpdate.isPresent()) {
-        if (lastUpdate.get().getTaskState().isDone() && System.currentTimeMillis() - lastUpdate.get().getTimestamp() > TimeUnit.HOURS.toMillis(2)) {
-          LOG.info("Task {} is done for > 2 hours, removing logrotate files");
+        if (lastUpdate.get().getTaskState().isDone() && System.currentTimeMillis() - lastUpdate.get().getTimestamp() > TimeUnit.MINUTES.toMillis(15)) {
+          LOG.info("Task {} is done for > 15 minutess, removing logrotate files");
           taskCleanup.cleanUpLogs();
         }
         if (lastUpdate.get().getTaskState().isFailed()) {

--- a/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/SingularityExecutorCleanup.java
+++ b/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/SingularityExecutorCleanup.java
@@ -13,6 +13,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -270,22 +271,28 @@ public class SingularityExecutorCleanup {
 
     boolean cleanupTaskAppDirectory = !taskDefinition.getExecutorData().getPreserveTaskSandboxAfterFinish().or(Boolean.FALSE);
 
+    if (taskDefinition.shouldLogrotateLogFile()) {
+      checkForUncompressedLogrotatedFile(taskDefinition);
+    }
+
     if (taskHistory.isPresent()) {
       final Optional<SingularityTaskHistoryUpdate> lastUpdate = JavaUtils.getLast(taskHistory.get().getTaskUpdates());
 
-      if (lastUpdate.isPresent() && lastUpdate.get().getTaskState().isFailed()) {
-        final long delta = System.currentTimeMillis() - lastUpdate.get().getTimestamp();
+      if (lastUpdate.isPresent()) {
+        if (lastUpdate.get().getTaskState().isDone() && System.currentTimeMillis() - lastUpdate.get().getTimestamp() > TimeUnit.HOURS.toMillis(2)) {
+          LOG.info("Task {} is done for > 2 hours, removing logrotate files");
+          taskCleanup.removeLogrotateFiles();
+        }
+        if (lastUpdate.get().getTaskState().isFailed()) {
+          final long delta = System.currentTimeMillis() - lastUpdate.get().getTimestamp();
 
-        if (delta < cleanupConfiguration.getCleanupAppDirectoryOfFailedTasksAfterMillis()) {
-          LOG.info("Not cleaning up task app directory of {} because only {} has elapsed since it failed (will cleanup after {})", taskDefinition.getTaskId(),
-              JavaUtils.durationFromMillis(delta), JavaUtils.durationFromMillis(cleanupConfiguration.getCleanupAppDirectoryOfFailedTasksAfterMillis()));
-          cleanupTaskAppDirectory = false;
+          if (delta < cleanupConfiguration.getCleanupAppDirectoryOfFailedTasksAfterMillis()) {
+            LOG.info("Not cleaning up task app directory of {} because only {} has elapsed since it failed (will cleanup after {})", taskDefinition.getTaskId(),
+                JavaUtils.durationFromMillis(delta), JavaUtils.durationFromMillis(cleanupConfiguration.getCleanupAppDirectoryOfFailedTasksAfterMillis()));
+            cleanupTaskAppDirectory = false;
+          }
         }
       }
-    }
-
-    if (taskDefinition.shouldLogrotateLogFile()) {
-      checkForUncompressedLogrotatedFile(taskDefinition);
     }
 
     boolean isDocker = (taskHistory.isPresent()


### PR DESCRIPTION
Currently when a task fails we don't clean up certain pieces for a while. We should clean up logs/logrotate right away so there aren't piles of stale logrotate configs pointing to directories that don't exist