### PR TITLE
tweak cooldown thresholds and evaluation logic

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -120,7 +120,7 @@ public class SingularityConfiguration extends Configuration {
 
   private int fastFailureCooldownCount = 3;
 
-  private long fastFailureCooldownMs = 60000;
+  private long fastFailureCooldownMs = 30000;
 
   private long fastCooldownExpiresMinutesWithoutFailure = 5;
 
@@ -128,7 +128,7 @@ public class SingularityConfiguration extends Configuration {
 
   private long slowFailureCooldownMs = 600000;
 
-  private long slowCooldownExpiresMinutesWithoutFailure = 8;
+  private long slowCooldownExpiresMinutesWithoutFailure = 5;
 
   private long cooldownMinScheduleSeconds = 120;
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCooldown.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCooldown.java
@@ -67,8 +67,9 @@ public class SingularityCooldown {
         .count();
     java.util.Optional<Long> mostRecentFailure = failureTimestamps.stream().max(Comparator.comparingLong(Long::valueOf));
 
-    return failureCount >= cooldownCount
-        && (!mostRecentFailure.isPresent() || mostRecentFailure.get() > System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(expiresAfterMins));
+    boolean mostRecentFailureOutsideWindow = mostRecentFailure.isPresent() && mostRecentFailure.get() > System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(expiresAfterMins);
+
+    return failureCount >= cooldownCount && !mostRecentFailureOutsideWindow;
   }
 
   boolean hasCooldownExpired(SingularityDeployStatistics deployStatistics, Optional<Long> recentFailureTimestamp) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCooldown.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCooldown.java
@@ -67,7 +67,7 @@ public class SingularityCooldown {
         .count();
     java.util.Optional<Long> mostRecentFailure = failureTimestamps.stream().max(Comparator.comparingLong(Long::valueOf));
 
-    boolean mostRecentFailureOutsideWindow = mostRecentFailure.isPresent() && mostRecentFailure.get() > System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(expiresAfterMins);
+    boolean mostRecentFailureOutsideWindow = !mostRecentFailure.isPresent() || mostRecentFailure.get() < System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(expiresAfterMins);
 
     return failureCount >= cooldownCount && !mostRecentFailureOutsideWindow;
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -591,7 +591,10 @@ public class SingularityScheduler {
     }
 
     if (!status.hasReason() || !status.getReason().equals(Reason.REASON_INVALID_OFFERS)) {
-      if (!state.isSuccess() && taskHistoryUpdateCreateResult == SingularityCreateResult.CREATED && cooldown.shouldEnterCooldown(request, requestState, deployStatistics, timestamp)) {
+      if (state != ExtendedTaskState.TASK_KILLED
+          && !state.isSuccess()
+          && taskHistoryUpdateCreateResult == SingularityCreateResult.CREATED
+          && cooldown.shouldEnterCooldown(request, requestState, deployStatistics, timestamp)) {
         LOG.info("Request {} is entering cooldown due to task {}", request.getId(), taskId);
         requestState = RequestState.SYSTEM_COOLDOWN;
         requestManager.cooldown(request, System.currentTimeMillis());
@@ -715,10 +718,6 @@ public class SingularityScheduler {
       } else {
         bldr.setAverageSchedulingDelayMillis(Optional.of(startedAt - dueTime));
       }
-
-      final SingularityDeployStatistics newStatistics = bldr.build();
-
-      deployManager.saveDeployStatistics(newStatistics);
     }
 
     bldr.setNumTasks(bldr.getNumTasks() + 1);


### PR DESCRIPTION
- There isn't a case where we want to evaluate cooldown on TASK_KILLED, skip if that's the status
- Check for the most recent failure being outside the time window wasn't correct
- Make cooldown clear a bit faster