### PR TITLE
Upstream validation

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/hooks/LoadBalancerClientImpl.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/hooks/LoadBalancerClientImpl.java
@@ -211,7 +211,7 @@ public class LoadBalancerClientImpl implements LoadBalancerClient {
     final BaragonService lbService = new BaragonService(deploy.getLoadBalancerServiceIdOverride().or(request.getId()), serviceOwners, deploy.getServiceBasePath().get(),
         deploy.getLoadBalancerAdditionalRoutes().or(Collections.<String>emptyList()), loadBalancerGroups, deploy.getLoadBalancerOptions().orNull(),
         deploy.getLoadBalancerTemplate(), deploy.getLoadBalancerDomains().or(Collections.<String>emptySet()));
-    final BaragonRequest loadBalancerRequest = new BaragonRequest(loadBalancerRequestId.toString(), lbService, addUpstreams, removeUpstreams);
+    final BaragonRequest loadBalancerRequest = new BaragonRequest(loadBalancerRequestId.toString(), lbService, addUpstreams, removeUpstreams, Collections.<UpstreamInfo>emptyList(),Optional.<String>absent(), Optional.of(RequestAction.UPDATE), false, false, false, true);
     return sendLoadBalancerRequest(loadBalancerRequestId, loadBalancerRequest, LoadBalancerMethod.ENQUEUE);
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
   <properties>
     <aws.sdk.version>1.11.497</aws.sdk.version>
-    <baragon.version>0.7.0</baragon.version>
+    <baragon.version>0.7.0-qa-SNAPSHOT</baragon.version>
     <basepom.jar.name.format>${singularity.jar.name.format}</basepom.jar.name.format>
     <basepom.release.profiles>oss-release</basepom.release.profiles>
     <dep.classmate.version>1.3.1</dep.classmate.version>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
   <properties>
     <aws.sdk.version>1.11.497</aws.sdk.version>
-    <baragon.version>0.7.0-qa-SNAPSHOT</baragon.version>
+    <baragon.version>0.8.0</baragon.version>
     <basepom.jar.name.format>${singularity.jar.name.format}</basepom.jar.name.format>
     <basepom.release.profiles>oss-release</basepom.release.profiles>
     <dep.classmate.version>1.3.1</dep.classmate.version>


### PR DESCRIPTION
We never want upstreams duplicated. Adding upstream validation to ensure that we don't ever get in a situation where we routing traffic to the wrong service. Instead, the task should fail to start.

Related Baragon PRs: https://github.com/HubSpot/Baragon/pull/298, https://github.com/HubSpot/Baragon/pull/300