### PR TITLE
Add token authenticator option

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTokenRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTokenRequest.java
@@ -10,11 +10,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "Request to create a new long lived auth token")
 public class SingularityTokenRequest {
   private final Optional<String> token;
-  private final SingularityUser user;
+  private final Optional<SingularityUser> user;
 
   @JsonCreator
   public SingularityTokenRequest(@JsonProperty("token") Optional<String> token,
-                                 SingularityUser user) {
+                                 @JsonProperty("user") Optional<SingularityUser> user) {
     this.token = token;
     this.user = user;
   }
@@ -24,8 +24,8 @@ public class SingularityTokenRequest {
     return token;
   }
 
-  @Schema(description = "User data associated with the token", required = true)
-  public SingularityUser getUser() {
+  @Schema(description = "User data associated with the token, will be the current logged in user if not provided", required = true)
+  public Optional<SingularityUser> getUser() {
     return user;
   }
 

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTokenRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTokenRequest.java
@@ -1,24 +1,26 @@
 package com.hubspot.singularity;
 
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Optional;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(description = "Response containing the generated long lived auth token and associated user data")
-public class SingularityTokenResponse {
-  private final String token;
+@Schema(description = "Request to create a new long lived auth token")
+public class SingularityTokenRequest {
+  private final Optional<String> token;
   private final SingularityUser user;
 
   @JsonCreator
-  public SingularityTokenResponse(@JsonProperty("token") String token,
-                                  @JsonProperty("user") SingularityUser user) {
+  public SingularityTokenRequest(@JsonProperty("token") Optional<String> token,
+                                 SingularityUser user) {
     this.token = token;
     this.user = user;
   }
 
-  @Schema(description = "The generated/saved token", required = true)
-  public String getToken() {
+  @Schema(description = "Optional token, will be auto-genearted if not specified", required = false)
+  public Optional<String> getToken() {
     return token;
   }
 
@@ -36,7 +38,7 @@ public class SingularityTokenResponse {
       return false;
     }
 
-    SingularityTokenResponse that = (SingularityTokenResponse) o;
+    SingularityTokenRequest that = (SingularityTokenRequest) o;
 
     if (token != null ? !token.equals(that.token) : that.token != null) {
       return false;
@@ -53,8 +55,8 @@ public class SingularityTokenResponse {
 
   @Override
   public String toString() {
-    return "SingularityTokenResponse{" +
-        "token='" + token + '\'' +
+    return "SingularityTokenRequest{" +
+        "token=" + token +
         ", user=" + user +
         '}';
   }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTokenResponse.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTokenResponse.java
@@ -1,0 +1,56 @@
+package com.hubspot.singularity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class SingularityTokenResponse {
+  private final String token;
+  private final SingularityUser user;
+
+  @JsonCreator
+  public SingularityTokenResponse(@JsonProperty("token") String token,
+                                  @JsonProperty("user") SingularityUser user) {
+    this.token = token;
+    this.user = user;
+  }
+
+  public String getToken() {
+    return token;
+  }
+
+  public SingularityUser getUser() {
+    return user;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    SingularityTokenResponse that = (SingularityTokenResponse) o;
+
+    if (token != null ? !token.equals(that.token) : that.token != null) {
+      return false;
+    }
+    return user != null ? user.equals(that.user) : that.user == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = token != null ? token.hashCode() : 0;
+    result = 31 * result + (user != null ? user.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "SingularityTokenResponse{" +
+        "token='" + token + '\'' +
+        ", user=" + user +
+        '}';
+  }
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAuthenticatorClass.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAuthenticatorClass.java
@@ -2,6 +2,7 @@ package com.hubspot.singularity.auth;
 
 import com.hubspot.singularity.auth.authenticator.SingularityAuthenticator;
 import com.hubspot.singularity.auth.authenticator.SingularityDisabledAuthenticator;
+import com.hubspot.singularity.auth.authenticator.SingularityTokenAuthenticator;
 import com.hubspot.singularity.auth.authenticator.SingularityWebhookAuthenticator;
 import com.hubspot.singularity.auth.authenticator.SingularityHeaderPassthroughAuthenticator;
 import com.hubspot.singularity.auth.authenticator.SingularityQueryParamAuthenticator;
@@ -10,7 +11,8 @@ public enum SingularityAuthenticatorClass {
   DISABLED(SingularityDisabledAuthenticator.class),
   HEADER_PASSTHROUGH(SingularityHeaderPassthroughAuthenticator.class),
   QUERYPARAM_PASSTHROUGH(SingularityQueryParamAuthenticator.class),
-  WEBHOOK(SingularityWebhookAuthenticator.class);
+  WEBHOOK(SingularityWebhookAuthenticator.class),
+  TOKEN(SingularityTokenAuthenticator.class);
 
   private final Class<? extends SingularityAuthenticator> authenticatorClass;
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/authenticator/SingularityTokenAuthenticator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/authenticator/SingularityTokenAuthenticator.java
@@ -1,0 +1,72 @@
+package com.hubspot.singularity.auth.authenticator;
+
+import java.util.concurrent.TimeUnit;
+
+import javax.ws.rs.container.ContainerRequestContext;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Strings;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.net.HttpHeaders;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.hubspot.singularity.SingularityUser;
+import com.hubspot.singularity.WebExceptions;
+import com.hubspot.singularity.data.AuthTokenManager;
+
+@Singleton
+public class SingularityTokenAuthenticator implements SingularityAuthenticator {
+  private static final Logger LOG = LoggerFactory.getLogger(SingularityTokenAuthenticator.class);
+
+  private final AuthTokenManager authTokenManager;
+  private final LoadingCache<String, SingularityUser> tokenCache;
+
+  @Inject
+  public SingularityTokenAuthenticator(AuthTokenManager authTokenManager) {
+    this.authTokenManager = authTokenManager;
+    this.tokenCache = CacheBuilder.<String, SingularityUserPermissionsResponse>newBuilder()
+        .expireAfterWrite(15, TimeUnit.SECONDS)
+        .build(new CacheLoader<String, SingularityUser>() {
+          @Override
+          public SingularityUser load(String token) {
+            return verifyUncached(token);
+          }
+        });
+  }
+
+  @Override
+  public java.util.Optional<SingularityUser> getUser(ContainerRequestContext context) {
+    String token = extractToken(context);
+    try {
+      return java.util.Optional.of(tokenCache.get(token));
+    } catch (Throwable t) {
+      throw WebExceptions.unauthorized(String.format("Exception while verifying token: %s", t.getMessage()));
+    }
+  }
+
+  private SingularityUser verifyUncached(String token) {
+    SingularityUser verified = authTokenManager.getUserIfValidToken(token);
+
+    if (verified == null) {
+      throw WebExceptions.unauthorized("No matching token found");
+    } else {
+      return verified;
+    }
+  }
+
+  private String extractToken(ContainerRequestContext context) {
+    final String authHeaderValue = context.getHeaderString(HttpHeaders.AUTHORIZATION);
+    if (Strings.isNullOrEmpty(authHeaderValue)) {
+      throw WebExceptions.unauthorized("No Authorization header present, please log in first");
+    } else {
+      if (!authHeaderValue.startsWith("Token")) {
+        throw WebExceptions.unauthorized("No Token specified in authorization header");
+      }
+      return authHeaderValue.replaceFirst("Token\\s+", "");
+    }
+  }
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/AuthTokenManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/AuthTokenManager.java
@@ -49,6 +49,19 @@ public class AuthTokenManager extends CuratorManager {
     save(getTokenPath(hashed), userData, userTranscoder);
   }
 
+  private void deleteToken(String hashed) {
+    delete(getTokenPath(hashed));
+  }
+
+  public void clearTokensForUser(String user) {
+    for (String hashed : getChildren(TOKEN_ROOT)) {
+      Optional<SingularityUser> maybeUser = getData(getTokenPath(hashed), userTranscoder);
+      if (maybeUser.isPresent() && maybeUser.get().getName().equals(user)) {
+        deleteToken(hashed);
+      }
+    }
+  }
+
   public SingularityUser getUserIfValidToken(String token) {
     for (String hashed : getChildren(TOKEN_ROOT)) {
       try {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/AuthTokenManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/AuthTokenManager.java
@@ -127,7 +127,7 @@ public class AuthTokenManager extends CuratorManager {
     return salt;
   }
 
-  private static String toHex(byte[] array) throws NoSuchAlgorithmException {
+  private static String toHex(byte[] array) {
     BigInteger bi = new BigInteger(1, array);
     String hex = bi.toString(16);
     int paddingLength = (array.length * 2) - hex.length();

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/AuthTokenManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/AuthTokenManager.java
@@ -1,0 +1,127 @@
+package com.hubspot.singularity.data;
+
+import java.math.BigInteger;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.spec.InvalidKeySpecException;
+import java.util.UUID;
+
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.Optional;
+import com.google.inject.Inject;
+import com.hubspot.singularity.SingularityUser;
+import com.hubspot.singularity.config.SingularityConfiguration;
+import com.hubspot.singularity.data.transcoders.Transcoder;
+
+public class AuthTokenManager extends CuratorManager {
+  private static final Logger LOG = LoggerFactory.getLogger(AuthTokenManager.class);
+
+  private static final String TOKEN_ROOT = "/tokens";
+  private static final String TOKEN_PATH = TOKEN_ROOT + "/%s";
+
+  private final Transcoder<SingularityUser> userTranscoder;
+
+  @Inject
+  public AuthTokenManager(CuratorFramework curator,
+                          SingularityConfiguration configuration,
+                          MetricRegistry metricRegistry,
+                          Transcoder<SingularityUser> userTranscoder) {
+    super(curator, configuration, metricRegistry);
+    this.userTranscoder = userTranscoder;
+  }
+
+  public String generateToken(SingularityUser userData) throws NoSuchAlgorithmException, InvalidKeySpecException {
+    String newToken = UUID.randomUUID().toString();
+    String hashed = generateTokenHash(newToken);
+    saveToken(hashed, userData);
+    return newToken;
+  }
+
+  private void saveToken(String hashed, SingularityUser userData) {
+    save(getTokenPath(hashed), userData, userTranscoder);
+  }
+
+  public SingularityUser getUserIfValidToken(String token) {
+    for (String hashed : getChildren(TOKEN_ROOT)) {
+      try {
+        if (validateToken(token, hashed)) {
+          Optional<SingularityUser> maybeUser = getData(getTokenPath(hashed), userTranscoder);
+          if (maybeUser.isPresent()) {
+            return maybeUser.get();
+          }
+        }
+      } catch (Throwable t) {
+        LOG.error("Unable to validate token", t);
+      }
+    }
+    LOG.debug("No matching token found");
+    return null;
+  }
+
+  private String getTokenPath(String hashed) {
+    return String.format(TOKEN_PATH, hashed);
+  }
+
+  // Implementation of PBKDF2WithHmacSHA1
+  private static boolean validateToken(String originalToken, String storedToken) throws NoSuchAlgorithmException, InvalidKeySpecException {
+    String[] parts = storedToken.split(":");
+    int iterations = Integer.parseInt(parts[0]);
+    byte[] salt = fromHex(parts[1]);
+    byte[] hash = fromHex(parts[2]);
+
+    PBEKeySpec spec = new PBEKeySpec(originalToken.toCharArray(), salt, iterations, hash.length * 8);
+    SecretKeyFactory skf = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1");
+    byte[] testHash = skf.generateSecret(spec).getEncoded();
+
+    int diff = hash.length ^ testHash.length;
+    for (int i = 0; i < hash.length && i < testHash.length; i++) {
+      diff |= hash[i] ^ testHash[i];
+    }
+    return diff == 0;
+  }
+
+  private static byte[] fromHex(String hex) throws NoSuchAlgorithmException {
+    byte[] bytes = new byte[hex.length() / 2];
+    for (int i = 0; i < bytes.length; i++) {
+      bytes[i] = (byte) Integer.parseInt(hex.substring(2 * i, 2 * i + 2), 16);
+    }
+    return bytes;
+  }
+
+  private static String generateTokenHash(String password) throws NoSuchAlgorithmException, InvalidKeySpecException {
+    int iterations = 1000;
+    char[] chars = password.toCharArray();
+    byte[] salt = getSalt();
+
+    PBEKeySpec spec = new PBEKeySpec(chars, salt, iterations, 64 * 8);
+    SecretKeyFactory skf = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1");
+    byte[] hash = skf.generateSecret(spec).getEncoded();
+    return iterations + ":" + toHex(salt) + ":" + toHex(hash);
+  }
+
+  private static byte[] getSalt() throws NoSuchAlgorithmException {
+    SecureRandom sr = SecureRandom.getInstance("SHA1PRNG");
+    byte[] salt = new byte[16];
+    sr.nextBytes(salt);
+    return salt;
+  }
+
+  private static String toHex(byte[] array) throws NoSuchAlgorithmException {
+    BigInteger bi = new BigInteger(1, array);
+    String hex = bi.toString(16);
+    int paddingLength = (array.length * 2) - hex.length();
+    if (paddingLength > 0) {
+      return String.format("%0" + paddingLength + "d", 0) + hex;
+    } else {
+      return hex;
+    }
+  }
+
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/AuthTokenManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/AuthTokenManager.java
@@ -40,12 +40,16 @@ public class AuthTokenManager extends CuratorManager {
 
   public SingularityTokenResponse generateToken(SingularityUser userData) throws NoSuchAlgorithmException, InvalidKeySpecException {
     String newToken = UUID.randomUUID().toString();
+    return saveToken(newToken, userData);
+  }
+
+  public SingularityTokenResponse saveToken(String newToken, SingularityUser userData) throws NoSuchAlgorithmException, InvalidKeySpecException {
     String hashed = generateTokenHash(newToken);
-    saveToken(hashed, userData);
+    writeToken(hashed, userData);
     return new SingularityTokenResponse(newToken, userData);
   }
 
-  private void saveToken(String hashed, SingularityUser userData) {
+  private void writeToken(String hashed, SingularityUser userData) {
     save(getTokenPath(hashed), userData, userTranscoder);
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/AuthTokenManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/AuthTokenManager.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
+import com.hubspot.singularity.SingularityTokenResponse;
 import com.hubspot.singularity.SingularityUser;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.transcoders.Transcoder;
@@ -37,11 +38,11 @@ public class AuthTokenManager extends CuratorManager {
     this.userTranscoder = userTranscoder;
   }
 
-  public String generateToken(SingularityUser userData) throws NoSuchAlgorithmException, InvalidKeySpecException {
+  public SingularityTokenResponse generateToken(SingularityUser userData) throws NoSuchAlgorithmException, InvalidKeySpecException {
     String newToken = UUID.randomUUID().toString();
     String hashed = generateTokenHash(newToken);
     saveToken(hashed, userData);
-    return newToken;
+    return new SingularityTokenResponse(newToken, userData);
   }
 
   private void saveToken(String hashed, SingularityUser userData) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityDataModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityDataModule.java
@@ -39,6 +39,7 @@ public class SingularityDataModule extends AbstractModule {
     bind(DisasterManager.class).in(Scopes.SINGLETON);
     bind(PriorityManager.class).in(Scopes.SINGLETON);
     bind(RequestGroupManager.class).in(Scopes.SINGLETON);
+    bind(AuthTokenManager.class).in(Scopes.SINGLETON);
   }
 
   @Provides

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/transcoders/SingularityTranscoderModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/transcoders/SingularityTranscoderModule.java
@@ -50,6 +50,7 @@ import com.hubspot.singularity.SingularityTaskShellCommandUpdate;
 import com.hubspot.singularity.SingularityTaskStatusHolder;
 import com.hubspot.singularity.SingularityTaskUsage;
 import com.hubspot.singularity.SingularityUpdatePendingDeployRequest;
+import com.hubspot.singularity.SingularityUser;
 import com.hubspot.singularity.SingularityUserSettings;
 import com.hubspot.singularity.SingularityWebhook;
 import com.hubspot.singularity.expiring.SingularityExpiringBounce;
@@ -100,6 +101,7 @@ public class SingularityTranscoderModule implements Module {
     bindTranscoder(binder).asJson(SingularityRequestGroup.class);
     bindTranscoder(binder).asJson(SingularityExpiringMachineState.class);
     bindTranscoder(binder).asJson(SingularityUserSettings.class);
+    bindTranscoder(binder).asJson(SingularityUser.class);
     bindTranscoder(binder).asJson(SingularitySlaveUsage.class);
     bindTranscoder(binder).asJson(SingularityTaskUsage.class);
     bindTranscoder(binder).asJson(SingularityClusterUtilization.class);

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/AuthResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/AuthResource.java
@@ -123,8 +123,8 @@ public class AuthResource {
           @ApiResponse(responseCode = "200", description = "tokens cleared successfully")
       }
   )
-  public SingularityTokenResponse generateToken(@Parameter(hidden = true) @Auth SingularityUser user, @PathParam("user") String userName) throws NoSuchAlgorithmException, InvalidKeySpecException {
+  public Response generateToken(@Parameter(hidden = true) @Auth SingularityUser user, @PathParam("user") String userName) throws NoSuchAlgorithmException, InvalidKeySpecException {
     authorizationHelper.checkAdminAuthorization(user);
-    return authTokenManager.clearTokensForUser(userName);
+    return Response.ok().build();
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/AuthResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/AuthResource.java
@@ -3,6 +3,7 @@ package com.hubspot.singularity.resources;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 
+import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -112,5 +113,18 @@ public class AuthResource {
   public SingularityTokenResponse generateToken(@Parameter(hidden = true) @Auth SingularityUser user, SingularityUser userForToken) throws NoSuchAlgorithmException, InvalidKeySpecException {
     authorizationHelper.checkAdminAuthorization(user);
     return authTokenManager.generateToken(userForToken);
+  }
+
+  @DELETE
+  @Path("/token/{user}")
+  @Operation(
+      summary = "Clear tokens for a user",
+      responses = {
+          @ApiResponse(responseCode = "200", description = "tokens cleared successfully")
+      }
+  )
+  public SingularityTokenResponse generateToken(@Parameter(hidden = true) @Auth SingularityUser user, @PathParam("user") String userName) throws NoSuchAlgorithmException, InvalidKeySpecException {
+    authorizationHelper.checkAdminAuthorization(user);
+    return authTokenManager.clearTokensForUser(userName);
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/AuthResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/AuthResource.java
@@ -17,6 +17,7 @@ import javax.ws.rs.core.Response;
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.hubspot.singularity.SingularityAuthorizationScope;
+import com.hubspot.singularity.SingularityTokenRequest;
 import com.hubspot.singularity.SingularityTokenResponse;
 import com.hubspot.singularity.SingularityUser;
 import com.hubspot.singularity.SingularityUserHolder;
@@ -110,9 +111,14 @@ public class AuthResource {
           @ApiResponse(responseCode = "200", description = "the user data and generated token")
       }
   )
-  public SingularityTokenResponse generateToken(@Parameter(hidden = true) @Auth SingularityUser user, SingularityUser userForToken) throws NoSuchAlgorithmException, InvalidKeySpecException {
+  public SingularityTokenResponse generateToken(@Parameter(hidden = true) @Auth SingularityUser user,
+                                                SingularityTokenRequest tokenRequest) throws NoSuchAlgorithmException, InvalidKeySpecException {
     authorizationHelper.checkAdminAuthorization(user);
-    return authTokenManager.generateToken(userForToken);
+    if (tokenRequest.getToken().isPresent()) {
+      return authTokenManager.saveToken(tokenRequest.getToken().get(), tokenRequest.getUser());
+    } else {
+      return authTokenManager.generateToken(tokenRequest.getUser());
+    }
   }
 
   @DELETE

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/AuthResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/AuthResource.java
@@ -125,6 +125,7 @@ public class AuthResource {
   )
   public Response generateToken(@Parameter(hidden = true) @Auth SingularityUser user, @PathParam("user") String userName) throws NoSuchAlgorithmException, InvalidKeySpecException {
     authorizationHelper.checkAdminAuthorization(user);
+    authTokenManager.clearTokensForUser(userName);
     return Response.ok().build();
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/AuthResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/AuthResource.java
@@ -1,7 +1,11 @@
 package com.hubspot.singularity.resources;
 
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -12,12 +16,14 @@ import javax.ws.rs.core.Response;
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.hubspot.singularity.SingularityAuthorizationScope;
+import com.hubspot.singularity.SingularityTokenResponse;
 import com.hubspot.singularity.SingularityUser;
 import com.hubspot.singularity.SingularityUserHolder;
 import com.hubspot.singularity.auth.SingularityAuthorizationHelper;
 import com.hubspot.singularity.auth.datastore.SingularityAuthDatastore;
 import com.hubspot.singularity.config.ApiPaths;
 import com.hubspot.singularity.config.SingularityConfiguration;
+import com.hubspot.singularity.data.AuthTokenManager;
 import com.hubspot.singularity.data.UserManager;
 
 import io.dropwizard.auth.Auth;
@@ -37,16 +43,19 @@ public class AuthResource {
   private final SingularityConfiguration configuration;
   private final SingularityAuthorizationHelper authorizationHelper;
   private final SingularityAuthDatastore authDatastore;
+  private final AuthTokenManager authTokenManager;
 
   @Inject
   public AuthResource(UserManager userManager,
                       SingularityConfiguration configuration,
                       SingularityAuthorizationHelper authorizationHelper,
-                      SingularityAuthDatastore authDatastore) {
+                      SingularityAuthDatastore authDatastore,
+                      AuthTokenManager authTokenManager) {
     this.userManager = userManager;
     this.configuration = configuration;
     this.authorizationHelper = authorizationHelper;
     this.authDatastore = authDatastore;
+    this.authTokenManager = authTokenManager;
   }
 
   @GET
@@ -90,5 +99,18 @@ public class AuthResource {
       @Parameter(description = "Scope to check for") @QueryParam("scope") @DefaultValue("READ") Optional<SingularityAuthorizationScope> scope) {
     authorizationHelper.checkForAuthorizationByRequestId(requestId, user, scope.or(SingularityAuthorizationScope.READ));
     return Response.ok().build();
+  }
+
+  @POST
+  @Path("/token")
+  @Operation(
+      summary = "Generate a new auth token for the provided user data, can only be done by an admin",
+      responses = {
+          @ApiResponse(responseCode = "200", description = "the user data and generated token")
+      }
+  )
+  public SingularityTokenResponse generateToken(@Parameter(hidden = true) @Auth SingularityUser user, SingularityUser userForToken) throws NoSuchAlgorithmException, InvalidKeySpecException {
+    authorizationHelper.checkAdminAuthorization(user);
+    return authTokenManager.generateToken(userForToken);
   }
 }


### PR DESCRIPTION
This adds a very simple token authentication and storage scheme. The main purpose while building this is currently as a backup system if our main webhook auth is unresponsive. I still need to give this a once over for security's sake. Using an implementation of _PBKDF2WithHmacSHA1_ for the stored version of tokens and each token is associated with specific user data (`SingularityUser` object).