### PR TITLE
Add ability to ignore logrotate hourly output

### DIFF
--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
@@ -123,6 +123,9 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
   @JsonProperty
   private String logrotateExtrasDateformat = "%Y%m%d";
 
+  @JsonProperty
+  private boolean ignoreLogrotateOutput = false;
+
   @NotNull
   @JsonProperty
   private LogrotateCompressionSettings logrotateCompressionSettings = LogrotateCompressionSettings.empty();
@@ -358,6 +361,14 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
 
   public String getLogrotateExtrasDateformat() {
     return logrotateExtrasDateformat;
+  }
+
+  public boolean isIgnoreLogrotateOutput() {
+    return ignoreLogrotateOutput;
+  }
+
+  public void setIgnoreLogrotateOutput(boolean ignoreLogrotateOutput) {
+    this.ignoreLogrotateOutput = ignoreLogrotateOutput;
   }
 
   public int getTailLogLinesToSave() {

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/models/LogrotateCronTemplateContext.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/models/LogrotateCronTemplateContext.java
@@ -11,12 +11,14 @@ public class LogrotateCronTemplateContext {
     private final String logrotateCommand;
     private final String logrotateStateFile;
     private final String logrotateConfig;
+    private final String outputRedirect;
 
     public LogrotateCronTemplateContext(SingularityExecutorConfiguration configuration, SingularityExecutorTaskDefinition taskDefinition, SingularityExecutorLogrotateFrequency logrotateFrequency) {
         this.logrotateCommand = configuration.getLogrotateCommand();
         this.logrotateStateFile = taskDefinition.getLogrotateStateFilePath().toString();
         this.logrotateConfig = Paths.get(configuration.getLogrotateHourlyConfDirectory()).resolve(taskDefinition.getTaskId()).toString();
         this.cronSchedule = logrotateFrequency.getCronSchedule().get();
+        this.outputRedirect = configuration.isIgnoreLogrotateOutput() ? "> /dev/null 2>&1" : "";
     }
 
     public String getLogrotateCommand() {
@@ -33,5 +35,9 @@ public class LogrotateCronTemplateContext {
 
     public String getCronSchedule() {
         return cronSchedule;
+    }
+
+    public String getOutputRedirect() {
+        return outputRedirect;
     }
 }

--- a/SingularityExecutor/src/main/resources/logrotate.cron.hbs
+++ b/SingularityExecutor/src/main/resources/logrotate.cron.hbs
@@ -1,1 +1,1 @@
-{{{ cronSchedule }}} root {{{ logrotateCommand }}} -f -s {{{ logrotateStateFile }}} {{{ logrotateConfig }}}
+{{{ cronSchedule }}} root {{{ logrotateCommand }}} -f -s {{{ logrotateStateFile }}} {{{ logrotateConfig }}} {{{ outputRedirect }}}


### PR DESCRIPTION
We often see the output of this flooding cron emails as tasks shut down or oom, since any cron output gets emailed. This will allow us to ignore that output since we already have executor cleanup to eventually come around and clean these up

cc @pranav 