### PR TITLE
Improve ExtendedTaskState readability

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/ExtendedTaskState.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/ExtendedTaskState.java
@@ -7,22 +7,22 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema
 public enum ExtendedTaskState {
-  TASK_LAUNCHED("launched", false, Optional.absent()), 
+  TASK_LAUNCHED("launched", false, Optional.absent()),
   TASK_STAGING("staging", false, Optional.of(MesosTaskState.TASK_STAGING)),
-  TASK_STARTING("starting", false, Optional.of(MesosTaskState.TASK_STARTING)), 
+  TASK_STARTING("starting", false, Optional.of(MesosTaskState.TASK_STARTING)),
   TASK_RUNNING("running", false, Optional.of(MesosTaskState.TASK_RUNNING)),
-  TASK_CLEANING("cleaning", false, Optional.absent()), 
-  TASK_KILLING("killing", false, Optional.of(MesosTaskState.TASK_KILLING)), 
+  TASK_CLEANING("cleaning", false, Optional.absent()),
+  TASK_KILLING("killing", false, Optional.of(MesosTaskState.TASK_KILLING)),
   TASK_FINISHED("finished", true, Optional.of(MesosTaskState.TASK_FINISHED)),
-  TASK_FAILED("failed", true, Optional.of(MesosTaskState.TASK_FAILED)), 
+  TASK_FAILED("failed", true, Optional.of(MesosTaskState.TASK_FAILED)),
   TASK_KILLED("killed", true, Optional.of(MesosTaskState.TASK_KILLED)),
-  TASK_LOST("lost", true, Optional.of(MesosTaskState.TASK_LOST)), 
-  TASK_LOST_WHILE_DOWN("lost", true, Optional.absent()), 
+  TASK_LOST("lost", true, Optional.of(MesosTaskState.TASK_LOST)),
+  TASK_LOST_WHILE_DOWN("lost", true, Optional.absent()),
   TASK_ERROR("error", true, Optional.of(MesosTaskState.TASK_ERROR)),
-  TASK_DROPPED("dropped", true, Optional.of(MesosTaskState.TASK_DROPPED)), 
-  TASK_GONE("gone", true, Optional.of(MesosTaskState.TASK_GONE)), 
+  TASK_DROPPED("dropped", true, Optional.of(MesosTaskState.TASK_DROPPED)),
+  TASK_GONE("gone", true, Optional.of(MesosTaskState.TASK_GONE)),
   TASK_UNREACHABLE("unreachable", true, Optional.of(MesosTaskState.TASK_UNREACHABLE)),
-  TASK_GONE_BY_OPERATOR("goneByOperator", true, Optional.of(MesosTaskState.TASK_GONE_BY_OPERATOR)), 
+  TASK_GONE_BY_OPERATOR("goneByOperator", true, Optional.of(MesosTaskState.TASK_GONE_BY_OPERATOR)),
   TASK_UNKNOWN("dropped", true, Optional.of(MesosTaskState.TASK_UNKNOWN));
 
   private final String displayName;

--- a/SingularityBase/src/main/java/com/hubspot/singularity/ExtendedTaskState.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/ExtendedTaskState.java
@@ -7,14 +7,23 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema
 public enum ExtendedTaskState {
-
-  TASK_LAUNCHED("launched", false, Optional.absent()), TASK_STAGING("staging", false, Optional.of(MesosTaskState.TASK_STAGING)),
-  TASK_STARTING("starting", false, Optional.of(MesosTaskState.TASK_STARTING)), TASK_RUNNING("running", false, Optional.of(MesosTaskState.TASK_RUNNING)),
-  TASK_CLEANING("cleaning", false, Optional.absent()), TASK_KILLING("killing", false, Optional.of(MesosTaskState.TASK_KILLING)), TASK_FINISHED("finished", true, Optional.of(MesosTaskState.TASK_FINISHED)),
-  TASK_FAILED("failed", true, Optional.of(MesosTaskState.TASK_FAILED)), TASK_KILLED("killed", true, Optional.of(MesosTaskState.TASK_KILLED)),
-  TASK_LOST("lost", true, Optional.of(MesosTaskState.TASK_LOST)), TASK_LOST_WHILE_DOWN("lost", true, Optional.absent()), TASK_ERROR("error", true, Optional.of(MesosTaskState.TASK_ERROR)),
-  TASK_DROPPED("dropped", true, Optional.of(MesosTaskState.TASK_DROPPED)), TASK_GONE("gone", true, Optional.of(MesosTaskState.TASK_GONE)), TASK_UNREACHABLE("unreachable", true, Optional.of(MesosTaskState.TASK_UNREACHABLE)),
-  TASK_GONE_BY_OPERATOR("goneByOperator", true, Optional.of(MesosTaskState.TASK_GONE_BY_OPERATOR)), TASK_UNKNOWN("dropped", true, Optional.of(MesosTaskState.TASK_UNKNOWN));
+  TASK_LAUNCHED("launched", false, Optional.absent()), 
+  TASK_STAGING("staging", false, Optional.of(MesosTaskState.TASK_STAGING)),
+  TASK_STARTING("starting", false, Optional.of(MesosTaskState.TASK_STARTING)), 
+  TASK_RUNNING("running", false, Optional.of(MesosTaskState.TASK_RUNNING)),
+  TASK_CLEANING("cleaning", false, Optional.absent()), 
+  TASK_KILLING("killing", false, Optional.of(MesosTaskState.TASK_KILLING)), 
+  TASK_FINISHED("finished", true, Optional.of(MesosTaskState.TASK_FINISHED)),
+  TASK_FAILED("failed", true, Optional.of(MesosTaskState.TASK_FAILED)), 
+  TASK_KILLED("killed", true, Optional.of(MesosTaskState.TASK_KILLED)),
+  TASK_LOST("lost", true, Optional.of(MesosTaskState.TASK_LOST)), 
+  TASK_LOST_WHILE_DOWN("lost", true, Optional.absent()), 
+  TASK_ERROR("error", true, Optional.of(MesosTaskState.TASK_ERROR)),
+  TASK_DROPPED("dropped", true, Optional.of(MesosTaskState.TASK_DROPPED)), 
+  TASK_GONE("gone", true, Optional.of(MesosTaskState.TASK_GONE)), 
+  TASK_UNREACHABLE("unreachable", true, Optional.of(MesosTaskState.TASK_UNREACHABLE)),
+  TASK_GONE_BY_OPERATOR("goneByOperator", true, Optional.of(MesosTaskState.TASK_GONE_BY_OPERATOR)), 
+  TASK_UNKNOWN("dropped", true, Optional.of(MesosTaskState.TASK_UNKNOWN));
 
   private final String displayName;
   private final boolean isDone;


### PR DESCRIPTION
I know that by the [Google Style docs](https://google.github.io/styleguide/javaguide.html#s4.8.1-enum-classes) this is optional but it improves readability. Do we mind having those line breaks?