### PR TITLE
Don't count pending tasks limited by instance count in task lag 

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityState.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityState.java
@@ -20,6 +20,9 @@ public class SingularityState {
   private final int scheduledTasks;
   private final int lateTasks;
   private final List<SingularityPendingTaskId> listLateTasks;
+  private final int onDemandLateTasks;
+  private final List<SingularityPendingTaskId> onDemandListLateTasks;
+
   private final int futureTasks;
   private final int cleaningTasks;
   private final int lbCleanupTasks;
@@ -88,6 +91,8 @@ public class SingularityState {
                           @JsonProperty("activeDeploys") List<SingularityDeployMarker> activeDeploys,
                           @JsonProperty("lateTasks") int lateTasks,
                           @JsonProperty("listLateTasks") List<SingularityPendingTaskId> listLateTasks,
+                          @JsonProperty("onDemandLateTasks") int onDemandLateTasks,
+                          @JsonProperty("onDemandListLateTasks") List<SingularityPendingTaskId> onDemandListLateTasks,
                           @JsonProperty("futureTasks") int futureTasks,
                           @JsonProperty("maxTaskLag") long maxTaskLag,
                           @JsonProperty("generatedAt") long generatedAt,
@@ -123,6 +128,8 @@ public class SingularityState {
     this.hostStates = hostStates;
     this.lateTasks = lateTasks;
     this.listLateTasks = listLateTasks == null ? Collections.emptyList() : listLateTasks;
+    this.onDemandLateTasks = onDemandLateTasks;
+    this.onDemandListLateTasks = onDemandListLateTasks == null ? Collections.emptyList() : onDemandListLateTasks;
     this.finishedRequests = finishedRequests;
     this.futureTasks = futureTasks;
     this.maxTaskLag = maxTaskLag;
@@ -275,14 +282,24 @@ public class SingularityState {
     return cleaningRequests;
   }
 
-  @Schema(description = "The count of tasks that have not been launched in time")
+  @Schema(description = "The count of tasks that have not been launched in time, excluding the on-demand tasks")
   public int getLateTasks() {
     return lateTasks;
   }
 
-  @Schema(description = "The list of all late tasks that have not been launched in time")
+  @Schema(description = "The list of all late tasks that have not been launched in time, excluding the on-demand tasks")
   public List<SingularityPendingTaskId> getListLateTasks() {
     return listLateTasks;
+  }
+
+  @Schema(description = "The count of on-demand tasks that have not been launched in time")
+  public int getOnDemandLateTasks() {
+    return onDemandLateTasks;
+  }
+
+  @Schema(description = "The list of all on-demand late tasks that have not been launched in time")
+  public List<SingularityPendingTaskId> getOnDemandListLateTasks() {
+    return onDemandListLateTasks;
   }
 
   @Schema(description = "The count of pending tasks that will be launched at a future time")

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/StateManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/StateManager.java
@@ -294,7 +294,7 @@ public class StateManager extends CuratorManager {
     final Optional<Double> minimumPriorityLevel = getMinimumPriorityLevel();
 
     final Map<Boolean, List<SingularityPendingTaskId>> lateTasksPartitionedByOnDemand = scheduledTasksInfo.getLateTasks().stream()
-        .collect(Collectors.partitioningBy(lateTask -> requestManager.getRequest(lateTask.getRequestId()).get().getRequest().getRequestType().equals(RequestType.ON_DEMAND)));
+        .collect(Collectors.partitioningBy(lateTask -> requestTypeIsOnDemand(lateTask));
     final List<SingularityPendingTaskId> onDemandLateTasks = lateTasksPartitionedByOnDemand.get(true);
     final List<SingularityPendingTaskId> lateTasks = lateTasksPartitionedByOnDemand.get(false);
 
@@ -303,6 +303,13 @@ public class StateManager extends CuratorManager {
         scheduledTasksInfo.getNumFutureTasks(), scheduledTasksInfo.getMaxTaskLag(), System.currentTimeMillis(), includeRequestIds ? overProvisionedRequestIds : null,
         includeRequestIds ? underProvisionedRequestIds : null, overProvisionedRequestIds.size(), underProvisionedRequestIds.size(), numFinishedRequests, unknownRacks, unknownSlaves, authDatastoreHealthy, minimumPriorityLevel,
         statusUpdateDeltaAvg.get(), lastHeartbeatTime.get());
+  }
+
+  private boolean requestTypeIsOnDemand(SingularityPendingTaskId taskId) {
+    if (requestManager.getRequest(taskId.getRequestId()).isPresent()) {
+      return requestManager.getRequest(taskId.getRequestId()).get().getRequest().getRequestType().equals(RequestType.ON_DEMAND);
+    }
+    return false;
   }
 
   private Map<String, Long> getNumTasks(List<SingularityRequestWithState> requests) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/StateManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/StateManager.java
@@ -294,7 +294,7 @@ public class StateManager extends CuratorManager {
     final Optional<Double> minimumPriorityLevel = getMinimumPriorityLevel();
 
     final Map<Boolean, List<SingularityPendingTaskId>> lateTasksPartitionedByOnDemand = scheduledTasksInfo.getLateTasks().stream()
-        .collect(Collectors.partitioningBy(lateTask -> requestTypeIsOnDemand(lateTask));
+        .collect(Collectors.partitioningBy(lateTask -> requestTypeIsOnDemand(lateTask)));
     final List<SingularityPendingTaskId> onDemandLateTasks = lateTasksPartitionedByOnDemand.get(true);
     final List<SingularityPendingTaskId> lateTasks = lateTasksPartitionedByOnDemand.get(false);
 


### PR DESCRIPTION
Currently, if you submit pending tasks in quick succession on an on demand request that has an instance count limit, you can end up with tasks that will wait for the first to complete before launching. We shouldn't page for task lag in these cases. I've separated the late tasks on on-demand requests from the rest of the late tasks. This allows us to get better metrics on task lag and improve our alerts.