### PR TITLE
Updating the alert banner to only show when there's a widespread issue

### DIFF
--- a/SingularityUI/app/components/common/Application.jsx
+++ b/SingularityUI/app/components/common/Application.jsx
@@ -21,6 +21,10 @@ class Application extends Component {
     );
   }
 
+  componentDidMount() {
+    this.notifyLateRequests(this.props.listLateTasks);
+  }
+
   componentWillUnmount() {
     clearTimeout(this.reenableTaskLagNotificationTimeoutId);
   }
@@ -48,7 +52,6 @@ class Application extends Component {
   }
 
   render() {
-    this.notifyLateRequests(this.props.listLateTasks);
     return (
       <div>
         <Title routes={this.props.routes} params={this.props.params} />

--- a/SingularityUI/app/components/common/Application.jsx
+++ b/SingularityUI/app/components/common/Application.jsx
@@ -34,7 +34,7 @@ class Application extends Component {
 
   notifyLateRequests(listLateTasks) {
     const { canShowTaskLagNotification: canNotify } = this.state;
-    const lateRequests = Utils.getListOfRequestsFromListOfTasks(listLateTasks)
+    const lateRequests = Utils.getListOfUniqueRequestsFromListOfTasks(listLateTasks)
     const shouldNotify = lateRequests.length >= MAX_LATE_REQUESTS;
     if (canNotify && shouldNotify) {
       Messenger().error({

--- a/SingularityUI/app/components/common/Application.jsx
+++ b/SingularityUI/app/components/common/Application.jsx
@@ -21,7 +21,7 @@ class Application extends Component {
     );
   }
 
-  componentDidMount() {
+  componentDidUpdate() {
     this.notifyLateRequests(this.props.listLateTasks);
   }
 

--- a/SingularityUI/app/components/common/Application.jsx
+++ b/SingularityUI/app/components/common/Application.jsx
@@ -41,7 +41,7 @@ class Application extends Component {
         onClickClose: this.dismissTaskLagNotification,
         message: `
           Singularity is experiencing some delays. The team has already been
-          notified. (Number of distinct late requests: ${lateRequests.length})
+          notified.
         `,
       });
     }

--- a/SingularityUI/app/components/common/Application.jsx
+++ b/SingularityUI/app/components/common/Application.jsx
@@ -7,7 +7,7 @@ import Title from './Title';
 import Utils from '../../utils';
 
 const DISMISS_TASK_LAG_NOFICATION_DURATION_IN_MS = 1000 * 60 * 60;
-const MAX_TASK_LAG_NOTIFICATION_THRESHOLD_IN_MS = 1000 * 60 * 3;
+const MAX_LATE_REQUESTS = 10;
 
 class Application extends Component {
   constructor(props) {
@@ -17,7 +17,7 @@ class Application extends Component {
     };
     _.bindAll(this,
       'dismissTaskLagNotification',
-      'notifyLag',
+      'notifyLateRequests',
     );
   }
 
@@ -32,23 +32,23 @@ class Application extends Component {
     }, DISMISS_TASK_LAG_NOFICATION_DURATION_IN_MS);
   }
 
-  notifyLag(maxTaskLag) {
+  notifyLateRequests(listLateTasks) {
     const { canShowTaskLagNotification: canNotify } = this.state;
-    const shouldNotify = maxTaskLag >= MAX_TASK_LAG_NOTIFICATION_THRESHOLD_IN_MS;
+    const lateRequests = Utils.getListOfRequestsFromListOfTasks(listLateTasks)
+    const shouldNotify = lateRequests.length >= MAX_LATE_REQUESTS;
     if (canNotify && shouldNotify) {
       Messenger().error({
         onClickClose: this.dismissTaskLagNotification,
         message: `
           Singularity is experiencing some delays. The team has already been
-          notified. (Max task lag: ${Utils.duration(maxTaskLag)})
+          notified. (Number of distinct late requests: ${lateRequests.length})
         `,
       });
     }
   }
 
   render() {
-    this.notifyLag(this.props.maxTaskLag);
-
+    this.notifyLateRequests(this.props.listLateTasks);
     return (
       <div>
         <Title routes={this.props.routes} params={this.props.params} />
@@ -64,14 +64,14 @@ Application.propTypes = {
   children: PropTypes.object,
   history: PropTypes.object.isRequired,
   location: PropTypes.object.isRequired,
-  maxTaskLag: PropTypes.number,
+  listLateTasks: PropTypes.arrayOf(PropTypes.object),
   params: PropTypes.object.isRequired,
   routes: PropTypes.arrayOf(PropTypes.object).isRequired,
 };
 
 const mapStateToProps = (state) => {
   return {
-    maxTaskLag: state.api.status.data.maxTaskLag
+    listLateTasks: state.api.status.data.listLateTasks,
   };
 };
 

--- a/SingularityUI/app/components/status/StatusPage.jsx
+++ b/SingularityUI/app/components/status/StatusPage.jsx
@@ -13,7 +13,7 @@ import Utils from '../../utils';
 const StatusPage = (props) => {
   const renderPercentage = (number, total) => number > 0 && `(${Math.round(number / total * 100)}%)`;
 
-  const renderLateRequests = (status) => Utils.getListOfRequestsFromListOfTasks(status.listLateTasks) > 10 && (<h4>Number of delayed requests: {(Utils.getListOfRequestsFromListOfTasks(status.listLateTasks).length)}</h4>);
+  const renderLateRequests = (status) => Utils.getListOfUniqueRequestsFromListOfTasks(status.listLateTasks) > 10 && (<h4>Number of delayed requests: {(Utils.getListOfUniqueRequestsFromListOfTasks(status.listLateTasks).length)}</h4>);
 
   const requestDetail = (status) => {
     const totalRequests = status.activeRequests + status.pausedRequests + status.cooldownRequests + status.pendingRequests + status.cleaningRequests;

--- a/SingularityUI/app/components/status/StatusPage.jsx
+++ b/SingularityUI/app/components/status/StatusPage.jsx
@@ -13,7 +13,7 @@ import Utils from '../../utils';
 const StatusPage = (props) => {
   const renderPercentage = (number, total) => number > 0 && `(${Math.round(number / total * 100)}%)`;
 
-  const renderTaskLag = (status) => status.maxTaskLag > 0 && (<h4>Max Task Lag: {Utils.duration(status.maxTaskLag)}</h4>);
+  const renderLateRequests = (status) => Utils.getListOfRequestsFromListOfTasks(status.listLateTasks) > 10 && (<h4>Number of delayed requests: {(Utils.getListOfRequestsFromListOfTasks(status.listLateTasks).length)}</h4>);
 
   const requestDetail = (status) => {
     const totalRequests = status.activeRequests + status.pausedRequests + status.cooldownRequests + status.pendingRequests + status.cleaningRequests;
@@ -183,7 +183,7 @@ const StatusPage = (props) => {
               </div>
               <div className="col-md-9 col-sm-9">
                 <StatusList data={getTasksData(status)} />
-                {renderTaskLag(status)}
+                {renderLateRequests(status)}
               </div>
           </div>
         </div>

--- a/SingularityUI/app/components/status/StatusPage.jsx
+++ b/SingularityUI/app/components/status/StatusPage.jsx
@@ -12,8 +12,7 @@ import Utils from '../../utils';
 
 const StatusPage = (props) => {
   const renderPercentage = (number, total) => number > 0 && `(${Math.round(number / total * 100)}%)`;
-
-  const renderLateRequests = (status) => Utils.getListOfUniqueRequestsFromListOfTasks(status.listLateTasks) > 10 && (<h4>Number of delayed requests: {(Utils.getListOfUniqueRequestsFromListOfTasks(status.listLateTasks).length)}</h4>);
+  const renderLateRequests = (status) => Utils.getListOfUniqueRequestsFromListOfTasks(status.listLateTasks).length > 10 && (<h4>Number of delayed requests: {(Utils.getListOfUniqueRequestsFromListOfTasks(status.listLateTasks).length)}</h4>);
 
   const requestDetail = (status) => {
     const totalRequests = status.activeRequests + status.pausedRequests + status.cooldownRequests + status.pendingRequests + status.cleaningRequests;

--- a/SingularityUI/app/utils.es6
+++ b/SingularityUI/app/utils.es6
@@ -228,7 +228,7 @@ const Utils = {
     return splits.slice(0, splits.length - 5).join('-');
   },
 
-  getListOfRequestsUniqueFromListOfTasks(listOfTasks) {
+  getListOfUniqueRequestsFromListOfTasks(listOfTasks) {
     const res = [];
     for (const TaskId in listOfTasks) {
       requestId = TaskId.requestId;

--- a/SingularityUI/app/utils.es6
+++ b/SingularityUI/app/utils.es6
@@ -228,6 +228,17 @@ const Utils = {
     return splits.slice(0, splits.length - 5).join('-');
   },
 
+  getListOfRequestsUniqueFromListOfTasks(listOfTasks) {
+    const res = [];
+    for (const TaskId in listOfTasks) {
+      requestId = TaskId.requestId;
+      if (!res.contains(requestId)){
+        res.push(requestId);
+      }
+    }
+    return res;
+  },
+
   getInstanceNoFromTaskId(taskId) {
     const splits = taskId.split('-')
     return splits[splits.length-3];

--- a/SingularityUI/app/utils.es6
+++ b/SingularityUI/app/utils.es6
@@ -229,14 +229,8 @@ const Utils = {
   },
 
   getListOfUniqueRequestsFromListOfTasks(listOfTasks) {
-    const res = [];
-    for (const TaskId in listOfTasks) {
-      requestId = TaskId.requestId;
-      if (!res.contains(requestId)){
-        res.push(requestId);
-      }
-    }
-    return res;
+    const requestIds = listOfTasks.map(taskId => taskId.requestId)
+    return _.uniq(requestIds);
   },
 
   getInstanceNoFromTaskId(taskId) {


### PR DESCRIPTION
Currently, the UI shows a banner when only a small count of tasks are overdue (when max task lag is greater than 3 minutes). I'm updating the UI to show an alert banner only when there's a widespread issue (when the count of distinct requests with overdue tasks is greater than 10). 