### PR TITLE
Do the entire deploy history persist under the request lock

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityDeployHistoryPersister.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityDeployHistoryPersister.java
@@ -88,7 +88,7 @@ public class SingularityDeployHistoryPersister extends SingularityHistoryPersist
 
           for (SingularityDeployHistory deployHistory : deployHistories) {
             numTotal.increment();
-            if (!shouldTransferDeploy(deployState.get(), deployHistory.getDeployMarker().getDeployId())) {
+            if (!shouldTransferDeploy(requestId, deployState.get(), deployHistory.getDeployMarker().getDeployId())) {
               continue;
             }
 
@@ -116,9 +116,9 @@ public class SingularityDeployHistoryPersister extends SingularityHistoryPersist
     return configuration.getMaxStaleDeploysPerRequestInZkWhenNoDatabase();
   }
 
-  private boolean shouldTransferDeploy(SingularityRequestDeployState deployState, String deployId) {
+  private boolean shouldTransferDeploy(String requestId, SingularityRequestDeployState deployState, String deployId) {
     if (deployState == null) {
-      LOG.warn("Missing request deploy state for request {}. deploy {}", deployState.getRequestId(), deployId);
+      LOG.warn("Missing request deploy state for request {}. deploy {}", requestId, deployId);
       return true;
     }
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityTestModule.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityTestModule.java
@@ -103,7 +103,7 @@ public class SingularityTestModule implements Module {
     rootLogger.setLevel(Level.toLevel(System.getProperty("singularity.test.log.level", "WARN")));
 
     Logger hsLogger = context.getLogger("com.hubspot");
-    hsLogger.setLevel(Level.toLevel(System.getProperty("singularity.test.log.level.for.com.hubspot", "WARN")));
+    hsLogger.setLevel(Level.toLevel(System.getProperty("singularity.test.log.level.for.com.hubspot", "TRACE")));
 
     this.ts = new TestingServer();
   }


### PR DESCRIPTION
We were grabbing the `Map<String, SingularityRequestDeployState>` before grabbing the request lock. So if the deploy checker ran at the right time right before this poller, the deploy state would be out of date. This changes the poller to loop over requests, holding the request lock for each during teh entire persist process