### PR TITLE
Bump to mesos 1.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,8 +69,8 @@
     <dropwizard.version>1.3.7</dropwizard.version>
     <horizon.version>0.1.1</horizon.version>
     <jukito.version>1.5</jukito.version>
-    <mesos.docker.tag>1.6.1</mesos.docker.tag>
-    <mesos.version>1.6.1</mesos.version>
+    <mesos.docker.tag>1.8.0</mesos.docker.tag>
+    <mesos.version>1.8.0</mesos.version>
     <ning.async.version>1.9.38</ning.async.version>
     <project.build.targetJdk>1.8</project.build.targetJdk>
     <singularity.jar.name.format>${project.artifactId}-${project.version}</singularity.jar.name.format>


### PR DESCRIPTION
No ground breaking changes in the recent versions on the framework side. The change with the most impact here will likely be the introduction of rapidjson in the mesos master. Jackson should handle reading the updated json just fine still.