### PR TITLE
Rework cooldown logic

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeployStatistics.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeployStatistics.java
@@ -87,12 +87,12 @@ public class SingularityDeployStatistics {
     return deployId;
   }
 
-  @Schema(description = "Number of tasks that have finished successfully for this deploy")
+  @Schema(description = "Number of sequential successful tasks (used in cooldown calculations)")
   public int getNumSuccess() {
     return numSuccess;
   }
 
-  @Schema(description = "Number of tasks that have finished with a failure for this deploy")
+  @Schema(description = "Number of sequential failed tasks (used in cooldown calculations)")
   public int getNumFailures() {
     return numFailures;
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -126,7 +126,7 @@ public class SingularityConfiguration extends Configuration {
 
   private long slowFailureCooldownMs = 600000;
 
-  private long slowCooldownExpiresMinutesWithoutFailure = 15;
+  private long slowCooldownExpiresMinutesWithoutFailure = 5;
 
   private long cooldownMinScheduleSeconds = 120;
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -122,11 +122,13 @@ public class SingularityConfiguration extends Configuration {
 
   private long fastFailureCooldownMs = 60000;
 
+  private long fastCooldownExpiresMinutesWithoutFailure = 5;
+
   private int slowFailureCooldownCount = 5;
 
   private long slowFailureCooldownMs = 600000;
 
-  private long slowCooldownExpiresMinutesWithoutFailure = 5;
+  private long slowCooldownExpiresMinutesWithoutFailure = 8;
 
   private long cooldownMinScheduleSeconds = 120;
 
@@ -522,6 +524,14 @@ public class SingularityConfiguration extends Configuration {
 
   public void setFastFailureCooldownMs(long fastFailureCooldownMs) {
     this.fastFailureCooldownMs = fastFailureCooldownMs;
+  }
+
+  public long getFastCooldownExpiresMinutesWithoutFailure() {
+    return fastCooldownExpiresMinutesWithoutFailure;
+  }
+
+  public void setFastCooldownExpiresMinutesWithoutFailure(long fastCooldownExpiresMinutesWithoutFailure) {
+    this.fastCooldownExpiresMinutesWithoutFailure = fastCooldownExpiresMinutesWithoutFailure;
   }
 
   public int getSlowFailureCooldownCount() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -118,11 +118,15 @@ public class SingularityConfiguration extends Configuration {
 
   private long considerTaskHealthyAfterRunningForSeconds = 5;
 
-  private int cooldownAfterFailures = 3;
+  private int fastFailureCooldownCount = 3;
 
-  private double cooldownAfterPctOfInstancesFail = 1.0;
+  private long fastFailureCooldownMs = 60000;
 
-  private long cooldownExpiresAfterMinutes = 15;
+  private int slowFailureCooldownCount = 5;
+
+  private long slowFailureCooldownMs = 600000;
+
+  private long slowCooldownExpiresMinutesWithoutFailure = 15;
 
   private long cooldownMinScheduleSeconds = 120;
 
@@ -468,10 +472,6 @@ public class SingularityConfiguration extends Configuration {
     return considerTaskHealthyAfterRunningForSeconds;
   }
 
-  public int getCooldownAfterFailures() {
-    return cooldownAfterFailures;
-  }
-
   public long getDebugCuratorCallOverBytes() {
     return debugCuratorCallOverBytes;
   }
@@ -504,16 +504,48 @@ public class SingularityConfiguration extends Configuration {
     this.debugCuratorCallOverMillis = debugCuratorCallOverMillis;
   }
 
-  public double getCooldownAfterPctOfInstancesFail() {
-    return cooldownAfterPctOfInstancesFail;
-  }
-
-  public long getCooldownExpiresAfterMinutes() {
-    return cooldownExpiresAfterMinutes;
-  }
-
   public long getCooldownMinScheduleSeconds() {
     return cooldownMinScheduleSeconds;
+  }
+
+  public int getFastFailureCooldownCount() {
+    return fastFailureCooldownCount;
+  }
+
+  public void setFastFailureCooldownCount(int fastFailureCooldownCount) {
+    this.fastFailureCooldownCount = fastFailureCooldownCount;
+  }
+
+  public long getFastFailureCooldownMs() {
+    return fastFailureCooldownMs;
+  }
+
+  public void setFastFailureCooldownMs(long fastFailureCooldownMs) {
+    this.fastFailureCooldownMs = fastFailureCooldownMs;
+  }
+
+  public int getSlowFailureCooldownCount() {
+    return slowFailureCooldownCount;
+  }
+
+  public void setSlowFailureCooldownCount(int slowFailureCooldownCount) {
+    this.slowFailureCooldownCount = slowFailureCooldownCount;
+  }
+
+  public long getSlowFailureCooldownMs() {
+    return slowFailureCooldownMs;
+  }
+
+  public void setSlowFailureCooldownMs(long slowFailureCooldownMs) {
+    this.slowFailureCooldownMs = slowFailureCooldownMs;
+  }
+
+  public long getSlowCooldownExpiresMinutesWithoutFailure() {
+    return slowCooldownExpiresMinutesWithoutFailure;
+  }
+
+  public void setSlowCooldownExpiresMinutesWithoutFailure(long slowCooldownExpiresMinutesWithoutFailure) {
+    this.slowCooldownExpiresMinutesWithoutFailure = slowCooldownExpiresMinutesWithoutFailure;
   }
 
   public int getCacheTasksMaxSize() {
@@ -978,18 +1010,6 @@ public class SingularityConfiguration extends Configuration {
 
   public void setConsiderTaskHealthyAfterRunningForSeconds(long considerTaskHealthyAfterRunningForSeconds) {
     this.considerTaskHealthyAfterRunningForSeconds = considerTaskHealthyAfterRunningForSeconds;
-  }
-
-  public void setCooldownAfterFailures(int cooldownAfterFailures) {
-    this.cooldownAfterFailures = cooldownAfterFailures;
-  }
-
-  public void setCooldownAfterPctOfInstancesFail(double cooldownAfterPctOfInstancesFail) {
-    this.cooldownAfterPctOfInstancesFail = cooldownAfterPctOfInstancesFail;
-  }
-
-  public void setCooldownExpiresAfterMinutes(long cooldownExpiresAfterMinutes) {
-    this.cooldownExpiresAfterMinutes = cooldownExpiresAfterMinutes;
   }
 
   public void setCooldownMinScheduleSeconds(long cooldownMinScheduleSeconds) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCooldown.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCooldown.java
@@ -3,6 +3,7 @@ package com.hubspot.singularity.scheduler;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import javax.inject.Singleton;
@@ -50,7 +51,7 @@ public class SingularityCooldown {
 
   }
 
-  private boolean hasFailureLoop(SingularityDeployStatistics deployStatistics, Optional<Long> recentFailureTimestamp, long cooldownPeriod, int cooldownCount, long expiresAfterMs) {
+  private boolean hasFailureLoop(SingularityDeployStatistics deployStatistics, Optional<Long> recentFailureTimestamp, long cooldownPeriod, int cooldownCount, long expiresAfterMins) {
     final long now = System.currentTimeMillis();
     long thresholdTime = now - cooldownPeriod;
     List<Long> failureTimestamps = deployStatistics.getInstanceSequentialFailureTimestamps().asMap()
@@ -67,7 +68,7 @@ public class SingularityCooldown {
     java.util.Optional<Long> mostRecentFailure = failureTimestamps.stream().max(Comparator.comparingLong(Long::valueOf));
 
     return failureCount >= cooldownCount
-        && (!mostRecentFailure.isPresent() || mostRecentFailure.get() > System.currentTimeMillis() - expiresAfterMs);
+        && (!mostRecentFailure.isPresent() || mostRecentFailure.get() > System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(expiresAfterMins));
   }
 
   boolean hasCooldownExpired(SingularityDeployStatistics deployStatistics, Optional<Long> recentFailureTimestamp) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCooldown.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCooldown.java
@@ -1,6 +1,9 @@
 package com.hubspot.singularity.scheduler;
 
-import java.util.concurrent.TimeUnit;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.inject.Singleton;
 
@@ -9,7 +12,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
-import com.hubspot.mesos.JavaUtils;
 import com.hubspot.singularity.RequestState;
 import com.hubspot.singularity.SingularityDeployStatistics;
 import com.hubspot.singularity.SingularityRequest;
@@ -22,79 +24,62 @@ public class SingularityCooldown {
   private static final Logger LOG = LoggerFactory.getLogger(SingularityCooldown.class);
 
   private final SingularityConfiguration configuration;
-  private final long cooldownExpiresAfterMillis;
 
   @Inject
   public SingularityCooldown(SingularityConfiguration configuration) {
     this.configuration = configuration;
-    this.cooldownExpiresAfterMillis = TimeUnit.MINUTES.toMillis(configuration.getCooldownExpiresAfterMinutes());
   }
 
-  public boolean shouldEnterCooldown(SingularityRequest request, SingularityTaskId taskId, RequestState requestState, SingularityDeployStatistics deployStatistics, long failureTimestamp) {
+  boolean shouldEnterCooldown(SingularityRequest request, SingularityTaskId taskId, RequestState requestState, SingularityDeployStatistics deployStatistics, long failureTimestamp) {
     if (requestState != RequestState.ACTIVE || !request.isAlwaysRunning()) {
       return false;
     }
 
-    if (configuration.getCooldownAfterFailures() < 1 || configuration.getCooldownExpiresAfterMinutes() < 1) {
-      return false;
-    }
-
-    final boolean failedTooManyTimes = hasFailedTooManyTimes(request, deployStatistics, Optional.of(taskId.getInstanceNo()), Optional.of(failureTimestamp));
-
-    if (failedTooManyTimes) {
-      LOG.trace("Request {} has failed at least {} times in {}", request.getId(), configuration.getCooldownAfterFailures(), configuration.getCooldownAfterFailures());
-    }
-
-    return failedTooManyTimes;
+    return hasFailedTooManyTimes(deployStatistics, Optional.of(failureTimestamp));
   }
 
-  private boolean hasFailedTooManyTimes(SingularityRequest request, SingularityDeployStatistics deployStatistics, Optional<Integer> instanceNo, Optional<Long> recentFailureTimestamp) {
+  private boolean hasFailedTooManyTimes(SingularityDeployStatistics deployStatistics, Optional<Long> recentFailureTimestamp) {
+    return hasFastFailureLoop(deployStatistics, recentFailureTimestamp) || hasSlowFailureLoop(deployStatistics, recentFailureTimestamp);
+  }
+
+  private boolean hasSlowFailureLoop(SingularityDeployStatistics deployStatistics, Optional<Long> recentFailureTimestamp) {
     final long now = System.currentTimeMillis();
-
-    int numInstancesThatMustFail = (int) Math.ceil(request.getInstancesSafe() * configuration.getCooldownAfterPctOfInstancesFail());
-    int numInstancesThatFailed = 0;
-
-    for (int i = 1; i < request.getInstancesSafe() + 1; i++) {
-      int numFailuresInsideCooldown = 0;
-
-      for (long failureTimestamp : deployStatistics.getInstanceSequentialFailureTimestamps().get(i)) {
-        if (hasFailedInsideCooldown(now, failureTimestamp)) {
-          numFailuresInsideCooldown++;
-        }
-      }
-
-      if (instanceNo.isPresent() && instanceNo.get() == i && recentFailureTimestamp.isPresent()) {
-        if (hasFailedInsideCooldown(now, recentFailureTimestamp.get())) {
-          numFailuresInsideCooldown++;
-        }
-      }
-
-      if (numFailuresInsideCooldown >= configuration.getCooldownAfterFailures()) {
-        numInstancesThatFailed++;
-      }
+    long thresholdTime = now - configuration.getSlowFailureCooldownMs();
+    List<Long> failureTimestamps = deployStatistics.getInstanceSequentialFailureTimestamps().asMap()
+        .values()
+        .stream()
+        .flatMap(Collection::stream)
+        .collect(Collectors.toList());
+    if (recentFailureTimestamp.isPresent()) {
+      failureTimestamps.add(recentFailureTimestamp.get());
     }
+    long failureCount = failureTimestamps.stream()
+        .filter((t) -> t > thresholdTime)
+        .count();
+    java.util.Optional<Long> mostRecentFailure = failureTimestamps.stream().max(Comparator.comparingLong(Long::valueOf));
 
-    return numInstancesThatFailed >= numInstancesThatMustFail;
+    return failureCount > configuration.getSlowFailureCooldownCount()
+        && mostRecentFailure.isPresent()
+        && mostRecentFailure.get() > configuration.getSlowCooldownExpiresMinutesWithoutFailure();
   }
 
-  public boolean hasCooldownExpired(SingularityRequest request, SingularityDeployStatistics deployStatistics, Optional<Integer> instanceNo, Optional<Long> recentFailureTimestamp) {
-    if (configuration.getCooldownExpiresAfterMinutes() < 1) {
-      return true;
+  private boolean hasFastFailureLoop(SingularityDeployStatistics deployStatistics, Optional<Long> recentFailureTimestamp) {
+    final long now = System.currentTimeMillis();
+    long thresholdTime = now - configuration.getFastFailureCooldownMs();
+    long failureCount = deployStatistics.getInstanceSequentialFailureTimestamps().asMap()
+        .values()
+        .stream()
+        .flatMap(Collection::stream)
+        .filter((t) -> t > thresholdTime)
+        .count();
+    if (recentFailureTimestamp.isPresent() && recentFailureTimestamp.get() > thresholdTime) {
+      failureCount++;
     }
 
-    final boolean hasCooldownExpired = !hasFailedTooManyTimes(request, deployStatistics, instanceNo, recentFailureTimestamp);
-
-    if (hasCooldownExpired) {
-      LOG.trace("Request {} cooldown has expired or is not valid because {} tasks have not failed in the last {}", deployStatistics.getRequestId(), configuration.getCooldownAfterFailures(), JavaUtils.durationFromMillis(cooldownExpiresAfterMillis));
-    }
-
-    return hasCooldownExpired;
+    return failureCount > configuration.getFastFailureCooldownCount();
   }
 
-  private boolean hasFailedInsideCooldown(long now, long failureTimestamp) {
-    final long timeSinceFailure = now - failureTimestamp;
-
-    return timeSinceFailure < cooldownExpiresAfterMillis;
+  boolean hasCooldownExpired(SingularityDeployStatistics deployStatistics, Optional<Long> recentFailureTimestamp) {
+    return !hasFailedTooManyTimes(deployStatistics, recentFailureTimestamp);
   }
-
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCooldown.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCooldown.java
@@ -15,7 +15,6 @@ import com.google.inject.Inject;
 import com.hubspot.singularity.RequestState;
 import com.hubspot.singularity.SingularityDeployStatistics;
 import com.hubspot.singularity.SingularityRequest;
-import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.config.SingularityConfiguration;
 
 @Singleton
@@ -30,7 +29,7 @@ public class SingularityCooldown {
     this.configuration = configuration;
   }
 
-  boolean shouldEnterCooldown(SingularityRequest request, SingularityTaskId taskId, RequestState requestState, SingularityDeployStatistics deployStatistics, long failureTimestamp) {
+  boolean shouldEnterCooldown(SingularityRequest request, RequestState requestState, SingularityDeployStatistics deployStatistics, long failureTimestamp) {
     if (requestState != RequestState.ACTIVE || !request.isAlwaysRunning()) {
       return false;
     }
@@ -58,7 +57,7 @@ public class SingularityCooldown {
         .count();
     java.util.Optional<Long> mostRecentFailure = failureTimestamps.stream().max(Comparator.comparingLong(Long::valueOf));
 
-    return failureCount > configuration.getSlowFailureCooldownCount()
+    return failureCount >= configuration.getSlowFailureCooldownCount()
         && mostRecentFailure.isPresent()
         && mostRecentFailure.get() > configuration.getSlowCooldownExpiresMinutesWithoutFailure();
   }
@@ -76,7 +75,7 @@ public class SingularityCooldown {
       failureCount++;
     }
 
-    return failureCount > configuration.getFastFailureCooldownCount();
+    return failureCount >= configuration.getFastFailureCooldownCount();
   }
 
   boolean hasCooldownExpired(SingularityDeployStatistics deployStatistics, Optional<Long> recentFailureTimestamp) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCooldown.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCooldown.java
@@ -59,7 +59,7 @@ public class SingularityCooldown {
 
     return failureCount >= configuration.getSlowFailureCooldownCount()
         && mostRecentFailure.isPresent()
-        && mostRecentFailure.get() > configuration.getSlowCooldownExpiresMinutesWithoutFailure();
+        && mostRecentFailure.get() > System.currentTimeMillis() - configuration.getSlowCooldownExpiresMinutesWithoutFailure();
   }
 
   private boolean hasFastFailureLoop(SingularityDeployStatistics deployStatistics, Optional<Long> recentFailureTimestamp) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCooldownChecker.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCooldownChecker.java
@@ -92,11 +92,7 @@ public class SingularityCooldownChecker {
       return true;
     }
 
-    if (cooldown.hasCooldownExpired(cooldownRequest.getRequest(), maybeDeployStatistics.get(), Optional.<Integer> absent(), Optional.<Long> absent())) {
-      return true;
-    }
-
-    return false;
+    return cooldown.hasCooldownExpired(maybeDeployStatistics.get(), Optional.absent());
   }
 
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCooldownPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCooldownPoller.java
@@ -5,7 +5,6 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Singleton;
 
 import com.google.inject.Inject;
-import com.hubspot.singularity.config.SingularityConfiguration;
 
 @Singleton
 public class SingularityCooldownPoller extends SingularityLeaderOnlyPoller {
@@ -13,9 +12,8 @@ public class SingularityCooldownPoller extends SingularityLeaderOnlyPoller {
   private final SingularityCooldownChecker checker;
 
   @Inject
-  SingularityCooldownPoller(SingularityConfiguration configuration, SingularityCooldownChecker checker) {
-    super(TimeUnit.MINUTES.toMillis(configuration.getCooldownExpiresAfterMinutes()) / 2, TimeUnit.MILLISECONDS, true);
-
+  SingularityCooldownPoller(SingularityCooldownChecker checker) {
+    super(1, TimeUnit.MINUTES, true);
     this.checker = checker;
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityNewTaskChecker.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityNewTaskChecker.java
@@ -314,7 +314,7 @@ public class SingularityNewTaskChecker {
   private void checkForRepeatedFailures(Optional<SingularityRequestWithState> requestWithState, SingularityTaskId taskId) {
     taskManager.markUnhealthyKill(taskId);
 
-    if (requestWithState.isPresent() && taskManager.getNumUnhealthyKills(taskId.getRequestId()) > configuration.getCooldownAfterFailures()) {
+    if (requestWithState.isPresent() && taskManager.getNumUnhealthyKills(taskId.getRequestId()) > configuration.getSlowFailureCooldownCount()) {
       mailer.sendReplacementTasksFailingMail(requestWithState.get().getRequest());
     }
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -591,7 +591,7 @@ public class SingularityScheduler {
     }
 
     if (!status.hasReason() || !status.getReason().equals(Reason.REASON_INVALID_OFFERS)) {
-      if (!state.isSuccess() && taskHistoryUpdateCreateResult == SingularityCreateResult.CREATED && cooldown.shouldEnterCooldown(request, taskId, requestState, deployStatistics, timestamp)) {
+      if (!state.isSuccess() && taskHistoryUpdateCreateResult == SingularityCreateResult.CREATED && cooldown.shouldEnterCooldown(request, requestState, deployStatistics, timestamp)) {
         LOG.info("Request {} is entering cooldown due to task {}", request.getId(), taskId);
         requestState = RequestState.SYSTEM_COOLDOWN;
         requestManager.cooldown(request, System.currentTimeMillis());

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -328,8 +328,8 @@ public class SingularityScheduler {
       return requestState;
     }
 
-    if (cooldown.hasCooldownExpired(request, deployStatistics, Optional.<Integer>absent(), Optional.<Long>absent())) {
-      requestManager.exitCooldown(request, System.currentTimeMillis(), Optional.<String>absent(), Optional.<String>absent());
+    if (cooldown.hasCooldownExpired(deployStatistics, Optional.absent())) {
+      requestManager.exitCooldown(request, System.currentTimeMillis(), Optional.absent(), Optional.absent());
       return RequestState.ACTIVE;
     }
 
@@ -735,18 +735,14 @@ public class SingularityScheduler {
       if (SingularityTaskHistoryUpdate.getUpdate(taskManager.getTaskHistoryUpdates(taskId), ExtendedTaskState.TASK_CLEANING).isPresent()) {
         LOG.debug("{} failed with {} after cleaning - ignoring it for cooldown", taskId, state);
       } else {
-
-        if (sequentialFailureTimestamps.size() < configuration.getCooldownAfterFailures()) {
-          sequentialFailureTimestamps.add(timestamp);
-        } else if (timestamp > sequentialFailureTimestamps.get(0)) {
-          sequentialFailureTimestamps.set(0, timestamp);
-        }
-
+        sequentialFailureTimestamps.add(timestamp);
+        bldr.setNumSuccess(0);
         bldr.setNumFailures(bldr.getNumFailures() + 1);
         Collections.sort(sequentialFailureTimestamps);
       }
     } else {
       bldr.setNumSuccess(bldr.getNumSuccess() + 1);
+      bldr.setNumFailures(0);
       sequentialFailureTimestamps.clear();
     }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/smtp/SmtpMailer.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/smtp/SmtpMailer.java
@@ -526,7 +526,7 @@ public class SmtpMailer implements SingularityMailer, Managed {
 
     final String subject = String.format("Replacement tasks for request %s are unhealthy — Singularity", request.getId());
 
-    templateProperties.put("numFailures", configuration.getCooldownAfterFailures());
+    templateProperties.put("numFailures", configuration.getSlowFailureCooldownCount());
 
     final String body = Jade4J.render(replacementTasksFailingTemplate, templateProperties);
 
@@ -562,9 +562,9 @@ public class SmtpMailer implements SingularityMailer, Managed {
 
     final String subject = String.format("Request %s has entered system cooldown — Singularity", request.getId());
 
-    templateProperties.put("numFailures", configuration.getCooldownAfterFailures());
+    templateProperties.put("numFailures", configuration.getSlowFailureCooldownCount());
     templateProperties.put("cooldownDelayFormat", DurationFormatUtils.formatDurationHMS(TimeUnit.SECONDS.toMillis(configuration.getCooldownMinScheduleSeconds())));
-    templateProperties.put("cooldownExpiresFormat", DurationFormatUtils.formatDurationHMS(TimeUnit.MINUTES.toMillis(configuration.getCooldownExpiresAfterMinutes())));
+    templateProperties.put("cooldownExpiresFormat", DurationFormatUtils.formatDurationHMS(TimeUnit.MINUTES.toMillis(configuration.getSlowCooldownExpiresMinutesWithoutFailure())));
 
     final String body = Jade4J.render(requestInCooldownTemplate, templateProperties);
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/SingularityCuratorTestBase.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/SingularityCuratorTestBase.java
@@ -18,7 +18,7 @@ import com.squarespace.jersey2.guice.JerseyGuiceUtils;
 public class SingularityCuratorTestBase {
 
   @Rule
-  public Timeout globalTimeout = Timeout.seconds(30); // 30 seconds max for each @Test method
+  public Timeout globalTimeout = Timeout.seconds(60); // 30 seconds max for each @Test method
 
   @Inject
   protected CuratorFramework cf;

--- a/SingularityService/src/test/java/com/hubspot/singularity/SingularityCuratorTestBase.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/SingularityCuratorTestBase.java
@@ -18,7 +18,7 @@ import com.squarespace.jersey2.guice.JerseyGuiceUtils;
 public class SingularityCuratorTestBase {
 
   @Rule
-  public Timeout globalTimeout = Timeout.seconds(60); // 30 seconds max for each @Test method
+  public Timeout globalTimeout = Timeout.seconds(30); // 30 seconds max for each @Test method
 
   @Inject
   protected CuratorFramework cf;

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -876,7 +876,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     initRequest();
     initFirstDeploy();
 
-    configuration.setFastFailureCooldownCount(1);
+    configuration.setFastFailureCooldownCount(2);
 
     SingularityTask firstTask = startTask(firstDeploy);
     statusUpdate(firstTask, TaskState.TASK_FAILED, Optional.of(System.currentTimeMillis() - TimeUnit.HOURS.toMillis(5)));
@@ -886,45 +886,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     SingularityTask secondTask = startTask(firstDeploy);
     statusUpdate(secondTask, TaskState.TASK_FAILED);
 
-    Assert.assertTrue(requestManager.getRequest(requestId).get().getState() == RequestState.SYSTEM_COOLDOWN);
-  }
-
-  @Test
-  public void testCooldownScalesToInstances() {
-    initRequest();
-    initFirstDeploy();
-
-    configuration.setSlowFailureCooldownCount(2);
-
-    requestManager.activate(request.toBuilder().setInstances(Optional.of(4)).build(), RequestHistoryType.CREATED, System.currentTimeMillis(), Optional.<String> absent(), Optional.<String>absent());
-
-    SingularityTask task1 = startTask(firstDeploy, 1);
-    SingularityTask task2 = startTask(firstDeploy, 2);
-    SingularityTask task3 = startTask(firstDeploy, 3);
-    SingularityTask task4 = startTask(firstDeploy, 4);
-
-    statusUpdate(task1, TaskState.TASK_FAILED);
-    statusUpdate(task2, TaskState.TASK_FAILED);
-    statusUpdate(task3, TaskState.TASK_FAILED);
-
-    Assert.assertTrue(requestManager.getRequest(requestId).get().getState() == RequestState.ACTIVE);
-
-    task1 = startTask(firstDeploy, 1);
-    task2 = startTask(firstDeploy, 2);
-    task3 = startTask(firstDeploy, 3);
-
-    statusUpdate(task1, TaskState.TASK_FAILED);
-    statusUpdate(task2, TaskState.TASK_FAILED);
-
-    Assert.assertTrue(requestManager.getRequest(requestId).get().getState() == RequestState.ACTIVE);
-
-    statusUpdate(task3, TaskState.TASK_FAILED);
-
-    Assert.assertTrue(requestManager.getRequest(requestId).get().getState() == RequestState.SYSTEM_COOLDOWN);
-
-    statusUpdate(task4, TaskState.TASK_FINISHED);
-
-    Assert.assertTrue(requestManager.getRequest(requestId).get().getState() == RequestState.ACTIVE);
+    Assert.assertTrue(requestManager.getRequest(requestId).get().getState() != RequestState.SYSTEM_COOLDOWN);
   }
 
   @Test

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -847,7 +847,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
 
     Assert.assertTrue(requestManager.getRequest(requestId).get().getState() == RequestState.ACTIVE);
 
-    configuration.setCooldownAfterFailures(2);
+    configuration.setFastFailureCooldownCount(2);
 
     SingularityTask firstTask = startTask(firstDeploy);
     SingularityTask secondTask = startTask(firstDeploy);
@@ -876,7 +876,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     initRequest();
     initFirstDeploy();
 
-    configuration.setCooldownAfterFailures(1);
+    configuration.setFastFailureCooldownCount(1);
 
     SingularityTask firstTask = startTask(firstDeploy);
     statusUpdate(firstTask, TaskState.TASK_FAILED, Optional.of(System.currentTimeMillis() - TimeUnit.HOURS.toMillis(5)));
@@ -894,8 +894,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     initRequest();
     initFirstDeploy();
 
-    configuration.setCooldownAfterFailures(2);
-    configuration.setCooldownAfterPctOfInstancesFail(.51);
+    configuration.setSlowFailureCooldownCount(2);
 
     requestManager.activate(request.toBuilder().setInstances(Optional.of(4)).build(), RequestHistoryType.CREATED, System.currentTimeMillis(), Optional.<String> absent(), Optional.<String>absent());
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityTestModule.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityTestModule.java
@@ -104,7 +104,7 @@ public class SingularityTestModule implements Module {
     rootLogger.setLevel(Level.toLevel(System.getProperty("singularity.test.log.level", "WARN")));
 
     Logger hsLogger = context.getLogger("com.hubspot");
-    hsLogger.setLevel(Level.toLevel(System.getProperty("singularity.test.log.level.for.com.hubspot", "WARN")));
+    hsLogger.setLevel(Level.toLevel(System.getProperty("singularity.test.log.level.for.com.hubspot", "DEBUG")));
 
     this.ts = new TestingServer();
   }


### PR DESCRIPTION
We have found that Singularity's cooldown logic does not accurately capture cases like a slow failure loop, partially due to the fact that we purge out of the deploy statistics after only a minute or two. This reworks the cooldown logic to do a few things:
- save all failures in the deploy statistics. Each is just a long, so not too worried about data size here
- add a fast vs slow cooldown. In this case 3 failures in a minute or 5 failures in 10 minutes as a default

TODOs:
- [x] fix up unit tests
- [x] Figure out if it's still worth scaling this to instance count somehow