### PR TITLE
On demand requests with instances shouldn't trigger task lag over instance count

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
@@ -200,7 +200,7 @@ public class SingularityRequest {
     return scheduleTimeZone;
   }
 
-  @Schema(nullable = true, description = "A count limit of tasks to run for on-demand requests")
+  @Schema(nullable = true, description = "A count of tasks to run for long-running requests or the limit on the number of concurrent tasks for on-demand requests")
   public Optional<Integer> getInstances() {
     return instances;
   }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
@@ -200,7 +200,7 @@ public class SingularityRequest {
     return scheduleTimeZone;
   }
 
-  @Schema(nullable = true, description = "A count of tasks to run for long-running requests")
+  @Schema(nullable = true, description = "A count limit of tasks to run for on-demand requests")
   public Optional<Integer> getInstances() {
     return instances;
   }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityState.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityState.java
@@ -383,6 +383,8 @@ public class SingularityState {
         ", scheduledTasks=" + scheduledTasks +
         ", lateTasks=" + lateTasks +
         ", listLateTasks=" + listLateTasks +
+        ", onDemandLateTasks=" + onDemandLateTasks +
+        ", onDemandListLateTasks=" + onDemandListLateTasks +
         ", futureTasks=" + futureTasks +
         ", cleaningTasks=" + cleaningTasks +
         ", lbCleanupTasks=" + lbCleanupTasks +

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/StateManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/StateManager.java
@@ -317,10 +317,13 @@ public class StateManager extends CuratorManager {
   private List<SingularityPendingTaskId> getOnDemandLateTasks (List<SingularityPendingTaskId> maybeOnDemandLateTasks) {
     List<SingularityPendingTaskId> onDemandLateTasks = new ArrayList<>();
     for (SingularityPendingTaskId maybeOnDemandLateTask : maybeOnDemandLateTasks) {
-      final Optional<Integer> maybeInstancesLimit = requestManager.getRequest(maybeOnDemandLateTask.getRequestId()).get().getRequest().getInstances();
-      if (maybeInstancesLimit.isPresent()) {
-        if (taskManager.getActiveTaskIdsForRequest(maybeOnDemandLateTask.getRequestId()).size() < maybeInstancesLimit.get()) {
-          onDemandLateTasks.add(maybeOnDemandLateTask);
+      final Optional<SingularityRequestWithState> maybeRequest = requestManager.getRequest(maybeOnDemandLateTask.getRequestId());
+      if (maybeRequest.isPresent()) {
+        final Optional<Integer> maybeInstancesLimit = maybeRequest.get().getRequest().getInstances();
+        if (maybeInstancesLimit.isPresent()) {
+          if (taskManager.getActiveTaskIdsForRequest(maybeOnDemandLateTask.getRequestId()).size() < maybeInstancesLimit.get()) {
+            onDemandLateTasks.add(maybeOnDemandLateTask);
+          }
         }
       }
     }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/StateManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/StateManager.java
@@ -296,15 +296,8 @@ public class StateManager extends CuratorManager {
     final Map<Boolean, List<SingularityPendingTaskId>> lateTasksPartitionedByOnDemand = scheduledTasksInfo.getLateTasks().stream()
         .collect(Collectors.partitioningBy(lateTask -> requestTypeIsOnDemand(lateTask)));
     final List<SingularityPendingTaskId> maybeOnDemandLateTasks = lateTasksPartitionedByOnDemand.get(true);
+    final List<SingularityPendingTaskId> onDemandLateTasks = getOnDemandLateTasks(maybeOnDemandLateTasks);
     final List<SingularityPendingTaskId> lateTasks = lateTasksPartitionedByOnDemand.get(false);
-
-    List<SingularityPendingTaskId> onDemandLateTasks = new ArrayList<>();
-    for (SingularityPendingTaskId maybeOnDemandLateTask : maybeOnDemandLateTasks) {
-      String requestId = requestManager.getRequest(maybeOnDemandLateTask.getRequestId()).get().getRequest().getId();
-      if (taskManager.getActiveTaskIdsForRequest(requestId).size() < maybeOnDemandLateTask.getInstanceNo()) {
-        onDemandLateTasks.add(maybeOnDemandLateTask);
-      }
-    }
 
     return new SingularityState(activeTasks, launchingTasks, numActiveRequests, cooldownRequests, numPausedRequests, scheduledTasks, pendingRequests, lbCleanupTasks, lbCleanupRequests, cleaningRequests, activeSlaves,
         deadSlaves, decommissioningSlaves, activeRacks, deadRacks, decommissioningRacks, cleaningTasks, states, oldestDeploy, numDeploys, oldestDeployStep, activeDeploys, lateTasks.size(), lateTasks, onDemandLateTasks.size(), onDemandLateTasks,
@@ -318,6 +311,20 @@ public class StateManager extends CuratorManager {
       return requestManager.getRequest(taskId.getRequestId()).get().getRequest().getRequestType().equals(RequestType.ON_DEMAND);
     }
     return false;
+  }
+
+  private List<SingularityPendingTaskId> getOnDemandLateTasks (List<SingularityPendingTaskId> maybeOnDemandLateTasks) {
+    List<SingularityPendingTaskId> onDemandLateTasks = new ArrayList<>();
+    for (SingularityPendingTaskId maybeOnDemandLateTask : maybeOnDemandLateTasks) {
+      String requestId = requestManager.getRequest(maybeOnDemandLateTask.getRequestId()).get().getRequest().getId();
+      Optional<Integer> maybeInstancesLimit = requestManager.getRequest(maybeOnDemandLateTask.getRequestId()).get().getRequest().getInstances();
+      if (maybeInstancesLimit.isPresent()) {
+        if (taskManager.getActiveTaskIdsForRequest(requestId).size() < maybeInstancesLimit.get()) {
+          onDemandLateTasks.add(maybeOnDemandLateTask);
+        }
+      }
+    }
+    return onDemandLateTasks;
   }
 
   private Map<String, Long> getNumTasks(List<SingularityRequestWithState> requests) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/StateManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/StateManager.java
@@ -296,8 +296,9 @@ public class StateManager extends CuratorManager {
     final Map<Boolean, List<SingularityPendingTaskId>> lateTasksPartitionedByOnDemand = scheduledTasksInfo.getLateTasks().stream()
         .collect(Collectors.partitioningBy(lateTask -> requestTypeIsOnDemand(lateTask)));
     final List<SingularityPendingTaskId> maybeOnDemandLateTasks = lateTasksPartitionedByOnDemand.get(true);
-    final List<SingularityPendingTaskId> onDemandLateTasks = getOnDemandLateTasks(maybeOnDemandLateTasks);
     final List<SingularityPendingTaskId> lateTasks = lateTasksPartitionedByOnDemand.get(false);
+
+    final List<SingularityPendingTaskId> onDemandLateTasks = getOnDemandLateTasks(maybeOnDemandLateTasks);
 
     return new SingularityState(activeTasks, launchingTasks, numActiveRequests, cooldownRequests, numPausedRequests, scheduledTasks, pendingRequests, lbCleanupTasks, lbCleanupRequests, cleaningRequests, activeSlaves,
         deadSlaves, decommissioningSlaves, activeRacks, deadRacks, decommissioningRacks, cleaningTasks, states, oldestDeploy, numDeploys, oldestDeployStep, activeDeploys, lateTasks.size(), lateTasks, onDemandLateTasks.size(), onDemandLateTasks,
@@ -316,10 +317,9 @@ public class StateManager extends CuratorManager {
   private List<SingularityPendingTaskId> getOnDemandLateTasks (List<SingularityPendingTaskId> maybeOnDemandLateTasks) {
     List<SingularityPendingTaskId> onDemandLateTasks = new ArrayList<>();
     for (SingularityPendingTaskId maybeOnDemandLateTask : maybeOnDemandLateTasks) {
-      String requestId = requestManager.getRequest(maybeOnDemandLateTask.getRequestId()).get().getRequest().getId();
-      Optional<Integer> maybeInstancesLimit = requestManager.getRequest(maybeOnDemandLateTask.getRequestId()).get().getRequest().getInstances();
+      final Optional<Integer> maybeInstancesLimit = requestManager.getRequest(maybeOnDemandLateTask.getRequestId()).get().getRequest().getInstances();
       if (maybeInstancesLimit.isPresent()) {
-        if (taskManager.getActiveTaskIdsForRequest(requestId).size() < maybeInstancesLimit.get()) {
+        if (taskManager.getActiveTaskIdsForRequest(maybeOnDemandLateTask.getRequestId()).size() < maybeInstancesLimit.get()) {
           onDemandLateTasks.add(maybeOnDemandLateTask);
         }
       }

--- a/SingularityService/src/test/java/com/hubspot/singularity/data/StateManagerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/data/StateManagerTest.java
@@ -85,7 +85,7 @@ public class StateManagerTest extends SingularitySchedulerTestBase{
     requestResource.postRequest(request.toBuilder().setInstances(Optional.of(2)).build(), singularityUser);
     initFirstDeploy();
 
-    configuration.setDeltaAfterWhichTasksAreLateMillis(TimeUnit.MILLISECONDS.toMillis(10));
+    configuration.setDeltaAfterWhichTasksAreLateMillis(0);
 
     requestResource.scheduleImmediately(
         singularityUser,

--- a/SingularityService/src/test/java/com/hubspot/singularity/data/StateManagerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/data/StateManagerTest.java
@@ -1,5 +1,7 @@
 package com.hubspot.singularity.data;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.mesos.v1.Protos.TaskState;
 import org.junit.Assert;
 import org.junit.Test;
@@ -10,6 +12,7 @@ import com.hubspot.singularity.SingularityPendingRequest;
 import com.hubspot.singularity.SingularityPendingRequest.PendingType;
 import com.hubspot.singularity.SingularityRequest;
 import com.hubspot.singularity.SingularityRequestHistory.RequestHistoryType;
+import com.hubspot.singularity.SingularityRunNowRequestBuilder;
 import com.hubspot.singularity.SingularityState;
 import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.SingularityTaskCleanup;
@@ -73,5 +76,49 @@ public class StateManagerTest extends SingularitySchedulerTestBase{
     SingularityState state = stateManager.getState(true, false);
     Assert.assertEquals(0, state.getOverProvisionedRequests());
     Assert.assertEquals(0, state.getUnderProvisionedRequests());
+  }
+
+  @Test
+  public void itDoesntCountInstancesOverLimitInOnDemandLateTasks() {
+    initOnDemandRequest();
+    SingularityRequest request = requestResource.getRequest(requestId, singularityUser).getRequest();
+    requestResource.postRequest(request.toBuilder().setInstances(Optional.of(2)).build(), singularityUser);
+    initFirstDeploy();
+
+    configuration.setDeltaAfterWhichTasksAreLateMillis(TimeUnit.MILLISECONDS.toMillis(10));
+
+    requestResource.scheduleImmediately(
+        singularityUser,
+        request.getId(),
+        new SingularityRunNowRequestBuilder()
+            .setRunAt(System.currentTimeMillis())
+            .build()
+    );
+    scheduler.drainPendingQueue();
+
+    SingularityState state = stateManager.getState(true, false);
+    System.out.println(state);
+
+    Assert.assertEquals(0, state.getActiveTasks());
+    Assert.assertEquals(1, state.getScheduledTasks());
+
+    launchTask(request, firstDeploy, 1, TaskState.TASK_RUNNING);
+    state = stateManager.getState(true, false);
+    System.out.println(state);
+
+    Assert.assertEquals(1, state.getActiveTasks());
+    Assert.assertEquals(1, state.getScheduledTasks());
+    Assert.assertEquals(1, state.getOnDemandLateTasks());
+    Assert.assertEquals(0, state.getLateTasks());
+
+    launchTask(request, firstDeploy, 2, TaskState.TASK_RUNNING);
+    state = stateManager.getState(true, false);
+    System.out.println(state);
+    Assert.assertEquals(2, state.getActiveTasks());
+    Assert.assertEquals(1, state.getScheduledTasks());
+    Assert.assertEquals(0, state.getOnDemandLateTasks());
+    Assert.assertEquals(0, state.getLateTasks());
+
+    configuration.setDeltaAfterWhichTasksAreLateMillis(TimeUnit.SECONDS.toMillis(30));
   }
 }


### PR DESCRIPTION
Currently, if you submit pending tasks in quick succession on an on demand request that has an instance count limit, you can end up with tasks that will wait for the first to complete before launching. We shouldn't page for task lag in these cases. 

[We previously separated the late tasks from on-demand requests from the rest of the late tasks](https://github.com/HubSpot/Singularity/pull/1881) and configured different alerting rules for them. In this PR, we ensure that we count the on-demand late tasks are within the task limit only so that on-demand late tasks blocked from launching because of instance count limit won't send alerts. 