### PR TITLE
Upgrade to basepom 25.4

### DIFF
--- a/EmbedSingularityExample/pom.xml
+++ b/EmbedSingularityExample/pom.xml
@@ -36,7 +36,3 @@
     </dependency>
   </dependencies>
 </project>
-<!-- Local Variables: -->
-<!-- mode: nxml -->
-<!-- nxml-child-indent: 2 -->
-<!-- End: -->

--- a/SingularityBase/pom.xml
+++ b/SingularityBase/pom.xml
@@ -64,7 +64,3 @@
   </dependencies>
 
 </project>
-<!-- Local Variables:     -->
-<!-- mode: nxml           -->
-<!-- nxml-child-indent: 2 -->
-<!-- End:                 -->

--- a/SingularityClient/pom.xml
+++ b/SingularityClient/pom.xml
@@ -178,7 +178,3 @@
   </build>
 
 </project>
-<!-- Local Variables: -->
-<!-- mode: nxml -->
-<!-- nxml-child-indent: 2 -->
-<!-- End: -->

--- a/SingularityExecutor/pom.xml
+++ b/SingularityExecutor/pom.xml
@@ -133,18 +133,6 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <!-- turn off Werror, because Antlr annotation processor logs a warning with JDK 7 -->
-          <compilerArguments combine.self="override"></compilerArguments>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
   <profiles>
     <profile>
       <id>build-docker-image</id>
@@ -203,7 +191,3 @@
     </profile>
   </profiles>
 </project>
-<!-- Local Variables:     -->
-<!-- mode: nxml           -->
-<!-- nxml-child-indent: 2 -->
-<!-- End:                 -->

--- a/SingularityExecutorCleanup/pom.xml
+++ b/SingularityExecutorCleanup/pom.xml
@@ -87,21 +87,4 @@
     </dependency>
 
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <!-- turn off Werror, because Antlr annotation processor logs a warning with JDK 7 -->
-          <compilerArguments combine.self="override"></compilerArguments>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>
-<!-- Local Variables:     -->
-<!-- mode: nxml           -->
-<!-- nxml-child-indent: 2 -->
-<!-- End:                 -->

--- a/SingularityMesosClient/pom.xml
+++ b/SingularityMesosClient/pom.xml
@@ -49,7 +49,3 @@
   </dependencies>
 
 </project>
-<!-- Local Variables:     -->
-<!-- mode: nxml           -->
-<!-- nxml-child-indent: 2 -->
-<!-- End:                 -->

--- a/SingularityRunnerBase/pom.xml
+++ b/SingularityRunnerBase/pom.xml
@@ -108,7 +108,3 @@
   </dependencies>
 
 </project>
-<!-- Local Variables:     -->
-<!-- mode: nxml           -->
-<!-- nxml-child-indent: 2 -->
-<!-- End:                 -->

--- a/SingularityS3Base/pom.xml
+++ b/SingularityS3Base/pom.xml
@@ -109,7 +109,3 @@
     </dependency>
   </dependencies>
 </project>
-<!-- Local Variables:     -->
-<!-- mode: nxml           -->
-<!-- nxml-child-indent: 2 -->
-<!-- End:                 -->

--- a/SingularityS3Downloader/pom.xml
+++ b/SingularityS3Downloader/pom.xml
@@ -98,7 +98,3 @@
 
   </dependencies>
 </project>
-<!-- Local Variables:     -->
-<!-- mode: nxml           -->
-<!-- nxml-child-indent: 2 -->
-<!-- End:                 -->

--- a/SingularityS3Uploader/pom.xml
+++ b/SingularityS3Uploader/pom.xml
@@ -121,7 +121,3 @@
   </dependencies>
 
 </project>
-<!-- Local Variables:     -->
-<!-- mode: nxml           -->
-<!-- nxml-child-indent: 2 -->
-<!-- End:                 -->

--- a/SingularityService/pom.xml
+++ b/SingularityService/pom.xml
@@ -600,7 +600,3 @@
     </profile>
   </profiles>
 </project>
-<!-- Local Variables: -->
-<!-- mode: nxml -->
-<!-- nxml-child-indent: 2 -->
-<!-- End: -->

--- a/SingularityServiceIntegrationTests/pom.xml
+++ b/SingularityServiceIntegrationTests/pom.xml
@@ -335,7 +335,3 @@
     </profile>
   </profiles>
 </project>
-<!-- Local Variables: -->
-<!-- mode: nxml -->
-<!-- nxml-child-indent: 2 -->
-<!-- End: -->

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>25.3</version>
+    <version>25.4</version>
   </parent>
 
   <artifactId>Singularity</artifactId>
@@ -72,7 +72,6 @@
     <mesos.docker.tag>1.8.0</mesos.docker.tag>
     <mesos.version>1.8.0</mesos.version>
     <ning.async.version>1.9.38</ning.async.version>
-    <project.build.targetJdk>1.8</project.build.targetJdk>
     <singularity.jar.name.format>${project.artifactId}-${project.version}</singularity.jar.name.format>
     <singularitybase.db.driver>mysql</singularitybase.db.driver>
     <singularitybase.image.revision>2</singularitybase.image.revision>
@@ -548,11 +547,6 @@
           </executions>
         </plugin>
         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-failsafe-plugin</artifactId>
-          <version>2.18.1</version>
-        </plugin>
-        <plugin>
           <groupId>pl.project13.maven</groupId>
           <artifactId>git-commit-id-plugin</artifactId>
           <configuration>
@@ -610,23 +604,6 @@
             </ignoredResourcePatterns>
           </configuration>
         </plugin>
-        <!-- Fixes issues with checkstlye if you use logback for logging in maven -->
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-checkstyle-plugin</artifactId>
-          <dependencies>
-            <dependency>
-              <groupId>org.slf4j</groupId>
-              <artifactId>jcl-over-slf4j</artifactId>
-              <version>1.7.5</version>
-            </dependency>
-            <dependency>
-              <groupId>org.slf4j</groupId>
-              <artifactId>slf4j-jdk14</artifactId>
-              <version>1.7.5</version>
-            </dependency>
-          </dependencies>
-        </plugin>
       </plugins>
     </pluginManagement>
   </build>
@@ -653,7 +630,3 @@
     <tag>HEAD</tag>
   </scm>
 </project>
-<!-- Local Variables: -->
-<!-- mode: nxml -->
-<!-- nxml-child-indent: 2 -->
-<!-- End: -->


### PR DESCRIPTION
I was hoping this would allow me to remove `.build-jdk8` however it seems like that will need to wait for https://github.com/spotbugs/spotbugs/issues/756

@ssalinas @baconmania @sjeropkipruto 