### PR TITLE
Also attempt to get TaskHistory from history manager for mail

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityMailPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityMailPoller.java
@@ -60,6 +60,9 @@ public class SingularityMailPoller extends SingularityLeaderOnlyPoller {
   private void checkToSendTaskFinishedMail(SingularityTaskId taskId) {
     Optional<SingularityRequestWithState> requestWithState = requestManager.getRequest(taskId.getRequestId());
     Optional<SingularityTaskHistory> taskHistory = taskManager.getTaskHistory(taskId);
+    if (!taskHistory.isPresent()) {
+      taskHistory = historyManager.getTaskHistory(taskId.getId());
+    }
 
     ShouldSendMailState shouldSendState = shouldSendTaskFinishedMail(taskId, requestWithState, taskHistory);
 


### PR DESCRIPTION
Side effect of the immediate persist changes. Mailer also needs to check history