### PR TITLE
Put a time limit on the uploader check so we don't get stuck

### DIFF
--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3UploaderDriver.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3UploaderDriver.java
@@ -309,7 +309,8 @@ public class SingularityS3UploaderDriver extends WatchServiceHelper implements S
     for (Entry<SingularityUploader, CompletableFuture<Integer>> uploaderToFuture : futures.entrySet()) {
       final SingularityUploader uploader = uploaderToFuture.getKey();
       try {
-        final int foundFiles = uploaderToFuture.getValue().get();
+        LOG.debug("Waiting for future for uploader {}", uploader);
+        final int foundFiles = uploaderToFuture.getValue().get(30, TimeUnit.SECONDS);
         final boolean isFinished = finishing.get(uploader);
 
         if (foundFiles == 0 && shouldExpire(uploader, isFinished)) {


### PR DESCRIPTION
We've seen slow leaks of uploader files, likely from the `chekcUploads` method getting stuck. IF this gets stuck and subsequent upload checks don't run, then files do not get cleaned up. Immediate uploads are still triggered fine, which is the majority of uploads from the SingularityExecutor.

To start, this just adds a timeout on the regular uploader check and some additional logging so we can know which future may be stuck