### PR TITLE
Make task history paging less flaky

### DIFF
--- a/SingularityUI/app/actions/ui/requestDetail.es6
+++ b/SingularityUI/app/actions/ui/requestDetail.es6
@@ -19,7 +19,6 @@ export const refresh = (requestId, location) => (dispatch, getState) => {
 
   const { taskHistoryPage, taskHistoryCount } = location.query;
   if (taskHistoryPage == null || taskHistoryPage == 1) {
-  console.log(taskHistoryPage)
     dispatch(FetchTaskHistoryForRequest.trigger(requestId, taskHistoryCount == null ? 10 : taskHistoryCount, taskHistoryPage == null ? 1 : taskHistoryPage));
   }
 

--- a/SingularityUI/app/actions/ui/requestDetail.es6
+++ b/SingularityUI/app/actions/ui/requestDetail.es6
@@ -8,7 +8,7 @@ import {
 import { FetchTaskCleanups, FetchScheduledTasksForRequest } from '../api/tasks';
 import { FetchRequestUtilization } from '../api/utilization';
 
-export const refresh = (requestId, location) => (dispatch, getState) => {
+export const refresh = (requestId, taskHistoryPage = 1, taskHistoryPageSize = 10) => (dispatch, getState) => {
   const requiredPromises = Promise.all([
     dispatch(FetchRequest.trigger(requestId)),
     dispatch(FetchRequestHistory.trigger(requestId, 5, 1))
@@ -17,9 +17,8 @@ export const refresh = (requestId, location) => (dispatch, getState) => {
   dispatch(FetchActiveTasksForRequest.trigger(requestId));
   dispatch(FetchTaskCleanups.trigger());
 
-  const { taskHistoryPage, taskHistoryCount } = location.query;
-  if (taskHistoryPage == null || taskHistoryPage == 1) {
-    dispatch(FetchTaskHistoryForRequest.trigger(requestId, taskHistoryCount == null ? 10 : taskHistoryCount, taskHistoryPage == null ? 1 : taskHistoryPage));
+  if (taskHistoryPage == 1) {
+    dispatch(FetchTaskHistoryForRequest.trigger(requestId, taskHistoryPageSize, taskHistoryPage));
   }
 
   dispatch(FetchDeploysForRequest.trigger(requestId, 5, 1));

--- a/SingularityUI/app/actions/ui/requestDetail.es6
+++ b/SingularityUI/app/actions/ui/requestDetail.es6
@@ -8,7 +8,7 @@ import {
 import { FetchTaskCleanups, FetchScheduledTasksForRequest } from '../api/tasks';
 import { FetchRequestUtilization } from '../api/utilization';
 
-export const refresh = (requestId) => (dispatch, getState) => {
+export const refresh = (requestId, location) => (dispatch, getState) => {
   const requiredPromises = Promise.all([
     dispatch(FetchRequest.trigger(requestId)),
     dispatch(FetchRequestHistory.trigger(requestId, 5, 1))
@@ -16,7 +16,13 @@ export const refresh = (requestId) => (dispatch, getState) => {
 
   dispatch(FetchActiveTasksForRequest.trigger(requestId));
   dispatch(FetchTaskCleanups.trigger());
-  dispatch(FetchTaskHistoryForRequest.trigger(requestId, 5, 1));
+
+  const { taskHistoryPage, taskHistoryCount } = location.query;
+  if (taskHistoryPage == null || taskHistoryPage == 1) {
+  console.log(taskHistoryPage)
+    dispatch(FetchTaskHistoryForRequest.trigger(requestId, taskHistoryCount == null ? 10 : taskHistoryCount, taskHistoryPage == null ? 1 : taskHistoryPage));
+  }
+
   dispatch(FetchDeploysForRequest.trigger(requestId, 5, 1));
   dispatch(FetchScheduledTasksForRequest.trigger(requestId));
   dispatch(FetchRequestUtilization.trigger(requestId, [404]))

--- a/SingularityUI/app/components/requestDetail/RequestDetailPage.jsx
+++ b/SingularityUI/app/components/requestDetail/RequestDetailPage.jsx
@@ -47,7 +47,7 @@ class RequestDetailPage extends Component {
   render() {
     const { deleted, router, location, params } = this.props;
     const { requestId } = params;
-    const { taskHistoryPage } = location.query;
+    const { taskHistoryPage, taskHistoryCount } = location.query;
     return (
       <div>
         <RequestHeader requestId={requestId} showBreadcrumbs={this.props.showBreadcrumbs} deleted={this.props.deleted} />
@@ -57,6 +57,8 @@ class RequestDetailPage extends Component {
         {deleted || (
           <TaskHistoryTable
             requestId={requestId}
+            location={this.props.location}
+            initialTaskCount={Number(taskHistoryCount) || 10}
             onPageChange={num => router.replace({ ...location, query: {...location.query, taskHistoryPage: num }})}
             initialPageNumber={Number(taskHistoryPage) || 1}
           />

--- a/SingularityUI/app/components/requestDetail/RequestDetailPage.jsx
+++ b/SingularityUI/app/components/requestDetail/RequestDetailPage.jsx
@@ -47,7 +47,7 @@ class RequestDetailPage extends Component {
   render() {
     const { deleted, router, location, params } = this.props;
     const { requestId } = params;
-    const { taskHistoryPage, taskHistoryCount } = location.query;
+    const { taskHistoryPage, taskHistoryPageSize } = location.query;
     return (
       <div>
         <RequestHeader requestId={requestId} showBreadcrumbs={this.props.showBreadcrumbs} deleted={this.props.deleted} />
@@ -58,7 +58,7 @@ class RequestDetailPage extends Component {
           <TaskHistoryTable
             requestId={requestId}
             location={this.props.location}
-            initialTaskCount={Number(taskHistoryCount) || 10}
+            initialPageSize={Number(taskHistoryPageSize) || 10}
             onPageChange={num => router.replace({ ...location, query: {...location.query, taskHistoryPage: num }})}
             initialPageNumber={Number(taskHistoryPage) || 1}
           />
@@ -118,4 +118,4 @@ const mapDispatchToProps = (dispatch, ownProps) => {
 export default withRouter(connect(
   mapStateToProps,
   mapDispatchToProps
-)(rootComponent(RequestDetailPage, (props) => refresh(props.params.requestId, props.location), true)));
+)(rootComponent(RequestDetailPage, (props) => refresh(props.params.requestId, Utils.maybe(props.location, ["query", "taskHistoryPage"]), Utils.maybe(props.location, ["query", "taskHistoryPageSize"])), true)));

--- a/SingularityUI/app/components/requestDetail/RequestDetailPage.jsx
+++ b/SingularityUI/app/components/requestDetail/RequestDetailPage.jsx
@@ -118,4 +118,4 @@ const mapDispatchToProps = (dispatch, ownProps) => {
 export default withRouter(connect(
   mapStateToProps,
   mapDispatchToProps
-)(rootComponent(RequestDetailPage, (props) => refresh(props.params.requestId), true)));
+)(rootComponent(RequestDetailPage, (props) => refresh(props.params.requestId, props.location), true)));

--- a/SingularityUI/app/components/requestDetail/TaskHistoryTable.jsx
+++ b/SingularityUI/app/components/requestDetail/TaskHistoryTable.jsx
@@ -31,7 +31,7 @@ class TaskHistoryTable extends Component {
     super(props);
     this.state = {
       loading: true,
-      tableChunkSize: props.initialTaskCount
+      tableChunkSize: props.initialPageSize
     };
   }
 
@@ -50,7 +50,7 @@ class TaskHistoryTable extends Component {
       loading: true
     })
     const { router, location } = this.props
-    router.replace({ ...location, query: {...location.query, taskHistoryCount: count }})
+    router.replace({ ...location, query: {...location.query, taskHistoryPageSize: count }})
     this.props.fetchTaskHistoryForRequest(this.props.requestId, count, 1).then(() => {
       this.setState({
         loading: false

--- a/SingularityUI/app/components/requestDetail/TaskHistoryTable.jsx
+++ b/SingularityUI/app/components/requestDetail/TaskHistoryTable.jsx
@@ -5,6 +5,7 @@ import { Row, Col, Button, Glyphicon, ButtonToolbar, ButtonGroup } from 'react-b
 import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
 import ToolTip from 'react-bootstrap/lib/Tooltip';
 import { Link } from 'react-router';
+import { withRouter } from 'react-router';
 
 import Utils from '../../utils';
 import Loader from '../common/Loader';
@@ -30,7 +31,7 @@ class TaskHistoryTable extends Component {
     super(props);
     this.state = {
       loading: true,
-      tableChunkSize: 5
+      tableChunkSize: props.initialTaskCount
     };
   }
 
@@ -48,6 +49,8 @@ class TaskHistoryTable extends Component {
       tableChunkSize: count,
       loading: true
     })
+    const { router, location } = this.props
+    router.replace({ ...location, query: {...location.query, taskHistoryCount: count }})
     this.props.fetchTaskHistoryForRequest(this.props.requestId, count, 1).then(() => {
       this.setState({
         loading: false
@@ -78,9 +81,9 @@ class TaskHistoryTable extends Component {
     const showButtons = (
       <ButtonToolbar>
         <ButtonGroup bsSize="small" className="pull-right">
-          <Button disabled={this.state.tableChunkSize == 5} onClick={() => this.handleTableSizeToggle(5)} >Show 5</Button>
           <Button disabled={this.state.tableChunkSize == 10} onClick={() => this.handleTableSizeToggle(10)} >Show 10</Button>
           <Button disabled={this.state.tableChunkSize == 20} onClick={() => this.handleTableSizeToggle(20)} >Show 20</Button>
+          <Button disabled={this.state.tableChunkSize == 50} onClick={() => this.handleTableSizeToggle(50)} >Show 50</Button>
         </ButtonGroup>
       </ButtonToolbar>
     )
@@ -223,7 +226,7 @@ const mapStateToProps = (state, ownProps) => ({
   )
 });
 
-export default connect(
+export default withRouter(connect(
   mapStateToProps,
   mapDispatchToProps
-)(TaskHistoryTable);
+)(TaskHistoryTable));


### PR DESCRIPTION
Fixes the task history page size to also be reflected in query params so that a refresh of this will not interrupt the current view