### PR TITLE
Add support for inactive task history filtered by deploy ID

### DIFF
--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
@@ -1079,6 +1079,12 @@ public class SingularityClient {
     return getInactiveTaskHistoryForRequest(requestId, 100, 1);
   }
 
+  public Collection<SingularityTaskIdHistory> getInactiveTaskHistoryForRequest(String requestId, String deployId) {
+    return getInactiveTaskHistoryForRequest(requestId, 100, 1, Optional.absent(), Optional.of(deployId),
+        Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(),
+        Optional.absent());
+  }
+
   public Collection<SingularityTaskIdHistory> getInactiveTaskHistoryForRequest(String requestId, int count, int page) {
     return getInactiveTaskHistoryForRequest(requestId, count, page, Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent());
   }
@@ -1094,6 +1100,21 @@ public class SingularityClient {
 
     return getCollectionWithParams(requestUri, type, Optional.of(params), TASKID_HISTORY_COLLECTION);
   }
+
+  public Collection<SingularityTaskIdHistory> getInactiveTaskHistoryForRequest(String requestId, int count, int page,
+     Optional<String> host, Optional<String> deployId, Optional<String> runId,
+     Optional<ExtendedTaskState> lastTaskStatus, Optional<Long> startedBefore, Optional<Long> startedAfter,
+     Optional<Long> updatedBefore, Optional<Long> updatedAfter, Optional<OrderDirection> orderDirection) {
+    final Function<String, String> requestUri = (singularityHost) -> String.format(REQUEST_INACTIVE_TASKS_HISTORY_FORMAT, getApiBase(singularityHost), requestId);
+
+    final String type = String.format("inactive (failed, killed, lost) task history for request %s", requestId);
+
+    Map<String, Object> params = taskSearchParams(Optional.of(requestId), deployId, runId, host, lastTaskStatus,
+        startedBefore, startedAfter, updatedBefore, updatedAfter, orderDirection, count, page);
+
+    return getCollectionWithParams(requestUri, type, Optional.of(params), TASKID_HISTORY_COLLECTION);
+  }
+
 
   public Optional<SingularityDeployHistory> getHistoryForRequestDeploy(String requestId, String deployId) {
     final Function<String, String> requestUri = (host) -> String.format(REQUEST_DEPLOY_HISTORY_FORMAT, getApiBase(host), requestId, deployId);


### PR DESCRIPTION
Inactive tasks can be filtered by deploy ID in the UI; adding support for this in the client as well.