### PR TITLE
Check assigned ports are available in SingularityExecutor

### DIFF
--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
@@ -240,6 +240,9 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
 
   private Optional<Long> maxServiceLogSizeMb = Optional.absent();
 
+  @JsonProperty
+  private boolean verifyAssignedPorts = false;
+
   public SingularityExecutorConfiguration() {
     super(Optional.of("singularity-executor.log"));
   }
@@ -720,6 +723,14 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
 
   }
 
+  public boolean isVerifyAssignedPorts() {
+    return verifyAssignedPorts;
+  }
+
+  public void setVerifyAssignedPorts(boolean verifyAssignedPorts) {
+    this.verifyAssignedPorts = verifyAssignedPorts;
+  }
+
   @Override
   public String toString() {
     return "SingularityExecutorConfiguration{" +
@@ -728,6 +739,7 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
         ", defaultRunAsUser='" + defaultRunAsUser + '\'' +
         ", taskAppDirectory='" + taskAppDirectory + '\'' +
         ", shutdownTimeoutWaitMillis=" + shutdownTimeoutWaitMillis +
+        ", initialIdleExecutorShutdownWaitMillis=" + initialIdleExecutorShutdownWaitMillis +
         ", idleExecutorShutdownWaitMillis=" + idleExecutorShutdownWaitMillis +
         ", stopDriverAfterMillis=" + stopDriverAfterMillis +
         ", globalTaskDefinitionDirectory='" + globalTaskDefinitionDirectory + '\'' +
@@ -740,11 +752,13 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
         ", logrotateCommand='" + logrotateCommand + '\'' +
         ", logrotateStateFile='" + logrotateStateFile + '\'' +
         ", logrotateConfDirectory='" + logrotateConfDirectory + '\'' +
+        ", logrotateHourlyConfDirectory='" + logrotateHourlyConfDirectory + '\'' +
         ", logrotateToDirectory='" + logrotateToDirectory + '\'' +
         ", logrotateMaxageDays=" + logrotateMaxageDays +
         ", logrotateCount=" + logrotateCount +
         ", logrotateDateformat='" + logrotateDateformat + '\'' +
         ", logrotateExtrasDateformat='" + logrotateExtrasDateformat + '\'' +
+        ", ignoreLogrotateOutput=" + ignoreLogrotateOutput +
         ", logrotateCompressionSettings=" + logrotateCompressionSettings +
         ", logrotateAdditionalFiles=" + logrotateAdditionalFiles +
         ", tailLogLinesToSave=" + tailLogLinesToSave +
@@ -774,8 +788,12 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
         ", logrotateFrequency=" + logrotateFrequency +
         ", cronDirectory='" + cronDirectory + '\'' +
         ", useFileAttributes=" + useFileAttributes +
-        ", defaultCfsPeriod=" + defaultCfsPeriod +
         ", defaultHealthcheckMaxRetries=" + defaultHealthcheckMaxRetries +
+        ", defaultCfsPeriod=" + defaultCfsPeriod +
+        ", extraScriptContent='" + extraScriptContent + '\'' +
+        ", extraDockerScriptContent='" + extraDockerScriptContent + '\'' +
+        ", maxServiceLogSizeMb=" + maxServiceLogSizeMb +
+        ", verifyAssignedPorts=" + verifyAssignedPorts +
         "} " + super.toString();
   }
 }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorTaskBuilder.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorTaskBuilder.java
@@ -1,7 +1,7 @@
 package com.hubspot.singularity.executor.config;
 
 import java.io.IOException;
-import java.net.Socket;
+import java.net.ServerSocket;
 import java.nio.file.Path;
 import java.util.stream.Collectors;
 
@@ -109,13 +109,13 @@ public class SingularityExecutorTaskBuilder {
 
   private boolean isPortInUse(int port) {
     try {
-      new Socket("127.0.0.1", port).close();
-      return true;
+      new ServerSocket(port, 1).close();
+      return false;
     } catch(IOException e) {
       // Could not connect.
     }
 
-    return false;
+    return true;
   }
 
   private SingularityTaskExecutorData readExecutorData(ObjectMapper objectMapper, Protos.TaskInfo taskInfo) {

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorTaskBuilder.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorTaskBuilder.java
@@ -1,10 +1,15 @@
 package com.hubspot.singularity.executor.config;
 
+import java.io.IOException;
+import java.net.Socket;
 import java.nio.file.Path;
+import java.util.stream.Collectors;
 
 import org.apache.mesos.ExecutorDriver;
 import org.apache.mesos.Protos;
+import org.apache.mesos.Protos.Resource;
 import org.apache.mesos.Protos.TaskInfo;
+import org.apache.mesos.Protos.Value.Range;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
@@ -74,6 +79,10 @@ public class SingularityExecutorTaskBuilder {
   public SingularityExecutorTask buildTask(String taskId, ExecutorDriver driver, TaskInfo taskInfo, Logger log) {
     SingularityTaskExecutorData taskExecutorData = readExecutorData(jsonObjectMapper, taskInfo);
 
+    if (executorConfiguration.isVerifyAssignedPorts()) {
+      checkAssignedPorts(taskInfo);
+    }
+
     SingularityExecutorTaskDefinition taskDefinition = new SingularityExecutorTaskDefinition(taskId, taskExecutorData, MesosUtils.getTaskDirectoryPath(taskId).toString(), executorPid,
         taskExecutorData.getServiceLog(), Files.getFileExtension(taskExecutorData.getServiceLog()), taskExecutorData.getServiceFinishedTailLog(), executorConfiguration.getTaskAppDirectory(),
         executorConfiguration.getExecutorBashLog(), executorConfiguration.getLogrotateStateFile(), executorConfiguration.getSignatureVerifyOut());
@@ -81,6 +90,32 @@ public class SingularityExecutorTaskBuilder {
     jsonObjectFileHelper.writeObject(taskDefinition, executorConfiguration.getTaskDefinitionPath(taskId), log);
 
     return new SingularityExecutorTask(driver, executorUtils, baseConfiguration, executorConfiguration, taskDefinition, executorPid, artifactFetcher, taskInfo, templateManager, log, jsonObjectFileHelper, dockerUtils, s3Configuration, jsonObjectMapper);
+  }
+
+  private void checkAssignedPorts(TaskInfo taskInfo) {
+    for (Resource portsResource : taskInfo.getResourcesList().stream()
+        .filter((r) -> r.getName().equals("ports"))
+        .collect(Collectors.toList())) {
+      for (Range r : portsResource.getRanges().getRangeList()) {
+        for (long port = r.getBegin(); port <= r.getEnd(); port++) {
+          if (isPortInUse((int) port)) {
+            throw new RuntimeException(String.format("Assigned port %d was already in use", port));
+          }
+        }
+      }
+    }
+
+  }
+
+  private boolean isPortInUse(int port) {
+    try {
+      new Socket("127.0.0.1", port).close();
+      return true;
+    } catch(IOException e) {
+      // Could not connect.
+    }
+
+    return false;
   }
 
   private SingularityTaskExecutorData readExecutorData(ObjectMapper objectMapper, Protos.TaskInfo taskInfo) {


### PR DESCRIPTION
Fail fast if some other process is using a port it isn't supposed to (as opposed to letting the process start and eventually throwing something like a BindException)