### PR TITLE
MySQL task resource usage storage

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/RequestUtilization.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/RequestUtilization.java
@@ -17,25 +17,25 @@ public class RequestUtilization {
   private int numTasks = 0;
 
   private long maxMemBytesUsed = 0;
-  private double maxMemTimestamp = 0;
+  private long maxMemTimestamp = 0;
   private long minMemBytesUsed = Long.MAX_VALUE;
-  private double minMemTimestamp = 0;
+  private long minMemTimestamp = 0;
   private double maxCpuUsed = 0;
-  private double maxCpusTimestamp = 0;
+  private long maxCpusTimestamp = 0;
   private double minCpuUsed = Double.MAX_VALUE;
-  private double minCpusTimestamp = 0;
+  private long minCpusTimestamp = 0;
   private long maxDiskBytesUsed = 0;
-  private double maxDiskTimestamp = 0;
+  private long maxDiskTimestamp = 0;
   private long minDiskBytesUsed = Long.MAX_VALUE;
-  private double minDiskTimestamp = 0;
+  private long minDiskTimestamp = 0;
 
   private double cpuBurstRating = 0;
 
   private double percentCpuTimeThrottled = 0;
   private double maxPercentCpuTimeThrottled = 0;
-  private double maxCpuThrottledTimestamp = 0;
+  private long maxCpuThrottledTimestamp = 0;
   private double minPercentCpuTimeThrottled = Double.MAX_VALUE;
-  private double minCpuThrottledTimestamp = 0;
+  private long minCpuThrottledTimestamp = 0;
 
   @JsonCreator
   public RequestUtilization(@JsonProperty("requestId") String requestId,
@@ -227,74 +227,74 @@ public class RequestUtilization {
     return this;
   }
 
-  public double getMaxMemTimestamp() {
+  public long getMaxMemTimestamp() {
     return maxMemTimestamp;
   }
 
-  public RequestUtilization setMaxMemTimestamp(double maxMemTimestamp) {
+  public RequestUtilization setMaxMemTimestamp(long maxMemTimestamp) {
     this.maxMemTimestamp = maxMemTimestamp;
     return this;
   }
 
-  public double getMinMemTimestamp() {
+  public long getMinMemTimestamp() {
     return minMemTimestamp;
   }
 
-  public RequestUtilization setMinMemTimestamp(double minMemTimestamp) {
+  public RequestUtilization setMinMemTimestamp(long minMemTimestamp) {
     this.minMemTimestamp = minMemTimestamp;
     return this;
   }
 
-  public double getMaxCpusTimestamp() {
+  public long getMaxCpusTimestamp() {
     return maxCpusTimestamp;
   }
 
-  public RequestUtilization setMaxCpusTimestamp(double maxCpusTimestamp) {
+  public RequestUtilization setMaxCpusTimestamp(long maxCpusTimestamp) {
     this.maxCpusTimestamp = maxCpusTimestamp;
     return this;
   }
 
-  public double getMinCpusTimestamp() {
+  public long getMinCpusTimestamp() {
     return minCpusTimestamp;
   }
 
-  public RequestUtilization setMinCpusTimestamp(double minCpusTimestamp) {
+  public RequestUtilization setMinCpusTimestamp(long minCpusTimestamp) {
     this.minCpusTimestamp = minCpusTimestamp;
     return this;
   }
 
-  public double getMaxDiskTimestamp() {
+  public long getMaxDiskTimestamp() {
     return maxDiskTimestamp;
   }
 
-  public RequestUtilization setMaxDiskTimestamp(double maxDiskTimestamp) {
+  public RequestUtilization setMaxDiskTimestamp(long maxDiskTimestamp) {
     this.maxDiskTimestamp = maxDiskTimestamp;
     return this;
   }
 
-  public double getMinDiskTimestamp() {
+  public long getMinDiskTimestamp() {
     return minDiskTimestamp;
   }
 
-  public RequestUtilization setMinDiskTimestamp(double minDiskTimestamp) {
+  public RequestUtilization setMinDiskTimestamp(long minDiskTimestamp) {
     this.minDiskTimestamp = minDiskTimestamp;
     return this;
   }
 
-  public double getMaxCpuThrottledTimestamp() {
+  public long getMaxCpuThrottledTimestamp() {
     return maxCpuThrottledTimestamp;
   }
 
-  public RequestUtilization setMaxCpuThrottledTimestamp(double maxCpuThrottledTimestamp) {
+  public RequestUtilization setMaxCpuThrottledTimestamp(long maxCpuThrottledTimestamp) {
     this.maxCpuThrottledTimestamp = maxCpuThrottledTimestamp;
     return this;
   }
 
-  public double getMinCpuThrottledTimestamp() {
+  public long getMinCpuThrottledTimestamp() {
     return minCpuThrottledTimestamp;
   }
 
-  public RequestUtilization setMinCpuThrottledTimestamp(double minCpuThrottledTimestamp) {
+  public RequestUtilization setMinCpuThrottledTimestamp(long minCpuThrottledTimestamp) {
     this.minCpuThrottledTimestamp = minCpuThrottledTimestamp;
     return this;
   }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskCurrentUsage.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskCurrentUsage.java
@@ -11,19 +11,16 @@ public class SingularityTaskCurrentUsage {
   private final long memoryTotalBytes;
   private final long timestamp;
   private final double cpusUsed;
-  private final double cpusTotal;
   private final long diskTotalBytes;
 
   @JsonCreator
   public SingularityTaskCurrentUsage(@JsonProperty("memoryTotalBytes") long memoryTotalBytes,
                                      @JsonProperty("long") long timestamp,
                                      @JsonProperty("cpusUsed") double cpusUsed,
-                                     @JsonProperty("cpusTotal") double cpusTotal,
                                      @JsonProperty("diskTotalBytes") long diskTotalBytes) {
     this.memoryTotalBytes = memoryTotalBytes;
     this.timestamp = timestamp;
     this.cpusUsed = cpusUsed;
-    this.cpusTotal = cpusTotal;
     this.diskTotalBytes = diskTotalBytes;
   }
 
@@ -40,11 +37,6 @@ public class SingularityTaskCurrentUsage {
   @Schema(description = "The cpus used by this task")
   public double getCpusUsed() {
     return cpusUsed;
-  }
-
-  @Schema(description = "The cpus allocated for this task")
-  public double getCpusTotal() {
-    return cpusTotal;
   }
 
   @Schema(description = "The total disk usage for this task in bytes")

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskCurrentUsage.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskCurrentUsage.java
@@ -11,16 +11,19 @@ public class SingularityTaskCurrentUsage {
   private final long memoryTotalBytes;
   private final long timestamp;
   private final double cpusUsed;
+  private final double cpusTotal;
   private final long diskTotalBytes;
 
   @JsonCreator
   public SingularityTaskCurrentUsage(@JsonProperty("memoryTotalBytes") long memoryTotalBytes,
                                      @JsonProperty("long") long timestamp,
                                      @JsonProperty("cpusUsed") double cpusUsed,
+                                     @JsonProperty("cpusTotal") double cpusTotal,
                                      @JsonProperty("diskTotalBytes") long diskTotalBytes) {
     this.memoryTotalBytes = memoryTotalBytes;
     this.timestamp = timestamp;
     this.cpusUsed = cpusUsed;
+    this.cpusTotal = cpusTotal;
     this.diskTotalBytes = diskTotalBytes;
   }
 
@@ -37,6 +40,11 @@ public class SingularityTaskCurrentUsage {
   @Schema(description = "The cpus used by this task")
   public double getCpusUsed() {
     return cpusUsed;
+  }
+
+  @Schema(description = "The cpus allocated for this task")
+  public double getCpusTotal() {
+    return cpusTotal;
   }
 
   @Schema(description = "The total disk usage for this task in bytes")

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskCurrentUsageWithId.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskCurrentUsageWithId.java
@@ -14,7 +14,7 @@ public class SingularityTaskCurrentUsageWithId extends SingularityTaskCurrentUsa
   private final SingularityTaskId taskId;
 
   public SingularityTaskCurrentUsageWithId(SingularityTaskId taskId, SingularityTaskCurrentUsage taskCurrentUsage) {
-    super(taskCurrentUsage.getMemoryTotalBytes(), taskCurrentUsage.getTimestamp(), taskCurrentUsage.getCpusUsed(), taskCurrentUsage.getCpusTotal(), taskCurrentUsage.getDiskTotalBytes());
+    super(taskCurrentUsage.getMemoryTotalBytes(), taskCurrentUsage.getTimestamp(), taskCurrentUsage.getCpusUsed(), taskCurrentUsage.getDiskTotalBytes());
 
     this.taskId = taskId;
   }
@@ -23,10 +23,9 @@ public class SingularityTaskCurrentUsageWithId extends SingularityTaskCurrentUsa
   public SingularityTaskCurrentUsageWithId(@JsonProperty("memoryTotalBytes") long memoryTotalBytes,
                                            @JsonProperty("long") long timestamp,
                                            @JsonProperty("cpusUsed") double cpusUsed,
-                                           @JsonProperty("cpusTotal") double cpusTotal,
                                            @JsonProperty("diskTotalBytes") long diskTotalBytes,
                                            @JsonProperty("taskId") SingularityTaskId taskId) {
-    super(memoryTotalBytes, timestamp, cpusUsed, cpusTotal, diskTotalBytes);
+    super(memoryTotalBytes, timestamp, cpusUsed, diskTotalBytes);
     this.taskId = taskId;
   }
 

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskCurrentUsageWithId.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskCurrentUsageWithId.java
@@ -14,7 +14,7 @@ public class SingularityTaskCurrentUsageWithId extends SingularityTaskCurrentUsa
   private final SingularityTaskId taskId;
 
   public SingularityTaskCurrentUsageWithId(SingularityTaskId taskId, SingularityTaskCurrentUsage taskCurrentUsage) {
-    super(taskCurrentUsage.getMemoryTotalBytes(), taskCurrentUsage.getTimestamp(), taskCurrentUsage.getCpusUsed(), taskCurrentUsage.getDiskTotalBytes());
+    super(taskCurrentUsage.getMemoryTotalBytes(), taskCurrentUsage.getTimestamp(), taskCurrentUsage.getCpusUsed(), taskCurrentUsage.getCpusTotal(), taskCurrentUsage.getDiskTotalBytes());
 
     this.taskId = taskId;
   }
@@ -23,9 +23,10 @@ public class SingularityTaskCurrentUsageWithId extends SingularityTaskCurrentUsa
   public SingularityTaskCurrentUsageWithId(@JsonProperty("memoryTotalBytes") long memoryTotalBytes,
                                            @JsonProperty("long") long timestamp,
                                            @JsonProperty("cpusUsed") double cpusUsed,
+                                           @JsonProperty("cpusTotal") double cpusTotal,
                                            @JsonProperty("diskTotalBytes") long diskTotalBytes,
                                            @JsonProperty("taskId") SingularityTaskId taskId) {
-    super(memoryTotalBytes, timestamp, cpusUsed, diskTotalBytes);
+    super(memoryTotalBytes, timestamp, cpusUsed, cpusTotal, diskTotalBytes);
     this.taskId = taskId;
   }
 

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskUsage.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskUsage.java
@@ -9,7 +9,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public class SingularityTaskUsage {
 
   private final long memoryTotalBytes;
-  private final long timestamp; // seconds
+  private final long timestamp; // epoch millis
   private final double cpuSeconds;
   private final long diskTotalBytes;
   private final long cpusNrPeriods;

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskUsage.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskUsage.java
@@ -9,7 +9,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public class SingularityTaskUsage {
 
   private final long memoryTotalBytes;
-  private final double timestamp; // seconds
+  private final long timestamp; // seconds
   private final double cpuSeconds;
   private final long diskTotalBytes;
   private final long cpusNrPeriods;
@@ -18,7 +18,7 @@ public class SingularityTaskUsage {
 
   @JsonCreator
   public SingularityTaskUsage(@JsonProperty("memoryTotalBytes") long memoryTotalBytes,
-                              @JsonProperty("timestamp") double timestamp,
+                              @JsonProperty("timestamp") long timestamp,
                               @JsonProperty("cpuSeconds") double cpuSeconds,
                               @JsonProperty("diskTotalBytes") long diskTotalBytes,
                               @JsonProperty("cpusNrPeriods") long cpusNrPeriods,
@@ -38,8 +38,8 @@ public class SingularityTaskUsage {
     return memoryTotalBytes;
   }
 
-  @Schema(description = "Timestamp this usage was recorded (epoch seconds)")
-  public double getTimestamp() {
+  @Schema(description = "Timestamp this usage was recorded (epoch millis)")
+  public long getTimestamp() {
     return timestamp;
   }
 
@@ -53,14 +53,17 @@ public class SingularityTaskUsage {
     return diskTotalBytes;
   }
 
+  @Schema(description = "Number of cpu periods used by this task (from cgroups)")
   public long getCpusNrPeriods() {
     return cpusNrPeriods;
   }
 
+  @Schema(description = "Number of cpu periods throttled for this task (from cgroups)")
   public long getCpusNrThrottled() {
     return cpusNrThrottled;
   }
 
+  @Schema(description = "Total cpu time throttled for this task(from cgroups)")
   public double getCpusThrottledTimeSecs() {
     return cpusThrottledTimeSecs;
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityServiceModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityServiceModule.java
@@ -28,7 +28,7 @@ public class SingularityServiceModule extends DropwizardAwareModule<SingularityC
     binder.install(new MetricsInstrumentationModule(getBootstrap().getMetricRegistry()));
 
     binder.install(new SingularityMainModule(getConfiguration()));
-    binder.install(new SingularityDataModule());
+    binder.install(new SingularityDataModule(getConfiguration()));
     binder.install(new SingularitySchedulerModule());
     binder.install(new SingularityResourceModule(getConfiguration().getUiConfiguration()));
     binder.install(new SingularityTranscoderModule());

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityDataModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityDataModule.java
@@ -8,10 +8,7 @@ import com.google.inject.Singleton;
 import com.hubspot.singularity.SingularityDeploy;
 import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.config.SingularityConfiguration;
-import com.hubspot.singularity.data.usage.JDBITaskUsageManager;
-import com.hubspot.singularity.data.usage.TaskUsageManager;
 import com.hubspot.singularity.data.usage.UsageManager;
-import com.hubspot.singularity.data.usage.ZkTaskUsageManager;
 import com.hubspot.singularity.helpers.RequestHelper;
 
 public class SingularityDataModule extends AbstractModule {
@@ -39,12 +36,6 @@ public class SingularityDataModule extends AbstractModule {
     bind(SingularityValidator.class).in(Scopes.SINGLETON);
     bind(UserManager.class).in(Scopes.SINGLETON);
     bind(UsageManager.class).in(Scopes.SINGLETON);
-
-    if (configuration.getDatabaseConfiguration().isPresent()) {
-      bind(TaskUsageManager.class).to(JDBITaskUsageManager.class).in(Scopes.SINGLETON);
-    } else {
-      bind(TaskUsageManager.class).to(ZkTaskUsageManager.class).in(Scopes.SINGLETON);
-    }
 
     bind(WebhookManager.class).in(Scopes.SINGLETON);
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityDataModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityDataModule.java
@@ -8,10 +8,19 @@ import com.google.inject.Singleton;
 import com.hubspot.singularity.SingularityDeploy;
 import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.config.SingularityConfiguration;
+import com.hubspot.singularity.data.usage.JDBITaskUsageManager;
+import com.hubspot.singularity.data.usage.TaskUsageManager;
 import com.hubspot.singularity.data.usage.UsageManager;
+import com.hubspot.singularity.data.usage.ZkTaskUsageManager;
 import com.hubspot.singularity.helpers.RequestHelper;
 
 public class SingularityDataModule extends AbstractModule {
+
+  private final SingularityConfiguration configuration;
+
+  public SingularityDataModule(final SingularityConfiguration configuration) {
+    this.configuration = configuration;
+  }
 
   @Override
   protected void configure() {
@@ -30,6 +39,13 @@ public class SingularityDataModule extends AbstractModule {
     bind(SingularityValidator.class).in(Scopes.SINGLETON);
     bind(UserManager.class).in(Scopes.SINGLETON);
     bind(UsageManager.class).in(Scopes.SINGLETON);
+
+    if (configuration.getDatabaseConfiguration().isPresent()) {
+      bind(TaskUsageManager.class).to(JDBITaskUsageManager.class).in(Scopes.SINGLETON);
+    } else {
+      bind(TaskUsageManager.class).to(ZkTaskUsageManager.class).in(Scopes.SINGLETON);
+    }
+
     bind(WebhookManager.class).in(Scopes.SINGLETON);
 
     bind(NotificationsManager.class).in(Scopes.SINGLETON);

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityDataModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityDataModule.java
@@ -8,6 +8,7 @@ import com.google.inject.Singleton;
 import com.hubspot.singularity.SingularityDeploy;
 import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.config.SingularityConfiguration;
+import com.hubspot.singularity.data.usage.UsageManager;
 import com.hubspot.singularity.helpers.RequestHelper;
 
 public class SingularityDataModule extends AbstractModule {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/MySQLHistoryJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/MySQLHistoryJDBI.java
@@ -3,15 +3,15 @@ package com.hubspot.singularity.data.history;
 import java.util.Date;
 import java.util.List;
 
-import com.hubspot.singularity.SingularityDeployHistory;
-import com.hubspot.singularity.SingularityRequestHistory;
-import com.hubspot.singularity.data.history.SingularityMappers.SingularityRequestIdCount;
-
 import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.SqlUpdate;
 import org.skife.jdbi.v2.sqlobject.customizers.Define;
 import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator;
+
+import com.hubspot.singularity.SingularityDeployHistory;
+import com.hubspot.singularity.SingularityRequestHistory;
+import com.hubspot.singularity.data.history.SingularityMappers.SingularityRequestIdCount;
 
 @UseStringTemplate3StatementLocator
 public abstract class MySQLHistoryJDBI extends AbstractHistoryJDBI {
@@ -48,7 +48,7 @@ public abstract class MySQLHistoryJDBI extends AbstractHistoryJDBI {
   @SqlQuery("SELECT COUNT(*) FROM requestHistory WHERE requestId = :requestId")
   public abstract int getRequestHistoryCount(@Bind("requestId") String requestId);
 
-  @SqlQuery("SELECT DISTINCT requestId FROM requestHistory WHERE requestId LIKE CONCAT(:requestIdLike, '%') LIMIT :limitStart, :limitCount")
+  @SqlQuery("SELECT DISTINCT requestId as id FROM requestHistory WHERE requestId LIKE CONCAT(:requestIdLike, '%') LIMIT :limitStart, :limitCount")
   public abstract List<String> getRequestHistoryLike(@Bind("requestIdLike") String requestIdLike, @Bind("limitStart") Integer limitStart, @Bind("limitCount") Integer limitCount);
 
   @SqlQuery("SELECT requestId, COUNT(*) as count FROM taskHistory WHERE updatedAt \\< :updatedAt GROUP BY requestId")
@@ -63,7 +63,7 @@ public abstract class MySQLHistoryJDBI extends AbstractHistoryJDBI {
   @SqlUpdate("DELETE FROM taskHistory WHERE requestId = :requestId AND updatedAt \\< :updatedAtBefore LIMIT :purgeLimitPerQuery")
   public abstract void deleteTaskHistoryForRequestBefore(@Bind("requestId") String requestId, @Bind("updatedAtBefore") Date updatedAtBefore, @Bind("purgeLimitPerQuery") Integer purgeLimitPerQuery);
 
-  @SqlQuery("SELECT DISTINCT requestId FROM taskHistory")
+  @SqlQuery("SELECT DISTINCT requestId as id FROM taskHistory")
   public abstract List<String> getRequestIdsInTaskHistory();
 
   @SqlQuery("SELECT COUNT(*) FROM taskHistory WHERE requestId = :requestId AND purged = false AND updatedAt \\< :updatedAtBefore")

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/PostgresHistoryJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/PostgresHistoryJDBI.java
@@ -3,15 +3,15 @@ package com.hubspot.singularity.data.history;
 import java.util.Date;
 import java.util.List;
 
-import com.hubspot.singularity.SingularityDeployHistory;
-import com.hubspot.singularity.SingularityRequestHistory;
-import com.hubspot.singularity.data.history.SingularityMappers.SingularityRequestIdCount;
-
 import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.SqlUpdate;
 import org.skife.jdbi.v2.sqlobject.customizers.Define;
 import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator;
+
+import com.hubspot.singularity.SingularityDeployHistory;
+import com.hubspot.singularity.SingularityRequestHistory;
+import com.hubspot.singularity.data.history.SingularityMappers.SingularityRequestIdCount;
 
 @UseStringTemplate3StatementLocator
 public abstract class PostgresHistoryJDBI extends AbstractHistoryJDBI {
@@ -48,7 +48,7 @@ public abstract class PostgresHistoryJDBI extends AbstractHistoryJDBI {
   @SqlQuery("SELECT COUNT(*) FROM requestHistory WHERE requestId = :requestId")
   public abstract int getRequestHistoryCount(@Bind("requestId") String requestId);
 
-  @SqlQuery("SELECT DISTINCT requestId FROM requestHistory WHERE requestId LIKE CONCAT(:requestIdLike, '%') OFFSET :limitStart LIMIT :limitCount")
+  @SqlQuery("SELECT DISTINCT requestId as id FROM requestHistory WHERE requestId LIKE CONCAT(:requestIdLike, '%') OFFSET :limitStart LIMIT :limitCount")
   public abstract List<String> getRequestHistoryLike(@Bind("requestIdLike") String requestIdLike, @Bind("limitStart") Integer limitStart, @Bind("limitCount") Integer limitCount);
 
   @SqlQuery("SELECT requestId, COUNT(*) as count FROM taskHistory WHERE updatedAt \\< :updatedAt GROUP BY requestId")
@@ -63,7 +63,7 @@ public abstract class PostgresHistoryJDBI extends AbstractHistoryJDBI {
   @SqlUpdate("DELETE FROM taskHistory WHERE requestId = :requestId AND updatedAt \\< :updatedAtBefore LIMIT :purgeLimitPerQuery")
   public abstract void deleteTaskHistoryForRequestBefore(@Bind("requestId") String requestId, @Bind("updatedAtBefore") Date updatedAtBefore, @Bind("purgeLimitPerQuery") Integer purgeLimitPerQuery);
 
-  @SqlQuery("SELECT DISTINCT requestId FROM taskHistory")
+  @SqlQuery("SELECT DISTINCT requestId as id FROM taskHistory")
   public abstract List<String> getRequestIdsInTaskHistory();
 
   @SqlQuery("SELECT COUNT(*) FROM taskHistory WHERE requestId = :requestId AND purged = false AND updatedAt \\< :updatedAtBefore")

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityHistoryModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityHistoryModule.java
@@ -28,6 +28,9 @@ import com.hubspot.singularity.SingularityManagedCachedThreadPoolFactory;
 import com.hubspot.singularity.SingularityManagedScheduledExecutorServiceFactory;
 import com.hubspot.singularity.async.AsyncSemaphore;
 import com.hubspot.singularity.config.SingularityConfiguration;
+import com.hubspot.singularity.data.usage.MySQLTaskUsageJDBI;
+import com.hubspot.singularity.data.usage.PostgresTaskUsageJDBI;
+import com.hubspot.singularity.data.usage.TaskUsageJDBI;
 
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.jdbi.DBIFactory;
@@ -81,9 +84,11 @@ public class SingularityHistoryModule extends AbstractModule {
   private void bindSpecificDatabase() {
     if (isPostgres(configuration)) {
       bind(HistoryJDBI.class).toProvider(PostgresHistoryJDBIProvider.class).in(Scopes.SINGLETON);
+      bind(TaskUsageJDBI.class).toProvider(PostgresTaskUsageJDBIProvider.class).in(Scopes.SINGLETON);
       // Currently many unit tests use h2
     } else if (isMySQL(configuration) || isH2(configuration)) {
       bind(HistoryJDBI.class).toProvider(MySQLHistoryJDBIProvider.class).in(Scopes.SINGLETON);
+      bind(TaskUsageJDBI.class).toProvider(MySQLTaskUsageJDBIProvider.class).in(Scopes.SINGLETON);
     } else {
       throw new IllegalStateException("Unknown driver class present " + configuration.get().getDriverClass());
     }
@@ -190,6 +195,36 @@ public class SingularityHistoryModule extends AbstractModule {
     @Override
     public PostgresHistoryJDBI get() {
       return dbi.onDemand(PostgresHistoryJDBI.class);
+    }
+
+  }
+
+  static class MySQLTaskUsageJDBIProvider implements Provider<TaskUsageJDBI> {
+    private final DBI dbi;
+
+    @Inject
+    public MySQLTaskUsageJDBIProvider(DBI dbi) {
+      this.dbi = dbi;
+    }
+
+    @Override
+    public MySQLTaskUsageJDBI get() {
+      return dbi.onDemand(MySQLTaskUsageJDBI.class);
+    }
+
+  }
+
+  static class PostgresTaskUsageJDBIProvider implements Provider<TaskUsageJDBI> {
+    private final DBI dbi;
+
+    @Inject
+    public PostgresTaskUsageJDBIProvider(DBI dbi) {
+      this.dbi = dbi;
+    }
+
+    @Override
+    public PostgresTaskUsageJDBI get() {
+      return dbi.onDemand(PostgresTaskUsageJDBI.class);
     }
 
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityHistoryModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityHistoryModule.java
@@ -64,6 +64,7 @@ public class SingularityHistoryModule extends AbstractModule {
     resultSetMappers.addBinding().to(SingularityMappers.SingularityDeployHistoryLiteMapper.class).in(Scopes.SINGLETON);
     resultSetMappers.addBinding().to(SingularityMappers.SingularityRequestIdCountMapper.class).in(Scopes.SINGLETON);
     resultSetMappers.addBinding().to(SingularityMappers.DateMapper.class).in(Scopes.SINGLETON);
+    resultSetMappers.addBinding().to(SingularityMappers.SingularityTaskUsageMapper.class).in(Scopes.SINGLETON);
 
     bind(TaskHistoryHelper.class).in(Scopes.SINGLETON);
     bind(RequestHistoryHelper.class).in(Scopes.SINGLETON);

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityHistoryModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityHistoryModule.java
@@ -28,6 +28,7 @@ import com.hubspot.singularity.SingularityManagedCachedThreadPoolFactory;
 import com.hubspot.singularity.SingularityManagedScheduledExecutorServiceFactory;
 import com.hubspot.singularity.async.AsyncSemaphore;
 import com.hubspot.singularity.config.SingularityConfiguration;
+import com.hubspot.singularity.data.history.SingularityMappers.SingularityIdMapper;
 import com.hubspot.singularity.data.usage.JDBITaskUsageManager;
 import com.hubspot.singularity.data.usage.MySQLTaskUsageJDBI;
 import com.hubspot.singularity.data.usage.PostgresTaskUsageJDBI;
@@ -58,13 +59,14 @@ public class SingularityHistoryModule extends AbstractModule {
     Multibinder<ResultSetMapper<?>> resultSetMappers = Multibinder.newSetBinder(binder(), new TypeLiteral<ResultSetMapper<?>>() {});
 
     resultSetMappers.addBinding().to(SingularityMappers.SingularityBytesMapper.class).in(Scopes.SINGLETON);
-    resultSetMappers.addBinding().to(SingularityMappers.SingularityRequestIdMapper.class).in(Scopes.SINGLETON);
+    resultSetMappers.addBinding().to(SingularityIdMapper.class).in(Scopes.SINGLETON);
     resultSetMappers.addBinding().to(SingularityMappers.SingularityRequestHistoryMapper.class).in(Scopes.SINGLETON);
     resultSetMappers.addBinding().to(SingularityMappers.SingularityTaskIdHistoryMapper.class).in(Scopes.SINGLETON);
     resultSetMappers.addBinding().to(SingularityMappers.SingularityDeployHistoryLiteMapper.class).in(Scopes.SINGLETON);
     resultSetMappers.addBinding().to(SingularityMappers.SingularityRequestIdCountMapper.class).in(Scopes.SINGLETON);
     resultSetMappers.addBinding().to(SingularityMappers.DateMapper.class).in(Scopes.SINGLETON);
     resultSetMappers.addBinding().to(SingularityMappers.SingularityTaskUsageMapper.class).in(Scopes.SINGLETON);
+    resultSetMappers.addBinding().to(SingularityMappers.SingularityTimestampMapper.class).in(Scopes.SINGLETON);
 
     bind(TaskHistoryHelper.class).in(Scopes.SINGLETON);
     bind(RequestHistoryHelper.class).in(Scopes.SINGLETON);

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityHistoryModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityHistoryModule.java
@@ -28,9 +28,12 @@ import com.hubspot.singularity.SingularityManagedCachedThreadPoolFactory;
 import com.hubspot.singularity.SingularityManagedScheduledExecutorServiceFactory;
 import com.hubspot.singularity.async.AsyncSemaphore;
 import com.hubspot.singularity.config.SingularityConfiguration;
+import com.hubspot.singularity.data.usage.JDBITaskUsageManager;
 import com.hubspot.singularity.data.usage.MySQLTaskUsageJDBI;
 import com.hubspot.singularity.data.usage.PostgresTaskUsageJDBI;
 import com.hubspot.singularity.data.usage.TaskUsageJDBI;
+import com.hubspot.singularity.data.usage.TaskUsageManager;
+import com.hubspot.singularity.data.usage.ZkTaskUsageManager;
 
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.jdbi.DBIFactory;
@@ -76,8 +79,10 @@ public class SingularityHistoryModule extends AbstractModule {
       bindSpecificDatabase();
       bind(HistoryManager.class).to(JDBIHistoryManager.class).in(Scopes.SINGLETON);
       bindMethodInterceptorForStringTemplateClassLoaderWorkaround();
+      bind(TaskUsageManager.class).to(JDBITaskUsageManager.class).in(Scopes.SINGLETON);
     } else {
       bind(HistoryManager.class).to(NoopHistoryManager.class).in(Scopes.SINGLETON);
+      bind(TaskUsageManager.class).to(ZkTaskUsageManager.class).in(Scopes.SINGLETON);
     }
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityMappers.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityMappers.java
@@ -62,14 +62,26 @@ public class SingularityMappers {
 
   }
 
-  static class SingularityRequestIdMapper implements ResultSetMapper<String> {
+  static class SingularityIdMapper implements ResultSetMapper<String> {
 
     @Inject
-    SingularityRequestIdMapper() {}
+    SingularityIdMapper() {}
 
     @Override
     public String map(int index, ResultSet r, StatementContext ctx) throws SQLException {
       return r.getString("id");
+    }
+
+  }
+
+  static class SingularityTimestampMapper implements ResultSetMapper<Long> {
+
+    @Inject
+    SingularityTimestampMapper() {}
+
+    @Override
+    public Long map(int index, ResultSet r, StatementContext ctx) throws SQLException {
+      return r.getLong("timestamp");
     }
 
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityMappers.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityMappers.java
@@ -69,7 +69,7 @@ public class SingularityMappers {
 
     @Override
     public String map(int index, ResultSet r, StatementContext ctx) throws SQLException {
-      return r.getString("requestId");
+      return r.getString("id");
     }
 
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityMappers.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityMappers.java
@@ -7,6 +7,12 @@ import java.util.Date;
 
 import javax.inject.Inject;
 
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.exceptions.ResultSetException;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.base.Optional;
 import com.hubspot.singularity.DeployState;
 import com.hubspot.singularity.ExtendedTaskState;
@@ -22,18 +28,11 @@ import com.hubspot.singularity.SingularityRequestHistory;
 import com.hubspot.singularity.SingularityRequestHistory.RequestHistoryType;
 import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.SingularityTaskIdHistory;
+import com.hubspot.singularity.SingularityTaskUsage;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.transcoders.IdTranscoder;
 import com.hubspot.singularity.data.transcoders.SingularityTranscoderException;
 import com.hubspot.singularity.data.transcoders.Transcoder;
-
-import org.skife.jdbi.v2.StatementContext;
-import org.skife.jdbi.v2.exceptions.ResultSetException;
-import org.skife.jdbi.v2.tweak.ResultSetMapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import io.dropwizard.db.DataSourceFactory;
 
 public class SingularityMappers {
 
@@ -160,6 +159,25 @@ public class SingularityMappers {
       return new SingularityRequestIdCount(r.getString("requestId"), r.getInt("count"));
     }
 
+  }
+
+  static class SingularityTaskUsageMapper implements ResultSetMapper<SingularityTaskUsage> {
+
+    @Inject
+    SingularityTaskUsageMapper() {}
+
+    @Override
+    public SingularityTaskUsage map(int index, ResultSet r, StatementContext ctx) throws SQLException {
+      return new SingularityTaskUsage(
+          r.getLong("memoryTotalBytes"),
+          r.getLong("timestamp"),
+          r.getDouble("cpuSeconds"),
+          r.getLong("diskTotalBytes"),
+          r.getLong("cpusNrPeriods"),
+          r.getLong("cpusNrThrottled"),
+          r.getDouble("cpusThrottledTimeSecs")
+      );
+    }
   }
 
   public static class SingularityRequestIdCount {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/transcoders/SingularityTranscoderModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/transcoders/SingularityTranscoderModule.java
@@ -33,11 +33,11 @@ import com.hubspot.singularity.SingularityRequestHistory;
 import com.hubspot.singularity.SingularityRequestLbCleanup;
 import com.hubspot.singularity.SingularityRequestWithState;
 import com.hubspot.singularity.SingularitySlave;
-import com.hubspot.singularity.SingularitySlaveUsage;
+import com.hubspot.singularity.SingularitySlaveUsageWithId;
 import com.hubspot.singularity.SingularityState;
 import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.SingularityTaskCleanup;
-import com.hubspot.singularity.SingularityTaskCurrentUsage;
+import com.hubspot.singularity.SingularityTaskCurrentUsageWithId;
 import com.hubspot.singularity.SingularityTaskDestroyFrameworkMessage;
 import com.hubspot.singularity.SingularityTaskHealthcheckResult;
 import com.hubspot.singularity.SingularityTaskHistory;
@@ -102,10 +102,10 @@ public class SingularityTranscoderModule implements Module {
     bindTranscoder(binder).asJson(SingularityExpiringMachineState.class);
     bindTranscoder(binder).asJson(SingularityUserSettings.class);
     bindTranscoder(binder).asJson(SingularityUser.class);
-    bindTranscoder(binder).asJson(SingularitySlaveUsage.class);
+    bindTranscoder(binder).asJson(SingularitySlaveUsageWithId.class);
     bindTranscoder(binder).asJson(SingularityTaskUsage.class);
     bindTranscoder(binder).asJson(SingularityClusterUtilization.class);
-    bindTranscoder(binder).asJson(SingularityTaskCurrentUsage.class);
+    bindTranscoder(binder).asJson(SingularityTaskCurrentUsageWithId.class);
     bindTranscoder(binder).asJson(RequestUtilization.class);
 
     bindTranscoder(binder).asCompressedJson(SingularityDeployHistory.class);

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/transcoders/SingularityTranscoderModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/transcoders/SingularityTranscoderModule.java
@@ -37,7 +37,6 @@ import com.hubspot.singularity.SingularitySlaveUsageWithId;
 import com.hubspot.singularity.SingularityState;
 import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.SingularityTaskCleanup;
-import com.hubspot.singularity.SingularityTaskCurrentUsageWithId;
 import com.hubspot.singularity.SingularityTaskDestroyFrameworkMessage;
 import com.hubspot.singularity.SingularityTaskHealthcheckResult;
 import com.hubspot.singularity.SingularityTaskHistory;
@@ -105,7 +104,6 @@ public class SingularityTranscoderModule implements Module {
     bindTranscoder(binder).asJson(SingularitySlaveUsageWithId.class);
     bindTranscoder(binder).asJson(SingularityTaskUsage.class);
     bindTranscoder(binder).asJson(SingularityClusterUtilization.class);
-    bindTranscoder(binder).asJson(SingularityTaskCurrentUsageWithId.class);
     bindTranscoder(binder).asJson(RequestUtilization.class);
 
     bindTranscoder(binder).asCompressedJson(SingularityDeployHistory.class);

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/JDBITaskUsageManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/JDBITaskUsageManager.java
@@ -1,0 +1,4 @@
+package com.hubspot.singularity.data.usage;
+
+public class JDBITaskUsageManager {
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/JDBITaskUsageManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/JDBITaskUsageManager.java
@@ -1,35 +1,64 @@
 package com.hubspot.singularity.data.usage;
 
+import java.util.Date;
 import java.util.List;
-import java.util.Map;
 
-import com.hubspot.singularity.SingularityTaskCurrentUsageWithId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.Inject;
+import com.hubspot.singularity.InvalidSingularityTaskIdException;
 import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.SingularityTaskUsage;
 
 public class JDBITaskUsageManager implements TaskUsageManager {
+  private static final Logger LOG = LoggerFactory.getLogger(JDBITaskUsageManager.class);
 
-  public void deleteTaskUsage(String taskId) {
+  private final MySQLTaskUsageJDBI taskUsageJDBI;
 
+  @Inject
+  public JDBITaskUsageManager(MySQLTaskUsageJDBI taskUsageJDBI) {
+    this.taskUsageJDBI = taskUsageJDBI;
   }
 
-  public void deleteSpecificTaskUsage(String taskId, double timestamp) {
-
+  public void deleteTaskUsage(SingularityTaskId taskId) {
+    taskUsageJDBI.deleteTaskUsage(taskId.getRequestId(), taskId.getId());
   }
 
-  public void saveCurrentTaskUsage(SingularityTaskCurrentUsageWithId usageWithId) {
-
+  public void deleteSpecificTaskUsage(SingularityTaskId taskId, long timestamp) {
+    taskUsageJDBI.deleteSpecificTaskUsage(taskId.getRequestId(), taskId.getId(), new Date(timestamp));
   }
 
-  public void saveSpecificTaskUsage(String taskId, SingularityTaskUsage usage) {
-
+  public void saveSpecificTaskUsage(SingularityTaskId taskId, SingularityTaskUsage usage) {
+    taskUsageJDBI.saveSpecificTaskUsage(taskId.getRequestId(), taskId.getId(), usage.getMemoryTotalBytes(), new Date(usage.getTimestamp()), usage.getCpuSeconds(), usage.getDiskTotalBytes(), usage.getCpusNrPeriods(), usage.getCpusNrThrottled(), usage.getCpusThrottledTimeSecs());
   }
 
-  public List<SingularityTaskUsage> getTaskUsage(String taskId) {
-
+  public List<SingularityTaskUsage> getTaskUsage(SingularityTaskId taskId) {
+    return taskUsageJDBI.getTaskUsage(taskId.getRequestId(), taskId.getId());
   }
 
-  public Map<String, SingularityTaskCurrentUsageWithId> getTaskCurrentUsages(List<SingularityTaskId> taskIds) {
+  public int countTasksWithUsage() {
+    return taskUsageJDBI.countTasksWithUsage();
+  }
 
+  public void cleanOldUsages(List<SingularityTaskId> activeTaskIds) {
+    for (String taskIdString : taskUsageJDBI.getUniqueTaskIds()) {
+      SingularityTaskId taskId = null;
+      try {
+        taskId = SingularityTaskId.valueOf(taskIdString);
+        if (activeTaskIds.contains(taskId)) {
+          continue;
+        }
+      } catch (InvalidSingularityTaskIdException e) {
+        LOG.warn("{} is not a valid task id, will remove task usage from zookeeper", taskIdString);
+      }
+      if (taskId == null) {
+        taskUsageJDBI.deleteTaskUsage(taskIdString);
+      } else {
+        taskUsageJDBI.deleteTaskUsage(taskId.getRequestId(), taskId.getId()); // better index
+      }
+
+      LOG.debug("Deleted obsolete task usage {}", taskIdString);
+    }
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/JDBITaskUsageManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/JDBITaskUsageManager.java
@@ -1,4 +1,35 @@
 package com.hubspot.singularity.data.usage;
 
-public class JDBITaskUsageManager {
+import java.util.List;
+import java.util.Map;
+
+import com.hubspot.singularity.SingularityTaskCurrentUsageWithId;
+import com.hubspot.singularity.SingularityTaskId;
+import com.hubspot.singularity.SingularityTaskUsage;
+
+public class JDBITaskUsageManager implements TaskUsageManager {
+
+  public void deleteTaskUsage(String taskId) {
+
+  }
+
+  public void deleteSpecificTaskUsage(String taskId, double timestamp) {
+
+  }
+
+  public void saveCurrentTaskUsage(SingularityTaskCurrentUsageWithId usageWithId) {
+
+  }
+
+  public void saveSpecificTaskUsage(String taskId, SingularityTaskUsage usage) {
+
+  }
+
+  public List<SingularityTaskUsage> getTaskUsage(String taskId) {
+
+  }
+
+  public Map<String, SingularityTaskCurrentUsageWithId> getTaskCurrentUsages(List<SingularityTaskId> taskIds) {
+
+  }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/JDBITaskUsageManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/JDBITaskUsageManager.java
@@ -22,11 +22,11 @@ public class JDBITaskUsageManager implements TaskUsageManager {
   }
 
   public void deleteTaskUsage(SingularityTaskId taskId) {
-    taskUsageJDBI.deleteTaskUsage(taskId.getRequestId(), taskId.getId());
+    taskUsageJDBI.deleteTaskUsage(taskId.getId());
   }
 
   public void deleteSpecificTaskUsage(SingularityTaskId taskId, long timestamp) {
-    taskUsageJDBI.deleteSpecificTaskUsage(taskId.getRequestId(), taskId.getId(), new Date(timestamp));
+    taskUsageJDBI.deleteSpecificTaskUsage(taskId.getId(), new Date(timestamp));
   }
 
   public void saveSpecificTaskUsage(SingularityTaskId taskId, SingularityTaskUsage usage) {
@@ -34,7 +34,7 @@ public class JDBITaskUsageManager implements TaskUsageManager {
   }
 
   public List<SingularityTaskUsage> getTaskUsage(SingularityTaskId taskId) {
-    return taskUsageJDBI.getTaskUsage(taskId.getRequestId(), taskId.getId());
+    return taskUsageJDBI.getTaskUsage(taskId.getId());
   }
 
   public int countTasksWithUsage() {
@@ -52,11 +52,7 @@ public class JDBITaskUsageManager implements TaskUsageManager {
       } catch (InvalidSingularityTaskIdException e) {
         LOG.warn("{} is not a valid task id, will remove task usage from zookeeper", taskIdString);
       }
-      if (taskId == null) {
-        taskUsageJDBI.deleteTaskUsage(taskIdString);
-      } else {
-        taskUsageJDBI.deleteTaskUsage(taskId.getRequestId(), taskId.getId()); // better index
-      }
+      taskUsageJDBI.deleteTaskUsage(taskIdString);
 
       LOG.debug("Deleted obsolete task usage {}", taskIdString);
     }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/JDBITaskUsageManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/JDBITaskUsageManager.java
@@ -1,6 +1,5 @@
 package com.hubspot.singularity.data.usage;
 
-import java.util.Date;
 import java.util.List;
 
 import org.slf4j.Logger;
@@ -26,11 +25,11 @@ public class JDBITaskUsageManager implements TaskUsageManager {
   }
 
   public void deleteSpecificTaskUsage(SingularityTaskId taskId, long timestamp) {
-    taskUsageJDBI.deleteSpecificTaskUsage(taskId.getId(), new Date(timestamp));
+    taskUsageJDBI.deleteSpecificTaskUsage(taskId.getId(), timestamp);
   }
 
   public void saveSpecificTaskUsage(SingularityTaskId taskId, SingularityTaskUsage usage) {
-    taskUsageJDBI.saveSpecificTaskUsage(taskId.getRequestId(), taskId.getId(), usage.getMemoryTotalBytes(), new Date(usage.getTimestamp()), usage.getCpuSeconds(), usage.getDiskTotalBytes(), usage.getCpusNrPeriods(), usage.getCpusNrThrottled(), usage.getCpusThrottledTimeSecs());
+    taskUsageJDBI.saveSpecificTaskUsage(taskId.getRequestId(), taskId.getId(), usage.getMemoryTotalBytes(), usage.getTimestamp(), usage.getCpuSeconds(), usage.getDiskTotalBytes(), usage.getCpusNrPeriods(), usage.getCpusNrThrottled(), usage.getCpusThrottledTimeSecs());
   }
 
   public List<SingularityTaskUsage> getTaskUsage(SingularityTaskId taskId) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/JDBITaskUsageManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/JDBITaskUsageManager.java
@@ -53,6 +53,7 @@ public class JDBITaskUsageManager implements TaskUsageManager {
               .sorted((t1, t2) -> Long.compare(t2, t1))
               .skip(configuration.getNumUsageToKeep())
               .forEach((timestamp) -> deleteSpecificTaskUsage(taskId, timestamp));
+          continue;
         }
       } catch (InvalidSingularityTaskIdException e) {
         LOG.warn("{} is not a valid task id, will remove task usage from zookeeper", taskIdString);

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/JDBITaskUsageManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/JDBITaskUsageManager.java
@@ -14,10 +14,10 @@ import com.hubspot.singularity.SingularityTaskUsage;
 public class JDBITaskUsageManager implements TaskUsageManager {
   private static final Logger LOG = LoggerFactory.getLogger(JDBITaskUsageManager.class);
 
-  private final MySQLTaskUsageJDBI taskUsageJDBI;
+  private final TaskUsageJDBI taskUsageJDBI;
 
   @Inject
-  public JDBITaskUsageManager(MySQLTaskUsageJDBI taskUsageJDBI) {
+  public JDBITaskUsageManager(TaskUsageJDBI taskUsageJDBI) {
     this.taskUsageJDBI = taskUsageJDBI;
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/MySQLTaskUsageJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/MySQLTaskUsageJDBI.java
@@ -16,12 +16,12 @@ public abstract class MySQLTaskUsageJDBI extends TaskUsageJDBI {
   @SqlUpdate("DELETE FROM taskUsage WHERE taskId = :taskId AND timestamp = :timestamp")
   public abstract void deleteSpecificTaskUsage(@Bind("taskId") String taskId, @Bind("timestamp") Date timestamp);
 
-  @SqlUpdate("INSERT INTO taskUsage (" + FILEDS + ") VALUES (" + FILED_VALUES + ")")
+  @SqlUpdate("INSERT INTO taskUsage (" + FIELDS + ") VALUES (" + FIELD_VALUES + ")")
   public abstract void saveSpecificTaskUsage(@Bind("requestId") String requestId, @Bind("taskId") String taskId, @Bind("memoryTotalBytes") long memoryTotalBytes,
                                              @Bind("timestamp") Date timestamp, @Bind("cpuSeconds") double cpuSeconds, @Bind("diskTotalBytes") long diskTotalBytes, @Bind("cpusNrPeriods") long cpusNrPeriods,
                                              @Bind("cpusNrThrottled") long cpusNrThrottled, @Bind("cpusThrottledTimeSecs") double cpusThrottledTimeSecs);
 
-  @SqlQuery("SELECT " + FILEDS + "FROM taskUsage WHERE taskId = :taskId")
+  @SqlQuery("SELECT " + FIELDS + "FROM taskUsage WHERE taskId = :taskId")
   public abstract List<SingularityTaskUsage> getTaskUsage(@Bind("taskId") String taskId);
 
   @SqlQuery("SELECT COUNT(DISTINCT taskId) FROM taskUsage")

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/MySQLTaskUsageJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/MySQLTaskUsageJDBI.java
@@ -26,6 +26,9 @@ public abstract class MySQLTaskUsageJDBI extends TaskUsageJDBI {
   @SqlQuery("SELECT DISTINCT taskId as id FROM taskUsage")
   public abstract List<String> getUniqueTaskIds();
 
+  @SqlQuery("SELECT DISTINCT timestamp FROM taskUsage WHERE taskId = :taskId")
+  public abstract List<Long> getUsageTimestampsForTask(@Bind("taskId") String taskId);
+
   @SqlQuery("SELECT COUNT(DISTINCT taskId) FROM taskUsage")
   public abstract int countTasksWithUsage();
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/MySQLTaskUsageJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/MySQLTaskUsageJDBI.java
@@ -10,23 +10,19 @@ import org.skife.jdbi.v2.sqlobject.SqlUpdate;
 import com.hubspot.singularity.SingularityTaskUsage;
 
 public abstract class MySQLTaskUsageJDBI extends TaskUsageJDBI {
-
-  @SqlUpdate("DELETE FROM taskUsage WHERE requestId = :requestId AND taskId = :taskId")
-  public abstract void deleteTaskUsage(@Bind("requestId") String requestId, @Bind("taskId") String taskId);
-
   @SqlUpdate("DELETE FROM taskUsage WHERE taskId = :taskId")
   public abstract void deleteTaskUsage(@Bind("taskId") String taskId);
 
-  @SqlUpdate("DELETE FROM taskUsage WHERE requestId = :requestId AND taskId = :taskId AND timestamp = :timestamp")
-  public abstract void deleteSpecificTaskUsage(@Bind("requestId") String requestId, @Bind("taskId") String taskId, @Bind("timestamp") Date timestamp);
+  @SqlUpdate("DELETE FROM taskUsage WHERE taskId = :taskId AND timestamp = :timestamp")
+  public abstract void deleteSpecificTaskUsage(@Bind("taskId") String taskId, @Bind("timestamp") Date timestamp);
 
   @SqlUpdate("INSERT INTO taskUsage (" + FILEDS + ") VALUES (" + FILED_VALUES + ")")
   public abstract void saveSpecificTaskUsage(@Bind("requestId") String requestId, @Bind("taskId") String taskId, @Bind("memoryTotalBytes") long memoryTotalBytes,
                                              @Bind("timestamp") Date timestamp, @Bind("cpuSeconds") double cpuSeconds, @Bind("diskTotalBytes") long diskTotalBytes, @Bind("cpusNrPeriods") long cpusNrPeriods,
                                              @Bind("cpusNrThrottled") long cpusNrThrottled, @Bind("cpusThrottledTimeSecs") double cpusThrottledTimeSecs);
 
-  @SqlQuery("SELECT " + FILEDS + "FROM taskUsage WHERE requestId = :requestId AND taskId = :taskId")
-  public abstract List<SingularityTaskUsage> getTaskUsage(@Bind("requestId") String requestId, @Bind("taskId") String taskId);
+  @SqlQuery("SELECT " + FILEDS + "FROM taskUsage WHERE taskId = :taskId")
+  public abstract List<SingularityTaskUsage> getTaskUsage(@Bind("taskId") String taskId);
 
   @SqlQuery("SELECT COUNT(DISTINCT taskId) FROM taskUsage")
   public abstract int countTasksWithUsage();

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/MySQLTaskUsageJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/MySQLTaskUsageJDBI.java
@@ -25,7 +25,7 @@ public abstract class MySQLTaskUsageJDBI extends TaskUsageJDBI {
                                              @Bind("timestamp") Date timestamp, @Bind("cpuSeconds") double cpuSeconds, @Bind("diskTotalBytes") long diskTotalBytes, @Bind("cpusNrPeriods") long cpusNrPeriods,
                                              @Bind("cpusNrThrottled") long cpusNrThrottled, @Bind("cpusThrottledTimeSecs") double cpusThrottledTimeSecs);
 
-  @SqlUpdate("SELECT " + FILEDS + "FROM taskUsage WHERE requestId = :requestId AND taskId = :taskId")
+  @SqlQuery("SELECT " + FILEDS + "FROM taskUsage WHERE requestId = :requestId AND taskId = :taskId")
   public abstract List<SingularityTaskUsage> getTaskUsage(@Bind("requestId") String requestId, @Bind("taskId") String taskId);
 
   @SqlQuery("SELECT COUNT(DISTINCT taskId) FROM taskUsage")

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/MySQLTaskUsageJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/MySQLTaskUsageJDBI.java
@@ -23,6 +23,9 @@ public abstract class MySQLTaskUsageJDBI extends TaskUsageJDBI {
   @SqlQuery("SELECT " + FIELDS + " FROM taskUsage WHERE taskId = :taskId")
   public abstract List<SingularityTaskUsage> getTaskUsage(@Bind("taskId") String taskId);
 
+  @SqlQuery("SELECT DISTINCT taskId FROM taskUsage")
+  public abstract List<String> getUniqueTaskIds();
+
   @SqlQuery("SELECT COUNT(DISTINCT taskId) FROM taskUsage")
   public abstract int countTasksWithUsage();
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/MySQLTaskUsageJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/MySQLTaskUsageJDBI.java
@@ -1,6 +1,5 @@
 package com.hubspot.singularity.data.usage;
 
-import java.util.Date;
 import java.util.List;
 
 import org.skife.jdbi.v2.sqlobject.Bind;
@@ -14,11 +13,11 @@ public abstract class MySQLTaskUsageJDBI extends TaskUsageJDBI {
   public abstract void deleteTaskUsage(@Bind("taskId") String taskId);
 
   @SqlUpdate("DELETE FROM taskUsage WHERE taskId = :taskId AND timestamp = :timestamp")
-  public abstract void deleteSpecificTaskUsage(@Bind("taskId") String taskId, @Bind("timestamp") Date timestamp);
+  public abstract void deleteSpecificTaskUsage(@Bind("taskId") String taskId, @Bind("timestamp") long timestamp);
 
   @SqlUpdate("INSERT INTO taskUsage (" + FIELDS + ") VALUES (" + FIELD_VALUES + ")")
   public abstract void saveSpecificTaskUsage(@Bind("requestId") String requestId, @Bind("taskId") String taskId, @Bind("memoryTotalBytes") long memoryTotalBytes,
-                                             @Bind("timestamp") Date timestamp, @Bind("cpuSeconds") double cpuSeconds, @Bind("diskTotalBytes") long diskTotalBytes, @Bind("cpusNrPeriods") long cpusNrPeriods,
+                                             @Bind("timestamp") long timestamp, @Bind("cpuSeconds") double cpuSeconds, @Bind("diskTotalBytes") long diskTotalBytes, @Bind("cpusNrPeriods") long cpusNrPeriods,
                                              @Bind("cpusNrThrottled") long cpusNrThrottled, @Bind("cpusThrottledTimeSecs") double cpusThrottledTimeSecs);
 
   @SqlQuery("SELECT " + FIELDS + " FROM taskUsage WHERE taskId = :taskId")

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/MySQLTaskUsageJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/MySQLTaskUsageJDBI.java
@@ -1,0 +1,33 @@
+package com.hubspot.singularity.data.usage;
+
+import java.util.Date;
+import java.util.List;
+
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+
+import com.hubspot.singularity.SingularityTaskUsage;
+
+public abstract class MySQLTaskUsageJDBI extends TaskUsageJDBI {
+
+  @SqlUpdate("DELETE FROM taskUsage WHERE requestId = :requestId AND taskId = :taskId")
+  public abstract void deleteTaskUsage(@Bind("requestId") String requestId, @Bind("taskId") String taskId);
+
+  @SqlUpdate("DELETE FROM taskUsage WHERE taskId = :taskId")
+  public abstract void deleteTaskUsage(@Bind("taskId") String taskId);
+
+  @SqlUpdate("DELETE FROM taskUsage WHERE requestId = :requestId AND taskId = :taskId AND timestamp = :timestamp")
+  public abstract void deleteSpecificTaskUsage(@Bind("requestId") String requestId, @Bind("taskId") String taskId, @Bind("timestamp") Date timestamp);
+
+  @SqlUpdate("INSERT INTO taskUsage (" + FILEDS + ") VALUES (" + FILED_VALUES + ")")
+  public abstract void saveSpecificTaskUsage(@Bind("requestId") String requestId, @Bind("taskId") String taskId, @Bind("memoryTotalBytes") long memoryTotalBytes,
+                                             @Bind("timestamp") Date timestamp, @Bind("cpuSeconds") double cpuSeconds, @Bind("diskTotalBytes") long diskTotalBytes, @Bind("cpusNrPeriods") long cpusNrPeriods,
+                                             @Bind("cpusNrThrottled") long cpusNrThrottled, @Bind("cpusThrottledTimeSecs") double cpusThrottledTimeSecs);
+
+  @SqlUpdate("SELECT " + FILEDS + "FROM taskUsage WHERE requestId = :requestId AND taskId = :taskId")
+  public abstract List<SingularityTaskUsage> getTaskUsage(@Bind("requestId") String requestId, @Bind("taskId") String taskId);
+
+  @SqlQuery("SELECT COUNT(DISTINCT taskId) FROM taskUsage")
+  public abstract int countTasksWithUsage();
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/MySQLTaskUsageJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/MySQLTaskUsageJDBI.java
@@ -23,7 +23,7 @@ public abstract class MySQLTaskUsageJDBI extends TaskUsageJDBI {
   @SqlQuery("SELECT " + FIELDS + " FROM taskUsage WHERE taskId = :taskId")
   public abstract List<SingularityTaskUsage> getTaskUsage(@Bind("taskId") String taskId);
 
-  @SqlQuery("SELECT DISTINCT taskId FROM taskUsage")
+  @SqlQuery("SELECT DISTINCT taskId as id FROM taskUsage")
   public abstract List<String> getUniqueTaskIds();
 
   @SqlQuery("SELECT COUNT(DISTINCT taskId) FROM taskUsage")

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/MySQLTaskUsageJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/MySQLTaskUsageJDBI.java
@@ -21,7 +21,7 @@ public abstract class MySQLTaskUsageJDBI extends TaskUsageJDBI {
                                              @Bind("timestamp") Date timestamp, @Bind("cpuSeconds") double cpuSeconds, @Bind("diskTotalBytes") long diskTotalBytes, @Bind("cpusNrPeriods") long cpusNrPeriods,
                                              @Bind("cpusNrThrottled") long cpusNrThrottled, @Bind("cpusThrottledTimeSecs") double cpusThrottledTimeSecs);
 
-  @SqlQuery("SELECT " + FIELDS + "FROM taskUsage WHERE taskId = :taskId")
+  @SqlQuery("SELECT " + FIELDS + " FROM taskUsage WHERE taskId = :taskId")
   public abstract List<SingularityTaskUsage> getTaskUsage(@Bind("taskId") String taskId);
 
   @SqlQuery("SELECT COUNT(DISTINCT taskId) FROM taskUsage")

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/PostgresTaskUsageJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/PostgresTaskUsageJDBI.java
@@ -10,23 +10,19 @@ import org.skife.jdbi.v2.sqlobject.SqlUpdate;
 import com.hubspot.singularity.SingularityTaskUsage;
 
 public abstract class PostgresTaskUsageJDBI extends TaskUsageJDBI {
-
-  @SqlUpdate("DELETE FROM taskUsage WHERE requestId = :requestId AND taskId = :taskId")
-  public abstract void deleteTaskUsage(@Bind("requestId") String requestId, @Bind("taskId") String taskId);
-
   @SqlUpdate("DELETE FROM taskUsage WHERE taskId = :taskId")
   public abstract void deleteTaskUsage(@Bind("taskId") String taskId);
 
-  @SqlUpdate("DELETE FROM taskUsage WHERE requestId = :requestId AND taskId = :taskId AND timestamp = :timestamp")
-  public abstract void deleteSpecificTaskUsage(@Bind("requestId") String requestId, @Bind("taskId") String taskId, @Bind("timestamp") Date timestamp);
+  @SqlUpdate("DELETE FROM taskUsage WHERE taskId = :taskId AND timestamp = :timestamp")
+  public abstract void deleteSpecificTaskUsage(@Bind("taskId") String taskId, @Bind("timestamp") Date timestamp);
 
   @SqlUpdate("INSERT INTO taskUsage (" + FILEDS + ") VALUES (" + FILED_VALUES + ")")
   public abstract void saveSpecificTaskUsage(@Bind("requestId") String requestId, @Bind("taskId") String taskId, @Bind("memoryTotalBytes") long memoryTotalBytes,
                                              @Bind("timestamp") Date timestamp, @Bind("cpuSeconds") double cpuSeconds, @Bind("diskTotalBytes") long diskTotalBytes, @Bind("cpusNrPeriods") long cpusNrPeriods,
                                              @Bind("cpusNrThrottled") long cpusNrThrottled, @Bind("cpusThrottledTimeSecs") double cpusThrottledTimeSecs);
 
-  @SqlUpdate("SELECT " + FILEDS + "FROM taskUsage WHERE requestId = :requestId AND taskId = :taskId")
-  public abstract List<SingularityTaskUsage> getTaskUsage(@Bind("requestId") String requestId, @Bind("taskId") String taskId);
+  @SqlQuery("SELECT " + FILEDS + "FROM taskUsage WHERE taskId = :taskId")
+  public abstract List<SingularityTaskUsage> getTaskUsage(@Bind("taskId") String taskId);
 
   @SqlQuery("SELECT COUNT(DISTINCT taskId) FROM taskUsage")
   public abstract int countTasksWithUsage();

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/PostgresTaskUsageJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/PostgresTaskUsageJDBI.java
@@ -26,6 +26,9 @@ public abstract class PostgresTaskUsageJDBI extends TaskUsageJDBI {
   @SqlQuery("SELECT DISTINCT taskId FROM taskUsage")
   public abstract List<String> getUniqueTaskIds();
 
+  @SqlQuery("SELECT DISTINCT timestamp FROM taskUsage WHERE taskId = :taskId")
+  public abstract List<Long> getUsageTimestampsForTask(@Bind("taskId") String taskId);
+
   @SqlQuery("SELECT COUNT(DISTINCT taskId) FROM taskUsage")
   public abstract int countTasksWithUsage();
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/PostgresTaskUsageJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/PostgresTaskUsageJDBI.java
@@ -23,6 +23,9 @@ public abstract class PostgresTaskUsageJDBI extends TaskUsageJDBI {
   @SqlQuery("SELECT " + FIELDS + "FROM taskUsage WHERE taskId = :taskId")
   public abstract List<SingularityTaskUsage> getTaskUsage(@Bind("taskId") String taskId);
 
+  @SqlQuery("SELECT DISTINCT taskId FROM taskUsage")
+  public abstract List<String> getUniqueTaskIds();
+
   @SqlQuery("SELECT COUNT(DISTINCT taskId) FROM taskUsage")
   public abstract int countTasksWithUsage();
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/PostgresTaskUsageJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/PostgresTaskUsageJDBI.java
@@ -1,0 +1,33 @@
+package com.hubspot.singularity.data.usage;
+
+import java.util.Date;
+import java.util.List;
+
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+
+import com.hubspot.singularity.SingularityTaskUsage;
+
+public abstract class PostgresTaskUsageJDBI extends TaskUsageJDBI {
+
+  @SqlUpdate("DELETE FROM taskUsage WHERE requestId = :requestId AND taskId = :taskId")
+  public abstract void deleteTaskUsage(@Bind("requestId") String requestId, @Bind("taskId") String taskId);
+
+  @SqlUpdate("DELETE FROM taskUsage WHERE taskId = :taskId")
+  public abstract void deleteTaskUsage(@Bind("taskId") String taskId);
+
+  @SqlUpdate("DELETE FROM taskUsage WHERE requestId = :requestId AND taskId = :taskId AND timestamp = :timestamp")
+  public abstract void deleteSpecificTaskUsage(@Bind("requestId") String requestId, @Bind("taskId") String taskId, @Bind("timestamp") Date timestamp);
+
+  @SqlUpdate("INSERT INTO taskUsage (" + FILEDS + ") VALUES (" + FILED_VALUES + ")")
+  public abstract void saveSpecificTaskUsage(@Bind("requestId") String requestId, @Bind("taskId") String taskId, @Bind("memoryTotalBytes") long memoryTotalBytes,
+                                             @Bind("timestamp") Date timestamp, @Bind("cpuSeconds") double cpuSeconds, @Bind("diskTotalBytes") long diskTotalBytes, @Bind("cpusNrPeriods") long cpusNrPeriods,
+                                             @Bind("cpusNrThrottled") long cpusNrThrottled, @Bind("cpusThrottledTimeSecs") double cpusThrottledTimeSecs);
+
+  @SqlUpdate("SELECT " + FILEDS + "FROM taskUsage WHERE requestId = :requestId AND taskId = :taskId")
+  public abstract List<SingularityTaskUsage> getTaskUsage(@Bind("requestId") String requestId, @Bind("taskId") String taskId);
+
+  @SqlQuery("SELECT COUNT(DISTINCT taskId) FROM taskUsage")
+  public abstract int countTasksWithUsage();
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/PostgresTaskUsageJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/PostgresTaskUsageJDBI.java
@@ -1,6 +1,5 @@
 package com.hubspot.singularity.data.usage;
 
-import java.util.Date;
 import java.util.List;
 
 import org.skife.jdbi.v2.sqlobject.Bind;
@@ -14,11 +13,11 @@ public abstract class PostgresTaskUsageJDBI extends TaskUsageJDBI {
   public abstract void deleteTaskUsage(@Bind("taskId") String taskId);
 
   @SqlUpdate("DELETE FROM taskUsage WHERE taskId = :taskId AND timestamp = :timestamp")
-  public abstract void deleteSpecificTaskUsage(@Bind("taskId") String taskId, @Bind("timestamp") Date timestamp);
+  public abstract void deleteSpecificTaskUsage(@Bind("taskId") String taskId, @Bind("timestamp") long timestamp);
 
   @SqlUpdate("INSERT INTO taskUsage (" + FIELDS + ") VALUES (" + FIELD_VALUES + ")")
   public abstract void saveSpecificTaskUsage(@Bind("requestId") String requestId, @Bind("taskId") String taskId, @Bind("memoryTotalBytes") long memoryTotalBytes,
-                                             @Bind("timestamp") Date timestamp, @Bind("cpuSeconds") double cpuSeconds, @Bind("diskTotalBytes") long diskTotalBytes, @Bind("cpusNrPeriods") long cpusNrPeriods,
+                                             @Bind("timestamp") long timestamp, @Bind("cpuSeconds") double cpuSeconds, @Bind("diskTotalBytes") long diskTotalBytes, @Bind("cpusNrPeriods") long cpusNrPeriods,
                                              @Bind("cpusNrThrottled") long cpusNrThrottled, @Bind("cpusThrottledTimeSecs") double cpusThrottledTimeSecs);
 
   @SqlQuery("SELECT " + FIELDS + "FROM taskUsage WHERE taskId = :taskId")

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/PostgresTaskUsageJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/PostgresTaskUsageJDBI.java
@@ -16,12 +16,12 @@ public abstract class PostgresTaskUsageJDBI extends TaskUsageJDBI {
   @SqlUpdate("DELETE FROM taskUsage WHERE taskId = :taskId AND timestamp = :timestamp")
   public abstract void deleteSpecificTaskUsage(@Bind("taskId") String taskId, @Bind("timestamp") Date timestamp);
 
-  @SqlUpdate("INSERT INTO taskUsage (" + FILEDS + ") VALUES (" + FILED_VALUES + ")")
+  @SqlUpdate("INSERT INTO taskUsage (" + FIELDS + ") VALUES (" + FIELD_VALUES + ")")
   public abstract void saveSpecificTaskUsage(@Bind("requestId") String requestId, @Bind("taskId") String taskId, @Bind("memoryTotalBytes") long memoryTotalBytes,
                                              @Bind("timestamp") Date timestamp, @Bind("cpuSeconds") double cpuSeconds, @Bind("diskTotalBytes") long diskTotalBytes, @Bind("cpusNrPeriods") long cpusNrPeriods,
                                              @Bind("cpusNrThrottled") long cpusNrThrottled, @Bind("cpusThrottledTimeSecs") double cpusThrottledTimeSecs);
 
-  @SqlQuery("SELECT " + FILEDS + "FROM taskUsage WHERE taskId = :taskId")
+  @SqlQuery("SELECT " + FIELDS + "FROM taskUsage WHERE taskId = :taskId")
   public abstract List<SingularityTaskUsage> getTaskUsage(@Bind("taskId") String taskId);
 
   @SqlQuery("SELECT COUNT(DISTINCT taskId) FROM taskUsage")

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/TaskUsageJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/TaskUsageJDBI.java
@@ -19,5 +19,7 @@ public abstract class TaskUsageJDBI {
 
   public abstract List<String> getUniqueTaskIds();
 
+  public abstract List<Long> getUsageTimestampsForTask(String taskId);
+
   public abstract int countTasksWithUsage();
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/TaskUsageJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/TaskUsageJDBI.java
@@ -1,5 +1,6 @@
 package com.hubspot.singularity.data.usage;
 
+import java.util.Date;
 import java.util.List;
 
 import com.hubspot.singularity.SingularityTaskUsage;
@@ -12,10 +13,10 @@ public abstract class TaskUsageJDBI {
 
   public abstract void deleteTaskUsage(String taskId);
 
-  public abstract void deleteSpecificTaskUsage(String requestId, String taskId, double timestamp);
+  public abstract void deleteSpecificTaskUsage(String requestId, String taskId, Date timestamp);
 
-  public abstract void saveSpecificTaskUsage(String requestId, String taskId, long memoryTotalBytes, double timestamp, double cpuSeconds, long diskTotalBytes, long cpusNrPeriods, long cpusNrThrottled,
-                                             double cpusThrottledTimeSecs, Long prevCpuSeconds, Long prevCpusNrPeriods, Long prevCpusNrThrottled, Double prevCpusThrottledTimeSecs);
+  public abstract void saveSpecificTaskUsage(String requestId, String taskId, long memoryTotalBytes, Date timestamp, double cpuSeconds, long diskTotalBytes, long cpusNrPeriods, long cpusNrThrottled,
+                                             double cpusThrottledTimeSecs);
 
   public abstract List<SingularityTaskUsage> getTaskUsage(String requestId, String taskId);
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/TaskUsageJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/TaskUsageJDBI.java
@@ -1,5 +1,25 @@
 package com.hubspot.singularity.data.usage;
 
-public abstract class TaskUsageJDBI {
+import java.util.List;
 
+import com.hubspot.singularity.SingularityTaskUsage;
+
+public abstract class TaskUsageJDBI {
+  static final String FILEDS = "requestId, taskId, memoryTotalBytes, timestamp, cpuSeconds, diskTotalBytes, cpusNrPeriods, cpusNrThrottled, cpusThrottledTimeSecs";
+  static final String FILED_VALUES = ":requestId, :taskId, :memoryTotalBytes, :timestamp, :cpuSeconds, :diskTotalBytes, :cpusNrPeriods, :cpusNrThrottled, :cpusThrottledTimeSecs";
+
+  public abstract void deleteTaskUsage(String requestId, String taskId);
+
+  public abstract void deleteTaskUsage(String taskId);
+
+  public abstract void deleteSpecificTaskUsage(String requestId, String taskId, double timestamp);
+
+  public abstract void saveSpecificTaskUsage(String requestId, String taskId, long memoryTotalBytes, double timestamp, double cpuSeconds, long diskTotalBytes, long cpusNrPeriods, long cpusNrThrottled,
+                                             double cpusThrottledTimeSecs, Long prevCpuSeconds, Long prevCpusNrPeriods, Long prevCpusNrThrottled, Double prevCpusThrottledTimeSecs);
+
+  public abstract List<SingularityTaskUsage> getTaskUsage(String requestId, String taskId);
+
+  public abstract List<String> getUniqueTaskIds();
+
+  public abstract int countTasksWithUsage();
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/TaskUsageJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/TaskUsageJDBI.java
@@ -1,6 +1,5 @@
 package com.hubspot.singularity.data.usage;
 
-import java.util.Date;
 import java.util.List;
 
 import com.hubspot.singularity.SingularityTaskUsage;
@@ -11,9 +10,9 @@ public abstract class TaskUsageJDBI {
 
   public abstract void deleteTaskUsage(String taskId);
 
-  public abstract void deleteSpecificTaskUsage(String taskId, Date timestamp);
+  public abstract void deleteSpecificTaskUsage(String taskId, long timestamp);
 
-  public abstract void saveSpecificTaskUsage(String requestId, String taskId, long memoryTotalBytes, Date timestamp, double cpuSeconds, long diskTotalBytes, long cpusNrPeriods, long cpusNrThrottled,
+  public abstract void saveSpecificTaskUsage(String requestId, String taskId, long memoryTotalBytes, long timestamp, double cpuSeconds, long diskTotalBytes, long cpusNrPeriods, long cpusNrThrottled,
                                              double cpusThrottledTimeSecs);
 
   public abstract List<SingularityTaskUsage> getTaskUsage(String taskId);

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/TaskUsageJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/TaskUsageJDBI.java
@@ -1,0 +1,5 @@
+package com.hubspot.singularity.data.usage;
+
+public abstract class TaskUsageJDBI {
+
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/TaskUsageJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/TaskUsageJDBI.java
@@ -6,8 +6,8 @@ import java.util.List;
 import com.hubspot.singularity.SingularityTaskUsage;
 
 public abstract class TaskUsageJDBI {
-  static final String FILEDS = "requestId, taskId, memoryTotalBytes, timestamp, cpuSeconds, diskTotalBytes, cpusNrPeriods, cpusNrThrottled, cpusThrottledTimeSecs";
-  static final String FILED_VALUES = ":requestId, :taskId, :memoryTotalBytes, :timestamp, :cpuSeconds, :diskTotalBytes, :cpusNrPeriods, :cpusNrThrottled, :cpusThrottledTimeSecs";
+  static final String FIELDS = "requestId, taskId, memoryTotalBytes, timestamp, cpuSeconds, diskTotalBytes, cpusNrPeriods, cpusNrThrottled, cpusThrottledTimeSecs";
+  static final String FIELD_VALUES = ":requestId, :taskId, :memoryTotalBytes, :timestamp, :cpuSeconds, :diskTotalBytes, :cpusNrPeriods, :cpusNrThrottled, :cpusThrottledTimeSecs";
 
   public abstract void deleteTaskUsage(String taskId);
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/TaskUsageJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/TaskUsageJDBI.java
@@ -9,16 +9,14 @@ public abstract class TaskUsageJDBI {
   static final String FILEDS = "requestId, taskId, memoryTotalBytes, timestamp, cpuSeconds, diskTotalBytes, cpusNrPeriods, cpusNrThrottled, cpusThrottledTimeSecs";
   static final String FILED_VALUES = ":requestId, :taskId, :memoryTotalBytes, :timestamp, :cpuSeconds, :diskTotalBytes, :cpusNrPeriods, :cpusNrThrottled, :cpusThrottledTimeSecs";
 
-  public abstract void deleteTaskUsage(String requestId, String taskId);
-
   public abstract void deleteTaskUsage(String taskId);
 
-  public abstract void deleteSpecificTaskUsage(String requestId, String taskId, Date timestamp);
+  public abstract void deleteSpecificTaskUsage(String taskId, Date timestamp);
 
   public abstract void saveSpecificTaskUsage(String requestId, String taskId, long memoryTotalBytes, Date timestamp, double cpuSeconds, long diskTotalBytes, long cpusNrPeriods, long cpusNrThrottled,
                                              double cpusThrottledTimeSecs);
 
-  public abstract List<SingularityTaskUsage> getTaskUsage(String requestId, String taskId);
+  public abstract List<SingularityTaskUsage> getTaskUsage(String taskId);
 
   public abstract List<String> getUniqueTaskIds();
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/TaskUsageManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/TaskUsageManager.java
@@ -1,4 +1,26 @@
 package com.hubspot.singularity.data.usage;
 
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+import com.hubspot.singularity.SingularityTaskCurrentUsageWithId;
+import com.hubspot.singularity.SingularityTaskId;
+import com.hubspot.singularity.SingularityTaskUsage;
+
 public interface TaskUsageManager {
+  Comparator<SingularityTaskUsage> TASK_USAGE_COMPARATOR_TIMESTAMP_ASC = Comparator.comparingDouble(SingularityTaskUsage::getTimestamp);
+  Comparator<String> TASK_USAGE_PATH_COMPARATOR_TIMESTAMP_ASC = Comparator.comparingDouble(Double::parseDouble);
+
+  void deleteTaskUsage(String taskId);
+
+  void deleteSpecificTaskUsage(String taskId, double timestamp);
+
+  void saveCurrentTaskUsage(SingularityTaskCurrentUsageWithId usageWithId);
+
+  void saveSpecificTaskUsage(String taskId, SingularityTaskUsage usage);
+
+  List<SingularityTaskUsage> getTaskUsage(String taskId);
+
+  Map<String, SingularityTaskCurrentUsageWithId> getTaskCurrentUsages(List<SingularityTaskId> taskIds);
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/TaskUsageManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/TaskUsageManager.java
@@ -2,25 +2,22 @@ package com.hubspot.singularity.data.usage;
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 
-import com.hubspot.singularity.SingularityTaskCurrentUsageWithId;
 import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.SingularityTaskUsage;
 
 public interface TaskUsageManager {
   Comparator<SingularityTaskUsage> TASK_USAGE_COMPARATOR_TIMESTAMP_ASC = Comparator.comparingDouble(SingularityTaskUsage::getTimestamp);
-  Comparator<String> TASK_USAGE_PATH_COMPARATOR_TIMESTAMP_ASC = Comparator.comparingDouble(Double::parseDouble);
 
-  void deleteTaskUsage(String taskId);
+  void deleteTaskUsage(SingularityTaskId taskId);
 
-  void deleteSpecificTaskUsage(String taskId, double timestamp);
+  void deleteSpecificTaskUsage(SingularityTaskId taskId, long timestamp);
 
-  void saveCurrentTaskUsage(SingularityTaskCurrentUsageWithId usageWithId);
+  void saveSpecificTaskUsage(SingularityTaskId taskId, SingularityTaskUsage usage);
 
-  void saveSpecificTaskUsage(String taskId, SingularityTaskUsage usage);
+  List<SingularityTaskUsage> getTaskUsage(SingularityTaskId taskId);
 
-  List<SingularityTaskUsage> getTaskUsage(String taskId);
+  int countTasksWithUsage();
 
-  Map<String, SingularityTaskCurrentUsageWithId> getTaskCurrentUsages(List<SingularityTaskId> taskIds);
+  void cleanOldUsages(List<SingularityTaskId> activeTaskIds);
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/TaskUsageManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/TaskUsageManager.java
@@ -1,0 +1,4 @@
+package com.hubspot.singularity.data.usage;
+
+public interface TaskUsageManager {
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/UsageManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/UsageManager.java
@@ -1,12 +1,8 @@
-package com.hubspot.singularity.data;
+package com.hubspot.singularity.data.usage;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -23,11 +19,9 @@ import com.hubspot.singularity.SingularityCreateResult;
 import com.hubspot.singularity.SingularityDeleteResult;
 import com.hubspot.singularity.SingularitySlaveUsage;
 import com.hubspot.singularity.SingularitySlaveUsageWithId;
-import com.hubspot.singularity.SingularityTaskCurrentUsage;
-import com.hubspot.singularity.SingularityTaskCurrentUsageWithId;
-import com.hubspot.singularity.SingularityTaskId;
-import com.hubspot.singularity.SingularityTaskUsage;
 import com.hubspot.singularity.config.SingularityConfiguration;
+import com.hubspot.singularity.data.CuratorAsyncManager;
+import com.hubspot.singularity.data.SingularityWebCache;
 import com.hubspot.singularity.data.transcoders.Transcoder;
 import com.hubspot.singularity.scheduler.SingularityLeaderCache;
 
@@ -37,20 +31,17 @@ public class UsageManager extends CuratorAsyncManager {
   private static final String ROOT_PATH = "/usage";
 
   private static final String SLAVE_PATH = ROOT_PATH + "/slaves";
-  private static final String TASK_PATH = ROOT_PATH + "/tasks";
   private static final String REQUESTS_PATH = ROOT_PATH + "/requests";
   private static final String USAGE_SUMMARY_PATH = ROOT_PATH + "/summary";
 
-  private static final String USAGE_HISTORY_PATH_KEY = "history";
   private static final String CURRENT_USAGE_NODE_KEY = "CURRENT";
 
   private final Transcoder<SingularitySlaveUsage> slaveUsageTranscoder;
-  private final Transcoder<SingularityTaskUsage> taskUsageTranscoder;
-  private final Transcoder<SingularityTaskCurrentUsage> taskCurrentUsageTranscoder;
   private final Transcoder<SingularityClusterUtilization> clusterUtilizationTranscoder;
   private final Transcoder<RequestUtilization> requestUtilizationTranscoder;
   private final SingularityWebCache webCache;
   private final SingularityLeaderCache leaderCache;
+  private final TaskUsageManager taskUsageManager;
 
   @Inject
   public UsageManager(CuratorFramework curator,
@@ -58,17 +49,15 @@ public class UsageManager extends CuratorAsyncManager {
                       MetricRegistry metricRegistry,
                       SingularityWebCache webCache,
                       SingularityLeaderCache leaderCache,
+                      TaskUsageManager taskUsageManager,
                       Transcoder<SingularitySlaveUsage> slaveUsageTranscoder,
-                      Transcoder<SingularityTaskUsage> taskUsageTranscoder,
-                      Transcoder<SingularityTaskCurrentUsage> taskCurrentUsageTranscoder,
                       Transcoder<SingularityClusterUtilization> clusterUtilizationTranscoder,
                       Transcoder<RequestUtilization> requestUtilizationTranscoder) {
     super(curator, configuration, metricRegistry);
     this.webCache = webCache;
     this.leaderCache = leaderCache;
+    this.taskUsageManager = taskUsageManager;
     this.slaveUsageTranscoder = slaveUsageTranscoder;
-    this.taskUsageTranscoder = taskUsageTranscoder;
-    this.taskCurrentUsageTranscoder = taskCurrentUsageTranscoder;
     this.clusterUtilizationTranscoder = clusterUtilizationTranscoder;
     this.requestUtilizationTranscoder = requestUtilizationTranscoder;
   }
@@ -77,53 +66,17 @@ public class UsageManager extends CuratorAsyncManager {
     return getChildren(SLAVE_PATH);
   }
 
-  public int getNumSlavesWithUsage() {
-    return getNumChildren(SLAVE_PATH);
-  }
-  public List<String> getTasksWithUsage() {
-    return getChildren(TASK_PATH);
-  }
-
-  // /slaves/<slaveid>/CURRENT
+  // /slaves/<slaveid>
   private String getSlaveIdFromCurrentUsagePath(String path) {
     return path.substring(path.indexOf(SLAVE_PATH) + SLAVE_PATH.length() + 1, path.lastIndexOf("/"));
-  }
-
-  // /tasks/<taskid>/CURRENT
-  private String getTaskIdFromCurrentUsagePath(String path) {
-    return path.substring(path.indexOf(TASK_PATH) + TASK_PATH.length() + 1, path.lastIndexOf("/"));
   }
 
   private String getSlaveUsagePath(String slaveId) {
     return ZKPaths.makePath(SLAVE_PATH, slaveId);
   }
 
-  private String getTaskUsagePath(String taskId) {
-    return ZKPaths.makePath(TASK_PATH, taskId);
-  }
-
-  private String getSlaveUsageHistoryPath(String slaveId) {
-    return ZKPaths.makePath(getSlaveUsagePath(slaveId), USAGE_HISTORY_PATH_KEY);
-  }
-
-  private String getTaskUsageHistoryPath(String taskId) {
-    return ZKPaths.makePath(getTaskUsagePath(taskId), USAGE_HISTORY_PATH_KEY);
-  }
-
-  private String getSpecificSlaveUsagePath(String slaveId, long timestamp) {
-    return ZKPaths.makePath(getSlaveUsageHistoryPath(slaveId), Long.toString(timestamp));
-  }
-
-  private String getSpecificTaskUsagePath(String taskId, double timestamp) {
-    return ZKPaths.makePath(getTaskUsageHistoryPath(taskId), Double.toString(timestamp));
-  }
-
   private String getCurrentSlaveUsagePath(String slaveId) {
     return ZKPaths.makePath(getSlaveUsagePath(slaveId), CURRENT_USAGE_NODE_KEY);
-  }
-
-  private String getCurrentTaskUsagePath(String taskId) {
-    return ZKPaths.makePath(getTaskUsagePath(taskId), CURRENT_USAGE_NODE_KEY);
   }
 
   private String getRequestPath(String requestId) {
@@ -134,57 +87,12 @@ public class UsageManager extends CuratorAsyncManager {
     return delete(getSlaveUsagePath(slaveId));
   }
 
-  public SingularityDeleteResult deleteTaskUsage(String taskId) {
-    return delete(getTaskUsagePath(taskId));
-  }
-
-  public SingularityDeleteResult deleteSpecificSlaveUsage(String slaveId, long timestamp) {
-    return delete(getSpecificSlaveUsagePath(slaveId, timestamp));
-  }
-
-  public SingularityDeleteResult deleteSpecificTaskUsage(String taskId, double timestamp) {
-    return delete(getSpecificTaskUsagePath(taskId, timestamp));
-  }
-
-  public SingularityCreateResult saveCurrentTaskUsage(String taskId, SingularityTaskCurrentUsage usage) {
-    return set(getCurrentTaskUsagePath(taskId), usage, taskCurrentUsageTranscoder);
-  }
-
-  public SingularityCreateResult saveSpecificTaskUsage(String taskId, SingularityTaskUsage usage) {
-    return save(getSpecificTaskUsagePath(taskId, usage.getTimestamp()), usage, taskUsageTranscoder);
-  }
-
   public SingularityCreateResult saveClusterUtilization(SingularityClusterUtilization utilization) {
     return save(USAGE_SUMMARY_PATH, utilization, clusterUtilizationTranscoder);
   }
 
-  public SingularityCreateResult saveSpecificSlaveUsageAndSetCurrent(String slaveId, SingularitySlaveUsage usage) {
-    set(getCurrentSlaveUsagePath(slaveId), usage, slaveUsageTranscoder);
-    return save(getSpecificSlaveUsagePath(slaveId, usage.getTimestamp()), usage, slaveUsageTranscoder);
-  }
-
-  private static final Comparator<SingularitySlaveUsage> SLAVE_USAGE_COMPARATOR_TIMESTAMP_ASC = Comparator.comparingLong(SingularitySlaveUsage::getTimestamp);
-
-  public List<SingularitySlaveUsage> getSlaveUsage(String slaveId) {
-    List<SingularitySlaveUsage> children = getAsyncChildren(getSlaveUsageHistoryPath(slaveId), slaveUsageTranscoder);
-    children.sort(SLAVE_USAGE_COMPARATOR_TIMESTAMP_ASC);
-    return children;
-  }
-
-  private static final Comparator<SingularityTaskUsage> TASK_USAGE_COMPARATOR_TIMESTAMP_ASC = Comparator.comparingDouble(SingularityTaskUsage::getTimestamp);
-
-  public List<SingularityTaskUsage> getTaskUsage(String taskId) {
-    List<SingularityTaskUsage> children = getAsyncChildren(getTaskUsageHistoryPath(taskId), taskUsageTranscoder);
-    children.sort(TASK_USAGE_COMPARATOR_TIMESTAMP_ASC);
-    return children;
-  }
-
-  private static final Comparator<String> TASK_USAGE_PATH_COMPARATOR_TIMESTAMP_ASC = Comparator.comparingDouble(Double::parseDouble);
-
-  public List<String> getTaskUsagePaths(String taskId) {
-    List<String> children = getChildren(getTaskUsageHistoryPath(taskId));
-    children.sort(TASK_USAGE_PATH_COMPARATOR_TIMESTAMP_ASC);
-    return children;
+  public SingularityCreateResult saveCurrentSlaveUsage(String slaveId, SingularitySlaveUsage usage) {
+    return set(getCurrentSlaveUsagePath(slaveId), usage, slaveUsageTranscoder);
   }
 
   public Optional<SingularityClusterUtilization> getClusterUtilization() {
@@ -258,30 +166,4 @@ public class UsageManager extends CuratorAsyncManager {
   public List<SingularitySlaveUsageWithId> getAllCurrentSlaveUsage() {
     return getCurrentSlaveUsages(getSlavesWithUsage());
   }
-
-  public List<Long> getSlaveUsageTimestamps(String slaveId) {
-    List<String> timestampStrings = getChildren(getSlaveUsageHistoryPath(slaveId));
-    List<Long> timestamps = new ArrayList<>(timestampStrings.size());
-    for (String timestampString : timestampStrings) {
-      timestamps.add(Long.parseLong(timestampString));
-    }
-    Collections.sort(timestamps);
-    return timestamps;
-  }
-
-  public List<SingularityTaskCurrentUsageWithId> getTaskCurrentUsages(List<SingularityTaskId> taskIds) {
-    List<String> paths = new ArrayList<>(taskIds.size());
-    for (SingularityTaskId taskId : taskIds) {
-      paths.add(getCurrentTaskUsagePath(taskId.getId()));
-    }
-
-    Map<String, SingularityTaskCurrentUsage> currentTaskUsages = getAsyncWithPath("getTaskCurrentUsages", paths, taskCurrentUsageTranscoder);
-    List<SingularityTaskCurrentUsageWithId> currentTaskUsagesWithIds = new ArrayList<>(paths.size());
-    for (Entry<String, SingularityTaskCurrentUsage> entry : currentTaskUsages.entrySet()) {
-      currentTaskUsagesWithIds.add(new SingularityTaskCurrentUsageWithId(SingularityTaskId.valueOf(getTaskIdFromCurrentUsagePath(entry.getKey())), entry.getValue()));
-    }
-
-    return currentTaskUsagesWithIds;
-  }
-
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/ZkTaskUsageManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/ZkTaskUsageManager.java
@@ -99,6 +99,7 @@ public class ZkTaskUsageManager extends CuratorAsyncManager implements TaskUsage
                 .forEach((timestamp) -> {
                   delete(getSpecificTaskUsagePath(taskId, timestamp));
                 });
+            continue;
           }
         } catch (InvalidSingularityTaskIdException e) {
           LOG.warn("{} is not a valid task id, will remove task usage from zookeeper", taskIdString);

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/ZkTaskUsageManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/ZkTaskUsageManager.java
@@ -1,10 +1,8 @@
 package com.hubspot.singularity.data.usage;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.utils.ZKPaths;
@@ -12,9 +10,6 @@ import org.apache.curator.utils.ZKPaths;
 import com.codahale.metrics.MetricRegistry;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import com.hubspot.singularity.SingularityCreateResult;
-import com.hubspot.singularity.SingularityDeleteResult;
-import com.hubspot.singularity.SingularityTaskCurrentUsage;
 import com.hubspot.singularity.SingularityTaskCurrentUsageWithId;
 import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.SingularityTaskUsage;
@@ -23,7 +18,7 @@ import com.hubspot.singularity.data.CuratorAsyncManager;
 import com.hubspot.singularity.data.transcoders.Transcoder;
 
 @Singleton
-public class ZkTaskUsageManager extends CuratorAsyncManager {
+public class ZkTaskUsageManager extends CuratorAsyncManager implements TaskUsageManager {
 
   private static final String ROOT_PATH = "/usage";
 
@@ -33,22 +28,17 @@ public class ZkTaskUsageManager extends CuratorAsyncManager {
   private static final String CURRENT_USAGE_NODE_KEY = "CURRENT";
 
   private final Transcoder<SingularityTaskUsage> taskUsageTranscoder;
-  private final Transcoder<SingularityTaskCurrentUsage> taskCurrentUsageTranscoder;
+  private final Transcoder<SingularityTaskCurrentUsageWithId> taskCurrentUsageTranscoder;
 
   @Inject
   public ZkTaskUsageManager(CuratorFramework curator,
                             SingularityConfiguration configuration,
                             MetricRegistry metricRegistry,
                             Transcoder<SingularityTaskUsage> taskUsageTranscoder,
-                            Transcoder<SingularityTaskCurrentUsage> taskCurrentUsageTranscoder) {
+                            Transcoder<SingularityTaskCurrentUsageWithId> taskCurrentUsageTranscoder) {
     super(curator, configuration, metricRegistry);
     this.taskUsageTranscoder = taskUsageTranscoder;
     this.taskCurrentUsageTranscoder = taskCurrentUsageTranscoder;
-  }
-
-  // /tasks/<taskid>/CURRENT
-  private String getTaskIdFromCurrentUsagePath(String path) {
-    return path.substring(path.indexOf(TASK_PATH) + TASK_PATH.length() + 1, path.lastIndexOf("/"));
   }
 
   private String getTaskUsagePath(String taskId) {
@@ -67,23 +57,21 @@ public class ZkTaskUsageManager extends CuratorAsyncManager {
     return ZKPaths.makePath(getTaskUsagePath(taskId), CURRENT_USAGE_NODE_KEY);
   }
 
-  public SingularityDeleteResult deleteTaskUsage(String taskId) {
-    return delete(getTaskUsagePath(taskId));
+  public void deleteTaskUsage(String taskId) {
+    delete(getTaskUsagePath(taskId));
   }
 
-  public SingularityDeleteResult deleteSpecificTaskUsage(String taskId, double timestamp) {
-    return delete(getSpecificTaskUsagePath(taskId, timestamp));
+  public void deleteSpecificTaskUsage(String taskId, double timestamp) {
+    delete(getSpecificTaskUsagePath(taskId, timestamp));
   }
 
-  public SingularityCreateResult saveCurrentTaskUsage(String taskId, SingularityTaskCurrentUsage usage) {
-    return set(getCurrentTaskUsagePath(taskId), usage, taskCurrentUsageTranscoder);
+  public void saveCurrentTaskUsage(SingularityTaskCurrentUsageWithId usageWithId) {
+    set(getCurrentTaskUsagePath(usageWithId.getTaskId().getId()), usageWithId, taskCurrentUsageTranscoder);
   }
 
-  public SingularityCreateResult saveSpecificTaskUsage(String taskId, SingularityTaskUsage usage) {
-    return save(getSpecificTaskUsagePath(taskId, usage.getTimestamp()), usage, taskUsageTranscoder);
+  public void saveSpecificTaskUsage(String taskId, SingularityTaskUsage usage) {
+    save(getSpecificTaskUsagePath(taskId, usage.getTimestamp()), usage, taskUsageTranscoder);
   }
-
-  private static final Comparator<SingularityTaskUsage> TASK_USAGE_COMPARATOR_TIMESTAMP_ASC = Comparator.comparingDouble(SingularityTaskUsage::getTimestamp);
 
   public List<SingularityTaskUsage> getTaskUsage(String taskId) {
     List<SingularityTaskUsage> children = getAsyncChildren(getTaskUsageHistoryPath(taskId), taskUsageTranscoder);
@@ -91,27 +79,18 @@ public class ZkTaskUsageManager extends CuratorAsyncManager {
     return children;
   }
 
-  private static final Comparator<String> TASK_USAGE_PATH_COMPARATOR_TIMESTAMP_ASC = Comparator.comparingDouble(Double::parseDouble);
-
   public List<String> getTaskUsagePaths(String taskId) {
     List<String> children = getChildren(getTaskUsageHistoryPath(taskId));
     children.sort(TASK_USAGE_PATH_COMPARATOR_TIMESTAMP_ASC);
     return children;
   }
 
-  public List<SingularityTaskCurrentUsageWithId> getTaskCurrentUsages(List<SingularityTaskId> taskIds) {
+  public Map<String, SingularityTaskCurrentUsageWithId> getTaskCurrentUsages(List<SingularityTaskId> taskIds) {
     List<String> paths = new ArrayList<>(taskIds.size());
     for (SingularityTaskId taskId : taskIds) {
       paths.add(getCurrentTaskUsagePath(taskId.getId()));
     }
 
-    Map<String, SingularityTaskCurrentUsage> currentTaskUsages = getAsyncWithPath("getTaskCurrentUsages", paths, taskCurrentUsageTranscoder);
-    List<SingularityTaskCurrentUsageWithId> currentTaskUsagesWithIds = new ArrayList<>(paths.size());
-    for (Entry<String, SingularityTaskCurrentUsage> entry : currentTaskUsages.entrySet()) {
-      currentTaskUsagesWithIds.add(new SingularityTaskCurrentUsageWithId(SingularityTaskId.valueOf(getTaskIdFromCurrentUsagePath(entry.getKey())), entry.getValue()));
-    }
-
-    return currentTaskUsagesWithIds;
+    return getAsyncWithPath("getTaskCurrentUsages", paths, taskCurrentUsageTranscoder);
   }
-
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/ZkTaskUsageManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/ZkTaskUsageManager.java
@@ -1,16 +1,20 @@
 package com.hubspot.singularity.data.usage;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.utils.ZKPaths;
+import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.MetricRegistry;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import com.hubspot.singularity.SingularityTaskCurrentUsageWithId;
+import com.hubspot.singularity.InvalidSingularityTaskIdException;
+import com.hubspot.singularity.SingularityDeleteResult;
 import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.SingularityTaskUsage;
 import com.hubspot.singularity.config.SingularityConfiguration;
@@ -19,6 +23,7 @@ import com.hubspot.singularity.data.transcoders.Transcoder;
 
 @Singleton
 public class ZkTaskUsageManager extends CuratorAsyncManager implements TaskUsageManager {
+  private static final Logger LOG = LoggerFactory.getLogger(ZkTaskUsageManager.class);
 
   private static final String ROOT_PATH = "/usage";
 
@@ -28,69 +33,72 @@ public class ZkTaskUsageManager extends CuratorAsyncManager implements TaskUsage
   private static final String CURRENT_USAGE_NODE_KEY = "CURRENT";
 
   private final Transcoder<SingularityTaskUsage> taskUsageTranscoder;
-  private final Transcoder<SingularityTaskCurrentUsageWithId> taskCurrentUsageTranscoder;
 
   @Inject
   public ZkTaskUsageManager(CuratorFramework curator,
                             SingularityConfiguration configuration,
                             MetricRegistry metricRegistry,
-                            Transcoder<SingularityTaskUsage> taskUsageTranscoder,
-                            Transcoder<SingularityTaskCurrentUsageWithId> taskCurrentUsageTranscoder) {
+                            Transcoder<SingularityTaskUsage> taskUsageTranscoder) {
     super(curator, configuration, metricRegistry);
     this.taskUsageTranscoder = taskUsageTranscoder;
-    this.taskCurrentUsageTranscoder = taskCurrentUsageTranscoder;
   }
 
-  private String getTaskUsagePath(String taskId) {
-    return ZKPaths.makePath(TASK_PATH, taskId);
+  private String getTaskUsagePath(SingularityTaskId taskId) {
+    return ZKPaths.makePath(TASK_PATH, taskId.getRequestId(), taskId.getId());
   }
 
-  private String getTaskUsageHistoryPath(String taskId) {
+  private String getTaskUsageHistoryPath(SingularityTaskId taskId) {
     return ZKPaths.makePath(getTaskUsagePath(taskId), USAGE_HISTORY_PATH_KEY);
   }
 
-  private String getSpecificTaskUsagePath(String taskId, double timestamp) {
+  private String getSpecificTaskUsagePath(SingularityTaskId taskId, double timestamp) {
     return ZKPaths.makePath(getTaskUsageHistoryPath(taskId), Double.toString(timestamp));
   }
 
-  private String getCurrentTaskUsagePath(String taskId) {
-    return ZKPaths.makePath(getTaskUsagePath(taskId), CURRENT_USAGE_NODE_KEY);
-  }
-
-  public void deleteTaskUsage(String taskId) {
+  public void deleteTaskUsage(SingularityTaskId taskId) {
     delete(getTaskUsagePath(taskId));
   }
 
-  public void deleteSpecificTaskUsage(String taskId, double timestamp) {
+  public void deleteSpecificTaskUsage(SingularityTaskId taskId, long timestamp) {
     delete(getSpecificTaskUsagePath(taskId, timestamp));
   }
 
-  public void saveCurrentTaskUsage(SingularityTaskCurrentUsageWithId usageWithId) {
-    set(getCurrentTaskUsagePath(usageWithId.getTaskId().getId()), usageWithId, taskCurrentUsageTranscoder);
-  }
-
-  public void saveSpecificTaskUsage(String taskId, SingularityTaskUsage usage) {
+  public void saveSpecificTaskUsage(SingularityTaskId taskId, SingularityTaskUsage usage) {
     save(getSpecificTaskUsagePath(taskId, usage.getTimestamp()), usage, taskUsageTranscoder);
   }
 
-  public List<SingularityTaskUsage> getTaskUsage(String taskId) {
+  public List<SingularityTaskUsage> getTaskUsage(SingularityTaskId taskId) {
     List<SingularityTaskUsage> children = getAsyncChildren(getTaskUsageHistoryPath(taskId), taskUsageTranscoder);
     children.sort(TASK_USAGE_COMPARATOR_TIMESTAMP_ASC);
     return children;
   }
 
-  public List<String> getTaskUsagePaths(String taskId) {
-    List<String> children = getChildren(getTaskUsageHistoryPath(taskId));
-    children.sort(TASK_USAGE_PATH_COMPARATOR_TIMESTAMP_ASC);
-    return children;
+  @VisibleForTesting
+  public int countTasksWithUsage() {
+    return getChildren(TASK_PATH).stream()
+        .map((requestId) -> checkExists(ZKPaths.makePath(TASK_PATH, requestId)))
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .mapToInt(Stat::getNumChildren)
+        .sum();
   }
 
-  public Map<String, SingularityTaskCurrentUsageWithId> getTaskCurrentUsages(List<SingularityTaskId> taskIds) {
-    List<String> paths = new ArrayList<>(taskIds.size());
-    for (SingularityTaskId taskId : taskIds) {
-      paths.add(getCurrentTaskUsagePath(taskId.getId()));
-    }
+  public void cleanOldUsages(List<SingularityTaskId> activeTaskIds) {
+    for (String requestId : getChildren(TASK_PATH)) {
+      for (String taskIdString : getChildren(ZKPaths.makePath(TASK_PATH, requestId))) {
+        SingularityTaskId taskId;
+        try {
+          taskId = SingularityTaskId.valueOf(taskIdString);
+          if (activeTaskIds.contains(taskId)) {
+            continue;
+          }
+        } catch (InvalidSingularityTaskIdException e) {
+          LOG.warn("{} is not a valid task id, will remove task usage from zookeeper", taskIdString);
+        }
+        SingularityDeleteResult result = delete(ZKPaths.makePath(TASK_PATH, requestId, taskIdString)); // manually constructed in case SingularityTaskId.valueOf fails
 
-    return getAsyncWithPath("getTaskCurrentUsages", paths, taskCurrentUsageTranscoder);
+        LOG.debug("Deleted obsolete task usage {} - {}", taskIdString, result);
+      }
+    }
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/ZkTaskUsageManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/ZkTaskUsageManager.java
@@ -30,7 +30,6 @@ public class ZkTaskUsageManager extends CuratorAsyncManager implements TaskUsage
   private static final String TASK_PATH = ROOT_PATH + "/tasks";
 
   private static final String USAGE_HISTORY_PATH_KEY = "history";
-  private static final String CURRENT_USAGE_NODE_KEY = "CURRENT";
 
   private final Transcoder<SingularityTaskUsage> taskUsageTranscoder;
 
@@ -51,8 +50,8 @@ public class ZkTaskUsageManager extends CuratorAsyncManager implements TaskUsage
     return ZKPaths.makePath(getTaskUsagePath(taskId), USAGE_HISTORY_PATH_KEY);
   }
 
-  private String getSpecificTaskUsagePath(SingularityTaskId taskId, double timestamp) {
-    return ZKPaths.makePath(getTaskUsageHistoryPath(taskId), Double.toString(timestamp));
+  private String getSpecificTaskUsagePath(SingularityTaskId taskId, long timestamp) {
+    return ZKPaths.makePath(getTaskUsageHistoryPath(taskId), Long.toString(timestamp));
   }
 
   public void deleteTaskUsage(SingularityTaskId taskId) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/ZkTaskUsageManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/ZkTaskUsageManager.java
@@ -1,0 +1,117 @@
+package com.hubspot.singularity.data.usage;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.utils.ZKPaths;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.hubspot.singularity.SingularityCreateResult;
+import com.hubspot.singularity.SingularityDeleteResult;
+import com.hubspot.singularity.SingularityTaskCurrentUsage;
+import com.hubspot.singularity.SingularityTaskCurrentUsageWithId;
+import com.hubspot.singularity.SingularityTaskId;
+import com.hubspot.singularity.SingularityTaskUsage;
+import com.hubspot.singularity.config.SingularityConfiguration;
+import com.hubspot.singularity.data.CuratorAsyncManager;
+import com.hubspot.singularity.data.transcoders.Transcoder;
+
+@Singleton
+public class ZkTaskUsageManager extends CuratorAsyncManager {
+
+  private static final String ROOT_PATH = "/usage";
+
+  private static final String TASK_PATH = ROOT_PATH + "/tasks";
+
+  private static final String USAGE_HISTORY_PATH_KEY = "history";
+  private static final String CURRENT_USAGE_NODE_KEY = "CURRENT";
+
+  private final Transcoder<SingularityTaskUsage> taskUsageTranscoder;
+  private final Transcoder<SingularityTaskCurrentUsage> taskCurrentUsageTranscoder;
+
+  @Inject
+  public ZkTaskUsageManager(CuratorFramework curator,
+                            SingularityConfiguration configuration,
+                            MetricRegistry metricRegistry,
+                            Transcoder<SingularityTaskUsage> taskUsageTranscoder,
+                            Transcoder<SingularityTaskCurrentUsage> taskCurrentUsageTranscoder) {
+    super(curator, configuration, metricRegistry);
+    this.taskUsageTranscoder = taskUsageTranscoder;
+    this.taskCurrentUsageTranscoder = taskCurrentUsageTranscoder;
+  }
+
+  // /tasks/<taskid>/CURRENT
+  private String getTaskIdFromCurrentUsagePath(String path) {
+    return path.substring(path.indexOf(TASK_PATH) + TASK_PATH.length() + 1, path.lastIndexOf("/"));
+  }
+
+  private String getTaskUsagePath(String taskId) {
+    return ZKPaths.makePath(TASK_PATH, taskId);
+  }
+
+  private String getTaskUsageHistoryPath(String taskId) {
+    return ZKPaths.makePath(getTaskUsagePath(taskId), USAGE_HISTORY_PATH_KEY);
+  }
+
+  private String getSpecificTaskUsagePath(String taskId, double timestamp) {
+    return ZKPaths.makePath(getTaskUsageHistoryPath(taskId), Double.toString(timestamp));
+  }
+
+  private String getCurrentTaskUsagePath(String taskId) {
+    return ZKPaths.makePath(getTaskUsagePath(taskId), CURRENT_USAGE_NODE_KEY);
+  }
+
+  public SingularityDeleteResult deleteTaskUsage(String taskId) {
+    return delete(getTaskUsagePath(taskId));
+  }
+
+  public SingularityDeleteResult deleteSpecificTaskUsage(String taskId, double timestamp) {
+    return delete(getSpecificTaskUsagePath(taskId, timestamp));
+  }
+
+  public SingularityCreateResult saveCurrentTaskUsage(String taskId, SingularityTaskCurrentUsage usage) {
+    return set(getCurrentTaskUsagePath(taskId), usage, taskCurrentUsageTranscoder);
+  }
+
+  public SingularityCreateResult saveSpecificTaskUsage(String taskId, SingularityTaskUsage usage) {
+    return save(getSpecificTaskUsagePath(taskId, usage.getTimestamp()), usage, taskUsageTranscoder);
+  }
+
+  private static final Comparator<SingularityTaskUsage> TASK_USAGE_COMPARATOR_TIMESTAMP_ASC = Comparator.comparingDouble(SingularityTaskUsage::getTimestamp);
+
+  public List<SingularityTaskUsage> getTaskUsage(String taskId) {
+    List<SingularityTaskUsage> children = getAsyncChildren(getTaskUsageHistoryPath(taskId), taskUsageTranscoder);
+    children.sort(TASK_USAGE_COMPARATOR_TIMESTAMP_ASC);
+    return children;
+  }
+
+  private static final Comparator<String> TASK_USAGE_PATH_COMPARATOR_TIMESTAMP_ASC = Comparator.comparingDouble(Double::parseDouble);
+
+  public List<String> getTaskUsagePaths(String taskId) {
+    List<String> children = getChildren(getTaskUsageHistoryPath(taskId));
+    children.sort(TASK_USAGE_PATH_COMPARATOR_TIMESTAMP_ASC);
+    return children;
+  }
+
+  public List<SingularityTaskCurrentUsageWithId> getTaskCurrentUsages(List<SingularityTaskId> taskIds) {
+    List<String> paths = new ArrayList<>(taskIds.size());
+    for (SingularityTaskId taskId : taskIds) {
+      paths.add(getCurrentTaskUsagePath(taskId.getId()));
+    }
+
+    Map<String, SingularityTaskCurrentUsage> currentTaskUsages = getAsyncWithPath("getTaskCurrentUsages", paths, taskCurrentUsageTranscoder);
+    List<SingularityTaskCurrentUsageWithId> currentTaskUsagesWithIds = new ArrayList<>(paths.size());
+    for (Entry<String, SingularityTaskCurrentUsage> entry : currentTaskUsages.entrySet()) {
+      currentTaskUsagesWithIds.add(new SingularityTaskCurrentUsageWithId(SingularityTaskId.valueOf(getTaskIdFromCurrentUsagePath(entry.getKey())), entry.getValue()));
+    }
+
+    return currentTaskUsagesWithIds;
+  }
+
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/ClearSlaveUsagesMigration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/ClearSlaveUsagesMigration.java
@@ -1,0 +1,33 @@
+package com.hubspot.singularity.data.zkmigrations;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.zookeeper.KeeperException.NoNodeException;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+@Singleton
+public class ClearSlaveUsagesMigration extends ZkDataMigration {
+
+  private final CuratorFramework curator;
+
+  @Inject
+  public ClearSlaveUsagesMigration(CuratorFramework curator) {
+    super(15); // TODO check this when merging
+    this.curator = curator;
+  }
+
+  @Override
+  public void applyMigration() {
+    try {
+      try {
+        // Data format has changed and usage will repopulate when the poller runs
+        curator.delete().deletingChildrenIfNeeded().forPath("/usage/slaves");
+      } catch (NoNodeException nee) {}
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/ClearUsagesMigration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/ClearUsagesMigration.java
@@ -23,6 +23,7 @@ public class ClearUsagesMigration extends ZkDataMigration {
       try {
         // Data format has changed and usage will repopulate when the poller runs
         curator.delete().deletingChildrenIfNeeded().forPath("/usage/slaves");
+        curator.delete().deletingChildrenIfNeeded().forPath("/usage/tasks");
       } catch (NoNodeException nee) {}
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/SingularityZkMigrationsModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/zkmigrations/SingularityZkMigrationsModule.java
@@ -28,6 +28,7 @@ public class SingularityZkMigrationsModule implements Module {
     dataMigrations.addBinding().to(SingularityRequestTypeMigration.class);
     dataMigrations.addBinding().to(PendingRequestDataMigration.class);
     dataMigrations.addBinding().to(SingularityPendingRequestWithRunIdMigration.class);
+    dataMigrations.addBinding().to(ClearSlaveUsagesMigration.class);
   }
 
   @Provides

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
@@ -184,13 +184,7 @@ public class SingularityMesosOfferScheduler {
     Map<String, RequestUtilization> requestUtilizations = usageManager.getRequestUtilizations(false);
     List<SingularityTaskId> activeTaskIds = taskManager.getActiveTaskIds();
 
-    Map<String, SingularitySlaveUsageWithId> currentSlaveUsages = usageManager.getCurrentSlaveUsages(
-        offerHolders.values()
-            .stream()
-            .map(SingularityOfferHolder::getSlaveId)
-            .collect(Collectors.toList()))
-        .stream()
-        .collect(Collectors.toMap(SingularitySlaveUsageWithId::getSlaveId, Function.identity()));
+    Map<String, SingularitySlaveUsageWithId> currentSlaveUsages = usageManager.getAllCurrentSlaveUsage();
 
     List<CompletableFuture<Void>> currentSlaveUsagesFutures = new ArrayList<>();
     for (SingularityOfferHolder offerHolder : offerHolders.values()) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
@@ -45,7 +45,7 @@ import com.hubspot.singularity.config.MesosConfiguration;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.DeployManager;
 import com.hubspot.singularity.data.TaskManager;
-import com.hubspot.singularity.data.UsageManager;
+import com.hubspot.singularity.data.usage.UsageManager;
 import com.hubspot.singularity.helpers.MesosUtils;
 import com.hubspot.singularity.helpers.SingularityMesosTaskHolder;
 import com.hubspot.singularity.mesos.SingularitySlaveUsageWithCalculatedScores.MaxProbableUsage;

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/UsageResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/UsageResource.java
@@ -1,6 +1,7 @@
 package com.hubspot.singularity.resources;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import javax.ws.rs.GET;
@@ -58,7 +59,7 @@ public class UsageResource {
   @GET
   @Path("/slaves")
   @Operation(summary = "Retrieve a list of slave resource usage models with slave ids")
-  public List<SingularitySlaveUsageWithId> getSlavesWithUsage(@Parameter(hidden = true) @Auth SingularityUser user) {
+  public Collection<SingularitySlaveUsageWithId> getSlavesWithUsage(@Parameter(hidden = true) @Auth SingularityUser user) {
     authorizationHelper.checkAdminAuthorization(user);
     return usageManager.getAllCurrentSlaveUsage();
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/UsageResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/UsageResource.java
@@ -28,7 +28,7 @@ import com.hubspot.singularity.auth.SingularityAuthorizationHelper;
 import com.hubspot.singularity.config.ApiPaths;
 import com.hubspot.singularity.data.SlaveManager;
 import com.hubspot.singularity.data.TaskManager;
-import com.hubspot.singularity.data.UsageManager;
+import com.hubspot.singularity.data.usage.UsageManager;
 
 import io.dropwizard.auth.Auth;
 import io.swagger.v3.oas.annotations.Operation;

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
@@ -52,7 +52,7 @@ import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.DeployManager;
 import com.hubspot.singularity.data.RequestManager;
 import com.hubspot.singularity.data.TaskManager;
-import com.hubspot.singularity.data.UsageManager;
+import com.hubspot.singularity.data.usage.UsageManager;
 import com.hubspot.singularity.data.history.RequestHistoryHelper;
 import com.hubspot.singularity.expiring.SingularityExpiringBounce;
 import com.hubspot.singularity.hooks.LoadBalancerClient;

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCache.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCache.java
@@ -501,4 +501,8 @@ public class SingularityLeaderCache {
   public Map<String, SingularitySlaveUsageWithId> getSlaveUsages() {
     return new HashMap<>(slaveUsages);
   }
+
+  public Optional<SingularitySlaveUsageWithId> getSlaveUsage(String slaveId) {
+    return Optional.fromNullable(slaveUsages.get(slaveId));
+  }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCacheCoordinator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCacheCoordinator.java
@@ -7,7 +7,7 @@ import com.hubspot.singularity.data.RackManager;
 import com.hubspot.singularity.data.RequestManager;
 import com.hubspot.singularity.data.SlaveManager;
 import com.hubspot.singularity.data.TaskManager;
-import com.hubspot.singularity.data.UsageManager;
+import com.hubspot.singularity.data.usage.UsageManager;
 
 @Singleton
 public class SingularityLeaderCacheCoordinator {

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsageCleanerPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsageCleanerPoller.java
@@ -12,7 +12,7 @@ import com.google.inject.Inject;
 import com.hubspot.singularity.SingularityDeleteResult;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.TaskManager;
-import com.hubspot.singularity.data.UsageManager;
+import com.hubspot.singularity.data.usage.UsageManager;
 
 public class SingularityUsageCleanerPoller extends SingularityLeaderOnlyPoller {
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsageCleanerPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsageCleanerPoller.java
@@ -1,68 +1,30 @@
 package com.hubspot.singularity.scheduler;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.inject.Inject;
-import com.hubspot.singularity.SingularityDeleteResult;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.TaskManager;
 import com.hubspot.singularity.data.usage.UsageManager;
 
 public class SingularityUsageCleanerPoller extends SingularityLeaderOnlyPoller {
-
-  private static final Logger LOG = LoggerFactory.getLogger(SingularityUsageCleanerPoller.class);
-
-  private final SingularityUsageHelper usageHelper;
   private final UsageManager usageManager;
   private final TaskManager taskManager;
 
   @Inject
-  SingularityUsageCleanerPoller(SingularityConfiguration configuration, SingularityUsageHelper usageHelper, UsageManager usageManager, TaskManager taskManager) {
+  SingularityUsageCleanerPoller(SingularityConfiguration configuration, UsageManager usageManager, TaskManager taskManager) {
     super(configuration.getCleanUsageEveryMillis(), TimeUnit.MILLISECONDS);
-
-    this.usageHelper = usageHelper;
     this.usageManager = usageManager;
     this.taskManager = taskManager;
   }
 
   @Override
   public void runActionOnPoll() {
-    deleteObsoleteSlaveUsage();
-    deleteObsoleteTaskUsage();
+    usageManager.cleanOldUsages(taskManager.getActiveTaskIds());
   }
 
-  private void deleteObsoleteSlaveUsage() {
-    Set<String> slaveIdsToTrackUsageFor = usageHelper.getSlaveIdsToTrackUsageFor();
-
-    for (String slaveIdWithUsage : usageManager.getSlavesWithUsage()) {
-      if (slaveIdsToTrackUsageFor.contains(slaveIdWithUsage)) {
-        continue;
-      }
-
-      SingularityDeleteResult result = usageManager.deleteSlaveUsage(slaveIdWithUsage);
-
-      LOG.debug("Deleted obsolete slave usage {} - {}", slaveIdWithUsage, result);
-    }
-  }
-
-  private void deleteObsoleteTaskUsage() {
-    Set<String> taskIds = new HashSet<>(taskManager.getActiveTaskIdsAsStrings());
-    List<String> taskIdsWithUsage = usageManager.getTasksWithUsage();
-
-    for (String taskIdWithUsage : taskIdsWithUsage) {
-      if (taskIds.contains(taskIdWithUsage)) {
-        continue;
-      }
-
-      SingularityDeleteResult result = usageManager.deleteTaskUsage(taskIdWithUsage);
-
-      LOG.debug("Deleted obsolete task usage {} - {}", taskIdWithUsage, result);
-    }
+  @Override
+  protected boolean abortsOnError() {
+    return false;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsageHelper.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsageHelper.java
@@ -174,8 +174,8 @@ public class SingularityUsageHelper {
         }
 
         SingularityTaskUsage latestUsage = getUsage(taskUsage);
-        usageManager.saveSpecificTaskUsage(task, latestUsage);
         List<SingularityTaskUsage> pastTaskUsages = usageManager.getTaskUsage(task);
+        usageManager.saveSpecificTaskUsage(task, latestUsage);
 
         Optional<SingularityTask> maybeTask = taskManager.getTask(task);
         Optional<Resources> maybeResources = Optional.absent();

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsageHelper.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsageHelper.java
@@ -41,7 +41,7 @@ import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.RequestManager;
 import com.hubspot.singularity.data.SlaveManager;
 import com.hubspot.singularity.data.TaskManager;
-import com.hubspot.singularity.data.UsageManager;
+import com.hubspot.singularity.data.usage.UsageManager;
 import com.hubspot.singularity.sentry.SingularityExceptionNotifier;
 
 @Singleton

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
@@ -35,7 +35,7 @@ import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.DeployManager;
 import com.hubspot.singularity.data.RequestManager;
 import com.hubspot.singularity.data.TaskManager;
-import com.hubspot.singularity.data.UsageManager;
+import com.hubspot.singularity.data.usage.UsageManager;
 
 public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosOfferSchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosOfferSchedulerTest.java
@@ -16,6 +16,7 @@ import com.google.inject.Inject;
 import com.hubspot.mesos.json.MesosTaskMonitorObject;
 import com.hubspot.singularity.MachineLoadMetric;
 import com.hubspot.singularity.RequestType;
+import com.hubspot.singularity.RequestUtilization;
 import com.hubspot.singularity.SingularityDeploy;
 import com.hubspot.singularity.SingularityDeployStatistics;
 import com.hubspot.singularity.SingularityDeployStatisticsBuilder;
@@ -164,6 +165,7 @@ public class SingularityMesosOfferSchedulerTest extends SingularitySchedulerTest
 
     requestResource.scale(requestId, new SingularityScaleRequest(Optional.of(3), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()), SingularityUser.DEFAULT_USER);
 
+    RequestUtilization requestUtilization = usageManager.getRequestUtilizations().get(requestId);
     Assert.assertEquals(2.0, usageManager.getRequestUtilizations().get(requestId).getCpuUsed(), 0.001);
 
     Offer host2Offer = createOffer(6, 30000, 107374182, "host2", "host2");

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosOfferSchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosOfferSchedulerTest.java
@@ -3,7 +3,6 @@ package com.hubspot.singularity.mesos;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.mesos.v1.Protos.Offer;
 import org.junit.Assert;
@@ -193,12 +192,12 @@ public class SingularityMesosOfferSchedulerTest extends SingularitySchedulerTest
     String t1 = taskId.getId();
 
     // 2 cpus used
-    MesosTaskMonitorObject t1u1 = getTaskMonitor(t1, 10, TimeUnit.MILLISECONDS.toSeconds(taskId.getStartedAt()) + 5, 1000);
+    MesosTaskMonitorObject t1u1 = getTaskMonitor(t1, 10, getTimestampSeconds(taskId, 5    ), 1000);
     mesosClient.setSlaveResourceUsage("host1", Collections.singletonList(t1u1));
     usagePoller.runActionOnPoll();
 
     // 1 cpus used
-    MesosTaskMonitorObject t1u2 = getTaskMonitor(t1, 11, TimeUnit.MILLISECONDS.toSeconds(taskId.getStartedAt()) + 6, 1000);
+    MesosTaskMonitorObject t1u2 = getTaskMonitor(t1, 11, getTimestampSeconds(taskId, 6), 1000);
     mesosClient.setSlaveResourceUsage("host1", Collections.singletonList(t1u2));
     usagePoller.runActionOnPoll();
     SingularitySlaveUsage smallUsage = new SingularitySlaveUsage(0.1, 0.1, Optional.of(10.0), 1, 1, Optional.of(30L), 1, 1, Optional.of(1024L), 1, System.currentTimeMillis(), 1, 30000, 10, 0, 0, 0, 0, 107374182);
@@ -264,5 +263,9 @@ public class SingularityMesosOfferSchedulerTest extends SingularitySchedulerTest
 
   private void setRequestType(RequestType type) {
     Mockito.when(request.getRequestType()).thenReturn(type);
+  }
+
+  private double getTimestampSeconds(SingularityTaskId taskId, long seconds) {
+    return ((double) taskId.getStartedAt() + seconds * 1000) / 1000;
   }
 }

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosOfferSchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosOfferSchedulerTest.java
@@ -23,6 +23,7 @@ import com.hubspot.singularity.SingularityPendingTask;
 import com.hubspot.singularity.SingularityPendingTaskId;
 import com.hubspot.singularity.SingularityRequest;
 import com.hubspot.singularity.SingularitySlaveUsage;
+import com.hubspot.singularity.SingularitySlaveUsageWithId;
 import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.SingularityTaskRequest;
 import com.hubspot.singularity.SingularityUser;
@@ -157,9 +158,9 @@ public class SingularityMesosOfferSchedulerTest extends SingularitySchedulerTest
     usagePoller.runActionOnPoll();
     SingularitySlaveUsage smallUsage = new SingularitySlaveUsage(0.1, 0.1, Optional.of(10.0), 1, 1, Optional.of(30L), 1, 1, Optional.of(1024L), 1, System.currentTimeMillis(), 1, 30000, 10, 0, 0, 0, 0, 107374182);
 
-    usageManager.saveSpecificSlaveUsageAndSetCurrent("host1", smallUsage);
-    usageManager.saveSpecificSlaveUsageAndSetCurrent("host2", smallUsage);
-    usageManager.saveSpecificSlaveUsageAndSetCurrent("host3", smallUsage);
+    usageManager.saveCurrentSlaveUsage(new SingularitySlaveUsageWithId(smallUsage, "host1"));
+    usageManager.saveCurrentSlaveUsage(new SingularitySlaveUsageWithId(smallUsage, "host2"));
+    usageManager.saveCurrentSlaveUsage(new SingularitySlaveUsageWithId(smallUsage, "host3"));
 
     requestResource.scale(requestId, new SingularityScaleRequest(Optional.of(3), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()), SingularityUser.DEFAULT_USER);
 
@@ -202,9 +203,9 @@ public class SingularityMesosOfferSchedulerTest extends SingularitySchedulerTest
     usagePoller.runActionOnPoll();
     SingularitySlaveUsage smallUsage = new SingularitySlaveUsage(0.1, 0.1, Optional.of(10.0), 1, 1, Optional.of(30L), 1, 1, Optional.of(1024L), 1, System.currentTimeMillis(), 1, 30000, 10, 0, 0, 0, 0, 107374182);
 
-    usageManager.saveSpecificSlaveUsageAndSetCurrent("host1", smallUsage);
-    usageManager.saveSpecificSlaveUsageAndSetCurrent("host2", smallUsage);
-    usageManager.saveSpecificSlaveUsageAndSetCurrent("host3", smallUsage);
+    usageManager.saveCurrentSlaveUsage(new SingularitySlaveUsageWithId(smallUsage, "host1"));
+    usageManager.saveCurrentSlaveUsage(new SingularitySlaveUsageWithId(smallUsage, "host2"));
+    usageManager.saveCurrentSlaveUsage(new SingularitySlaveUsageWithId(smallUsage, "host3"));
 
     requestResource.scale(requestId, new SingularityScaleRequest(Optional.of(3), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional
         .absent()), SingularityUser.DEFAULT_USER);

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosOfferSchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosOfferSchedulerTest.java
@@ -29,7 +29,7 @@ import com.hubspot.singularity.SingularityUser;
 import com.hubspot.singularity.api.SingularityScaleRequest;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.DeployManager;
-import com.hubspot.singularity.data.UsageManager;
+import com.hubspot.singularity.data.usage.UsageManager;
 import com.hubspot.singularity.mesos.SingularitySlaveUsageWithCalculatedScores.MaxProbableUsage;
 import com.hubspot.singularity.scheduler.SingularitySchedulerTestBase;
 import com.hubspot.singularity.scheduler.SingularityUsagePoller;

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosOfferSchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosOfferSchedulerTest.java
@@ -16,7 +16,6 @@ import com.google.inject.Inject;
 import com.hubspot.mesos.json.MesosTaskMonitorObject;
 import com.hubspot.singularity.MachineLoadMetric;
 import com.hubspot.singularity.RequestType;
-import com.hubspot.singularity.RequestUtilization;
 import com.hubspot.singularity.SingularityDeploy;
 import com.hubspot.singularity.SingularityDeployStatistics;
 import com.hubspot.singularity.SingularityDeployStatisticsBuilder;
@@ -154,7 +153,7 @@ public class SingularityMesosOfferSchedulerTest extends SingularitySchedulerTest
     String t1 = taskId.getId();
 
     // 2 cpus used
-    MesosTaskMonitorObject t1u1 = getTaskMonitor(t1, 10, TimeUnit.MILLISECONDS.toSeconds(taskId.getStartedAt()) + 5, 1000);
+    MesosTaskMonitorObject t1u1 = getTaskMonitor(t1, 10,(double) (taskId.getStartedAt() + 5000) / 1000, 1000);
     mesosClient.setSlaveResourceUsage("host1", Collections.singletonList(t1u1));
     usagePoller.runActionOnPoll();
     SingularitySlaveUsage smallUsage = new SingularitySlaveUsage(0.1, 0.1, Optional.of(10.0), 1, 1, Optional.of(30L), 1, 1, Optional.of(1024L), 1, System.currentTimeMillis(), 1, 30000, 10, 0, 0, 0, 0, 107374182);
@@ -165,7 +164,6 @@ public class SingularityMesosOfferSchedulerTest extends SingularitySchedulerTest
 
     requestResource.scale(requestId, new SingularityScaleRequest(Optional.of(3), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()), SingularityUser.DEFAULT_USER);
 
-    RequestUtilization requestUtilization = usageManager.getRequestUtilizations().get(requestId);
     Assert.assertEquals(2.0, usageManager.getRequestUtilizations().get(requestId).getCpuUsed(), 0.001);
 
     Offer host2Offer = createOffer(6, 30000, 107374182, "host2", "host2");

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTestBase.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTestBase.java
@@ -42,12 +42,9 @@ import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.hubspot.baragon.models.BaragonRequestState;
 import com.hubspot.deploy.HealthcheckOptionsBuilder;
+import com.hubspot.mesos.Resources;
 import com.hubspot.mesos.json.MesosTaskMonitorObject;
 import com.hubspot.mesos.json.MesosTaskStatisticsObject;
-import com.hubspot.singularity.SingularityLeaderController;
-import com.hubspot.singularity.helpers.MesosProtosUtils;
-import com.hubspot.singularity.helpers.MesosUtils;
-import com.hubspot.mesos.Resources;
 import com.hubspot.mesos.protos.MesosTaskStatusObject;
 import com.hubspot.singularity.DeployState;
 import com.hubspot.singularity.LoadBalancerRequestType;
@@ -94,6 +91,8 @@ import com.hubspot.singularity.data.SlaveManager;
 import com.hubspot.singularity.data.TaskManager;
 import com.hubspot.singularity.data.zkmigrations.ZkDataMigrationRunner;
 import com.hubspot.singularity.event.SingularityEventListener;
+import com.hubspot.singularity.helpers.MesosProtosUtils;
+import com.hubspot.singularity.helpers.MesosUtils;
 import com.hubspot.singularity.mesos.SingularityMesosScheduler;
 import com.hubspot.singularity.resources.DeployResource;
 import com.hubspot.singularity.resources.PriorityResource;
@@ -748,7 +747,7 @@ public class SingularitySchedulerTestBase extends SingularityCuratorTestBase {
     return new MesosTaskStatisticsObject(1, 0L, 0L, 0, 0, cpuSecs, 0L, 0L, 0L, 0L, 0L, memBytes, 0L, 0L, timestamp);
   }
 
-  protected MesosTaskMonitorObject getTaskMonitor(String id, double cpuSecs, long timestampSeconds, int memBytes) {
+  protected MesosTaskMonitorObject getTaskMonitor(String id, double cpuSecs, double timestampSeconds, int memBytes) {
     return new MesosTaskMonitorObject(null, null, "singularity", id, getStatistics(cpuSecs, timestampSeconds, memBytes));
   }
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityTestModule.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityTestModule.java
@@ -206,7 +206,7 @@ public class SingularityTestModule implements Module {
           }
         }));
 
-    mainBinder.install(new SingularityDataModule());
+    mainBinder.install(new SingularityDataModule(configuration));
     mainBinder.install(new SingularitySchedulerModule());
     mainBinder.install(new SingularityTranscoderModule());
     mainBinder.install(new SingularityHistoryModule(configuration));

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityUsageTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityUsageTest.java
@@ -72,7 +72,7 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
 
     Assert.assertEquals(2, first.getCpuSeconds(), 0);
     Assert.assertEquals(100, first.getMemoryTotalBytes(), 0);
-    Assert.assertEquals(5, first.getTimestamp(), 0);
+    Assert.assertEquals(5000, first.getTimestamp(), 0);
   }
 
   @Test
@@ -578,14 +578,8 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
     }
   }
 
-  private long getTimestampSeconds(SingularityTaskId taskId, long seconds) {
-    return TimeUnit.MILLISECONDS.toSeconds(taskId.getStartedAt()) + seconds;
-  }
-
-  private void saveTaskUsage(SingularityTaskId taskId, long... times) {
-    for (long time : times) {
-      usageManager.saveSpecificTaskUsage(taskId, new SingularityTaskUsage(0, time, 0, 0, 0, 0, 0));
-    }
+  private double getTimestampSeconds(SingularityTaskId taskId, long seconds) {
+    return ((double) taskId.getStartedAt() + seconds * 1000) / 1000;
   }
 
   private void testUtilization(SingularityClusterUtilization utilization,

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityUsageTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityUsageTest.java
@@ -23,7 +23,7 @@ import com.hubspot.singularity.SingularityTaskCurrentUsageWithId;
 import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.SingularityTaskUsage;
 import com.hubspot.singularity.TaskCleanupType;
-import com.hubspot.singularity.data.UsageManager;
+import com.hubspot.singularity.data.usage.UsageManager;
 
 public class SingularityUsageTest extends SingularitySchedulerTestBase {
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityUsageTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityUsageTest.java
@@ -18,8 +18,8 @@ import com.hubspot.singularity.MachineState;
 import com.hubspot.singularity.RequestUtilization;
 import com.hubspot.singularity.SingularityClusterUtilization;
 import com.hubspot.singularity.SingularitySlaveUsage;
+import com.hubspot.singularity.SingularitySlaveUsageWithId;
 import com.hubspot.singularity.SingularityTask;
-import com.hubspot.singularity.SingularityTaskCurrentUsageWithId;
 import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.SingularityTaskUsage;
 import com.hubspot.singularity.TaskCleanupType;
@@ -65,15 +65,10 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
 
     String slaveId = firstTask.getAgentId().getValue();
 
-    List<String> slaves = usageManager.getSlavesWithUsage();
+    Assert.assertEquals(0, usageManager.getSlaveUsage(slaveId).get().getCpusUsed(), 0);
+    Assert.assertEquals(100, usageManager.getSlaveUsage(slaveId).get().getMemoryBytesUsed(), 0);
 
-    Assert.assertEquals(1, slaves.size());
-    Assert.assertEquals(slaves.get(0), slaveId);
-
-    Assert.assertEquals(0, usageManager.getSlaveUsage(slaveId).get(0).getCpusUsed(), 0);
-    Assert.assertEquals(100, usageManager.getSlaveUsage(slaveId).get(0).getMemoryBytesUsed(), 0);
-
-    SingularityTaskUsage first = usageManager.getTaskUsage(firstTask.getTaskId().getId()).get(0);
+    SingularityTaskUsage first = usageManager.getTaskUsage(firstTask.getTaskId()).get(0);
 
     Assert.assertEquals(2, first.getCpuSeconds(), 0);
     Assert.assertEquals(100, first.getMemoryTotalBytes(), 0);
@@ -103,10 +98,10 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
     usagePoller.runActionOnPoll();
     cleaner.runActionOnPoll();
 
-    Assert.assertEquals(2, usageManager.getTasksWithUsage().size());
-    Assert.assertEquals(1, usageManager.getSlavesWithUsage().size());
+    Assert.assertEquals(2, usageManager.countTasksWithUsage());
+    Assert.assertEquals(1, usageManager.getAllCurrentSlaveUsage().size());
 
-    Assert.assertEquals(1100, usageManager.getAllCurrentSlaveUsage().get(0).getMemoryBytesUsed(), 0);
+    Assert.assertEquals(1100, usageManager.getSlaveUsage(slaveId).get().getMemoryBytesUsed(), 0);
 
     // kill task one
     statusUpdate(taskManager.getActiveTasks().get(0), TaskState.TASK_KILLED);
@@ -114,15 +109,15 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
 
     cleaner.runActionOnPoll();
 
-    Assert.assertEquals(1, usageManager.getTasksWithUsage().size());
-    Assert.assertEquals(1, usageManager.getSlavesWithUsage().size());
+    Assert.assertEquals(1, usageManager.countTasksWithUsage());
+    Assert.assertEquals(1, usageManager.getAllCurrentSlaveUsage().size());
 
     slaveManager.changeState(slaveId, MachineState.DEAD, Optional.absent(), Optional.absent());
 
     cleaner.runActionOnPoll();
 
-    Assert.assertEquals(1, usageManager.getTasksWithUsage().size());
-    Assert.assertEquals(0, usageManager.getSlavesWithUsage().size());
+    Assert.assertEquals(1, usageManager.countTasksWithUsage());
+    Assert.assertEquals(0, usageManager.getAllCurrentSlaveUsage().size());
   }
 
   @Test
@@ -137,14 +132,14 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
 
     List<SingularityTaskId> taskIds = taskManager.getActiveTaskIds();
 
-    String t1 = taskIds.get(0).getId();
-    String t2 = taskIds.get(1).getId();
+    SingularityTaskId t1 = taskIds.get(0);
+    SingularityTaskId t2 = taskIds.get(1);
 
     String slaveId = slaveManager.getObjectIds().get(0);
     String host = slaveManager.getObjects().get(0).getHost();
 
-    MesosTaskMonitorObject t1u1 = getTaskMonitor(t1, 2, 5, 100);
-    MesosTaskMonitorObject t2u1 = getTaskMonitor(t2, 10, 5, 1024);
+    MesosTaskMonitorObject t1u1 = getTaskMonitor(t1.getId(), 2, 5, 100);
+    MesosTaskMonitorObject t2u1 = getTaskMonitor(t2.getId(), 10, 5, 1024);
 
     mesosClient.setSlaveResourceUsage(host, Arrays.asList(t1u1, t2u1));
 
@@ -155,8 +150,8 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
 
     // 5 seconds have elapsed, t1 has used 1 CPU the whole time = 5 + 2
     // t2 has used 2.5 CPUs the whole time =
-    MesosTaskMonitorObject t1u2 = getTaskMonitor(t1, 7, 10, 125);
-    MesosTaskMonitorObject t2u2 = getTaskMonitor(t2, 22.5, 10, 750);
+    MesosTaskMonitorObject t1u2 = getTaskMonitor(t1.getId(), 7, 10, 125);
+    MesosTaskMonitorObject t2u2 = getTaskMonitor(t2.getId(), 22.5, 10, 750);
 
     mesosClient.setSlaveResourceUsage(host, Arrays.asList(t1u2, t2u2));
 
@@ -164,9 +159,9 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
     cleaner.runActionOnPoll();
 
     // check usage now
-    Assert.assertEquals(3.5, usageManager.getSlaveUsage(slaveId).get(1).getCpusUsed(), 0);
-    Assert.assertEquals(875, usageManager.getSlaveUsage(slaveId).get(1).getMemoryBytesUsed(), 0);
-    Assert.assertEquals(2, usageManager.getSlaveUsage(slaveId).get(1).getNumTasks(), 0);
+    Assert.assertEquals(3.5, usageManager.getSlaveUsage(slaveId).get().getCpusUsed(), 0);
+    Assert.assertEquals(875, usageManager.getSlaveUsage(slaveId).get().getMemoryBytesUsed(), 0);
+    Assert.assertEquals(2, usageManager.getSlaveUsage(slaveId).get().getNumTasks(), 0);
 
     // check task usage
     Assert.assertEquals(22.5, usageManager.getTaskUsage(t2).get(1).getCpuSeconds(), 0);
@@ -174,8 +169,8 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
 
     Thread.sleep(2);
 
-    MesosTaskMonitorObject t1u3 = getTaskMonitor(t1, 8, 11, 125);
-    MesosTaskMonitorObject t2u3 = getTaskMonitor(t2, 23.5, 11, 1024);
+    MesosTaskMonitorObject t1u3 = getTaskMonitor(t1.getId(), 8, 11, 125);
+    MesosTaskMonitorObject t2u3 = getTaskMonitor(t2.getId(), 23.5, 11, 1024);
 
     mesosClient.setSlaveResourceUsage(host, Arrays.asList(t1u3, t2u3));
 
@@ -184,30 +179,15 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
 
     //check that there is only 2 usages
 
-    Assert.assertEquals(2, usageManager.getSlaveUsage(slaveId).size());
     Assert.assertEquals(3, usageManager.getTaskUsage(t1).size());
     Assert.assertEquals(3, usageManager.getTaskUsage(t2).size());
 
     Assert.assertEquals(10.0, usageManager.getTaskUsage(t2).get(0).getCpuSeconds(), 0);
     Assert.assertEquals(22.5, usageManager.getTaskUsage(t2).get(1).getCpuSeconds(), 0);
 
-    Assert.assertEquals(875, usageManager.getSlaveUsage(slaveId).get(0).getMemoryBytesUsed(), 0);
-    Assert.assertEquals(1149, usageManager.getSlaveUsage(slaveId).get(1).getMemoryBytesUsed(), 0);
+    Assert.assertEquals(1149, usageManager.getSlaveUsage(slaveId).get().getMemoryBytesUsed(), 0);
 
-    Assert.assertEquals(slaveId, usageManager.getAllCurrentSlaveUsage().get(0).getSlaveId());
-    Assert.assertEquals(1149, usageManager.getAllCurrentSlaveUsage().get(0).getMemoryBytesUsed(), 0);
-
-    List<SingularityTaskCurrentUsageWithId> taskCurrentUsages = usageManager.getTaskCurrentUsages(taskManager.getActiveTaskIds());
-
-    Assert.assertEquals(2, taskCurrentUsages.size());
-
-    List<SingularityTaskId> activeTaskIds = taskManager.getActiveTaskIds();
-
-    for (SingularityTaskCurrentUsageWithId taskCurrentUsage : taskCurrentUsages) {
-      activeTaskIds.remove(taskCurrentUsage.getTaskId());
-    }
-
-    Assert.assertTrue(activeTaskIds.isEmpty());
+    Assert.assertEquals(2, usageManager.countTasksWithUsage());
   }
 
   @Test
@@ -220,16 +200,16 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
     resourceOffers(1);
 
     SingularityTaskId taskId = taskManager.getActiveTaskIds().get(0);
-    String t1 = taskId.getId();
+    SingularityTaskId t1 = taskId;
     String host = slaveManager.getObjects().get(0).getHost();
 
     // used 8 cpu
-    MesosTaskMonitorObject t1u1 = getTaskMonitor(t1, 40, getTimestampSeconds(taskId, 5), 800);
+    MesosTaskMonitorObject t1u1 = getTaskMonitor(t1.getId(), 40, getTimestampSeconds(taskId, 5), 800);
     mesosClient.setSlaveResourceUsage(host, Collections.singletonList(t1u1));
     usagePoller.runActionOnPoll();
 
     // used 8 cpu
-    MesosTaskMonitorObject t1u2 = getTaskMonitor(t1, 80, getTimestampSeconds(taskId, 10), 850);
+    MesosTaskMonitorObject t1u2 = getTaskMonitor(t1.getId(), 80, getTimestampSeconds(taskId, 10), 850);
     mesosClient.setSlaveResourceUsage(host, Collections.singletonList(t1u2));
     usagePoller.runActionOnPoll();
 
@@ -258,16 +238,15 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
     resourceOffers(1);
 
     SingularityTaskId taskId = taskManager.getActiveTaskIds().get(0);
-    String t1 = taskId.getId();
     String host = slaveManager.getObjects().get(0).getHost();
 
     // 2 cpus used
-    MesosTaskMonitorObject t1u1 = getTaskMonitor(t1, 10, getTimestampSeconds(taskId, 5), 1024);
+    MesosTaskMonitorObject t1u1 = getTaskMonitor(taskId.getId(), 10, getTimestampSeconds(taskId, 5), 1024);
     mesosClient.setSlaveResourceUsage(host, Collections.singletonList(t1u1));
     usagePoller.runActionOnPoll();
 
     // 2 cpus used
-    MesosTaskMonitorObject t1u2 = getTaskMonitor(t1, 20, getTimestampSeconds(taskId, 10), 900);
+    MesosTaskMonitorObject t1u2 = getTaskMonitor(taskId.getId(), 20, getTimestampSeconds(taskId, 10), 900);
     mesosClient.setSlaveResourceUsage(host, Collections.singletonList(t1u2));
     usagePoller.runActionOnPoll();
 
@@ -275,7 +254,7 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
 
     SingularityClusterUtilization utilization = usageManager.getClusterUtilization().get();
 
-    int taskUsages = usageManager.getTaskUsage(t1).size();
+    int taskUsages = usageManager.getTaskUsage(taskId).size();
     testUtilization(utilization, 2, taskUsages, cpuReserved, memMbReserved,
         0, 0, 1,
         0, 0, 86,
@@ -295,16 +274,15 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
     resourceOffers(1);
 
     SingularityTaskId taskId = taskManager.getActiveTaskIds().get(0);
-    String t1 = taskId.getId();
     String host = slaveManager.getObjects().get(0).getHost();
 
     // 4 cpus used
-    MesosTaskMonitorObject t1u1 = getTaskMonitor(t1, 20, getTimestampSeconds(taskId, 5), 1024);
+    MesosTaskMonitorObject t1u1 = getTaskMonitor(taskId.getId(), 20, getTimestampSeconds(taskId, 5), 1024);
     mesosClient.setSlaveResourceUsage(host, Collections.singletonList(t1u1));
     usagePoller.runActionOnPoll();
 
     // 4 cpus used
-    MesosTaskMonitorObject t1u2 = getTaskMonitor(t1, 40, getTimestampSeconds(taskId, 10), 1024);
+    MesosTaskMonitorObject t1u2 = getTaskMonitor(taskId.getId(), 40, getTimestampSeconds(taskId, 10), 1024);
     mesosClient.setSlaveResourceUsage(host, Collections.singletonList(t1u2));
     usagePoller.runActionOnPoll();
 
@@ -312,7 +290,7 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
 
     SingularityClusterUtilization utilization = usageManager.getClusterUtilization().get();
 
-    int taskUsages = usageManager.getTaskUsage(t1).size();
+    int taskUsages = usageManager.getTaskUsage(taskId).size();
     testUtilization(utilization, 2, taskUsages, cpuReserved, memMbReserved,
         1, 0, 0,
         2, 0, 0,
@@ -320,37 +298,6 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
         2, 0, 0);
 
     Assert.assertEquals(requestId, utilization.getMaxOverUtilizedCpuRequestId());
-  }
-
-  @Test
-  public void itCorrectlyDeletesOldUsage() {
-    configuration.setNumUsageToKeep(2);
-    configuration.setCheckUsageEveryMillis(TimeUnit.MINUTES.toMillis(1));
-    long now = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
-
-    // no usages exist, none are deleted
-    String taskId = "newTask";
-    clearUsages(taskId);
-
-    // 1 usage exists, none are deleted
-    taskId = "singleUsage";
-    saveTaskUsage(taskId, now);
-    clearUsages(taskId);
-    Assert.assertEquals(1, usageManager.getTaskUsage(taskId).size());
-
-    // 2 usages exist 1 min apart, none are deleted
-    taskId = "twoUsages";
-    saveTaskUsage(taskId, now, now + TimeUnit.MINUTES.toSeconds(1));
-    clearUsages(taskId);
-    Assert.assertEquals(2, usageManager.getTaskUsage(taskId).size());
-
-    // 3 usages, oldest is deleted
-    taskId = "threeUsages";
-    saveTaskUsage(taskId, now, now + TimeUnit.MINUTES.toSeconds(3), now + TimeUnit.MINUTES.toSeconds(4));
-    clearUsages(taskId);
-    Assert.assertEquals(2, usageManager.getTaskUsage(taskId).size());
-    Assert.assertEquals(now, (long) usageManager.getTaskUsage(taskId).get(0).getTimestamp());
-    Assert.assertEquals(now + TimeUnit.MINUTES.toSeconds(3), (long) usageManager.getTaskUsage(taskId).get(1).getTimestamp());
   }
 
   @Test
@@ -386,8 +333,8 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
     SingularityClusterUtilization utilization = usageManager.getClusterUtilization().get();
     List<RequestUtilization> requestUtilizations = new ArrayList<>(usageManager.getRequestUtilizations().values());
 
-    int t1TaskUsages = usageManager.getTaskUsage(t1.getId()).size();
-    int t2TaskUsages = usageManager.getTaskUsage(t2.getId()).size();
+    int t1TaskUsages = usageManager.getTaskUsage(t1).size();
+    int t2TaskUsages = usageManager.getTaskUsage(t2).size();
     Assert.assertEquals(2, t1TaskUsages);
     Assert.assertEquals(2, t2TaskUsages);
 
@@ -421,8 +368,8 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
     SingularityClusterUtilization utilization = usageManager.getClusterUtilization().get();
     List<RequestUtilization> requestUtilizations = new ArrayList<>(usageManager.getRequestUtilizations().values());
 
-    int t1TaskUsages = usageManager.getTaskUsage(t1.getId()).size();
-    int t2TaskUsages = usageManager.getTaskUsage(t2.getId()).size();
+    int t1TaskUsages = usageManager.getTaskUsage(t1).size();
+    int t2TaskUsages = usageManager.getTaskUsage(t2).size();
     Assert.assertEquals(1, t1TaskUsages);
     Assert.assertEquals(1, t2TaskUsages);
     Assert.assertEquals(1, requestUtilizations.size());
@@ -449,8 +396,8 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
     utilization = usageManager.getClusterUtilization().get();
     requestUtilizations = new ArrayList<>(usageManager.getRequestUtilizations().values());
 
-    t1TaskUsages = usageManager.getTaskUsage(t1.getId()).size();
-    t2TaskUsages = usageManager.getTaskUsage(t2.getId()).size();
+    t1TaskUsages = usageManager.getTaskUsage(t1).size();
+    t2TaskUsages = usageManager.getTaskUsage(t2).size();
     Assert.assertEquals(2, t1TaskUsages);
     Assert.assertEquals(2, t2TaskUsages);
     Assert.assertEquals(1, requestUtilizations.size());
@@ -477,8 +424,8 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
     utilization = usageManager.getClusterUtilization().get();
     requestUtilizations = new ArrayList<>(usageManager.getRequestUtilizations().values());
 
-    t1TaskUsages = usageManager.getTaskUsage(t1.getId()).size();
-    t2TaskUsages = usageManager.getTaskUsage(t2.getId()).size();
+    t1TaskUsages = usageManager.getTaskUsage(t1).size();
+    t2TaskUsages = usageManager.getTaskUsage(t2).size();
     Assert.assertEquals(3, t1TaskUsages);
     Assert.assertEquals(3, t2TaskUsages);
     Assert.assertEquals(1, requestUtilizations.size());
@@ -504,7 +451,7 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
       saveAndSchedule(requestManager.getRequest(requestId).get().getRequest().toBuilder().setInstances(Optional.of(3)));
       resourceOffers(1);
       SingularitySlaveUsage highUsage = new SingularitySlaveUsage(15, 10, Optional.of(10.0), 1, 1, Optional.of(30L), 1, 1, Optional.of(1024L), 1, System.currentTimeMillis(), 1, 30000, 10, 15, 15, 15, 0, 107374182);
-      usageManager.saveSpecificSlaveUsageAndSetCurrent("host1", highUsage);
+      usageManager.saveCurrentSlaveUsage(new SingularitySlaveUsageWithId(highUsage, "host1"));
 
       SingularityTaskId taskId1 = taskManager.getActiveTaskIds().get(0);
       String t1 = taskId1.getId();
@@ -555,7 +502,7 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
       saveAndSchedule(requestManager.getRequest(requestId).get().getRequest().toBuilder().setInstances(Optional.of(3)));
       resourceOffers(1);
       SingularitySlaveUsage highUsage = new SingularitySlaveUsage(15, 10, Optional.of(10.0), 1, 1, Optional.of(30L), 1, 1, Optional.of(1024L), 1, System.currentTimeMillis(), 1, 30000, 10, 15, 15, 15, 0, 107374182);
-      usageManager.saveSpecificSlaveUsageAndSetCurrent("host1", highUsage);
+      usageManager.saveCurrentSlaveUsage(new SingularitySlaveUsageWithId(highUsage, "host1"));
 
       SingularityTaskId taskId1 = taskManager.getActiveTaskIds().get(0);
       String t1 = taskId1.getId();
@@ -601,7 +548,7 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
       saveAndSchedule(requestManager.getRequest(requestId).get().getRequest().toBuilder().setInstances(Optional.of(3)));
       resourceOffers(1);
       SingularitySlaveUsage highUsage = new SingularitySlaveUsage(15, 10, Optional.of(10.0), 1, 1, Optional.of(30L), 1, 1, Optional.of(1024L), 1, System.currentTimeMillis(), 1, 30000, 10, 15, 15, 15, 0, 107374182);
-      usageManager.saveSpecificSlaveUsageAndSetCurrent("host1", highUsage);
+      usageManager.saveCurrentSlaveUsage(new SingularitySlaveUsageWithId(highUsage, "host1"));
 
       SingularityTaskId taskId1 = taskManager.getActiveTaskIds().get(0);
       String t1 = taskId1.getId();
@@ -635,14 +582,10 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
     return TimeUnit.MILLISECONDS.toSeconds(taskId.getStartedAt()) + seconds;
   }
 
-  private void saveTaskUsage(String taskId, long... times) {
+  private void saveTaskUsage(SingularityTaskId taskId, long... times) {
     for (long time : times) {
       usageManager.saveSpecificTaskUsage(taskId, new SingularityTaskUsage(0, time, 0, 0, 0, 0, 0));
     }
-  }
-
-  private void clearUsages(String taskId) {
-    usageHelper.clearOldUsage(taskId);
   }
 
   private void testUtilization(SingularityClusterUtilization utilization,

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityUsageTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityUsageTest.java
@@ -127,7 +127,7 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
     saveAndSchedule(request.toBuilder().setInstances(Optional.of(2)));
     resourceOffers(1);
 
-    configuration.setNumUsageToKeep(2);
+    configuration.setNumUsageToKeep(3);
     configuration.setCheckUsageEveryMillis(1);
 
     List<SingularityTaskId> taskIds = taskManager.getActiveTaskIds();

--- a/mysql/migrations.sql
+++ b/mysql/migrations.sql
@@ -124,3 +124,15 @@ ALTER TABLE `taskHistory`
 ALTER TABLE `taskHistory`
   DROP KEY `startedAt2`,
   ADD KEY `startedAt3` (`startedAt`)
+
+--changeset ssalinas:17 dbms:mysql
+CREATE TABLE `taskUsage` (
+  `taskId` varchar(200) NOT NULL DEFAULT '',
+  `requestId` varchar(100) NOT NULL,
+  `memoryTotalBytes` BIGINT UNSIGNED NOT NULL,
+  `cpusUsed` DOUBLE UNSIGNED NOT NULL,
+  `cpusTotal` DOUBLE UNSIGNED NOT NULL,
+  `diskTotalBytes` BIGINT UNSIGNED NOT NULL,
+  `timestamp` timestamp NOT NULL,
+
+

--- a/mysql/migrations.sql
+++ b/mysql/migrations.sql
@@ -134,8 +134,7 @@ CREATE TABLE `taskUsage` (
   `cpusTotal` DOUBLE UNSIGNED NOT NULL,
   `diskTotalBytes` BIGINT UNSIGNED NOT NULL,
   `timestamp` TIMESTAMP NOT NULL,
-   PRIMARY KEY (`taskId`, `timestamp`),
-   KEY `requestId` (`requestId`)
+   PRIMARY KEY (`taskId`, `timestamp`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 

--- a/mysql/migrations.sql
+++ b/mysql/migrations.sql
@@ -136,5 +136,3 @@ CREATE TABLE `taskUsage` (
   `timestamp` TIMESTAMP NOT NULL,
    PRIMARY KEY (`taskId`, `timestamp`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-

--- a/mysql/migrations.sql
+++ b/mysql/migrations.sql
@@ -133,7 +133,7 @@ CREATE TABLE `taskUsage` (
   `cpuSeconds` DOUBLE UNSIGNED NOT NULL,
   `cpusThrottledTimeSecs` DOUBLE UNSIGNED NOT NULL,
   `diskTotalBytes` BIGINT UNSIGNED NOT NULL,
-  `timestamp` TIMESTAMP NOT NULL,
+  `timestamp` BIGINT UNSIGNED NOT NULL,
   `cpusNrPeriods` BIGINT UNSIGNED NOT NULL,
   `cpusNrThrottled` BIGINT UNSIGNED NOT NULL,
    PRIMARY KEY (`taskId`, `timestamp`)

--- a/mysql/migrations.sql
+++ b/mysql/migrations.sql
@@ -127,12 +127,15 @@ ALTER TABLE `taskHistory`
 
 --changeset ssalinas:17 dbms:mysql
 CREATE TABLE `taskUsage` (
-  `taskId` varchar(200) NOT NULL DEFAULT '',
   `requestId` varchar(100) NOT NULL,
+  `taskId` varchar(200) NOT NULL DEFAULT '',
   `memoryTotalBytes` BIGINT UNSIGNED NOT NULL,
   `cpusUsed` DOUBLE UNSIGNED NOT NULL,
   `cpusTotal` DOUBLE UNSIGNED NOT NULL,
   `diskTotalBytes` BIGINT UNSIGNED NOT NULL,
-  `timestamp` timestamp NOT NULL,
+  `timestamp` TIMESTAMP NOT NULL,
+   PRIMARY KEY (`taskId`, `timestamp`),
+   KEY `requestId` (`requestId`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 

--- a/mysql/migrations.sql
+++ b/mysql/migrations.sql
@@ -130,9 +130,11 @@ CREATE TABLE `taskUsage` (
   `requestId` varchar(100) NOT NULL,
   `taskId` varchar(200) NOT NULL DEFAULT '',
   `memoryTotalBytes` BIGINT UNSIGNED NOT NULL,
-  `cpusUsed` DOUBLE UNSIGNED NOT NULL,
-  `cpusTotal` DOUBLE UNSIGNED NOT NULL,
+  `cpuSeconds` DOUBLE UNSIGNED NOT NULL,
+  `cpusThrottledTimeSecs` DOUBLE UNSIGNED NOT NULL,
   `diskTotalBytes` BIGINT UNSIGNED NOT NULL,
   `timestamp` TIMESTAMP NOT NULL,
+  `cpusNrPeriods` BIGINT UNSIGNED NOT NULL,
+  `cpusNrThrottled` BIGINT UNSIGNED NOT NULL,
    PRIMARY KEY (`taskId`, `timestamp`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
Last (for now) in the 'be nice to zookeeper' series. We store cluster, slave, request, and task level resource usage, currently all in zookeeper. This does a few things to make that more scalable:
- For request/slave we only ever need the current. Stop saving history, and make sure recent slave usages are also leader cached
- Task usages, if in zk, need to be namespaced by request id to avoid extra large list children calls of all task ids
- Task usages will be stored in mysql if it is configured, which will require a migration to be run to create the table
- A zk migration has been added to clean all current usage data. This data will be rewritten the next time the poller runs and is not required for scheduling
- task usage timestamps are now stored in millis instead of seconds
- `usage/slaves/{slaveId}/tasks/current` endpoint is removed