### PR TITLE
Clarify logging in offer scheduler

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
@@ -414,11 +414,12 @@ public class SingularityMesosOfferScheduler {
       estimatedCpusToAdd = getEstimatedCpuUsageForRequest(requestUtilization);
     }
     if (mesosConfiguration.isOmitOverloadedHosts() && maybeSlaveUsage.isPresent() && maybeSlaveUsage.get().isCpuOverloaded(estimatedCpusToAdd)) {
-      LOG.debug("Slave {} is overloaded (load5 {}/{}, load1 {}/{}, estimated cpus to add: {}), ignoring offer",
+      LOG.debug("Slave {} is overloaded (load5 {}/{}, load1 {}/{}, estimated cpus to add: {}, already committed cpus: {}), ignoring offer",
           offerHolder.getHostname(),
           maybeSlaveUsage.get().getSlaveUsage().getSystemLoad5Min(), maybeSlaveUsage.get().getSlaveUsage().getSystemCpusTotal(),
           maybeSlaveUsage.get().getSlaveUsage().getSystemLoad1Min(), maybeSlaveUsage.get().getSlaveUsage().getSystemCpusTotal(),
-          estimatedCpusToAdd);
+          estimatedCpusToAdd,
+          maybeSlaveUsage.get().getEstimatedAddedCpusUsage());
       return 0;
     }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveUsageWithCalculatedScores.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveUsageWithCalculatedScores.java
@@ -129,6 +129,10 @@ class SingularitySlaveUsageWithCalculatedScores {
     return diskInUseScore;
   }
 
+  public double getEstimatedAddedCpusUsage() {
+    return estimatedAddedCpusUsage;
+  }
+
   void addEstimatedCpuUsage(double estimatedAddedCpus) {
     this.estimatedAddedCpusUsage += estimatedAddedCpus;
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -461,7 +461,7 @@ public class SingularityScheduler {
 
     final int numMissingInstances = getNumMissingInstances(matchingTaskIds, request, pendingRequest, maybePendingDeploy);
 
-    LOG.debug("Missing {} instances of request {} (matching tasks: {}), pending request: {}, pending deploy: {}", numMissingInstances, request.getId(), matchingTaskIds, pendingRequest,
+    LOG.debug("Missing {} instances of request {} (matching tasks: {}), pending request: {}, pending deploy: {}", numMissingInstances, request.getId(), matchingTaskIds.size() < 20 ? matchingTaskIds : matchingTaskIds.size(), pendingRequest,
       maybePendingDeploy);
 
     if (numMissingInstances > 0) {


### PR DESCRIPTION
- Don't log all task IDs if there are more than 30, hard to even read the line
- Also log the cpus already committed to an offer when considering it overloaded