### PR TITLE
Alternative way to specify auth for the mesos scheduler api

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/config/MesosConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/MesosConfiguration.java
@@ -69,6 +69,9 @@ public class MesosConfiguration {
   private double recheckMetricsLoad1Threshold = 0.75;
   private double recheckMetricsLoad5Threshold = 0.8;
 
+  private Optional<String> mesosUsername;
+  private Optional<String> mesosPassword;
+
   public int getMaxNumInstancesPerRequest() {
     return maxNumInstancesPerRequest;
   }
@@ -371,5 +374,21 @@ public class MesosConfiguration {
 
   public void setRecheckMetricsLoad5Threshold(double recheckMetricsLoad5Threshold) {
     this.recheckMetricsLoad5Threshold = recheckMetricsLoad5Threshold;
+  }
+
+  public Optional<String> getMesosUsername() {
+    return mesosUsername;
+  }
+
+  public void setMesosUsername(Optional<String> mesosUsername) {
+    this.mesosUsername = mesosUsername;
+  }
+
+  public Optional<String> getMesosPassword() {
+    return mesosPassword;
+  }
+
+  public void setMesosPassword(Optional<String> mesosPassword) {
+    this.mesosPassword = mesosPassword;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
@@ -431,9 +431,14 @@ public class SingularityMesosSchedulerImpl extends SingularityMesosScheduler {
     }
     URI masterUri = URI.create(nextMaster);
 
+    String userInfo = masterUri.getUserInfo();
+    if (userInfo == null && mesosConfiguration.getMesosUsername().isPresent() && mesosConfiguration.getMesosPassword().isPresent()) {
+      userInfo = String.format("%s:%s", mesosConfiguration.getMesosUsername().get(), mesosConfiguration.getMesosPassword().get());
+    }
+
     mesosSchedulerClient.subscribe(new URI(
         masterUri.getScheme() == null ? "http" : masterUri.getScheme(),
-        masterUri.getUserInfo(),
+        userInfo,
         masterUri.getHost(),
         masterUri.getPort(),
         Strings.isNullOrEmpty(masterUri.getPath()) ? "/api/v1/scheduler" : masterUri.getPath(),


### PR DESCRIPTION
Allow as a masterUri of user:host@hostname or as separate mesosUsername/mesosPassword config fields in the yaml. Will allow easier rotation of these parameters separately