### PR TITLE
Add builder methods to `SingularityRequestBuilder` & `SingularityDeployBuilder`

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeployBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeployBuilder.java
@@ -16,7 +16,7 @@ import com.hubspot.singularity.api.SingularityRunNowRequest;
 
 public class SingularityDeployBuilder {
 
-  private final String requestId;
+  private String requestId;
 
   private String id;
 
@@ -168,6 +168,11 @@ public class SingularityDeployBuilder {
 
   public String getRequestId() {
     return requestId;
+  }
+
+  public SingularityDeployBuilder setRequestId(String requestId) {
+    this.requestId = requestId;
+    return this;
   }
 
   public String getId() {

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestBuilder.java
@@ -11,8 +11,8 @@ import com.google.common.base.Optional;
 
 public class SingularityRequestBuilder {
 
-  private final String id;
-  private final RequestType requestType;
+  private String id;
+  private RequestType requestType;
 
   private Optional<List<String>> owners;
   private Optional<Integer> numRetriesOnFailure;
@@ -119,6 +119,11 @@ public class SingularityRequestBuilder {
 
   public String getId() {
     return id;
+  }
+
+  public SingularityRequestBuilder setId(String id) {
+    this.id = id;
+    return this;
   }
 
   public Optional<List<String>> getOwners() {
@@ -245,6 +250,11 @@ public class SingularityRequestBuilder {
 
   public RequestType getRequestType() {
     return requestType;
+  }
+
+  public SingularityRequestBuilder setRequestType(RequestType requestType) {
+    this.requestType = requestType;
+    return this;
   }
 
   public Optional<Long> getWaitAtLeastMillisAfterTaskFinishesForReschedule() {


### PR DESCRIPTION
* Adds `setRequestId` to `SingularityDeployBuilder `
* Adds `setRequestType`, and `setId` to `SingularityRequestBuilder`

These methods are useful for "cloning" other requests and deploys from template requests, removing a lot of unnecessary boilerplate.