### PR TITLE
The zoo is under new management (zk cleanup)

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/deploy/HealthcheckOptions.java
+++ b/SingularityBase/src/main/java/com/hubspot/deploy/HealthcheckOptions.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
+import com.hubspot.singularity.HealthcheckMethod;
 import com.hubspot.singularity.HealthcheckProtocol;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -20,6 +21,7 @@ public class HealthcheckOptions {
   private final Optional<Integer> portIndex;
   private final Optional<Long> portNumber;
   private final Optional<HealthcheckProtocol> protocol;
+  private final Optional<HealthcheckMethod> method;
   private final Optional<Integer> startupTimeoutSeconds;
   private final Optional<Integer> startupDelaySeconds;
   private final Optional<Integer> startupIntervalSeconds;
@@ -34,6 +36,7 @@ public class HealthcheckOptions {
                             @JsonProperty("portIndex") Optional<Integer> portIndex,
                             @JsonProperty("portNumber") Optional<Long> portNumber,
                             @JsonProperty("protocol") Optional<HealthcheckProtocol> protocol,
+                            @JsonProperty("method") Optional<HealthcheckMethod> method,
                             @JsonProperty("startupTimeoutSeconds") Optional<Integer> startupTimeoutSeconds,
                             @JsonProperty("startupDelaySeconds") Optional<Integer> startupDelaySeconds,
                             @JsonProperty("startupIntervalSeconds") Optional<Integer> startupIntervalSeconds,
@@ -46,6 +49,7 @@ public class HealthcheckOptions {
     this.portIndex = portIndex;
     this.portNumber = portNumber;
     this.protocol = protocol;
+    this.method = method;
     this.startupTimeoutSeconds = startupTimeoutSeconds;
     this.startupDelaySeconds = startupDelaySeconds;
     this.startupIntervalSeconds = startupIntervalSeconds;
@@ -59,7 +63,9 @@ public class HealthcheckOptions {
   public HealthcheckOptions(String uri,
                             Optional<Integer> portIndex,
                             Optional<Long> portNumber,
-                            Optional<HealthcheckProtocol> protocol,Optional<Integer> startupTimeoutSeconds,
+                            Optional<HealthcheckProtocol> protocol,
+                            Optional<HealthcheckMethod> method,
+                            Optional<Integer> startupTimeoutSeconds,
                             Optional<Integer> startupDelaySeconds,
                             Optional<Integer> startupIntervalSeconds,
                             Optional<Integer> intervalSeconds,
@@ -71,6 +77,7 @@ public class HealthcheckOptions {
     this.portIndex = portIndex;
     this.portNumber = portNumber;
     this.protocol = protocol;
+    this.method = method;
     this.startupTimeoutSeconds = startupTimeoutSeconds;
     this.startupDelaySeconds = startupDelaySeconds;
     this.startupIntervalSeconds = startupIntervalSeconds;
@@ -87,6 +94,7 @@ public class HealthcheckOptions {
       .setPortIndex(portIndex)
       .setPortNumber(portNumber)
       .setProtocol(protocol)
+      .setMethod(method)
       .setStartupTimeoutSeconds(startupTimeoutSeconds)
       .setStartupDelaySeconds(startupDelaySeconds)
       .setStartupIntervalSeconds(startupIntervalSeconds)
@@ -102,7 +110,7 @@ public class HealthcheckOptions {
     return uri;
   }
 
-  @Schema(description = "Perform healthcheck on this dynamically allocated port (e.g. 0 for first port), defaults to first port")
+  @Schema(description = "Perform healthcheck on this dynamically allocated port (e.g. 0 for first port); defaults to first port")
   public Optional<Integer> getPortIndex() {
     return portIndex;
   }
@@ -112,9 +120,14 @@ public class HealthcheckOptions {
     return portNumber;
   }
 
-  @Schema(description = "Healthcheck protocol - HTTP or HTTPS")
+  @Schema(description = "Healthcheck protocol - HTTP or HTTPS for HTTP/1, HTTP2 or HTTPS2 for HTTP/2")
   public Optional<HealthcheckProtocol> getProtocol() {
     return protocol;
+  }
+
+  @Schema(description ="Healthcheck HTTP method - GET or POST; GET by default")
+  public Optional<HealthcheckMethod> getMethod() {
+    return method;
   }
 
   @Schema(description = "Consider the task unhealthy/failed if the app has not started responding to healthchecks in this amount of time")
@@ -170,6 +183,7 @@ public class HealthcheckOptions {
         Objects.equals(portIndex, that.portIndex) &&
         Objects.equals(portNumber, that.portNumber) &&
         Objects.equals(protocol, that.protocol) &&
+        Objects.equals(method, that.method) &&
         Objects.equals(startupTimeoutSeconds, that.startupTimeoutSeconds) &&
         Objects.equals(startupDelaySeconds, that.startupDelaySeconds) &&
         Objects.equals(startupIntervalSeconds, that.startupIntervalSeconds) &&
@@ -182,7 +196,7 @@ public class HealthcheckOptions {
 
   @Override
   public int hashCode() {
-    return Objects.hash(uri, portIndex, portNumber, protocol, startupTimeoutSeconds, startupDelaySeconds, startupIntervalSeconds, intervalSeconds, responseTimeoutSeconds, maxRetries, failureStatusCodes, healthcheckResultFilePath);
+    return Objects.hash(uri, portIndex, portNumber, protocol, method, startupTimeoutSeconds, startupDelaySeconds, startupIntervalSeconds, intervalSeconds, responseTimeoutSeconds, maxRetries, failureStatusCodes, healthcheckResultFilePath);
   }
 
   @Override
@@ -192,6 +206,7 @@ public class HealthcheckOptions {
         ", portIndex=" + portIndex +
         ", portNumber=" + portNumber +
         ", protocol=" + protocol +
+        ", method=" + method +
         ", startupTimeoutSeconds=" + startupTimeoutSeconds +
         ", startupDelaySeconds=" + startupDelaySeconds +
         ", startupIntervalSeconds=" + startupIntervalSeconds +

--- a/SingularityBase/src/main/java/com/hubspot/deploy/HealthcheckOptionsBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/deploy/HealthcheckOptionsBuilder.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import javax.validation.constraints.NotNull;
 
 import com.google.common.base.Optional;
+import com.hubspot.singularity.HealthcheckMethod;
 import com.hubspot.singularity.HealthcheckProtocol;
 
 public class HealthcheckOptionsBuilder {
@@ -14,6 +15,7 @@ public class HealthcheckOptionsBuilder {
   private Optional<Integer> portIndex;
   private Optional<Long> portNumber;
   private Optional<HealthcheckProtocol> protocol;
+  private Optional<HealthcheckMethod> method;
   private Optional<Integer> startupTimeoutSeconds;
   private Optional<Integer> startupDelaySeconds;
   private Optional<Integer> startupIntervalSeconds;
@@ -32,6 +34,7 @@ public class HealthcheckOptionsBuilder {
     this.portIndex = Optional.absent();
     this.portNumber = Optional.absent();
     this.protocol = Optional.absent();
+    this.method = Optional.absent();
     this.startupTimeoutSeconds = Optional.absent();
     this.startupDelaySeconds = Optional.absent();
     this.startupIntervalSeconds = Optional.absent();
@@ -75,6 +78,15 @@ public class HealthcheckOptionsBuilder {
 
   public HealthcheckOptionsBuilder setProtocol(Optional<HealthcheckProtocol> protocol) {
     this.protocol = protocol;
+    return this;
+  }
+
+  public Optional<HealthcheckMethod> getMethod() {
+    return method;
+  }
+
+  public HealthcheckOptionsBuilder setMethod(Optional<HealthcheckMethod> method) {
+    this.method = method;
     return this;
   }
 
@@ -151,7 +163,7 @@ public class HealthcheckOptionsBuilder {
   }
 
   public HealthcheckOptions build() {
-    return new HealthcheckOptions(uri, portIndex, portNumber, protocol, startupTimeoutSeconds, startupDelaySeconds, startupIntervalSeconds, intervalSeconds, responseTimeoutSeconds, maxRetries, failureStatusCodes, healthcheckResultFilePath);
+    return new HealthcheckOptions(uri, portIndex, portNumber, protocol, method, startupTimeoutSeconds, startupDelaySeconds, startupIntervalSeconds, intervalSeconds, responseTimeoutSeconds, maxRetries, failureStatusCodes, healthcheckResultFilePath);
   }
 
   @Override
@@ -167,6 +179,7 @@ public class HealthcheckOptionsBuilder {
         Objects.equals(portIndex, that.portIndex) &&
         Objects.equals(portNumber, that.portNumber) &&
         Objects.equals(protocol, that.protocol) &&
+        Objects.equals(method, that.method) &&
         Objects.equals(startupTimeoutSeconds, that.startupTimeoutSeconds) &&
         Objects.equals(startupDelaySeconds, that.startupDelaySeconds) &&
         Objects.equals(startupIntervalSeconds, that.startupIntervalSeconds) &&
@@ -179,7 +192,7 @@ public class HealthcheckOptionsBuilder {
 
   @Override
   public int hashCode() {
-    return Objects.hash(uri, portIndex, portNumber, protocol, startupTimeoutSeconds, startupDelaySeconds, startupIntervalSeconds, intervalSeconds, responseTimeoutSeconds, maxRetries, failureStatusCodes, healthcheckResultFilePath);
+    return Objects.hash(uri, portIndex, portNumber, protocol, method, startupTimeoutSeconds, startupDelaySeconds, startupIntervalSeconds, intervalSeconds, responseTimeoutSeconds, maxRetries, failureStatusCodes, healthcheckResultFilePath);
   }
 
   @Override
@@ -189,6 +202,7 @@ public class HealthcheckOptionsBuilder {
         ", portIndex=" + portIndex +
         ", portNumber=" + portNumber +
         ", protocol=" + protocol +
+        ", method=" + method +
         ", startupTimeoutSeconds=" + startupTimeoutSeconds +
         ", startupDelaySeconds=" + startupDelaySeconds +
         ", startupIntervalSeconds=" + startupIntervalSeconds +

--- a/SingularityBase/src/main/java/com/hubspot/singularity/HealthcheckMethod.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/HealthcheckMethod.java
@@ -1,0 +1,16 @@
+package com.hubspot.singularity;
+
+public enum  HealthcheckMethod {
+
+  GET("GET"), POST("POST");
+
+  private String method;
+
+  private HealthcheckMethod(String method) {
+    this.method = method;
+  }
+
+  public String getMethod() {
+    return method;
+  }
+}

--- a/SingularityBase/src/main/java/com/hubspot/singularity/HealthcheckProtocol.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/HealthcheckProtocol.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema
 public enum HealthcheckProtocol {
 
-  HTTP("http"), HTTPS("https");
+  HTTP("http"), HTTPS("https"), HTTP2("http"), HTTPS2("https");
 
   private final String protocol;
 

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeploy.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeploy.java
@@ -203,6 +203,7 @@ public class SingularityDeploy {
         healthcheckPortIndex,
         Optional.<Long>absent(),
         healthcheckProtocol,
+        Optional.<HealthcheckMethod>absent(),
         Optional.<Integer>absent(),
         Optional.<Integer>absent(),
         Optional.<Integer>absent(),

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorModule.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorModule.java
@@ -45,8 +45,8 @@ public class SingularityExecutorModule extends AbstractModule {
   @Named(LOCAL_DOWNLOAD_HTTP_CLIENT)
   public AsyncHttpClient providesHttpClient(SingularityExecutorConfiguration configuration) {
     AsyncHttpClientConfig.Builder configBldr = new AsyncHttpClientConfig.Builder();
-    configBldr.setRequestTimeoutInMs((int) configuration.getLocalDownloadServiceTimeoutMillis());
-    configBldr.setIdleConnectionTimeoutInMs((int) configuration.getLocalDownloadServiceTimeoutMillis());
+    configBldr.setRequestTimeout((int) configuration.getLocalDownloadServiceTimeoutMillis());
+    configBldr.setPooledConnectionIdleTimeout((int) configuration.getLocalDownloadServiceTimeoutMillis());
     configBldr.addRequestFilter(new ThrottleRequestFilter(configuration.getLocalDownloadServiceMaxConnections()));
 
     return new AsyncHttpClient(configBldr.build());

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorArtifactFetcher.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorArtifactFetcher.java
@@ -1,6 +1,5 @@
 package com.hubspot.singularity.executor.task;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
@@ -172,8 +171,8 @@ public class SingularityExecutorArtifactFetcher {
           ListenableFuture<Response> future = localDownloadHttpClient.executeRequest(postRequestBldr.build());
 
           futures.add(new FutureHolder(future, System.currentTimeMillis(), s3Artifact));
-        } catch (IOException ioe) {
-          throw Throwables.propagate(ioe);
+        } catch (Throwable t) {
+          throw new RuntimeException(t);
         }
       }
 

--- a/SingularityService/pom.xml
+++ b/SingularityService/pom.xml
@@ -14,6 +14,16 @@
     <basepom.shaded.main-class>com.hubspot.singularity.SingularityService</basepom.shaded.main-class>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>okhttp</artifactId>
+        <version>3.10.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
 
     <dependency>
@@ -134,6 +144,11 @@
     <dependency>
       <groupId>com.ning</groupId>
       <artifactId>async-http-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
     </dependency>
 
     <dependency>

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityAuthModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityAuthModule.java
@@ -29,8 +29,8 @@ public class SingularityAuthModule extends DropwizardAwareModule<SingularityConf
       if (clazz == SingularityAuthenticatorClass.WEBHOOK) {
         AuthConfiguration authConfiguration = getConfiguration().getAuthConfiguration();
         AsyncHttpClientConfig clientConfig = new AsyncHttpClientConfig.Builder()
-            .setConnectionTimeoutInMs(authConfiguration.getWebhookAuthConnectTimeoutMs())
-            .setRequestTimeoutInMs(authConfiguration.getWebhookAuthRequestTimeoutMs())
+            .setConnectTimeout(authConfiguration.getWebhookAuthConnectTimeoutMs())
+            .setRequestTimeout(authConfiguration.getWebhookAuthRequestTimeoutMs())
             .setMaxRequestRetry(authConfiguration.getWebhookAuthRetries())
             .build();
         SingularityAsyncHttpClient webhookAsyncHttpClient = new SingularityAsyncHttpClient(clientConfig);

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityMainModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityMainModule.java
@@ -89,6 +89,7 @@ import io.dropwizard.jetty.HttpConnectorFactory;
 import io.dropwizard.jetty.HttpsConnectorFactory;
 import io.dropwizard.server.DefaultServerFactory;
 import io.dropwizard.server.SimpleServerFactory;
+import okhttp3.OkHttpClient;
 
 
 public class SingularityMainModule implements Module {
@@ -158,6 +159,7 @@ public class SingularityMainModule implements Module {
     binder.bind(MetricRegistry.class).toProvider(DropwizardMetricRegistryProvider.class).in(Scopes.SINGLETON);
 
     binder.bind(AsyncHttpClient.class).to(SingularityAsyncHttpClient.class).in(Scopes.SINGLETON);
+    binder.bind(OkHttpClient.class).to(SingularityOkHttpClient.class).in(Scopes.SINGLETON);
     binder.bind(ServerProvider.class).in(Scopes.SINGLETON);
 
     binder.bind(SingularityDropwizardHealthcheck.class).in(Scopes.SINGLETON);

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityOkHttpClient.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityOkHttpClient.java
@@ -1,0 +1,34 @@
+package com.hubspot.singularity;
+
+import java.io.IOException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.Inject;
+
+import io.dropwizard.lifecycle.Managed;
+import okhttp3.OkHttpClient;
+
+public class SingularityOkHttpClient extends OkHttpClient implements Managed {
+  private static final Logger LOG = LoggerFactory.getLogger(SingularityOkHttpClient.class);
+
+  @Inject
+  SingularityOkHttpClient() {}
+
+  @Override
+  public void start() {}
+
+  @Override
+  public void stop() {
+    dispatcher().executorService().shutdown();
+    connectionPool().evictAll();
+    if (cache() != null) {
+      try {
+        cache().delete();
+      } catch (IOException e) {
+        LOG.warn("Unable to clean up client cache!");
+      }
+    }
+  }
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -251,6 +251,8 @@ public class SingularityConfiguration extends Configuration {
 
   private long reconcileSlavesEveryMinutes = TimeUnit.HOURS.toMinutes(1);
 
+  private long cleanInactiveHostListEveryHours = 24;
+
   @JsonProperty("s3")
   private S3Configuration s3Configuration;
 
@@ -1217,6 +1219,14 @@ public class SingularityConfiguration extends Configuration {
 
   public void setReconcileSlavesEveryMinutes(long reconcileSlavesEveryMinutes) {
     this.reconcileSlavesEveryMinutes = reconcileSlavesEveryMinutes;
+  }
+
+  public long getCleanInactiveHostListEveryHours() {
+    return cleanInactiveHostListEveryHours;
+  }
+
+  public void setCleanInactiveHostListEveryHours(long cleanInactiveHostListEveryHours) {
+    this.cleanInactiveHostListEveryHours = cleanInactiveHostListEveryHours;
   }
 
   public long getCacheTasksForMillis() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -146,6 +146,8 @@ public class SingularityConfiguration extends Configuration {
 
   private long deleteDeadSlavesAfterHours = TimeUnit.DAYS.toHours(7);
 
+  private int maxMachineHistoryEntries = 10;
+
   private long deleteStaleRequestsFromZkWhenNoDatabaseAfterHours = TimeUnit.DAYS.toHours(14);
 
   private Optional<Integer> maxRequestsWithHistoryInZkWhenNoDatabase = Optional.absent();
@@ -688,6 +690,14 @@ public class SingularityConfiguration extends Configuration {
 
   public void setDeleteDeadSlavesAfterHours(long deleteDeadSlavesAfterHours) {
     this.deleteDeadSlavesAfterHours = deleteDeadSlavesAfterHours;
+  }
+
+  public int getMaxMachineHistoryEntries() {
+    return maxMachineHistoryEntries;
+  }
+
+  public void setMaxMachineHistoryEntries(int maxMachineHistoryEntries) {
+    this.maxMachineHistoryEntries = maxMachineHistoryEntries;
   }
 
   public int getListenerThreadpoolSize() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/AbstractMachineManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/AbstractMachineManager.java
@@ -224,7 +224,7 @@ public abstract class AbstractMachineManager<T extends SingularityMachineAbstrac
 
   public void clearOldHistory(String machineId) {
     List<SingularityMachineStateHistoryUpdate> histories = getHistory(machineId);
-    histories.sort(Comparator.comparingLong(SingularityMachineStateHistoryUpdate::getTimestamp));
+    histories.sort(Comparator.comparingLong(SingularityMachineStateHistoryUpdate::getTimestamp).reversed());
     histories.stream()
         .skip(maxHistoryEntries)
         .forEach((history) -> {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/AbstractMachineManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/AbstractMachineManager.java
@@ -120,6 +120,17 @@ public abstract class AbstractMachineManager<T extends SingularityMachineAbstrac
   }
 
   public Optional<T> getObject(String objectId) {
+    Optional<T> maybeCached = getObjectFromLeaderCache(objectId);
+    if(!maybeCached.isPresent()) {
+      return getObjectNoCache(objectId);
+    } else {
+      return maybeCached;
+    }
+  }
+
+  protected abstract Optional<T> getObjectFromLeaderCache(String objectId);
+
+  public Optional<T> getObjectNoCache(String objectId) {
     return getData(getObjectPath(objectId), transcoder);
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/CuratorAsyncManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/CuratorAsyncManager.java
@@ -354,6 +354,7 @@ public abstract class CuratorAsyncManager extends CuratorManager {
     for (String child : getChildren(parentPath)) {
       allPaths.add(ZKPaths.makePath(parentPath, child));
     }
+    LOG.info("All paths {}", allPaths);
 
     final List<T> results = new ArrayList<>();
     final CountDownLatch latch = new CountDownLatch(allPaths.size());

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/CuratorAsyncManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/CuratorAsyncManager.java
@@ -354,7 +354,6 @@ public abstract class CuratorAsyncManager extends CuratorManager {
     for (String child : getChildren(parentPath)) {
       allPaths.add(ZKPaths.makePath(parentPath, child));
     }
-    LOG.info("All paths {}", allPaths);
 
     final List<T> results = new ArrayList<>();
     final CountDownLatch latch = new CountDownLatch(allPaths.size());

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/InactiveSlaveManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/InactiveSlaveManager.java
@@ -4,8 +4,10 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.curator.framework.CuratorFramework;
+import org.apache.zookeeper.data.Stat;
 
 import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.hubspot.singularity.config.SingularityConfiguration;
@@ -39,5 +41,14 @@ public class InactiveSlaveManager extends CuratorManager {
 
   private String pathOf(String host) {
     return String.format("%s/%s", ROOT_PATH, host);
+  }
+
+  public void cleanInactiveSlavesList(long thresholdTime) {
+    for (String host : getInactiveSlaves()) {
+      Optional<Stat> stat = checkExists(pathOf(host));
+      if (stat.isPresent() && stat.get().getMtime() < thresholdTime) {
+        delete(pathOf(host));
+      }
+    }
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/RackManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/RackManager.java
@@ -1,12 +1,13 @@
 package com.hubspot.singularity.data;
 
+import java.util.List;
+
 import org.apache.curator.framework.CuratorFramework;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import com.hubspot.singularity.MachineState;
 import com.hubspot.singularity.SingularityMachineStateHistoryUpdate;
 import com.hubspot.singularity.SingularityRack;
 import com.hubspot.singularity.config.SingularityConfiguration;
@@ -39,7 +40,7 @@ public class RackManager extends AbstractMachineManager<SingularityRack> {
   }
 
   public void activateLeaderCache() {
-    leaderCache.cacheRacks(getObjects());
+    leaderCache.cacheRacks(getObjectsNoCache(getRoot()));
   }
 
   public Optional<SingularityRack> getRack(String rackName) {
@@ -51,21 +52,18 @@ public class RackManager extends AbstractMachineManager<SingularityRack> {
   }
 
   @Override
-  public int getNumActive() {
-    if (leaderCache.active()) {
-      return Math.toIntExact(leaderCache.getRacks().stream().filter(x -> x.getCurrentState().getState().equals(MachineState.ACTIVE)).count());
-    }
-
-    return super.getNumActive();
+  public List<SingularityRack> getObjectsFromLeaderCache() {
+    return leaderCache.getRacks();
   }
 
   @Override
-  public void saveObject(SingularityRack rack) {
-    if (leaderCache.active()) {
-      leaderCache.putRack(rack);
-    }
+  public void saveObjectToLeaderCache(SingularityRack rack) {
+    leaderCache.putRack(rack);
+  }
 
-    super.saveObject(rack);
+  @Override
+  public void deleteFromLeaderCache(String rackId) {
+    leaderCache.removeRack(rackId);
   }
 
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/RequestManager.java
@@ -201,6 +201,10 @@ public class RequestManager extends CuratorAsyncManager {
     return getChildren(NORMAL_PATH_ROOT);
   }
 
+  public long getAllRequestIdsBytes() {
+    return getAllRequestIds().stream().mapToLong(x -> x.getBytes().length).sum();
+  }
+
   public List<String> getRequestIdsWithHistory() {
     return getChildren(HISTORY_PATH_ROOT);
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SandboxManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SandboxManager.java
@@ -22,7 +22,6 @@ import com.hubspot.mesos.json.MesosFileChunkObject;
 import com.hubspot.mesos.json.MesosFileObject;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.ning.http.client.AsyncHttpClient;
-import com.ning.http.client.PerRequestConfig;
 import com.ning.http.client.Response;
 
 @Singleton
@@ -52,13 +51,10 @@ public class SandboxManager {
 
   public Collection<MesosFileObject> browse(String slaveHostname, String fullPath) throws SlaveNotFoundException {
     try {
-      PerRequestConfig timeoutConfig = new PerRequestConfig();
-      timeoutConfig.setRequestTimeoutInMs((int) configuration.getSandboxHttpTimeoutMillis());
-
       Response response = asyncHttpClient
           .prepareGet(String.format("http://%s:5051/files/browse", slaveHostname))
-          .setPerRequestConfig(timeoutConfig)
-          .addQueryParameter("path", fullPath)
+          .setRequestTimeout((int) configuration.getSandboxHttpTimeoutMillis())
+          .addQueryParam("path", fullPath)
           .execute()
           .get();
 
@@ -88,18 +84,16 @@ public class SandboxManager {
   public Optional<MesosFileChunkObject> read(String slaveHostname, String fullPath, Optional<Long> offset, Optional<Long> length) throws SlaveNotFoundException {
     try {
       final AsyncHttpClient.BoundRequestBuilder builder = asyncHttpClient.prepareGet(String.format("http://%s:5051/files/read", slaveHostname))
-          .addQueryParameter("path", fullPath);
+          .addQueryParam("path", fullPath);
 
-      PerRequestConfig timeoutConfig = new PerRequestConfig();
-      timeoutConfig.setRequestTimeoutInMs((int) configuration.getSandboxHttpTimeoutMillis());
-      builder.setPerRequestConfig(timeoutConfig);
+      builder.setRequestTimeout((int) configuration.getSandboxHttpTimeoutMillis());
 
       if (offset.isPresent()) {
-        builder.addQueryParameter("offset", offset.get().toString());
+        builder.addQueryParam("offset", offset.get().toString());
       }
 
       if (length.isPresent()) {
-        builder.addQueryParameter("length", length.get().toString());
+        builder.addQueryParam("length", length.get().toString());
       }
 
       final Response response = builder.execute().get();

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SlaveManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SlaveManager.java
@@ -1,12 +1,13 @@
 package com.hubspot.singularity.data;
 
+import java.util.List;
+
 import org.apache.curator.framework.CuratorFramework;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import com.hubspot.singularity.MachineState;
 import com.hubspot.singularity.SingularityMachineStateHistoryUpdate;
 import com.hubspot.singularity.SingularitySlave;
 import com.hubspot.singularity.config.SingularityConfiguration;
@@ -38,7 +39,7 @@ public class SlaveManager extends AbstractMachineManager<SingularitySlave> {
   }
 
   public void activateLeaderCache() {
-    leaderCache.cacheSlaves(getObjects());
+    leaderCache.cacheSlaves(getObjectsNoCache(getRoot()));
   }
 
   public Optional<SingularitySlave> getSlave(String slaveId) {
@@ -50,23 +51,17 @@ public class SlaveManager extends AbstractMachineManager<SingularitySlave> {
   }
 
   @Override
-  public int getNumActive() {
-    if (leaderCache.active()) {
-      return Math.toIntExact(leaderCache.getSlaves().stream().filter(x -> x.getCurrentState().getState().equals(MachineState.ACTIVE)).count());
-    }
-
-    return super.getNumActive();
+  public List<SingularitySlave> getObjectsFromLeaderCache() {
+    return leaderCache.getSlaves();
   }
 
   @Override
-  public void saveObject(SingularitySlave slave) {
-    if (leaderCache.active()) {
-      leaderCache.putSlave(slave);
-    }
-
-    super.saveObject(slave);
+  public void saveObjectToLeaderCache(SingularitySlave singularitySlave) {
+    leaderCache.putSlave(singularitySlave);
   }
 
-
-
+  @Override
+  public void deleteFromLeaderCache(String slaveId) {
+    leaderCache.removeSlave(slaveId);
+  }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SlaveManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SlaveManager.java
@@ -3,6 +3,8 @@ package com.hubspot.singularity.data;
 import java.util.List;
 
 import org.apache.curator.framework.CuratorFramework;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Optional;
@@ -17,6 +19,7 @@ import com.hubspot.singularity.scheduler.SingularityLeaderCache;
 
 @Singleton
 public class SlaveManager extends AbstractMachineManager<SingularitySlave> {
+  private static final Logger LOG = LoggerFactory.getLogger(SlaveManager.class);
 
   private static final String SLAVE_ROOT = "/slaves";
   private final SingularityLeaderCache leaderCache;
@@ -42,26 +45,38 @@ public class SlaveManager extends AbstractMachineManager<SingularitySlave> {
     leaderCache.cacheSlaves(getObjectsNoCache(getRoot()));
   }
 
-  public Optional<SingularitySlave> getSlave(String slaveId) {
+  @Override
+  public Optional<SingularitySlave> getObjectFromLeaderCache(String slaveId) {
     if (leaderCache.active()) {
       return leaderCache.getSlave(slaveId);
     }
 
-    return getObject(slaveId);
+    return Optional.absent(); // fallback to zk
   }
 
   @Override
   public List<SingularitySlave> getObjectsFromLeaderCache() {
-    return leaderCache.getSlaves();
+    if (leaderCache.active()) {
+      return leaderCache.getSlaves();
+    }
+    return null; // fallback to zk
   }
 
   @Override
   public void saveObjectToLeaderCache(SingularitySlave singularitySlave) {
-    leaderCache.putSlave(singularitySlave);
+    if (leaderCache.active()) {
+      leaderCache.putSlave(singularitySlave);
+    } else {
+      LOG.info("Asked to save slaves to leader cache when not active");
+    }
   }
 
   @Override
   public void deleteFromLeaderCache(String slaveId) {
-    leaderCache.removeSlave(slaveId);
+    if (leaderCache.active()) {
+      leaderCache.removeSlave(slaveId);
+    } else {
+      LOG.info("Asked to remove slave from leader cache when not active");
+    }
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -1161,4 +1161,20 @@ public class TaskManager extends CuratorAsyncManager {
   public SingularityDeleteResult deleteRequestId(String requestId) {
     return delete(getRequestPath(requestId));
   }
+
+  public long getTaskStatusBytes() {
+    return countBytes(getChildren(LAST_ACTIVE_TASK_STATUSES_PATH_ROOT));
+  }
+
+  public long getActiveTaskIdBytes() {
+    return countBytes(getChildren(ACTIVE_PATH_ROOT));
+  }
+
+  public long getTaskHistoryIdBytes() {
+    return countBytes(getChildren(HISTORY_PATH_ROOT));
+  }
+
+  private long countBytes(List<String> list) {
+    return list.stream().mapToLong(x -> x.getBytes().length).sum();
+  }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -1166,10 +1166,6 @@ public class TaskManager extends CuratorAsyncManager {
     return countBytes(getChildren(LAST_ACTIVE_TASK_STATUSES_PATH_ROOT));
   }
 
-  public long getActiveTaskIdBytes() {
-    return countBytes(getChildren(ACTIVE_PATH_ROOT));
-  }
-
   public long getTaskHistoryIdBytes() {
     return countBytes(getChildren(HISTORY_PATH_ROOT));
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -69,7 +69,6 @@ public class TaskManager extends CuratorAsyncManager {
 
   private static final String TASKS_ROOT = "/tasks";
 
-  private static final String ACTIVE_PATH_ROOT = TASKS_ROOT + "/active";
   private static final String LAST_ACTIVE_TASK_STATUSES_PATH_ROOT = TASKS_ROOT + "/statuses";
   private static final String PENDING_PATH_ROOT = TASKS_ROOT + "/scheduled";
   private static final String CLEANUP_PATH_ROOT = TASKS_ROOT + "/cleanup";
@@ -158,7 +157,7 @@ public class TaskManager extends CuratorAsyncManager {
   // since we can't use creatingParentsIfNeeded in transactions
   public void createRequiredParents() {
     create(HISTORY_PATH_ROOT);
-    create(ACTIVE_PATH_ROOT);
+    create(LAST_ACTIVE_TASK_STATUSES_PATH_ROOT);
   }
 
   private String getLastHealthcheckPath(SingularityTaskId taskId) {
@@ -182,7 +181,11 @@ public class TaskManager extends CuratorAsyncManager {
   }
 
   private String getLastActiveTaskStatusPath(SingularityTaskId taskId) {
-    return ZKPaths.makePath(LAST_ACTIVE_TASK_STATUSES_PATH_ROOT, taskId.getId());
+    return ZKPaths.makePath(LAST_ACTIVE_TASK_STATUSES_PATH_ROOT, taskId.getRequestId(), taskId.getId());
+  }
+
+  private String getLastActiveTaskParent(String requestId) {
+    return ZKPaths.makePath(LAST_ACTIVE_TASK_STATUSES_PATH_ROOT, requestId);
   }
 
   private String getHealthcheckPath(SingularityTaskHealthcheckResult healthcheck) {
@@ -253,12 +256,12 @@ public class TaskManager extends CuratorAsyncManager {
     return ZKPaths.makePath(getRequestPath(taskId.getRequestId()), taskId.getId());
   }
 
-  private String getActivePath(String taskId) {
-    return ZKPaths.makePath(ACTIVE_PATH_ROOT, taskId);
+  private String getPendingPath(SingularityPendingTaskId pendingTaskId) {
+    return ZKPaths.makePath(PENDING_PATH_ROOT, pendingTaskId.getRequestId(), pendingTaskId.getId());
   }
 
-  private String getPendingPath(SingularityPendingTaskId pendingTaskId) {
-    return ZKPaths.makePath(PENDING_PATH_ROOT, pendingTaskId.getId());
+  private String getPendingForRequestPath(String requestId) {
+    return ZKPaths.makePath(PENDING_PATH_ROOT, requestId);
   }
 
   private String getPendingTasksToDeletePath(SingularityPendingTaskId pendingTaskId) { return ZKPaths.makePath(PENDING_TASKS_TO_DELETE_PATH_ROOT, pendingTaskId.getId()); }
@@ -287,14 +290,22 @@ public class TaskManager extends CuratorAsyncManager {
     if (leaderCache.active()) {
       return leaderCache.getNumActiveTasks();
     }
-    return getNumChildren(ACTIVE_PATH_ROOT);
+    int total = 0;
+    for (String requestId : getChildren(LAST_ACTIVE_TASK_STATUSES_PATH_ROOT)) {
+      total += getNumChildren(getLastActiveTaskParent(requestId));
+    }
+    return total;
   }
 
   public int getNumScheduledTasks() {
     if (leaderCache.active()) {
       return leaderCache.getNumPendingTasks();
     }
-    return getNumChildren(PENDING_PATH_ROOT);
+    int total = 0;
+    for (String requestId : getChildren(PENDING_PATH_ROOT)) {
+      total += getNumChildren(getPendingForRequestPath(requestId));
+    }
+    return total;
   }
 
   public void saveLoadBalancerState(SingularityTaskId taskId, LoadBalancerRequestType requestType, SingularityLoadBalancerUpdate lbUpdate) {
@@ -370,7 +381,14 @@ public class TaskManager extends CuratorAsyncManager {
     if (leaderCache.active()) {
       return leaderCache.getActiveTaskIdsAsStrings();
     }
-    return getChildren(ACTIVE_PATH_ROOT);
+
+    List<String> results = new ArrayList<>();
+
+    for (String requestId : getChildren(LAST_ACTIVE_TASK_STATUSES_PATH_ROOT)) {
+      results.addAll(getChildren(getLastActiveTaskParent(requestId)));
+    }
+
+    return results;
   }
 
   public List<SingularityTaskId> getActiveTaskIds() {
@@ -386,7 +404,7 @@ public class TaskManager extends CuratorAsyncManager {
       return webCache.getActiveTaskIds();
     }
 
-    return getTaskIds(ACTIVE_PATH_ROOT);
+    return getAsyncNestedChildIdsAsList(LAST_ACTIVE_TASK_STATUSES_PATH_ROOT, LAST_ACTIVE_TASK_STATUSES_PATH_ROOT, taskIdTranscoder);
   }
 
   public List<SingularityTaskId> getCleanupTaskIds() {
@@ -609,12 +627,12 @@ public class TaskManager extends CuratorAsyncManager {
     return delete(getUpdatePath(taskId, state));
   }
 
-  public boolean isActiveTask(String taskId) {
+  public boolean isActiveTask(SingularityTaskId taskId) {
     if (leaderCache.active()) {
       return leaderCache.isActiveTask(taskId);
     }
 
-    return exists(getActivePath(taskId));
+    return exists(getLastActiveTaskStatusPath(taskId));
   }
 
   public SingularityCreateResult markUnhealthyKill(SingularityTaskId taskId) {
@@ -669,7 +687,7 @@ public class TaskManager extends CuratorAsyncManager {
     final List<String> paths = Lists.newArrayListWithCapacity(taskIds.size());
 
     for (SingularityTaskId taskId : taskIds) {
-      paths.add(getActivePath(taskId.getId()));
+      paths.add(getLastActiveTaskStatusPath(taskId));
     }
 
     return exists("filterActiveTaskIds", paths, taskIdTranscoder);
@@ -695,7 +713,7 @@ public class TaskManager extends CuratorAsyncManager {
     final Map<String, SingularityTaskId> pathsMap = Maps.newHashMap();
 
     for (SingularityTaskId taskId : taskIds) {
-      pathsMap.put(getActivePath(taskId.getId()), taskId);
+      pathsMap.put(getLastActiveTaskStatusPath(taskId), taskId);
     }
 
     return notExists("filterInactiveTaskIds", pathsMap);
@@ -830,14 +848,14 @@ public class TaskManager extends CuratorAsyncManager {
   public void activateLeaderCache() {
     leaderCache.cachePendingTasks(fetchPendingTasks());
     leaderCache.cachePendingTasksToDelete(getPendingTasksMarkedForDeletion());
-    leaderCache.cacheActiveTaskIds(getTaskIds(ACTIVE_PATH_ROOT));
+    leaderCache.cacheActiveTaskIds(getActiveTaskIds(false));
     leaderCache.cacheCleanupTasks(fetchCleanupTasks());
     leaderCache.cacheKilledTasks(fetchKilledTaskIdRecords());
     leaderCache.cacheTaskHistoryUpdates(getAllTaskHistoryUpdates());
   }
 
   private List<SingularityPendingTask> fetchPendingTasks() {
-    return getAsyncChildren(PENDING_PATH_ROOT, pendingTaskTranscoder);
+    return getAsyncNestedChildrenAsList(PENDING_PATH_ROOT, getChildren(PENDING_PATH_ROOT), pendingTaskTranscoder);
   }
 
   public List<SingularityPendingTaskId> getPendingTaskIds() {
@@ -853,22 +871,26 @@ public class TaskManager extends CuratorAsyncManager {
       return webCache.getPendingTaskIds();
     }
 
-    return getChildrenAsIds(PENDING_PATH_ROOT, pendingTaskIdTranscoder);
+    return getAsyncNestedChildIdsAsList(PENDING_PATH_ROOT, PENDING_PATH_ROOT, pendingTaskIdTranscoder);
   }
 
   public List<SingularityPendingTaskId> getPendingTaskIdsForRequest(final String requestId) {
-    List<SingularityPendingTaskId> pendingTaskIds = getPendingTaskIds();
-    return pendingTaskIds.stream()
-        .filter(pendingTaskId -> pendingTaskId.getRequestId().equals(requestId))
-        .collect(Collectors.collectingAndThen(Collectors.toList(), ImmutableList::copyOf));
+    return getChildrenAsIds(getPendingForRequestPath(requestId), pendingTaskIdTranscoder);
   }
 
-  public List<SingularityPendingTask> getPendingTasksForRequest(final String requestId) {
-    return getAsync(
-        PENDING_PATH_ROOT,
-        getPendingTaskIdsForRequest(requestId).stream().map(this::getPendingPath).collect(Collectors.toList()),
-        pendingTaskTranscoder
-    );
+  public List<SingularityPendingTask> getPendingTasksForRequest(final String requestId, boolean useWebCache) {
+    if (leaderCache.active()) {
+      return leaderCache.getPendingTasks().stream()
+          .filter((p) -> p.getPendingTaskId().getRequestId().equals(requestId))
+          .collect(Collectors.toList());
+    }
+
+    if (useWebCache && webCache.useCachedPendingTasks()) {
+      return webCache.getPendingTasks().stream()
+          .filter((p) -> p.getPendingTaskId().getRequestId().equals(requestId))
+          .collect(Collectors.toList());
+    }
+    return getAsyncChildren(getPendingForRequestPath(requestId), pendingTaskTranscoder);
   }
 
   public List<SingularityPendingTask> getPendingTasks() {
@@ -935,7 +957,7 @@ public class TaskManager extends CuratorAsyncManager {
 
       CuratorTransactionFinal transaction = curator.inTransaction().create().forPath(path, taskTranscoder.toBytes(task)).and();
 
-      transaction.create().forPath(getActivePath(task.getTaskId().getId())).and().commit();
+      transaction.create().forPath(getLastActiveTaskStatusPath(task.getTaskId())).and().commit();
 
       leaderCache.putActiveTask(task);
       taskCache.set(path, task);
@@ -991,6 +1013,7 @@ public class TaskManager extends CuratorAsyncManager {
 
   @Timed
   public SingularityDeleteResult deleteLastActiveTaskStatus(SingularityTaskId taskId) {
+    leaderCache.deleteActiveTaskId(taskId);
     return delete(getLastActiveTaskStatusPath(taskId));
   }
 
@@ -1081,11 +1104,6 @@ public class TaskManager extends CuratorAsyncManager {
     }
 
     return result;
-  }
-
-  public void deleteActiveTask(String taskId) {
-    leaderCache.deleteActiveTaskId(taskId);
-    delete(getActivePath(taskId));
   }
 
   public void deletePendingTask(SingularityPendingTaskId pendingTaskId) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -848,7 +848,12 @@ public class TaskManager extends CuratorAsyncManager {
   }
 
   private List<SingularityPendingTask> fetchPendingTasks() {
-    return getAsyncNestedChildrenAsList(PENDING_PATH_ROOT, getChildren(PENDING_PATH_ROOT), pendingTaskTranscoder);
+    return getAsyncNestedChildrenAsList(
+        PENDING_PATH_ROOT,
+        getChildren(PENDING_PATH_ROOT).stream()
+            .map((p) -> ZKPaths.makePath(PENDING_PATH_ROOT, p))
+            .collect(Collectors.toList()),
+        pendingTaskTranscoder);
   }
 
   public List<SingularityPendingTaskId> getPendingTaskIds() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/CleanOldNodesMigration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/CleanOldNodesMigration.java
@@ -37,7 +37,7 @@ public class CleanOldNodesMigration extends ZkDataMigration {
       for (SingularityRequestGroup requestGroup : requestGroupManager.getRequestGroups(false)) {
         List<String> ids = requestGroup.getRequestIds()
             .stream()
-            .filter((id) -> allIds.contains(id))
+            .filter(allIds::contains)
             .collect(Collectors.toList());
         if (ids.isEmpty()) {
           requestGroupManager.deleteRequestGroup(requestGroup.getId());

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/CleanOldNodesMigration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/CleanOldNodesMigration.java
@@ -1,0 +1,32 @@
+package com.hubspot.singularity.data.zkmigrations;
+
+import java.util.List;
+
+import org.apache.curator.framework.CuratorFramework;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+
+public class CleanOldNodesMigration extends ZkDataMigration {
+  private final CuratorFramework curatorFramework;
+
+  @Inject
+  public CleanOldNodesMigration(CuratorFramework curatorFramework) {
+    super(12);
+    this.curatorFramework = curatorFramework;
+  }
+
+  @Override
+  public void applyMigration() {
+    List<String> toClean = ImmutableList.of("/disasters/previous-stats", "/disasters/stats", "/disasters/task-credits", "/offer-state");
+    try {
+      for (String node : toClean) {
+        if (curatorFramework.checkExists().forPath(node) != null) {
+          curatorFramework.delete().deletingChildrenIfNeeded().forPath(node);
+        }
+      }
+    } catch (Throwable t) {
+      throw new RuntimeException(t);
+    }
+  }
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/CleanOldNodesMigration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/CleanOldNodesMigration.java
@@ -1,19 +1,27 @@
 package com.hubspot.singularity.data.zkmigrations;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.curator.framework.CuratorFramework;
 
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
+import com.hubspot.singularity.SingularityRequestGroup;
+import com.hubspot.singularity.data.RequestGroupManager;
+import com.hubspot.singularity.data.RequestManager;
 
 public class CleanOldNodesMigration extends ZkDataMigration {
   private final CuratorFramework curatorFramework;
+  private final RequestGroupManager requestGroupManager;
+  private final RequestManager requestManager;
 
   @Inject
-  public CleanOldNodesMigration(CuratorFramework curatorFramework) {
+  public CleanOldNodesMigration(CuratorFramework curatorFramework, RequestGroupManager requestGroupManager, RequestManager requestManager) {
     super(12);
     this.curatorFramework = curatorFramework;
+    this.requestGroupManager = requestGroupManager;
+    this.requestManager = requestManager;
   }
 
   @Override
@@ -23,6 +31,24 @@ public class CleanOldNodesMigration extends ZkDataMigration {
       for (String node : toClean) {
         if (curatorFramework.checkExists().forPath(node) != null) {
           curatorFramework.delete().deletingChildrenIfNeeded().forPath(node);
+        }
+      }
+      List<String> allIds = requestManager.getAllRequestIds();
+      for (SingularityRequestGroup requestGroup : requestGroupManager.getRequestGroups(false)) {
+        List<String> ids = requestGroup.getRequestIds()
+            .stream()
+            .filter((id) -> allIds.contains(id))
+            .collect(Collectors.toList());
+        if (ids.isEmpty()) {
+          requestGroupManager.deleteRequestGroup(requestGroup.getId());
+        } else {
+          if (!ids.equals(requestGroup.getRequestIds())) {
+            requestGroupManager.saveRequestGroup(new SingularityRequestGroup(
+                requestGroup.getId(),
+                ids,
+                requestGroup.getMetadata()
+            ));
+          }
         }
       }
     } catch (Throwable t) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/NamespaceActiveTasksMigration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/NamespaceActiveTasksMigration.java
@@ -24,8 +24,6 @@ public class NamespaceActiveTasksMigration extends ZkDataMigration {
   public void applyMigration() {
     try {
       if (curatorFramework.checkExists().forPath(ACTIVE_TASKS_ROOT) != null) {
-        curatorFramework.delete().deletingChildrenIfNeeded().forPath(ACTIVE_TASKS_ROOT);
-
         List<String> currentActive = curatorFramework.getChildren().forPath(ACTIVE_STATUSES_ROOT);
         for (String taskIdString : currentActive) {
           SingularityTaskId taskId = SingularityTaskId.valueOf(taskIdString);
@@ -39,6 +37,8 @@ public class NamespaceActiveTasksMigration extends ZkDataMigration {
           }
           curatorFramework.delete().forPath(oldPath);
         }
+
+        curatorFramework.delete().deletingChildrenIfNeeded().forPath(ACTIVE_TASKS_ROOT);
       }
     } catch (Throwable t) {
       throw new RuntimeException(t);

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/NamespaceActiveTasksMigration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/NamespaceActiveTasksMigration.java
@@ -4,11 +4,16 @@ import java.util.List;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.utils.ZKPaths;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.inject.Inject;
+import com.hubspot.singularity.InvalidSingularityTaskIdException;
 import com.hubspot.singularity.SingularityTaskId;
 
 public class NamespaceActiveTasksMigration extends ZkDataMigration {
+  private static final Logger LOG = LoggerFactory.getLogger(NamespaceActiveTasksMigration.class);
+
   private static final String ACTIVE_TASKS_ROOT = "/tasks/active";
   private static final String ACTIVE_STATUSES_ROOT = "/tasks/statuses";
 
@@ -26,16 +31,20 @@ public class NamespaceActiveTasksMigration extends ZkDataMigration {
       if (curatorFramework.checkExists().forPath(ACTIVE_TASKS_ROOT) != null) {
         List<String> currentActive = curatorFramework.getChildren().forPath(ACTIVE_STATUSES_ROOT);
         for (String taskIdString : currentActive) {
-          SingularityTaskId taskId = SingularityTaskId.valueOf(taskIdString);
-          String oldPath = ZKPaths.makePath(ACTIVE_STATUSES_ROOT, taskIdString);
-          byte[] oldData = curatorFramework.getData().forPath(oldPath);
-          String newPath = ZKPaths.makePath(ACTIVE_STATUSES_ROOT, taskId.getRequestId(), taskIdString);
-          if (curatorFramework.checkExists().forPath(newPath) != null) {
-            curatorFramework.setData().forPath(newPath, oldData);
-          } else {
-            curatorFramework.create().creatingParentsIfNeeded().forPath(newPath, oldData);
+          try {
+            SingularityTaskId taskId = SingularityTaskId.valueOf(taskIdString);
+            String oldPath = ZKPaths.makePath(ACTIVE_STATUSES_ROOT, taskIdString);
+            byte[] oldData = curatorFramework.getData().forPath(oldPath);
+            String newPath = ZKPaths.makePath(ACTIVE_STATUSES_ROOT, taskId.getRequestId(), taskIdString);
+            if (curatorFramework.checkExists().forPath(newPath) != null) {
+              curatorFramework.setData().forPath(newPath, oldData);
+            } else {
+              curatorFramework.create().creatingParentsIfNeeded().forPath(newPath, oldData);
+            }
+            curatorFramework.delete().forPath(oldPath);
+          } catch (InvalidSingularityTaskIdException e) {
+            LOG.warn("Found invalid task id {}. This is likely because the migration did not finish successfully on a previous run. Will continue to migrate additional nodes", taskIdString);
           }
-          curatorFramework.delete().forPath(oldPath);
         }
 
         curatorFramework.delete().deletingChildrenIfNeeded().forPath(ACTIVE_TASKS_ROOT);

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/NamespaceActiveTasksMigration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/NamespaceActiveTasksMigration.java
@@ -1,0 +1,47 @@
+package com.hubspot.singularity.data.zkmigrations;
+
+import java.util.List;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.utils.ZKPaths;
+
+import com.google.inject.Inject;
+import com.hubspot.singularity.SingularityTaskId;
+
+public class NamespaceActiveTasksMigration extends ZkDataMigration {
+  private static final String ACTIVE_TASKS_ROOT = "/tasks/active";
+  private static final String ACTIVE_STATUSES_ROOT = "/tasks/statuses";
+
+  private final CuratorFramework curatorFramework;
+
+  @Inject
+  public NamespaceActiveTasksMigration(CuratorFramework curatorFramework) {
+    super(14);
+    this.curatorFramework = curatorFramework;
+  }
+
+  @Override
+  public void applyMigration() {
+    try {
+      if (curatorFramework.checkExists().forPath(ACTIVE_TASKS_ROOT) != null) {
+        curatorFramework.delete().deletingChildrenIfNeeded().forPath(ACTIVE_TASKS_ROOT);
+
+        List<String> currentActive = curatorFramework.getChildren().forPath(ACTIVE_STATUSES_ROOT);
+        for (String taskIdString : currentActive) {
+          SingularityTaskId taskId = SingularityTaskId.valueOf(taskIdString);
+          String oldPath = ZKPaths.makePath(ACTIVE_STATUSES_ROOT, taskIdString);
+          byte[] oldData = curatorFramework.getData().forPath(oldPath);
+          String newPath = ZKPaths.makePath(ACTIVE_STATUSES_ROOT, taskId.getRequestId(), taskIdString);
+          if (curatorFramework.checkExists().forPath(newPath) != null) {
+            curatorFramework.setData().forPath(newPath, oldData);
+          } else {
+            curatorFramework.create().creatingParentsIfNeeded().forPath(newPath, oldData);
+          }
+          curatorFramework.delete().forPath(oldPath);
+        }
+      }
+    } catch (Throwable t) {
+      throw new RuntimeException(t);
+    }
+  }
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/NamespacePendingTasksMigration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/NamespacePendingTasksMigration.java
@@ -1,0 +1,44 @@
+package com.hubspot.singularity.data.zkmigrations;
+
+import java.util.List;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.utils.ZKPaths;
+
+import com.google.inject.Inject;
+import com.hubspot.singularity.SingularityPendingTaskId;
+
+public class NamespacePendingTasksMigration extends ZkDataMigration {
+  private static final String PENDING_TASK_ROOT = "/tasks/scheduled";
+
+  private final CuratorFramework curatorFramework;
+
+  @Inject
+  public NamespacePendingTasksMigration(CuratorFramework curatorFramework) {
+    super(13);
+    this.curatorFramework = curatorFramework;
+  }
+
+  @Override
+  public void applyMigration() {
+    try {
+      if (curatorFramework.checkExists().forPath(PENDING_TASK_ROOT) != null) {
+        List<String> currentPendingTasks = curatorFramework.getChildren().forPath(PENDING_TASK_ROOT);
+        for (String taskIdString : currentPendingTasks) {
+          SingularityPendingTaskId pendingTaskId = SingularityPendingTaskId.valueOf(taskIdString);
+          String oldPath = ZKPaths.makePath(PENDING_TASK_ROOT, taskIdString);
+          byte[] oldData = curatorFramework.getData().forPath(oldPath);
+          String newPath = ZKPaths.makePath(PENDING_TASK_ROOT, pendingTaskId.getRequestId(), taskIdString);
+          if (curatorFramework.checkExists().forPath(newPath) != null) {
+            curatorFramework.setData().forPath(newPath, oldData);
+          } else {
+            curatorFramework.create().creatingParentsIfNeeded().forPath(newPath, oldData);
+          }
+          curatorFramework.delete().forPath(oldPath);
+        }
+      }
+    } catch (Throwable t) {
+      throw new RuntimeException(t);
+    }
+  }
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/NamespacePendingTasksMigration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/NamespacePendingTasksMigration.java
@@ -4,11 +4,16 @@ import java.util.List;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.utils.ZKPaths;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.inject.Inject;
+import com.hubspot.singularity.InvalidSingularityTaskIdException;
 import com.hubspot.singularity.SingularityPendingTaskId;
 
 public class NamespacePendingTasksMigration extends ZkDataMigration {
+  private static final Logger LOG = LoggerFactory.getLogger(NamespacePendingTasksMigration.class);
+
   private static final String PENDING_TASK_ROOT = "/tasks/scheduled";
 
   private final CuratorFramework curatorFramework;
@@ -25,16 +30,20 @@ public class NamespacePendingTasksMigration extends ZkDataMigration {
       if (curatorFramework.checkExists().forPath(PENDING_TASK_ROOT) != null) {
         List<String> currentPendingTasks = curatorFramework.getChildren().forPath(PENDING_TASK_ROOT);
         for (String taskIdString : currentPendingTasks) {
-          SingularityPendingTaskId pendingTaskId = SingularityPendingTaskId.valueOf(taskIdString);
-          String oldPath = ZKPaths.makePath(PENDING_TASK_ROOT, taskIdString);
-          byte[] oldData = curatorFramework.getData().forPath(oldPath);
-          String newPath = ZKPaths.makePath(PENDING_TASK_ROOT, pendingTaskId.getRequestId(), taskIdString);
-          if (curatorFramework.checkExists().forPath(newPath) != null) {
-            curatorFramework.setData().forPath(newPath, oldData);
-          } else {
-            curatorFramework.create().creatingParentsIfNeeded().forPath(newPath, oldData);
+          try {
+            SingularityPendingTaskId pendingTaskId = SingularityPendingTaskId.valueOf(taskIdString);
+            String oldPath = ZKPaths.makePath(PENDING_TASK_ROOT, taskIdString);
+            byte[] oldData = curatorFramework.getData().forPath(oldPath);
+            String newPath = ZKPaths.makePath(PENDING_TASK_ROOT, pendingTaskId.getRequestId(), taskIdString);
+            if (curatorFramework.checkExists().forPath(newPath) != null) {
+              curatorFramework.setData().forPath(newPath, oldData);
+            } else {
+              curatorFramework.create().creatingParentsIfNeeded().forPath(newPath, oldData);
+            }
+            curatorFramework.delete().forPath(oldPath);
+          } catch (InvalidSingularityTaskIdException e) {
+            LOG.warn("Found invalid task id {}, will skip", taskIdString);
           }
-          curatorFramework.delete().forPath(oldPath);
         }
       }
     } catch (Throwable t) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/SingularityZkMigrationsModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/SingularityZkMigrationsModule.java
@@ -28,6 +28,9 @@ public class SingularityZkMigrationsModule implements Module {
     dataMigrations.addBinding().to(SingularityRequestTypeMigration.class);
     dataMigrations.addBinding().to(PendingRequestDataMigration.class);
     dataMigrations.addBinding().to(SingularityPendingRequestWithRunIdMigration.class);
+    dataMigrations.addBinding().to(CleanOldNodesMigration.class);
+    dataMigrations.addBinding().to(NamespacePendingTasksMigration.class);
+    dataMigrations.addBinding().to(NamespaceActiveTasksMigration.class);
   }
 
   @Provides

--- a/SingularityService/src/main/java/com/hubspot/singularity/helpers/RebalancingHelper.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/helpers/RebalancingHelper.java
@@ -70,7 +70,7 @@ public class RebalancingHelper {
     Map<String, Map<String, Set<SingularityTaskId>>> attributeTaskMap = new HashMap<>();
 
     for (SingularityTaskId taskId : remainingActiveTasks) {
-      SingularitySlave slave = slaveManager.getSlave(taskManager.getTask(taskId).get().getMesosTask().getSlaveId().getValue()).get();
+      SingularitySlave slave = slaveManager.getObject(taskManager.getTask(taskId).get().getMesosTask().getSlaveId().getValue()).get();
       for (Entry<String, String> entry : slave.getAttributes().entrySet()) {
         attributeTaskMap
             .computeIfAbsent(entry.getKey(), key -> new HashMap<>())

--- a/SingularityService/src/main/java/com/hubspot/singularity/hooks/LoadBalancerClientImpl.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/hooks/LoadBalancerClientImpl.java
@@ -8,10 +8,10 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
@@ -98,7 +98,7 @@ public class LoadBalancerClientImpl implements LoadBalancerClient {
 
   private void addAllQueryParams(BoundRequestBuilder boundRequestBuilder, Map<String, String> queryParams) {
     for (Map.Entry<String, String> entry : queryParams.entrySet()) {
-      boundRequestBuilder.addQueryParameter(entry.getKey(), entry.getValue());
+      boundRequestBuilder.addQueryParam(entry.getKey(), entry.getValue());
     }
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/hooks/SingularityWebhookSender.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/hooks/SingularityWebhookSender.java
@@ -1,6 +1,5 @@
 package com.hubspot.singularity.hooks;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -209,13 +208,13 @@ public class SingularityWebhookSender {
     try {
       handler.setCompletableFuture(webhookFuture);
       postRequest.execute(handler);
-    } catch (IOException e) {
-      LOG.warn("Couldn't execute webhook to {}", uri, e);
+    } catch (Throwable t) {
+      LOG.warn("Couldn't execute webhook to {}", uri, t);
 
       if (handler.shouldDeleteUpdateDueToQueueAboveCapacity()) {
         handler.deleteWebhookUpdate();
       }
-      webhookFuture.completeExceptionally(e);
+      webhookFuture.completeExceptionally(t);
     }
     return webhookFuture;
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
@@ -153,6 +153,9 @@ public class SingularityMesosSchedulerImpl extends SingularityMesosScheduler {
         heartbeatIntervalSeconds = Optional.of(advertisedHeartbeatIntervalSeconds);
       }
 
+      // Should be called before activation of leader cache or cache could be left empty
+      startup.checkMigrations();
+
       leaderCacheCoordinator.activateLeaderCache();
       MasterInfo newMasterInfo = subscribed.getMasterInfo();
       masterInfo.set(newMasterInfo);

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosStatusUpdateHandler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosStatusUpdateHandler.java
@@ -258,9 +258,7 @@ public class SingularityMesosStatusUpdateHandler {
       }
     }
 
-    final boolean isActiveTask = taskManager.isActiveTask(taskId);
-
-    if (isActiveTask && !taskState.isDone()) {
+    if (!taskState.isDone()) {
       if (task.isPresent()) {
         final Optional<SingularityPendingDeploy> pendingDeploy = deployManager.getPendingDeploy(taskIdObj.getRequestId());
 
@@ -298,19 +296,19 @@ public class SingularityMesosStatusUpdateHandler {
 
       taskManager.deleteKilledRecord(taskIdObj);
 
-      handleCompletedTaskState(status, taskIdObj, taskState, taskHistoryUpdateCreateResult, task, timestamp, isActiveTask);
+      handleCompletedTaskState(status, taskIdObj, taskState, taskHistoryUpdateCreateResult, task, timestamp);
     }
 
     saveNewTaskStatusHolder(taskIdObj, newTaskStatusHolder, taskState);
   }
 
   private synchronized void handleCompletedTaskState(TaskStatus status, SingularityTaskId taskIdObj, ExtendedTaskState taskState,
-      SingularityCreateResult taskHistoryUpdateCreateResult, Optional<SingularityTask> task, long timestamp, boolean isActiveTask) {
+      SingularityCreateResult taskHistoryUpdateCreateResult, Optional<SingularityTask> task, long timestamp) {
     // Method synchronized to prevent race condition where two tasks complete at the same time but the leader cache holding the state
     // doesn't get updated between each task completion. If this were to happen, then slaves would never transition from DECOMMISSIONING to
     // DECOMMISSIONED because each task state check thinks the other task is still running.
     slaveAndRackManager.checkStateAfterFinishedTask(taskIdObj, status.getAgentId().getValue(), leaderCache);
-    scheduler.handleCompletedTask(task, taskIdObj, isActiveTask, timestamp, taskState, taskHistoryUpdateCreateResult, status);
+    scheduler.handleCompletedTask(task, taskIdObj, timestamp, taskState, taskHistoryUpdateCreateResult, status);
   }
 
   public CompletableFuture<Boolean> processStatusUpdateAsync(Protos.TaskStatus status) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackManager.java
@@ -88,7 +88,7 @@ public class SingularitySlaveAndRackManager {
     final String rackId = offerHolder.getRackId();
     final String slaveId = offerHolder.getSlaveId();
 
-    final MachineState currentSlaveState = slaveManager.getSlave(slaveId).get().getCurrentState().getState();
+    final MachineState currentSlaveState = slaveManager.getObject(slaveId).get().getCurrentState().getState();
 
     if (currentSlaveState == MachineState.FROZEN) {
       return SlaveMatchState.SLAVE_FROZEN;
@@ -98,7 +98,7 @@ public class SingularitySlaveAndRackManager {
       return SlaveMatchState.SLAVE_DECOMMISSIONING;
     }
 
-    final MachineState currentRackState = rackManager.getRack(rackId).get().getCurrentState().getState();
+    final MachineState currentRackState = rackManager.getObject(rackId).get().getCurrentState().getState();
 
     if (currentRackState == MachineState.FROZEN) {
       return SlaveMatchState.RACK_FROZEN;
@@ -308,7 +308,7 @@ public class SingularitySlaveAndRackManager {
     if (!taskRequest.getRequest().getSlaveAttributeMinimums().isPresent()) {
       return true;
     }
-    Map<String, String> offerAttributes = slaveManager.getSlave(offerHolder.getSlaveId()).get().getAttributes();
+    Map<String, String> offerAttributes = slaveManager.getObject(offerHolder.getSlaveId()).get().getAttributes();
 
     Integer numDesiredInstances = taskRequest.getRequest().getInstancesSafe();
     Integer numActiveInstances = activeTaskIdsForRequest.size();
@@ -537,7 +537,7 @@ public class SingularitySlaveAndRackManager {
   }
 
   void checkStateAfterFinishedTask(SingularityTaskId taskId, String slaveId, SingularityLeaderCache leaderCache) {
-    Optional<SingularitySlave> slave = slaveManager.getSlave(slaveId);
+    Optional<SingularitySlave> slave = slaveManager.getObject(slaveId);
 
     if (!slave.isPresent()) {
       final String message = String.format("Couldn't find slave with id %s for task %s", slaveId, taskId);

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityStartup.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityStartup.java
@@ -73,14 +73,16 @@ class SingularityStartup {
     this.taskReconciliation = taskReconciliation;
   }
 
+  public void checkMigrations() {
+    zkDataMigrationRunner.checkMigrations();
+  }
+
   public void startup(MasterInfo masterInfo) {
     final long start = System.currentTimeMillis();
 
     final String uri = mesosClient.getMasterUri(MesosUtils.getMasterHostAndPort(masterInfo));
 
     LOG.info("Starting up... fetching state data from: " + uri);
-
-    zkDataMigrationRunner.checkMigrations();
 
     MesosMasterStateObject state = mesosClient.getMasterState(uri);
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractLeaderAwareResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractLeaderAwareResource.java
@@ -89,7 +89,7 @@ public class AbstractLeaderAwareResource {
     try {
       LOG.trace("Sending request to leader: {}", httpRequest);
       response = httpClient.executeRequest(httpRequest).get();
-    } catch (IOException|ExecutionException|InterruptedException e) {
+    } catch (ExecutionException|InterruptedException e) {
       LOG.error("Could not proxy request {} to leader", e);
       throw new WebApplicationException(e, 500);
     }
@@ -120,7 +120,7 @@ public class AbstractLeaderAwareResource {
     if (parameterNames != null) {
       while (parameterNames.hasMoreElements()) {
         String parameterName = parameterNames.nextElement();
-        requestBuilder.addQueryParameter(parameterName, request.getParameter(parameterName));
+        requestBuilder.addQueryParam(parameterName, request.getParameter(parameterName));
         LOG.trace("Copied query param {}={}", parameterName, request.getParameter(parameterName));
       }
     }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractLeaderAwareResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractLeaderAwareResource.java
@@ -94,6 +94,11 @@ public class AbstractLeaderAwareResource {
       throw new WebApplicationException(e, 500);
     }
 
+    // void responses
+    if (clazz.isAssignableFrom(Response.class)) {
+      return (T) response;
+    }
+
     try {
       if (response.getStatusCode() > 399) {
         throw new WebApplicationException(response.getResponseBody(Charsets.UTF_8.toString()), response.getStatusCode());

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/MetricsResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/MetricsResource.java
@@ -55,7 +55,6 @@ public class MetricsResource {
     return ImmutableMap.of(
         "allRequestIds", requestManager.getAllRequestIdsBytes(),
         "taskStatuses", taskManager.getTaskStatusBytes(),
-        "activeTaskIds", taskManager.getActiveTaskIdBytes(),
         "taskHistoryIds", taskManager.getTaskHistoryIdBytes()
     );
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestGroupResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestGroupResource.java
@@ -2,6 +2,7 @@ package com.hubspot.singularity.resources;
 
 import java.util.List;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -9,14 +10,20 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
+import org.apache.curator.framework.recipes.leader.LeaderLatch;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.hubspot.singularity.SingularityRequestGroup;
 import com.hubspot.singularity.config.ApiPaths;
 import com.hubspot.singularity.data.RequestGroupManager;
 import com.hubspot.singularity.data.SingularityValidator;
+import com.ning.http.client.AsyncHttpClient;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -30,12 +37,14 @@ import io.swagger.v3.oas.annotations.tags.Tags;
 @Produces({MediaType.APPLICATION_JSON})
 @Schema(title = "Manages Singularity Request Groups, which are collections of one or more Singularity Requests")
 @Tags({@Tag(name = "Request Groups")})
-public class RequestGroupResource {
+public class RequestGroupResource extends AbstractLeaderAwareResource {
   private final RequestGroupManager requestGroupManager;
   private final SingularityValidator validator;
 
   @Inject
-  public RequestGroupResource(RequestGroupManager requestGroupManager, SingularityValidator validator) {
+  public RequestGroupResource(AsyncHttpClient httpClient, LeaderLatch leaderLatch, ObjectMapper objectMapper,
+                              RequestGroupManager requestGroupManager, SingularityValidator validator) {
+    super(httpClient, leaderLatch, objectMapper);
     this.requestGroupManager = requestGroupManager;
     this.validator = validator;
   }
@@ -63,19 +72,24 @@ public class RequestGroupResource {
   @DELETE
   @Path("/group/{requestGroupId}")
   @Operation(summary = "Delete a specific Singularity request group by ID")
-  public void deleteRequestGroup(
-      @Parameter(required = true, description = "The id of the request group") @PathParam("requestGroupId") String requestGroupId) {
-    requestGroupManager.deleteRequestGroup(requestGroupId);
+  public Response deleteRequestGroup(
+      @Parameter(required = true, description = "The id of the request group") @PathParam("requestGroupId") String requestGroupId,
+      @Context HttpServletRequest requestContext) {
+    return maybeProxyToLeader(requestContext, Response.class, null, () -> {
+      requestGroupManager.deleteRequestGroup(requestGroupId);
+      return Response.ok().build();
+    });
   }
 
   @POST
   @Operation(summary = "Create a Singularity request group")
   public SingularityRequestGroup saveRequestGroup(
-      @RequestBody(required = true, description = "The new request group to create") SingularityRequestGroup requestGroup) {
-    validator.checkRequestGroup(requestGroup);
-
-    requestGroupManager.saveRequestGroup(requestGroup);
-
-    return requestGroup;
+      @RequestBody(required = true, description = "The new request group to create") SingularityRequestGroup requestGroup,
+      @Context HttpServletRequest requestContext) {
+    return maybeProxyToLeader(requestContext, SingularityRequestGroup.class, requestGroup, () -> {
+      validator.checkRequestGroup(requestGroup);
+      requestGroupManager.saveRequestGroup(requestGroup);
+      return requestGroup;
+    });
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
@@ -92,7 +92,6 @@ import com.ning.http.client.AsyncHttpClient.BoundRequestBuilder;
 import com.ning.http.client.HttpResponseBodyPart;
 import com.ning.http.client.HttpResponseHeaders;
 import com.ning.http.client.HttpResponseStatus;
-import com.ning.http.client.PerRequestConfig;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.dropwizard.auth.Auth;
@@ -663,14 +662,11 @@ public class TaskResource extends AbstractLeaderAwareResource {
         httpPrefix, slaveHostname, httpPort);
 
     try {
-      PerRequestConfig unlimitedTimeout = new PerRequestConfig();
-      unlimitedTimeout.setRequestTimeoutInMs(-1);
-
       NingOutputToJaxRsStreamingOutputWrapper streamingOutputNingHandler = new NingOutputToJaxRsStreamingOutputWrapper(
           httpClient
               .prepareGet(url)
-              .addQueryParameter("path", fileFullPath)
-              .setPerRequestConfig(unlimitedTimeout)
+              .addQueryParam("path", fileFullPath)
+              .setRequestTimeout(-1)
       );
 
       // Strip file path down to just a file name if we can

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
@@ -38,7 +38,6 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.hubspot.jackson.jaxrs.PropertyFiltering;
@@ -256,7 +255,7 @@ public class TaskResource extends AbstractLeaderAwareResource {
       @Parameter(description = "Use the cached version of this data to limit expensive api calls") @QueryParam("useWebCache") Boolean useWebCache) {
     authorizationHelper.checkForAuthorizationByRequestId(requestId, user, SingularityAuthorizationScope.READ);
 
-    final List<SingularityPendingTask> tasks = Lists.newArrayList(Iterables.filter(taskManager.getPendingTasks(useWebCache(useWebCache)), SingularityPendingTask.matchingRequest(requestId)));
+    final List<SingularityPendingTask> tasks = Lists.newArrayList(taskManager.getPendingTasksForRequest(requestId, true));
 
     return taskRequestManager.getTaskRequests(tasks);
   }
@@ -345,7 +344,7 @@ public class TaskResource extends AbstractLeaderAwareResource {
 
     Optional<SingularityTask> task = taskManager.getTask(taskIdObj);
 
-    checkNotFound(task.isPresent() && taskManager.isActiveTask(taskId), "No active task with id %s", taskId);
+    checkNotFound(task.isPresent() && taskManager.isActiveTask(taskIdObj), "No active task with id %s", taskId);
 
     if (task.isPresent()) {
       authorizationHelper.checkForAuthorizationByRequestId(task.get().getTaskId().getRequestId(), user, scope);
@@ -593,7 +592,7 @@ public class TaskResource extends AbstractLeaderAwareResource {
     authorizationHelper.checkForAuthorizationByTaskId(taskId, user, SingularityAuthorizationScope.WRITE);
     validator.checkActionEnabled(SingularityAction.RUN_SHELL_COMMAND);
 
-    if (!taskManager.isActiveTask(taskId)) {
+    if (!taskManager.isActiveTask(taskIdObj)) {
       throw WebExceptions.badRequest("%s is not an active task, can't run %s on it", taskId, shellCommand.getName());
     }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskTrackerResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskTrackerResource.java
@@ -92,7 +92,7 @@ public class TaskTrackerResource {
       }
     }
     // Check if it's pending
-    for (SingularityPendingTask pendingTask : taskManager.getPendingTasksForRequest(requestId)) {
+    for (SingularityPendingTask pendingTask : taskManager.getPendingTasksForRequest(requestId, false)) {
       if (pendingTask.getRunId().isPresent() && pendingTask.getRunId().get().equals(runId)) {
         return Optional.of(new SingularityTaskState(
             Optional.absent(),

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
@@ -34,7 +34,7 @@ import com.hubspot.singularity.SingularityKilledTaskIdRecord;
 import com.hubspot.singularity.SingularityLoadBalancerUpdate;
 import com.hubspot.singularity.SingularityPendingRequest;
 import com.hubspot.singularity.SingularityPendingRequest.PendingType;
-import com.hubspot.singularity.SingularityPendingTask;
+import com.hubspot.singularity.SingularityPendingTaskId;
 import com.hubspot.singularity.SingularityRequest;
 import com.hubspot.singularity.SingularityRequestCleanup;
 import com.hubspot.singularity.SingularityRequestDeployState;
@@ -340,7 +340,7 @@ public class SingularityCleaner {
 
   private void processRequestCleanup(long start, AtomicInteger numTasksKilled, AtomicInteger numScheduledTasksRemoved, SingularityRequestCleanup requestCleanup) {
     final List<SingularityTaskId> activeTaskIds = taskManager.getActiveTaskIdsForRequest(requestCleanup.getRequestId());
-    final List<SingularityPendingTask> pendingTasks = taskManager.getPendingTasksForRequest(requestCleanup.getRequestId());
+    final List<SingularityPendingTaskId> pendingTaskIds = taskManager.getPendingTaskIdsForRequest(requestCleanup.getRequestId());
     final String requestId = requestCleanup.getRequestId();
     final Optional<SingularityRequestWithState> requestWithState = requestManager.getRequest(requestId);
 
@@ -403,9 +403,9 @@ public class SingularityCleaner {
     }
 
     if (killScheduledTasks) {
-      for (SingularityPendingTask matchingTask : Iterables.filter(pendingTasks, SingularityPendingTask.matchingRequest(requestId))) {
-        LOG.debug("Deleting scheduled task {} due to {}", matchingTask, requestCleanup);
-        taskManager.deletePendingTask(matchingTask.getPendingTaskId());
+      for (SingularityPendingTaskId matchingTaskId : pendingTaskIds) {
+        LOG.debug("Deleting scheduled task {} due to {}", matchingTaskId, requestCleanup);
+        taskManager.deletePendingTask(matchingTaskId);
         numScheduledTasksRemoved.getAndIncrement();
       }
     }
@@ -538,7 +538,7 @@ public class SingularityCleaner {
   }
 
   private boolean isValidTask(SingularityTaskCleanup cleanupTask) {
-    return taskManager.isActiveTask(cleanupTask.getTaskId().getId());
+    return taskManager.isActiveTask(cleanupTask.getTaskId());
   }
 
   private void checkKilledTaskIdRecords() {
@@ -560,7 +560,7 @@ public class SingularityCleaner {
         .forEach((killedTaskIdRecordsForRequest) -> {
           lock.runWithRequestLock(() -> {
             for (SingularityKilledTaskIdRecord killedTaskIdRecord : killedTaskIdRecordsForRequest.getValue()) {
-              if (!taskManager.isActiveTask(killedTaskIdRecord.getTaskId().getId())) {
+              if (!taskManager.isActiveTask(killedTaskIdRecord.getTaskId())) {
                 SingularityDeleteResult deleteResult = taskManager.deleteKilledRecord(killedTaskIdRecord.getTaskId());
 
                 LOG.debug("Deleting obsolete {} - {}", killedTaskIdRecord, deleteResult);
@@ -903,7 +903,7 @@ public class SingularityCleaner {
       return false;
     }
     for (String taskId : cleanup.getActiveTaskIds()) {
-      if (taskManager.isActiveTask(taskId)) {
+      if (taskManager.isActiveTask(SingularityTaskId.valueOf(taskId))) {
         LOG.trace("Request still has active tasks, will wait for lb request cleanup");
         return false;
       }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
@@ -50,6 +50,7 @@ import com.hubspot.singularity.SingularityTaskShellCommandUpdate;
 import com.hubspot.singularity.TaskCleanupType;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.DeployManager;
+import com.hubspot.singularity.data.RequestGroupManager;
 import com.hubspot.singularity.data.RequestManager;
 import com.hubspot.singularity.data.TaskManager;
 import com.hubspot.singularity.data.UsageManager;
@@ -76,6 +77,7 @@ public class SingularityCleaner {
   private final SingularityMesosScheduler scheduler;
   private final SingularitySchedulerLock lock;
   private final UsageManager usageManager;
+  private final RequestGroupManager requestGroupManager;
 
   private final SingularityConfiguration configuration;
   private final long killNonLongRunningTasksInCleanupAfterMillis;
@@ -83,7 +85,8 @@ public class SingularityCleaner {
   @Inject
   public SingularityCleaner(TaskManager taskManager, SingularityDeployHealthHelper deployHealthHelper, DeployManager deployManager, RequestManager requestManager,
                             SingularityConfiguration configuration, LoadBalancerClient lbClient, SingularityExceptionNotifier exceptionNotifier,
-                            RequestHistoryHelper requestHistoryHelper, SingularityMesosScheduler scheduler, SingularitySchedulerLock lock, UsageManager usageManager) {
+                            RequestHistoryHelper requestHistoryHelper, SingularityMesosScheduler scheduler, SingularitySchedulerLock lock, UsageManager usageManager,
+                            RequestGroupManager requestGroupManager) {
     this.taskManager = taskManager;
     this.lbClient = lbClient;
     this.deployHealthHelper = deployHealthHelper;
@@ -94,6 +97,7 @@ public class SingularityCleaner {
     this.scheduler = scheduler;
     this.lock = lock;
     this.usageManager = usageManager;
+    this.requestGroupManager = requestGroupManager;
 
     this.configuration = configuration;
 
@@ -523,6 +527,7 @@ public class SingularityCleaner {
     deployManager.deleteRequestId(requestCleanup.getRequestId());
     LOG.trace("Deleted stale request data for {}", requestCleanup.getRequestId());
     usageManager.deleteRequestUtilization(requestCleanup.getRequestId());
+    requestGroupManager.removeFromAllGroups(requestCleanup.getRequestId());
   }
 
   public int drainCleanupQueue() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityHealthcheckAsyncHandler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityHealthcheckAsyncHandler.java
@@ -28,6 +28,7 @@ public class SingularityHealthcheckAsyncHandler extends AsyncCompletionHandler<R
   private final TaskManager taskManager;
   private final int maxHealthcheckResponseBodyBytes;
   private final List<Integer> failureStatusCodes;
+  private String healthcheckUri = ""; // For logging purposes only
 
   public SingularityHealthcheckAsyncHandler(SingularityExceptionNotifier exceptionNotifier, SingularityConfiguration configuration, SingularityHealthchecker healthchecker,
       SingularityNewTaskChecker newTaskChecker, TaskManager taskManager, SingularityTask task) {
@@ -42,6 +43,10 @@ public class SingularityHealthcheckAsyncHandler extends AsyncCompletionHandler<R
       configuration.getHealthcheckFailureStatusCodes();
 
     startTime = System.currentTimeMillis();
+  }
+
+  public void setHealthcehckUri(String healthcheckUri) {
+    this.healthcheckUri = healthcheckUri;
   }
 
   @Override
@@ -59,9 +64,9 @@ public class SingularityHealthcheckAsyncHandler extends AsyncCompletionHandler<R
 
   @Override
   public void onThrowable(Throwable t) {
-    LOG.trace("Exception while making health check for task {}", task.getTaskId(), t);
+    LOG.trace("Exception while making health check for task {} ({})", task.getTaskId(), healthcheckUri, t);
 
-    saveResult(Optional.<Integer> absent(), Optional.<String> absent(), Optional.of(String.format("Healthcheck failed due to exception: %s", t.getMessage())), Optional.of(t));
+    saveResult(Optional.<Integer> absent(), Optional.<String> absent(), Optional.of(String.format("Healthcheck (%s) failed due to exception: %s", healthcheckUri, t.getMessage())), Optional.of(t));
   }
 
   public void saveResult(Optional<Integer> statusCode, Optional<String> responseBody, Optional<String> errorMessage, Optional<Throwable> throwable) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityHealthcheckAsyncHandler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityHealthcheckAsyncHandler.java
@@ -76,7 +76,7 @@ public class SingularityHealthcheckAsyncHandler extends AsyncCompletionHandler<R
       taskManager.saveHealthcheckResult(result);
 
       if (result.isFailed()) {
-        if (!taskManager.isActiveTask(task.getTaskId().getId())) {
+        if (!taskManager.isActiveTask(task.getTaskId())) {
           LOG.trace("Task {} is not active, not re-enqueueing healthcheck", task.getTaskId());
           return;
         }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityHealthcheckAsyncHandler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityHealthcheckAsyncHandler.java
@@ -41,7 +41,7 @@ public class SingularityHealthcheckAsyncHandler {
     startTime = System.currentTimeMillis();
   }
 
-  public void setHealthcehckUri(String healthcheckUri) {
+  public void setHealthcheckUri(String healthcheckUri) {
     this.healthcheckUri = healthcheckUri;
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityHealthchecker.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityHealthchecker.java
@@ -278,13 +278,14 @@ public class SingularityHealthchecker {
   }
 
   private void asyncHealthcheck(final SingularityTask task) {
-    final SingularityHealthcheckAsyncHandler handler = new SingularityHealthcheckAsyncHandler(exceptionNotifier, configuration, this, newTaskChecker, taskManager, task);
     final Optional<String> uri = getHealthcheckUri(task);
+    final SingularityHealthcheckAsyncHandler handler = new SingularityHealthcheckAsyncHandler(exceptionNotifier, configuration, this, newTaskChecker, taskManager, task);
 
     if (!uri.isPresent()) {
       saveFailure(handler, "Invalid healthcheck uri or ports not present");
       return;
     }
+    handler.setHealthcehckUri(uri.get());
 
     final Integer timeoutSeconds = task.getTaskRequest().getDeploy().getHealthcheck().isPresent() ?
       task.getTaskRequest().getDeploy().getHealthcheck().get().getResponseTimeoutSeconds().or(configuration.getHealthcheckTimeoutSeconds()) : configuration.getHealthcheckTimeoutSeconds();

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityHealthchecker.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityHealthchecker.java
@@ -337,7 +337,7 @@ public class SingularityHealthchecker {
       saveFailure(handler, "Invalid healthcheck uri or ports not present");
       return;
     }
-    handler.setHealthcehckUri(uri.get());
+    handler.setHealthcheckUri(uri.get());
 
     final Integer timeoutSeconds;
     final String method;

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityHealthchecker.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityHealthchecker.java
@@ -1,5 +1,6 @@
 package com.hubspot.singularity.scheduler;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.RejectedExecutionException;
@@ -21,6 +22,7 @@ import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 import com.hubspot.deploy.HealthcheckOptions;
 import com.hubspot.singularity.ExtendedTaskState;
+import com.hubspot.singularity.HealthcheckMethod;
 import com.hubspot.singularity.HealthcheckProtocol;
 import com.hubspot.singularity.SingularityAbort;
 import com.hubspot.singularity.SingularityAction;
@@ -37,8 +39,13 @@ import com.hubspot.singularity.data.TaskManager;
 import com.hubspot.singularity.helpers.MesosProtosUtils;
 import com.hubspot.singularity.helpers.MesosUtils;
 import com.hubspot.singularity.sentry.SingularityExceptionNotifier;
+import com.ning.http.client.AsyncCompletionHandler;
 import com.ning.http.client.AsyncHttpClient;
 import com.ning.http.client.RequestBuilder;
+
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.OkHttpClient;
 
 @Singleton
 public class SingularityHealthchecker {
@@ -47,6 +54,7 @@ public class SingularityHealthchecker {
   private static final Logger LOG = LoggerFactory.getLogger(SingularityHealthchecker.class);
 
   private final AsyncHttpClient http;
+  private final OkHttpClient http2;
   private final SingularityConfiguration configuration;
   private final TaskManager taskManager;
   private final SingularityAbort abort;
@@ -62,10 +70,11 @@ public class SingularityHealthchecker {
 
   @Inject
   public SingularityHealthchecker(SingularityManagedScheduledExecutorServiceFactory executorServiceFactory,
-                                  AsyncHttpClient http, SingularityConfiguration configuration, SingularityNewTaskChecker newTaskChecker,
+                                  AsyncHttpClient http, OkHttpClient http2, SingularityConfiguration configuration, SingularityNewTaskChecker newTaskChecker,
                                   TaskManager taskManager, SingularityAbort abort, SingularityExceptionNotifier exceptionNotifier, DisasterManager disasterManager,
                                   MesosProtosUtils mesosProtosUtils) {
     this.http = http;
+    this.http2 = http2;
     this.configuration = configuration;
     this.newTaskChecker = newTaskChecker;
     this.taskManager = taskManager;
@@ -277,6 +286,49 @@ public class SingularityHealthchecker {
     return true;
   }
 
+  private Callback wrappedHttp2Handler(final SingularityHealthcheckAsyncHandler handler) {
+    return new Callback() {
+      @Override
+      public void onFailure(Call call, IOException e) {
+        handler.onFailed(e);
+      }
+
+      @Override
+      public void onResponse(Call call, okhttp3.Response response) throws IOException {
+        Optional<String> maybeResponseExcerpt = Optional.absent();
+
+        String responseExcerpt = response.peekBody(configuration.getMaxHealthcheckResponseBodyBytes()).string();
+        if (responseExcerpt.length() > 0) {
+          maybeResponseExcerpt = Optional.of(responseExcerpt);
+        }
+
+        handler.onCompleted(Optional.of(response.code()), maybeResponseExcerpt);
+      }
+    };
+  }
+
+  private AsyncCompletionHandler<com.ning.http.client.Response> wrappedHttp1Handler(final SingularityHealthcheckAsyncHandler handler) {
+    return new AsyncCompletionHandler<com.ning.http.client.Response>() {
+      @Override
+      public void onThrowable(Throwable t) {
+        handler.onFailed(t);
+      }
+
+      @Override
+      public com.ning.http.client.Response onCompleted(com.ning.http.client.Response response) throws Exception {
+        Optional<String> maybeResponseExcerpt = Optional.absent();
+
+        if (response.hasResponseBody()) {
+          maybeResponseExcerpt = Optional.of(response.getResponseBodyExcerpt(configuration.getMaxHealthcheckResponseBodyBytes()));
+        }
+
+        handler.onCompleted(Optional.of(response.getStatusCode()), maybeResponseExcerpt);
+
+        return response;
+      }
+    };
+  }
+
   private void asyncHealthcheck(final SingularityTask task) {
     final Optional<String> uri = getHealthcheckUri(task);
     final SingularityHealthcheckAsyncHandler handler = new SingularityHealthcheckAsyncHandler(exceptionNotifier, configuration, this, newTaskChecker, taskManager, task);
@@ -287,18 +339,47 @@ public class SingularityHealthchecker {
     }
     handler.setHealthcehckUri(uri.get());
 
-    final Integer timeoutSeconds = task.getTaskRequest().getDeploy().getHealthcheck().isPresent() ?
-      task.getTaskRequest().getDeploy().getHealthcheck().get().getResponseTimeoutSeconds().or(configuration.getHealthcheckTimeoutSeconds()) : configuration.getHealthcheckTimeoutSeconds();
+    final Integer timeoutSeconds;
+    final String method;
+
+    if (task.getTaskRequest().getDeploy().getHealthcheck().isPresent()) {
+      HealthcheckOptions options = task.getTaskRequest().getDeploy().getHealthcheck().get();
+
+      method = options.getMethod().or(HealthcheckMethod.GET).getMethod();
+      timeoutSeconds = options.getResponseTimeoutSeconds().or(configuration.getHealthcheckTimeoutSeconds());
+    } else {
+      timeoutSeconds = configuration.getHealthcheckTimeoutSeconds();
+      method = HealthcheckMethod.GET.getMethod();
+    }
 
     try {
-      RequestBuilder builder = new RequestBuilder("GET");
-      builder.setFollowRedirects(true);
-      builder.setUrl(uri.get());
-      builder.setRequestTimeout((int) TimeUnit.SECONDS.toMillis(timeoutSeconds));
+      HealthcheckProtocol protocol = task.getTaskRequest().getDeploy().getHealthcheck().get().getProtocol().or(HealthcheckProtocol.HTTP);
 
       LOG.trace("Issuing a healthcheck ({}) for task {} with timeout {}s", uri.get(), task.getTaskId(), timeoutSeconds);
 
-      http.prepareRequest(builder.build()).execute(handler);
+      if (protocol == HealthcheckProtocol.HTTP2 || protocol == HealthcheckProtocol.HTTPS2) {
+        // Creates a lightweight new client which shares the underlying resource pools of the original instance.
+        http2.newBuilder()
+            .retryOnConnectionFailure(false)
+            .followRedirects(true)
+            .connectTimeout(timeoutSeconds, TimeUnit.SECONDS)
+            .readTimeout(timeoutSeconds, TimeUnit.SECONDS)
+            .cache(null)
+            .build()
+            .newCall(
+                new okhttp3.Request.Builder()
+                    .method(method, null)
+                    .url(uri.get())
+                    .build()
+            ).enqueue(wrappedHttp2Handler(handler));
+      } else {
+        RequestBuilder builder = new RequestBuilder("GET");
+        builder.setFollowRedirects(true);
+        builder.setUrl(uri.get());
+        builder.setRequestTimeout((int) TimeUnit.SECONDS.toMillis(timeoutSeconds));
+
+        http.prepareRequest(builder.build()).execute(wrappedHttp1Handler(handler));
+      }
     } catch (Throwable t) {
       LOG.debug("Exception while preparing healthcheck ({}) for task ({})", uri.get(), task.getTaskId(), t);
       exceptionNotifier.notify(String.format("Error preparing healthcheck (%s)", t.getMessage()), t, ImmutableMap.of("taskId", task.getTaskId().toString()));

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCache.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCache.java
@@ -174,13 +174,13 @@ public class SingularityLeaderCache {
     pendingTaskIdToPendingTask.put(pendingTask.getPendingTaskId(), pendingTask);
   }
 
-  public void deleteActiveTaskId(String taskId) {
+  public void deleteActiveTaskId(SingularityTaskId taskId) {
     if (!active) {
       LOG.warn("deleteActiveTask {}, but not active", taskId);
       return;
     }
 
-    activeTaskIds.remove(SingularityTaskId.valueOf(taskId));
+    activeTaskIds.remove(taskId);
   }
 
   public List<SingularityTaskId> exists(List<SingularityTaskId> taskIds) {
@@ -234,8 +234,8 @@ public class SingularityLeaderCache {
     return pendingTaskIdToPendingTask.size();
   }
 
-  public boolean isActiveTask(String taskId) {
-    return activeTaskIds.contains(SingularityTaskId.valueOf(taskId));
+  public boolean isActiveTask(SingularityTaskId taskId) {
+    return activeTaskIds.contains(taskId);
   }
 
   public void putActiveTask(SingularityTask task) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCache.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCache.java
@@ -437,8 +437,8 @@ public class SingularityLeaderCache {
     return new ArrayList<>(racks.values());
   }
 
-  public Optional<SingularityRack> getRack(String rackName) {
-    return Optional.fromNullable(racks.get(rackName));
+  public Optional<SingularityRack> getRack(String rackId) {
+    return Optional.fromNullable(racks.get(rackId));
   }
 
   public void putRack(SingularityRack rack) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCache.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCache.java
@@ -409,8 +409,8 @@ public class SingularityLeaderCache {
     historyUpdates.remove(taskId);
   }
 
-  public Collection<SingularitySlave> getSlaves() {
-    return slaves.values();
+  public List<SingularitySlave> getSlaves() {
+    return new ArrayList<>(slaves.values());
   }
 
   public Optional<SingularitySlave> getSlave(String slaveId) {
@@ -425,8 +425,16 @@ public class SingularityLeaderCache {
     slaves.put(slave.getId(), slave);
   }
 
-  public Collection<SingularityRack> getRacks() {
-    return racks.values();
+  public void removeSlave(String slaveId) {
+    if (!active) {
+      LOG.warn("remove slave {}, but not active", slaveId);
+      return;
+    }
+    slaves.remove(slaveId);
+  }
+
+  public List<SingularityRack> getRacks() {
+    return new ArrayList<>(racks.values());
   }
 
   public Optional<SingularityRack> getRack(String rackName) {
@@ -439,6 +447,14 @@ public class SingularityLeaderCache {
     }
 
     racks.put(rack.getId(), rack);
+  }
+
+  public void removeRack(String rackId) {
+    if (!active) {
+      LOG.warn("remove rack {}, but not active", rackId);
+      return;
+    }
+    racks.remove(rackId);
   }
 
   public void putRequestUtilization(RequestUtilization requestUtilization) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityNewTaskChecker.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityNewTaskChecker.java
@@ -321,7 +321,7 @@ public class SingularityNewTaskChecker {
 
   @VisibleForTesting
   CheckTaskState getTaskState(SingularityTask task, Optional<SingularityRequestWithState> requestWithState, SingularityHealthchecker healthchecker) {
-    if (!taskManager.isActiveTask(task.getTaskId().getId())) {
+    if (!taskManager.isActiveTask(task.getTaskId())) {
       return CheckTaskState.OBSOLETE;
     }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -643,13 +643,9 @@ public class SingularityScheduler {
   }
 
   @Timed
-  public void handleCompletedTask(Optional<SingularityTask> task, SingularityTaskId taskId, boolean wasActive, long timestamp, ExtendedTaskState state,
+  public void handleCompletedTask(Optional<SingularityTask> task, SingularityTaskId taskId, long timestamp, ExtendedTaskState state,
     SingularityCreateResult taskHistoryUpdateCreateResult, Protos.TaskStatus status) {
     final SingularityDeployStatistics deployStatistics = getDeployStatistics(taskId.getRequestId(), taskId.getDeployId());
-
-    if (wasActive) {
-      taskManager.deleteActiveTask(taskId.getId());
-    }
 
     if (!task.isPresent() || task.get().getTaskRequest().getRequest().isLoadBalanced()) {
       taskManager.createLBCleanupTask(taskId);

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularitySlaveReconciliationPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularitySlaveReconciliationPoller.java
@@ -57,6 +57,7 @@ public class SingularitySlaveReconciliationPoller extends SingularityLeaderOnlyP
     refereshSlavesAndRacks();
     checkDeadSlaves();
     inactiveSlaveManager.cleanInactiveSlavesList(System.currentTimeMillis() - TimeUnit.HOURS.toMillis(configuration.getCleanInactiveHostListEveryHours()));
+    clearOldSlaveHistory();
   }
 
   private void refereshSlavesAndRacks() {
@@ -101,6 +102,12 @@ public class SingularitySlaveReconciliationPoller extends SingularityLeaderOnlyP
 
 
     LOG.debug("Checked {} dead slaves, deleted {} in {}", deadSlaves.size(), deleted, JavaUtils.duration(start));
+  }
+
+  private void clearOldSlaveHistory() {
+    for (SingularitySlave singularitySlave : slaveManager.getObjects()) {
+      slaveManager.clearOldHistory(singularitySlave.getId());
+    }
   }
 
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityTaskShellCommandDispatchPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityTaskShellCommandDispatchPoller.java
@@ -58,7 +58,7 @@ public class SingularityTaskShellCommandDispatchPoller extends SingularityLeader
     for (SingularityTaskShellCommandRequest shellRequest : shellRequests) {
       Optional<SingularityTask> task = taskManager.getTask(shellRequest.getTaskId());
 
-      if (!task.isPresent() || !taskManager.isActiveTask(shellRequest.getTaskId().getId())) {
+      if (!task.isPresent() || !taskManager.isActiveTask(shellRequest.getTaskId())) {
         LOG.info("Skipping shell request {} because {} didn't exist or isn't active", shellRequest, shellRequest.getTaskId());
         continue;
       }

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityStartupTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityStartupTest.java
@@ -44,7 +44,7 @@ public class SingularityStartupTest extends SingularitySchedulerTestBase {
 
     Assert.assertTrue(taskManager.getActiveTaskIds().size() == 1);
 
-    taskManager.deleteActiveTask(task.getTaskId().getId());
+    taskManager.deleteLastActiveTaskStatus(task.getTaskId());
 
     resourceOffers();
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityHealthchecksTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityHealthchecksTest.java
@@ -416,7 +416,7 @@ public class SingularityHealthchecksTest extends SingularitySchedulerTestBase {
     try {
       setConfigurationForNoDelay();
       initRequest();
-      HealthcheckOptions options = new HealthcheckOptionsBuilder("http://uri").setPortIndex(Optional.of(1)).setStartupDelaySeconds(Optional.of(0)).build();
+      HealthcheckOptions options = new HealthcheckOptionsBuilder("/uri").setPortIndex(Optional.of(1)).setStartupDelaySeconds(Optional.of(0)).build();
       firstDeploy = initAndFinishDeploy(request, new SingularityDeployBuilder(request.getId(), firstDeployId).setCommand(Optional.of("sleep 100"))
           .setHealthcheck(Optional.of(options)), Optional.of(new Resources(1, 64, 3, 0)));
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityHealthchecksTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityHealthchecksTest.java
@@ -433,8 +433,9 @@ public class SingularityHealthchecksTest extends SingularitySchedulerTestBase {
 
       newTaskChecker.enqueueNewTaskCheck(firstTask, requestManager.getRequest(requestId), healthchecker);
 
-      Awaitility.await("healthcheck present").atMost(5, TimeUnit.SECONDS).until(() -> taskManager.getLastHealthcheck(firstTask.getTaskId()).isPresent());
+      Awaitility.await("healthcheck present").atMost(6, TimeUnit.SECONDS).until(() -> taskManager.getLastHealthcheck(firstTask.getTaskId()).isPresent());
 
+      Optional<SingularityTaskHealthcheckResult> result = taskManager.getLastHealthcheck(firstTask.getTaskId());
       Assert.assertTrue(taskManager.getLastHealthcheck(firstTask.getTaskId()).get().toString().contains("host1:81"));
     } finally {
       unsetConfigurationForNoDelay();

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -1535,12 +1535,12 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
 
     taskManager.deleteTaskHistory(taskOne.getTaskId());
 
-    Assert.assertTrue(taskManager.isActiveTask(taskOne.getTaskId().getId()));
+    Assert.assertTrue(taskManager.isActiveTask(taskOne.getTaskId()));
 
     statusUpdate(taskOne, TaskState.TASK_RUNNING);
     statusUpdate(taskOne, TaskState.TASK_FAILED);
 
-    Assert.assertTrue(!taskManager.isActiveTask(taskOne.getTaskId().getId()));
+    Assert.assertTrue(!taskManager.isActiveTask(taskOne.getTaskId()));
 
     Assert.assertEquals(2, taskManager.getTaskHistoryUpdates(taskOne.getTaskId()).size());
   }

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityTestModule.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityTestModule.java
@@ -104,7 +104,7 @@ public class SingularityTestModule implements Module {
     rootLogger.setLevel(Level.toLevel(System.getProperty("singularity.test.log.level", "WARN")));
 
     Logger hsLogger = context.getLogger("com.hubspot");
-    hsLogger.setLevel(Level.toLevel(System.getProperty("singularity.test.log.level.for.com.hubspot", "TRACE")));
+    hsLogger.setLevel(Level.toLevel(System.getProperty("singularity.test.log.level.for.com.hubspot", "WARN")));
 
     this.ts = new TestingServer();
   }

--- a/SingularityUI/app/components/newDeployForm/NewDeployForm.jsx
+++ b/SingularityUI/app/components/newDeployForm/NewDeployForm.jsx
@@ -1338,7 +1338,21 @@ class NewDeployForm extends Component {
         onChange={newValue => this.updateField('protocol', newValue.value)}
         options={[
           { label: 'HTTP', value: 'HTTP' },
-          { label: 'HTTPS', value: 'HTTPS' }
+          { label: 'HTTPS', value: 'HTTPS' },
+          { label: 'HTTP2', value: 'HTTP2' },
+          { label: 'HTTPS2', value: 'HTTPS2' }
+        ]}
+      />
+    );
+    const healthCheckMethod = (
+      <SelectFormGroup
+        id="hc-method"
+        label="HC Method"
+        value={this.getValueOrDefault('method')}
+        onChange={newValue => this.updateField('method', newValue.value)}
+        options={[
+          { label: 'GET', value: 'GET' },
+          { label: 'POST', value: 'POST' }
         ]}
       />
     );
@@ -1573,8 +1587,11 @@ class NewDeployForm extends Component {
                 </div>
               </div>
               <div className="row">
-                <div className="col-md-6">
+                <div className="col-md-4">
                   {healthCheckProtocol}
+                </div>
+                <div className="col-md-2">
+                  {healthCheckMethod}
                 </div>
                 <div className="col-md-6">
                   {healthcheckStartupDelaySeconds}

--- a/SingularityUI/app/components/newDeployForm/fields.es6
+++ b/SingularityUI/app/components/newDeployForm/fields.es6
@@ -87,6 +87,7 @@ export const FIELDS = {
         {id: 'portIndex', type: 'number'},
         {id: 'portNumber', type: 'number'},
         {id: 'protocol', type: 'text', default: 'HTTP'},
+        {id: 'method', type: 'text', default: 'GET'},
         {id: 'startupDelaySeconds', type: 'number'},
         {id: 'startupTimeoutSeconds', type: 'number'},
         {id: 'startupIntervalSeconds', type: 'number'},

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <dep.rxJava.version>1.3.8</dep.rxJava.version>
     <dep.slf4j.version>1.7.25</dep.slf4j.version>
     <dep.swagger.version>2.0.0</dep.swagger.version>
-    <dep.zookeeper.version>3.5.4-beta</dep.zookeeper.version>
+    <dep.zookeeper.version>3.4.10</dep.zookeeper.version>
     <dropwizard.guicier.version>1.3.5.1</dropwizard.guicier.version>
     <dropwizard.version>1.3.7</dropwizard.version>
     <horizon.version>0.1.1</horizon.version>
@@ -378,6 +378,102 @@
           <exclusion>
             <groupId>org.apache.servicemix.bundles</groupId>
             <artifactId>org.apache.servicemix.bundles.antlr</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.curator</groupId>
+        <artifactId>curator-client</artifactId>
+        <version>${dep.curator.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.curator</groupId>
+        <artifactId>curator-framework</artifactId>
+        <version>${dep.curator.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.curator</groupId>
+        <artifactId>curator-recipes</artifactId>
+        <version>${dep.curator.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.curator</groupId>
+        <artifactId>curator-test</artifactId>
+        <version>${dep.curator.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
           </exclusion>
         </exclusions>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
     <jukito.version>1.5</jukito.version>
     <mesos.docker.tag>1.6.1</mesos.docker.tag>
     <mesos.version>1.6.1</mesos.version>
+    <ning.async.version>1.9.38</ning.async.version>
     <project.build.targetJdk>1.8</project.build.targetJdk>
     <singularity.jar.name.format>${project.artifactId}-${project.version}</singularity.jar.name.format>
     <singularitybase.db.driver>mysql</singularitybase.db.driver>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>25.1</version>
+    <version>25.3</version>
   </parent>
 
   <artifactId>Singularity</artifactId>
@@ -35,7 +35,7 @@
     <basepom.release.profiles>oss-release</basepom.release.profiles>
     <dep.classmate.version>1.3.1</dep.classmate.version>
     <dep.commons-lang3.version>3.7</dep.commons-lang3.version>
-    <dep.curator.version>2.12.0</dep.curator.version>
+    <dep.curator.version>4.2.0</dep.curator.version>
     <dep.dropwizard-metrics.version>4.0.2</dep.dropwizard-metrics.version>
     <dep.findbugs.jsr.version>3.0.2</dep.findbugs.jsr.version>
     <dep.google.cloud.version>1.15.0</dep.google.cloud.version>
@@ -57,13 +57,14 @@
     <dep.logback.version>1.2.3</dep.logback.version>
     <dep.mesos.rxjava.version>0.1.0</dep.mesos.rxjava.version>
     <dep.metrics-guice.version>3.1.3</dep.metrics-guice.version>
+    <dep.netty3.version>3.10.6.Final</dep.netty3.version>
     <dep.netty.version>4.1.22.Final</dep.netty.version>
     <dep.protobuf-java.version>3.5.1</dep.protobuf-java.version>
     <dep.reflections.version>0.9.11</dep.reflections.version>
     <dep.rxJava.version>1.3.8</dep.rxJava.version>
     <dep.slf4j.version>1.7.25</dep.slf4j.version>
     <dep.swagger.version>2.0.0</dep.swagger.version>
-    <dep.zookeeper.version>3.4.8</dep.zookeeper.version>
+    <dep.zookeeper.version>3.5.4-beta</dep.zookeeper.version>
     <dropwizard.guicier.version>1.3.5.1</dropwizard.guicier.version>
     <dropwizard.version>1.3.7</dropwizard.version>
     <horizon.version>0.1.1</horizon.version>

--- a/pom.xml
+++ b/pom.xml
@@ -457,7 +457,11 @@
       <dependency>
         <groupId>org.apache.curator</groupId>
         <artifactId>curator-test</artifactId>
-        <version>${dep.curator.version}</version>
+        <!--
+        Hardcode this to an older version because we're still on ZooKeeper client 3.4.x
+        https://issues.apache.org/jira/browse/CURATOR-428?focusedCommentId=16106765&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-16106765
+        -->
+        <version>2.13.0</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Be much nicer to zookeeper by avoiding possible large payloads, specifically:

- Namespace pending tasks by request id so that the list children call for this does not get to large when there are thousands of pending tasks
  - Avoid the list + filter call, which required fetching all pending task ids to find the ones for a particular request
- Remove usage of the /tasks/active node entirely since we have this data elsewhere
- Namespaces last active task statuses nodes by request id and use this data to power the active tasks list instead
- clean up nodes from old features that are no longer used

Still TODO on this PR:
- [x] automatic cleanup of request groups when a request is deleted
- [x] revisit caching to determine if any additional data can be leader cached
- [x] more aggressive pruning of inactive slaves data