### PR TITLE
More efficient active tasks call for executor cleanup

### DIFF
--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
@@ -138,7 +138,7 @@ public class SingularityClient {
   private static final String TASKS_KILL_TASK_FORMAT = TASKS_FORMAT + "/task/%s";
   private static final String TASKS_GET_ACTIVE_FORMAT = TASKS_FORMAT + "/active";
   private static final String TASKS_GET_ACTIVE_ON_SLAVE_FORMAT = TASKS_FORMAT + "/active/slave/%s";
-  private static final String TASKS_GET_ACTIVE_IDS_ON_SLAVE_FORMAT = TASKS_GET_ACTIVE_ON_SLAVE_FORMAT + "/ids"
+  private static final String TASKS_GET_ACTIVE_IDS_ON_SLAVE_FORMAT = TASKS_GET_ACTIVE_ON_SLAVE_FORMAT + "/ids";
   private static final String TASKS_GET_SCHEDULED_FORMAT = TASKS_FORMAT + "/scheduled";
   private static final String TASKS_GET_SCHEDULED_IDS_FORMAT = TASKS_GET_SCHEDULED_FORMAT + "/ids";
   private static final String TASKS_BY_STATE_FORMAT =TASKS_FORMAT + "/ids/request/%s";

--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
@@ -138,6 +138,7 @@ public class SingularityClient {
   private static final String TASKS_KILL_TASK_FORMAT = TASKS_FORMAT + "/task/%s";
   private static final String TASKS_GET_ACTIVE_FORMAT = TASKS_FORMAT + "/active";
   private static final String TASKS_GET_ACTIVE_ON_SLAVE_FORMAT = TASKS_FORMAT + "/active/slave/%s";
+  private static final String TASKS_GET_ACTIVE_IDS_ON_SLAVE_FORMAT = TASKS_GET_ACTIVE_ON_SLAVE_FORMAT + "/ids"
   private static final String TASKS_GET_SCHEDULED_FORMAT = TASKS_FORMAT + "/scheduled";
   private static final String TASKS_GET_SCHEDULED_IDS_FORMAT = TASKS_GET_SCHEDULED_FORMAT + "/ids";
   private static final String TASKS_BY_STATE_FORMAT =TASKS_FORMAT + "/ids/request/%s";
@@ -219,6 +220,7 @@ public class SingularityClient {
   private static final TypeReference<Collection<SingularityPendingRequest>> PENDING_REQUESTS_COLLECTION = new TypeReference<Collection<SingularityPendingRequest>>() {};
   private static final TypeReference<Collection<SingularityRequestCleanup>> CLEANUP_REQUESTS_COLLECTION = new TypeReference<Collection<SingularityRequestCleanup>>() {};
   private static final TypeReference<Collection<SingularityTask>> TASKS_COLLECTION = new TypeReference<Collection<SingularityTask>>() {};
+  private static final TypeReference<Collection<SingularityTaskId>> TASK_IDS_COLLECTION = new TypeReference<Collection<SingularityTaskId>>() {};
   private static final TypeReference<Collection<SingularityTaskIdHistory>> TASKID_HISTORY_COLLECTION = new TypeReference<Collection<SingularityTaskIdHistory>>() {};
   private static final TypeReference<Collection<SingularityRack>> RACKS_COLLECTION = new TypeReference<Collection<SingularityRack>>() {};
   private static final TypeReference<Collection<SingularitySlave>> SLAVES_COLLECTION = new TypeReference<Collection<SingularitySlave>>() {};
@@ -866,6 +868,12 @@ public class SingularityClient {
     final Function<String, String> requestUri = (host) -> String.format(TASKS_GET_ACTIVE_ON_SLAVE_FORMAT, getApiBase(host), slaveId);
 
     return getCollection(requestUri, String.format("active tasks on slave %s", slaveId), TASKS_COLLECTION);
+  }
+
+  public Collection<SingularityTaskId> getActiveTaskIdsOnSlave(final String slaveId) {
+    final Function<String, String> requestUri = (host) -> String.format(TASKS_GET_ACTIVE_IDS_ON_SLAVE_FORMAT, getApiBase(host), slaveId);
+
+    return getCollection(requestUri, String.format("active tasks on slave %s", slaveId), TASK_IDS_COLLECTION);
   }
 
   public Optional<SingularityTaskCleanupResult> killTask(String taskId, Optional<SingularityKillTaskRequest> killTaskRequest) {

--- a/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/SingularityExecutorCleanup.java
+++ b/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/SingularityExecutorCleanup.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,7 +31,6 @@ import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.hubspot.mesos.JavaUtils;
@@ -39,10 +39,10 @@ import com.hubspot.mesos.client.MesosClient;
 import com.hubspot.singularity.MachineState;
 import com.hubspot.singularity.SingularityClientCredentials;
 import com.hubspot.singularity.SingularitySlave;
-import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.SingularityTaskExecutorData;
 import com.hubspot.singularity.SingularityTaskHistory;
 import com.hubspot.singularity.SingularityTaskHistoryUpdate;
+import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.client.SingularityClient;
 import com.hubspot.singularity.client.SingularityClientException;
 import com.hubspot.singularity.client.SingularityClientProvider;
@@ -317,15 +317,10 @@ public class SingularityExecutorCleanup {
   private Set<String> getRunningTaskIds() {
     final String slaveId = mesosClient.getSlaveState(mesosClient.getSlaveUri(hostname)).getId();
 
-    final Collection<SingularityTask> activeTasks = singularityClient.getActiveTasksOnSlave(slaveId);
-
-    final Set<String> runningTaskIds = Sets.newHashSet();
-
-    for (SingularityTask task : activeTasks) {
-      runningTaskIds.add(task.getTaskId().getId());
-    }
-
-    return runningTaskIds;
+    return singularityClient.getActiveTaskIdsOnSlave(slaveId)
+        .stream()
+        .map(SingularityTaskId::getId)
+        .collect(Collectors.toSet());
   }
 
   private boolean executorStillRunning(SingularityExecutorTaskDefinition taskDefinition) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -506,6 +506,14 @@ public class TaskManager extends CuratorAsyncManager {
     return tasks;
   }
 
+  public List<SingularityTaskId> getTaskIdsOnSlave(Collection<SingularityTaskId> activeTaskIds, SingularitySlave slave) {
+    final String sanitizedHost = JavaUtils.getReplaceHyphensWithUnderscores(slave.getHost());
+
+    return activeTaskIds.stream()
+        .filter((t) -> t.getSanitizedHost().equals(sanitizedHost))
+        .collect(Collectors.toList());
+  }
+
   public List<SingularityTaskHistoryUpdate> getTaskHistoryUpdates(SingularityTaskId taskId) {
     if (leaderCache.active()) {
       return leaderCache.getTaskHistoryUpdates(taskId);


### PR DESCRIPTION
With many slaves these calls can build up when they all run on a cron at once. The endpoint they use fetches full tasks rather than just ids, so it causes too many zk calls. This adds an endpoint to just grab the ids since that is all cleanup needs. The endpoint is essentially the same as the getTasksOnSlave one without the extra call to hydrate each task