### PR TITLE
Ability to rotate at a max service log size

### DIFF
--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
@@ -232,6 +232,8 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
 
   private String extraDockerScriptContent = "";
 
+  private Optional<Long> maxServiceLogSizeMb = Optional.absent();
+
   public SingularityExecutorConfiguration() {
     super(Optional.of("singularity-executor.log"));
   }
@@ -684,6 +686,14 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
 
   public void setExtraDockerScriptContent(String extraDockerScriptContent) {
     this.extraDockerScriptContent = extraDockerScriptContent;
+  }
+
+  public Optional<Long> getMaxServiceLogSizeMb() {
+    return maxServiceLogSizeMb;
+  }
+
+  public void setMaxServiceLogSizeMb(Optional<Long> maxServiceLogSizeMb) {
+    this.maxServiceLogSizeMb = maxServiceLogSizeMb;
   }
 
   @Override

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTask.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTask.java
@@ -61,7 +61,7 @@ public class SingularityExecutorTask {
 
     this.taskDefinition = taskDefinition;
 
-    this.taskLogManager = new SingularityExecutorTaskLogManager(taskDefinition, templateManager, baseConfiguration, executorConfiguration, log, jsonObjectFileHelper);
+    this.taskLogManager = new SingularityExecutorTaskLogManager(taskDefinition, templateManager, baseConfiguration, executorConfiguration, log, jsonObjectFileHelper, executorConfiguration.getMaxServiceLogSizeMb().isPresent());
     this.taskCleanup = new SingularityExecutorTaskCleanup(taskLogManager, executorConfiguration, taskDefinition, log, dockerUtils);
     this.processBuilder = new SingularityExecutorTaskProcessBuilder(this, executorUtils, artifactFetcher, templateManager, executorConfiguration, taskDefinition.getExecutorData(), executorPid, dockerUtils, objectMapper);
     this.artifactVerifier = new SingularityExecutorArtifactVerifier(taskDefinition, log, executorConfiguration, s3Configuration);

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskLogManager.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskLogManager.java
@@ -76,6 +76,7 @@ public class SingularityExecutorTaskLogManager {
   private void startLogChecker() {
     try {
       if (logCheckExecutor != null) {
+        log.info("Starting service log checker to rotate logs over {} MB", configuration.getMaxServiceLogSizeMb());
         logCheckFuture = logCheckExecutor.scheduleAtFixedRate(this::checkServiceLogSize, 5, 5, TimeUnit.MINUTES);
       }
     } catch (Throwable t) {
@@ -100,6 +101,7 @@ public class SingularityExecutorTaskLogManager {
     try {
       long fileBytes = taskDefinition.getServiceLogOutPath().toFile().length();
       long fileMb = fileBytes / 1024 / 1024;
+      log.debug("service log is currently {} MB (limit before logrotate: {} MB)", fileMb, configuration.getMaxServiceLogSizeMb());
       if (configuration.getMaxServiceLogSizeMb().isPresent() && fileMb > configuration.getMaxServiceLogSizeMb().get()) {
         manualLogrotate();
       }

--- a/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/SingularityExecutorCleanup.java
+++ b/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/SingularityExecutorCleanup.java
@@ -265,7 +265,7 @@ public class SingularityExecutorCleanup {
   }
 
   private TaskCleanupResult cleanTask(SingularityExecutorTaskDefinition taskDefinition, Optional<SingularityTaskHistory> taskHistory) {
-    SingularityExecutorTaskLogManager logManager = new SingularityExecutorTaskLogManager(taskDefinition, templateManager, baseConfiguration, executorConfiguration, LOG, jsonObjectFileHelper);
+    SingularityExecutorTaskLogManager logManager = new SingularityExecutorTaskLogManager(taskDefinition, templateManager, baseConfiguration, executorConfiguration, LOG, jsonObjectFileHelper, false);
 
     SingularityExecutorTaskCleanup taskCleanup = new SingularityExecutorTaskCleanup(logManager, executorConfiguration, taskDefinition, LOG, dockerUtils);
 


### PR DESCRIPTION
More of me getting tired of being paged for disk filling up. Adds the ability for the executor to occasionally poll the size of the service log file and, if over a configured size, run a manual logrotate