### PR TITLE
Faster run now enqueue

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityPendingRequestParent.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityPendingRequestParent.java
@@ -19,6 +19,12 @@ public class SingularityPendingRequestParent extends SingularityRequestParent {
         singularityRequestParent.getExpiringSkipHealthchecks(), singularityRequestParent.getTaskIds(), singularityRequestParent.getLastHistory(), singularityRequestParent.getMostRecentTask());
   }
 
+  public static SingularityPendingRequestParent minimalFromRequestParent(SingularityRequestWithState requestWithState, SingularityPendingRequest pendingRequest) {
+    return new SingularityPendingRequestParent(requestWithState.getRequest(), requestWithState.getState(), Optional.absent(), Optional.absent(),
+        Optional.absent(), Optional.absent(), pendingRequest, Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(),
+        Optional.absent(), Optional.absent());
+  }
+
   @JsonCreator
   public SingularityPendingRequestParent(@JsonProperty("request") SingularityRequest request,
                                          @JsonProperty("state") RequestState state,

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityPendingRequestParent.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityPendingRequestParent.java
@@ -19,7 +19,7 @@ public class SingularityPendingRequestParent extends SingularityRequestParent {
         singularityRequestParent.getExpiringSkipHealthchecks(), singularityRequestParent.getTaskIds(), singularityRequestParent.getLastHistory(), singularityRequestParent.getMostRecentTask());
   }
 
-  public static SingularityPendingRequestParent minimalFromRequestParent(SingularityRequestWithState requestWithState, SingularityPendingRequest pendingRequest) {
+  public static SingularityPendingRequestParent minimalFromRequestWithState(SingularityRequestWithState requestWithState, SingularityPendingRequest pendingRequest) {
     return new SingularityPendingRequestParent(requestWithState.getRequest(), requestWithState.getState(), Optional.absent(), Optional.absent(),
         Optional.absent(), Optional.absent(), pendingRequest, Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(),
         Optional.absent(), Optional.absent());

--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
@@ -441,7 +441,7 @@ public class SingularityClient {
     return executeRequest(hostToUri, type, body, Method.PUT, Optional.absent());
   }
 
-  private <T> Optional<T> post(Function<String, String> hostToUri, String type, Optional<?> body, Optional<Class<T>> clazz) {
+  private <T> Optional<T> post(Function<String, String> hostToUri, String type, Optional<?> body, Optional<Class<T>> clazz, Optional<Map<String, Object>> queryParams) {
     try {
       HttpResponse response = executeRequest(hostToUri, type, body, Method.POST, Optional.absent());
 
@@ -461,6 +461,10 @@ public class SingularityClient {
 
   private HttpResponse post(Function<String, String> hostToUri, String type, Optional<?> body) {
     return executeRequest(hostToUri, type, body, Method.POST, Optional.absent());
+  }
+
+  private HttpResponse post(Function<String, String> hostToUri, String type, Optional<?> body, Map<String, Object> queryParams) {
+    return executeRequest(hostToUri, type, body, Method.POST, Optional.of(queryParams));
   }
 
   private HttpResponse executeRequest(Function<String, String> hostToUri, String type, Optional<?> body, Method method, Optional<Map<String, Object>> queryParams) {
@@ -621,9 +625,20 @@ public class SingularityClient {
   }
 
   public SingularityPendingRequestParent runSingularityRequest(String requestId, Optional<SingularityRunNowRequest> runNowRequest) {
+    return runSingularityRequest(requestId, runNowRequest, false);
+  }
+
+  /**
+   *
+   * @param requestId
+   * @param runNowRequest
+   * @param minimalReturn - if `true` will return a SingularityPendingRequestParent that is _not_ hydrated with extra task + deploy information
+   * @return
+   */
+  public SingularityPendingRequestParent runSingularityRequest(String requestId, Optional<SingularityRunNowRequest> runNowRequest, boolean minimalReturn) {
     final Function<String, String> requestUri = (host) -> String.format(REQUEST_RUN_FORMAT, getApiBase(host), requestId);
 
-    final HttpResponse response = post(requestUri, String.format("run of request %s", requestId), runNowRequest);
+    final HttpResponse response = post(requestUri, String.format("run of request %s", requestId), runNowRequest, ImmutableMap.of("minimal", String.valueOf(minimalReturn)));
 
     return response.getAs(SingularityPendingRequestParent.class);
   }

--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
@@ -441,7 +441,7 @@ public class SingularityClient {
     return executeRequest(hostToUri, type, body, Method.PUT, Optional.absent());
   }
 
-  private <T> Optional<T> post(Function<String, String> hostToUri, String type, Optional<?> body, Optional<Class<T>> clazz, Optional<Map<String, Object>> queryParams) {
+  private <T> Optional<T> post(Function<String, String> hostToUri, String type, Optional<?> body, Optional<Class<T>> clazz) {
     try {
       HttpResponse response = executeRequest(hostToUri, type, body, Method.POST, Optional.absent());
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -423,7 +423,7 @@ public class RequestResource extends AbstractRequestResource {
     checkConflict(result != SingularityCreateResult.EXISTED, "%s is already pending, please try again soon", requestId);
 
     if (minimalReturn) {
-      return SingularityPendingRequestParent.minimalFromRequestParent(requestWithState, pendingRequest);
+      return SingularityPendingRequestParent.minimalFromRequestWithState(requestWithState, pendingRequest);
     } else {
       return SingularityPendingRequestParent.fromSingularityRequestParent(fillEntireRequest(requestWithState), pendingRequest);
     }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -392,11 +392,16 @@ public class RequestResource extends AbstractRequestResource {
         @Parameter(hidden = true) @Auth SingularityUser user,
         @Parameter(required = true, description = "The request ID to run") @PathParam("requestId") String requestId,
         @Parameter(hidden = true) @Context HttpServletRequest requestContext,
+        @QueryParam("minimal") Boolean minimalReturn,
         @RequestBody(description = "Settings specific to this run of the request") SingularityRunNowRequest runNowRequest) {
-    return maybeProxyToLeader(requestContext, SingularityPendingRequestParent.class, runNowRequest, () -> scheduleImmediately(user, requestId, runNowRequest));
+    return maybeProxyToLeader(requestContext, SingularityPendingRequestParent.class, runNowRequest, () -> scheduleImmediately(user, requestId, runNowRequest, Optional.fromNullable(minimalReturn).or(false)));
   }
 
   public SingularityPendingRequestParent scheduleImmediately(SingularityUser user, String requestId, SingularityRunNowRequest runNowRequest) {
+    return scheduleImmediately(user, requestId, runNowRequest, false);
+  }
+
+  public SingularityPendingRequestParent scheduleImmediately(SingularityUser user, String requestId, SingularityRunNowRequest runNowRequest, boolean minimalReturn) {
     final Optional<SingularityRunNowRequest> maybeRunNowRequest = Optional.fromNullable(runNowRequest);
     SingularityRequestWithState requestWithState = fetchRequestWithState(requestId, user);
 
@@ -417,7 +422,11 @@ public class RequestResource extends AbstractRequestResource {
 
     checkConflict(result != SingularityCreateResult.EXISTED, "%s is already pending, please try again soon", requestId);
 
-    return SingularityPendingRequestParent.fromSingularityRequestParent(fillEntireRequest(requestWithState), pendingRequest);
+    if (minimalReturn) {
+      return SingularityPendingRequestParent.minimalFromRequestParent(requestWithState, pendingRequest);
+    } else {
+      return SingularityPendingRequestParent.fromSingularityRequestParent(fillEntireRequest(requestWithState), pendingRequest);
+    }
   }
 
   @GET


### PR DESCRIPTION
There are a number of zk calls associated with hydrating the object returned by a run now request. For a client that does not need the information, offer the option to skip it