### PR TITLE
Fix task history page size on refresh

### DIFF
--- a/SingularityUI/app/actions/ui/requestDetail.es6
+++ b/SingularityUI/app/actions/ui/requestDetail.es6
@@ -1,7 +1,6 @@
 import { FetchRequest } from '../api/requests';
 import {
   FetchActiveTasksForRequest,
-  FetchTaskHistoryForRequest,
   FetchDeploysForRequest,
   FetchRequestHistory,
 } from '../api/history';

--- a/SingularityUI/app/components/requestDetail/ActiveTasksTable.jsx
+++ b/SingularityUI/app/components/requestDetail/ActiveTasksTable.jsx
@@ -103,12 +103,9 @@ const mapStateToProps = (state, ownProps) => {
   })
 }};
 
-const mapDispatchToProps = (dispatch, ownProps) => {
-  const { taskHistoryPage, taskHistoryPageSize } = ownProps.location.query;
-  return {
-    fetchTaskHistoryForRequest: () => dispatch(FetchTaskHistoryForRequest.trigger(ownProps.requestId, taskHistoryPage || 1, taskHistoryPageSize || 10))
-  }
-};
+const mapDispatchToProps = (dispatch, ownProps) => ({
+  fetchTaskHistoryForRequest: () => dispatch(FetchTaskHistoryForRequest.trigger(ownProps.requestId, ownProps.taskHistoryPage, ownProps.taskHistoryPageSize))
+});
 
 export default connect(
   mapStateToProps,

--- a/SingularityUI/app/components/requestDetail/ActiveTasksTable.jsx
+++ b/SingularityUI/app/components/requestDetail/ActiveTasksTable.jsx
@@ -20,11 +20,9 @@ import {
   LogLinkAndActions
 } from '../tasks/Columns';
 
-import { FetchTaskHistoryForRequest } from '../../actions/api/history';
-
 import TaskStateBreakdown from './TaskStateBreakdown';
 
-const ActiveTasksTable = ({request, requestId, tasksAPI, healthyTaskIds, cleaningTaskIds, fetchTaskHistoryForRequest}) => {
+const ActiveTasksTable = ({request, requestId, tasksAPI, healthyTaskIds, cleaningTaskIds}) => {
   const tasks = tasksAPI ? tasksAPI.data : [];
   const emptyTableMessage = (Utils.api.isFirstLoad(tasksAPI)
     ? <p>Loading...</p>
@@ -65,7 +63,6 @@ const ActiveTasksTable = ({request, requestId, tasksAPI, healthyTaskIds, cleanin
         data={tasksWithHealth}
         keyGetter={(task) => task.taskId.id}
         emptyTableMessage={emptyTableMessage}
-        triggerOnDataSizeChange={fetchTaskHistoryForRequest}
       >
         {Health}
         {InstanceNumberWithHostname}
@@ -84,7 +81,6 @@ ActiveTasksTable.propTypes = {
   tasksAPI: PropTypes.object.isRequired,
   healthyTaskIds: PropTypes.array.isRequired,
   cleaningTaskIds: PropTypes.array.isRequired,
-  fetchTaskHistoryForRequest: PropTypes.func.isRequired
 };
 
 const mapStateToProps = (state, ownProps) => {
@@ -102,10 +98,6 @@ const mapStateToProps = (state, ownProps) => {
     return task.id;
   })
 }};
-
-const mapDispatchToProps = (dispatch, ownProps) => ({
-  fetchTaskHistoryForRequest: () => dispatch(FetchTaskHistoryForRequest.trigger(ownProps.requestId, 5, 1))
-});
 
 export default connect(
   mapStateToProps,

--- a/SingularityUI/app/components/requestDetail/ActiveTasksTable.jsx
+++ b/SingularityUI/app/components/requestDetail/ActiveTasksTable.jsx
@@ -103,10 +103,12 @@ const mapStateToProps = (state, ownProps) => {
   })
 }};
 
-const mapDispatchToProps = (dispatch, ownProps) => ({
+const mapDispatchToProps = (dispatch, ownProps) => {
   const { taskHistoryPage, taskHistoryPageSize } = ownProps.location.query;
-  fetchTaskHistoryForRequest: () => dispatch(FetchTaskHistoryForRequest.trigger(ownProps.requestId, taskHistoryPage || 1, taskHistoryPageSize || 10))
-});
+  return {
+    fetchTaskHistoryForRequest: () => dispatch(FetchTaskHistoryForRequest.trigger(ownProps.requestId, taskHistoryPage || 1, taskHistoryPageSize || 10))
+  }
+};
 
 export default connect(
   mapStateToProps,

--- a/SingularityUI/app/components/requestDetail/ActiveTasksTable.jsx
+++ b/SingularityUI/app/components/requestDetail/ActiveTasksTable.jsx
@@ -20,9 +20,11 @@ import {
   LogLinkAndActions
 } from '../tasks/Columns';
 
+import { FetchTaskHistoryForRequest } from '../../actions/api/history';
+
 import TaskStateBreakdown from './TaskStateBreakdown';
 
-const ActiveTasksTable = ({request, requestId, tasksAPI, healthyTaskIds, cleaningTaskIds}) => {
+const ActiveTasksTable = ({request, requestId, tasksAPI, healthyTaskIds, cleaningTaskIds, fetchTaskHistoryForRequest}) => {
   const tasks = tasksAPI ? tasksAPI.data : [];
   const emptyTableMessage = (Utils.api.isFirstLoad(tasksAPI)
     ? <p>Loading...</p>
@@ -63,6 +65,7 @@ const ActiveTasksTable = ({request, requestId, tasksAPI, healthyTaskIds, cleanin
         data={tasksWithHealth}
         keyGetter={(task) => task.taskId.id}
         emptyTableMessage={emptyTableMessage}
+        triggerOnDataSizeChange={fetchTaskHistoryForRequest}
       >
         {Health}
         {InstanceNumberWithHostname}
@@ -81,6 +84,7 @@ ActiveTasksTable.propTypes = {
   tasksAPI: PropTypes.object.isRequired,
   healthyTaskIds: PropTypes.array.isRequired,
   cleaningTaskIds: PropTypes.array.isRequired,
+  fetchTaskHistoryForRequest: PropTypes.func.isRequired
 };
 
 const mapStateToProps = (state, ownProps) => {
@@ -98,6 +102,11 @@ const mapStateToProps = (state, ownProps) => {
     return task.id;
   })
 }};
+
+const mapDispatchToProps = (dispatch, ownProps) => ({
+  const { taskHistoryPage, taskHistoryPageSize } = ownProps.location.query;
+  fetchTaskHistoryForRequest: () => dispatch(FetchTaskHistoryForRequest.trigger(ownProps.requestId, taskHistoryPage || 1, taskHistoryPageSize || 10))
+});
 
 export default connect(
   mapStateToProps,

--- a/SingularityUI/app/components/requestDetail/RequestDetailPage.jsx
+++ b/SingularityUI/app/components/requestDetail/RequestDetailPage.jsx
@@ -61,7 +61,6 @@ class RequestDetailPage extends Component {
             initialPageSize={Number(taskHistoryPageSize) || 10}
             onPageChange={num => router.replace({ ...location, query: {...location.query, taskHistoryPage: num }})}
             initialPageNumber={Number(taskHistoryPage) || 1}
-            refresh={this.props.fetchTaskHistoryForRequest}
           />
         )}
         {deleted || <RequestUtilization requestId={requestId} />}

--- a/SingularityUI/app/components/requestDetail/RequestDetailPage.jsx
+++ b/SingularityUI/app/components/requestDetail/RequestDetailPage.jsx
@@ -52,7 +52,7 @@ class RequestDetailPage extends Component {
       <div>
         <RequestHeader requestId={requestId} showBreadcrumbs={this.props.showBreadcrumbs} deleted={this.props.deleted} />
         {deleted || <RequestExpiringActions requestId={requestId} />}
-        {deleted || <ActiveTasksTable requestId={requestId} />}
+        {deleted || <ActiveTasksTable requestId={requestId} taskHistoryPage={Number(taskHistoryPage) || 1} taskHistoryPageSize={Number(taskHistoryPageSize) || 10} />}
         {deleted || <PendingTasksTable requestId={requestId} />}
         {deleted || (
           <TaskHistoryTable


### PR DESCRIPTION
Any refreshing in the UI tends to break the user experience paging through lots of task history. Resetting them to the beginning. Pull in the current page + page size when doing this