### PR TITLE
Skip fuser/lsof check when uploader is marked as immediate

### DIFF
--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityUploader.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityUploader.java
@@ -94,7 +94,7 @@ public abstract class SingularityUploader {
     for (int i = 0; i < toUpload.size(); i++) {
       final Context context = metrics.getUploadTimer().time();
       final Path file = toUpload.get(i);
-      if (!configuration.isCheckForOpenFiles() || !isFileOpen(file, configuration.isCheckOpenFilesViaFuser())) {
+      if (!configuration.isCheckForOpenFiles() || uploadMetadata.isImmediate() || !isFileOpen(file, configuration.isCheckOpenFilesViaFuser())) {
         try {
           uploadSingle(i, file);
           metrics.upload();


### PR DESCRIPTION
One of the slower/expensive parts of the uploader right now when there are many files is checking if the files are still in use. The `immediate` flag is used to signify that the file is ready for upload and done being written to. If this flag is set, skip the lsof/fuser check. SingularityExecutor uses this flag on clean shutdown, so this should alleviate the need for the check in the majority of cases