### PR TITLE
one more spot for backpressure handling

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerClient.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerClient.java
@@ -230,7 +230,7 @@ public class SingularityMesosSchedulerClient {
 
       // toSerialised handles the fact that we can add calls on different threads.
       publisher = p.toSerialized();
-      return publisher;
+      return publisher.onBackpressureBuffer();
     });
 
     MesosClient<Call, Event> client = clientBuilder.build();


### PR DESCRIPTION
We are still seeing some `! rx.exceptions.MissingBackpressureException: PublishSubject: could not emit value due to lack of requests` type exceptions. Need to test more but I believe this is the last spot we are missing backpressure