### PR TITLE
Fix non-paginated fetch of s3 logs for task

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/S3LogResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/S3LogResource.java
@@ -387,6 +387,12 @@ public class S3LogResource extends AbstractHistoryResource {
               for (S3ObjectSummary objectSummary : result.getObjectSummaries()) {
                 objectSummaryHolders.add(new S3ObjectSummaryHolder(group, objectSummary));
               }
+              while (result.isTruncated() && result.getContinuationToken() != null) {
+                result = s3Client.listObjectsV2(new ListObjectsV2Request().withBucketName(s3Bucket).withPrefix(s3Prefix).withContinuationToken(result.getContinuationToken()));
+                for (S3ObjectSummary objectSummary : result.getObjectSummaries()) {
+                  objectSummaryHolders.add(new S3ObjectSummaryHolder(group, objectSummary));
+                }
+              }
               return objectSummaryHolders;
             }
           }


### PR DESCRIPTION
We weren't checking if there were more results beyond the first page. Previously we never had this many logs, but now that we've added thread dumps, there are quite a few more than previously per task