### PR TITLE
Reduce S3Uploader memory usage during directory scan

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/mesos/JavaUtils.java
+++ b/SingularityBase/src/main/java/com/hubspot/mesos/JavaUtils.java
@@ -145,25 +145,6 @@ public final class JavaUtils {
     return t;
   }
 
-  public static Iterable<Path> iterable(final Path directory) {
-    try (DirectoryStream<Path> dirStream = Files.newDirectoryStream(directory);) {
-      Iterator<Path> iterator = dirStream.iterator();
-      return Lists.newArrayList(iterator);
-    } catch (IOException e) {
-      throw Throwables.propagate(e);
-    }
-  }
-
-  public static Path getValidDirectory(String directoryPath, String name) {
-    Preconditions.checkState(!directoryPath.isEmpty(), "Path for %s can't be empty", name);
-
-    Path path = Paths.get(directoryPath);
-
-    Preconditions.checkState(Files.isDirectory(path), "Path %s for %s wasn't a directory", path, name);
-
-    return path;
-  }
-
   public static <K, V> Map<K, V> nonNullImmutable(Map<K, V> map) {
     if (map == null) {
       return Collections.emptyMap();

--- a/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/SingularityExecutorCleanup.java
+++ b/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/SingularityExecutorCleanup.java
@@ -164,7 +164,7 @@ public class SingularityExecutorCleanup {
     }
 
     try {
-      try (Stream<Path> paths = Files.walk(directory)) {
+      try (Stream<Path> paths = Files.walk(directory, 1)) {
         paths.forEach((file) -> {
           if (!Objects.toString(file.getFileName()).endsWith(executorConfiguration.getGlobalTaskDefinitionSuffix())) {
             LOG.debug("Ignoring file {} that doesn't have suffix {}", file, executorConfiguration.getGlobalTaskDefinitionSuffix());

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityUploader.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityUploader.java
@@ -14,6 +14,7 @@ import java.nio.file.attribute.UserDefinedFileAttributeView;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 
 import org.slf4j.Logger;
@@ -140,21 +141,29 @@ public abstract class SingularityUploader {
       return Collections.emptyList();
     }
 
-    for (Path file : JavaUtils.iterable(directory)) {
-      handleFile(file, isFinished, toUpload);
-    }
-
+    Files.walk(directory).forEach((file) -> {
+      try {
+        handleFile(file, isFinished, toUpload);
+      } catch (IOException ioe) {
+        throw new RuntimeException(ioe);
+      }
+    });
     return toUpload;
   }
 
-  private int handleFile(Path path, boolean isFinished, List<Path> toUpload) throws IOException {
-    int found = 0;
+  private AtomicInteger handleFile(Path path, boolean isFinished, List<Path> toUpload) throws IOException {
+    AtomicInteger found = new AtomicInteger();
     if (Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS)) {
       if (uploadMetadata.isCheckSubdirectories()) {
         LOG.trace("{} was a directory, checking files in directory", path);
-        for (Path file : JavaUtils.iterable(path)) {
-          found += handleFile(file, isFinished, toUpload);
-        }
+        Files.walk(path).forEach((file) -> {
+          try {
+            found.getAndAdd(handleFile(file, isFinished, toUpload).get());
+          } catch (IOException ioe) {
+            throw new RuntimeException(ioe);
+          }
+        });
+
       } else {
         LOG.trace("{} was a directory, skipping", path);
       }
@@ -175,7 +184,7 @@ public abstract class SingularityUploader {
       return found;
     }
 
-    found++;
+    found.incrementAndGet();
 
     toUpload.add(path);
 

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityUploader.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityUploader.java
@@ -144,6 +144,9 @@ public abstract class SingularityUploader {
 
     try (Stream<Path> paths = Files.walk(directory, 1)) {
       paths.forEach((file) -> {
+        if (file.equals(directory)) {
+          return;
+        }
         try {
           handleFile(file, isFinished, toUpload);
         } catch (IOException ioe) {
@@ -161,6 +164,9 @@ public abstract class SingularityUploader {
         LOG.trace("{} was a directory, checking files in directory", path);
         try (Stream<Path> paths = Files.walk(path, 1)) {
           paths.forEach((file) -> {
+            if (file.equals(path)) {
+              return; // Files.walk includes an element that is the starting path itself, skip this
+            }
             try {
               found.getAndAdd(handleFile(file, isFinished, toUpload).get());
             } catch (IOException ioe) {

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityUploader.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityUploader.java
@@ -142,7 +142,7 @@ public abstract class SingularityUploader {
       return Collections.emptyList();
     }
 
-    try (Stream<Path> paths = Files.walk(directory)) {
+    try (Stream<Path> paths = Files.walk(directory, 1)) {
       paths.forEach((file) -> {
         try {
           handleFile(file, isFinished, toUpload);
@@ -159,7 +159,7 @@ public abstract class SingularityUploader {
     if (Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS)) {
       if (uploadMetadata.isCheckSubdirectories()) {
         LOG.trace("{} was a directory, checking files in directory", path);
-        try (Stream<Path> paths = Files.walk(path)) {
+        try (Stream<Path> paths = Files.walk(path, 1)) {
           paths.forEach((file) -> {
             try {
               found.getAndAdd(handleFile(file, isFinished, toUpload).get());


### PR DESCRIPTION
Our `JavaUtils. iterable` function was previously taking a DirectoryStream -> Lists.newArrayList(stream.iterator()). This caused all paths in a directory to be in memory at once. For particularly large directories this was causing ooms in the uploader. Files.walk does this in more of a streaming fashion and should save us from loading the entire directory tree in memory before iterating over it