### PR TITLE
UI Performance Updates

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -54,7 +54,7 @@ public class SingularityConfiguration extends Configuration {
 
   private long cacheDeploysForMillis = TimeUnit.DAYS.toMillis(5);
 
-  private long cacheStateForMillis = TimeUnit.SECONDS.toMillis(30);
+  private long cacheStateForMillis = TimeUnit.SECONDS.toMillis(60);
 
   private long checkDeploysEverySeconds = 5;
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -20,7 +20,6 @@ import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.annotation.Timed;
-import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
@@ -459,14 +458,9 @@ public class TaskManager extends CuratorAsyncManager {
       return webCache.getActiveTasks();
     }
 
-    List<String> children = Lists.transform(getActiveTaskIds(), new Function<SingularityTaskId, String>() {
-
-      @Override
-      public String apply(SingularityTaskId taskId) {
-        return getTaskPath(taskId);
-      }
-
-    });
+    List<String> children = getActiveTaskIds().stream()
+        .map(this::getTaskPath)
+        .collect(Collectors.toList());
 
     List<SingularityTask> activeTasks = getAsync("getActiveTasks", children, taskTranscoder, taskCache);
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
@@ -326,6 +326,16 @@ public class TaskResource extends AbstractLeaderAwareResource {
 
   @GET
   @PropertyFiltering
+  @Path("/active/ids")
+  @Operation(summary = "Retrieve the list of active task ids for all requests")
+  public List<SingularityTaskId> getActiveTaskIds(
+      @Parameter(hidden = true) @Auth SingularityUser user,
+      @Parameter(description = "Use the cached version of this data to limit expensive api calls") @QueryParam("useWebCache") Boolean useWebCache) {
+    return authorizationHelper.filterByAuthorizedRequests(user, taskManager.getActiveTaskIds(), SingularityTransformHelpers.TASK_ID_TO_REQUEST_ID, SingularityAuthorizationScope.READ);
+  }
+
+  @GET
+  @PropertyFiltering
   @Path("/cleaning")
   @Operation(summary = "Retrieve the list of cleaning tasks for all requests")
   public List<SingularityTaskCleanup> getCleaningTasks(

--- a/SingularityUI/app/actions/api/tasks.es6
+++ b/SingularityUI/app/actions/api/tasks.es6
@@ -4,7 +4,7 @@ export const FetchTasksInState = buildApiAction(
   'FETCH_TASKS',
   (state, renderNotFoundIf404) => {
     const stateToFetch = state !== 'decommissioning' ? state : 'active';
-
+    let ids = ""
     let propertyString = '?property=';
     const propertyJoin = '&property=';
 
@@ -13,14 +13,15 @@ export const FetchTasksInState = buildApiAction(
         propertyString += ['offers', 'taskId', 'mesosTask.resources', 'rackId', 'taskRequest.request.requestType'].join(propertyJoin);
         break;
       case 'scheduled':
-        propertyString += ['offers', 'taskId', 'mesosTask.resources', 'rackId', 'taskRequest.request.requestType', 'pendingTask'].join(propertyJoin);
+        ids = "/ids"
+        propertyString = '';
         break;
       default:
         propertyString = '';
     }
 
     return {
-      url: `/tasks/${stateToFetch}${propertyString}`,
+      url: `/tasks/${stateToFetch}${ids}${propertyString}`,
       renderNotFoundIf404
     };
   }

--- a/SingularityUI/app/actions/api/tasks.es6
+++ b/SingularityUI/app/actions/api/tasks.es6
@@ -2,7 +2,7 @@ import { buildApiAction, buildJsonApiAction } from './base';
 
 export const FetchTasksInState = buildApiAction(
   'FETCH_TASKS',
-  (state, renderNotFoundIf404) => {
+  (state, renderNotFoundIf404, showResources) => {
     const stateToFetch = state !== 'decommissioning' ? state : 'active';
     let ids = ""
     let propertyString = '?property=';
@@ -10,7 +10,12 @@ export const FetchTasksInState = buildApiAction(
 
     switch (stateToFetch) {
       case 'active':
-        propertyString += ['offers', 'taskId', 'mesosTask.resources', 'rackId', 'taskRequest.request.requestType'].join(propertyJoin);
+        if (showResources) {
+          propertyString += ['offers', 'taskId', 'mesosTask.resources', 'rackId', 'taskRequest.request.requestType'].join(propertyJoin);
+        } else {
+          ids = "/ids"
+          propertyString = '';
+        }
         break;
       case 'scheduled':
         ids = "/ids"

--- a/SingularityUI/app/actions/ui/tasks.es6
+++ b/SingularityUI/app/actions/ui/tasks.es6
@@ -1,7 +1,7 @@
 import { FetchTasksInState, FetchTaskCleanups } from '../../actions/api/tasks';
 
-export const refresh = (state) => (dispatch) =>
+export const refresh = (state, showResources) => (dispatch) =>
   Promise.all([
-    dispatch(FetchTasksInState.trigger(state || 'active', true)),
+    dispatch(FetchTasksInState.trigger(state || 'active', true, showResources)),
     dispatch(FetchTaskCleanups.trigger()),
   ]);

--- a/SingularityUI/app/components/common/Application.jsx
+++ b/SingularityUI/app/components/common/Application.jsx
@@ -7,7 +7,7 @@ import Title from './Title';
 import Utils from '../../utils';
 
 const DISMISS_TASK_LAG_NOFICATION_DURATION_IN_MS = 1000 * 60 * 60;
-const MAX_LATE_REQUESTS = 10;
+const MAX_LATE_REQUESTS = 20;
 
 class Application extends Component {
   constructor(props) {
@@ -47,6 +47,7 @@ class Application extends Component {
           Singularity is experiencing some delays. The team has already been
           notified.
         `,
+        hideAfter: 5,
       });
     }
   }

--- a/SingularityUI/app/components/requestDetail/ActiveTasksTable.jsx
+++ b/SingularityUI/app/components/requestDetail/ActiveTasksTable.jsx
@@ -104,7 +104,7 @@ const mapStateToProps = (state, ownProps) => {
 }};
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
-  fetchTaskHistoryForRequest: () => dispatch(FetchTaskHistoryForRequest.trigger(ownProps.requestId, ownProps.taskHistoryPage, ownProps.taskHistoryPageSize))
+  fetchTaskHistoryForRequest: () => dispatch(FetchTaskHistoryForRequest.trigger(ownProps.requestId, ownProps.taskHistoryPageSize, ownProps.taskHistoryPage))
 });
 
 export default connect(

--- a/SingularityUI/app/components/tasks/Columns.jsx
+++ b/SingularityUI/app/components/tasks/Columns.jsx
@@ -232,7 +232,7 @@ export const NextRun = (
     id="nextRun"
     key="nextRun"
     cellData={
-      (rowData) => rowData.pendingTask.pendingTaskId.nextRunAt
+      (rowData) => rowData.nextRunAt
     }
     cellRender={(cellData) => {
       let label = <span className={`label label-${Utils.getLabelClassFromTaskState('TASK_SCHEDULED')}`}>SCHEDULED</span>;
@@ -257,7 +257,7 @@ export const PendingType = (
     id="pendingType"
     key="pendingType"
     cellData={
-      (rowData) => rowData.pendingTask.pendingTaskId.pendingType
+      (rowData) => rowData.pendingType
     }
     cellRender={(cellData) => (
       <div>
@@ -283,55 +283,35 @@ export const DeployId = (
   />
 );
 
+export const RequestId = (
+  <Column
+    label="Request ID"
+    id="requestId"
+    key="requestId"
+    cellData={
+      (rowData) => rowData
+    }
+    sortData={(cellData) => cellData.requestId}
+    cellRender={(cellData) =>
+      <Link to={`request/${cellData.requestId}`}>{cellData.requestId}</Link>
+    }
+    sortable={true}
+  />
+);
+
 export const PendingDeployId = (
   <Column
     label="Deploy ID"
     id="pendingDeployId"
     key="pendingDeployId"
     cellData={
-      (rowData) => rowData.pendingTask.pendingTaskId
+      (rowData) => rowData
     }
     sortData={(cellData) => cellData.deployId}
     cellRender={(cellData) =>
       <Link to={`request/${cellData.requestId}/deploy/${cellData.deployId}`}>{cellData.deployId}</Link>
     }
     sortable={true}
-  />
-);
-
-export const ScheduledActions = (
-  <Column
-    label=""
-    id="actions"
-    key="actions"
-    className="actions-column"
-    cellRender={(cellData) => (
-      <div className="hidden-xs">
-        <RunNowButton requestId={cellData.pendingTask.pendingTaskId.requestId} />
-        {cellData.request && cellData.request.requestType == "ON_DEMAND" &&
-            <DeletePendingTaskButton
-                taskId={cellData.pendingTask.pendingTaskId.id}
-                requestType={cellData.request.requestType}
-            />
-        }
-        <JSONButton className="inline" object={cellData} showOverlay={true}>
-          {'{ }'}
-        </JSONButton>
-      </div>
-    )}
-  />
-);
-
-export const ScheduledTaskId = (
-  <Column
-    label="Task ID"
-    id="taskId"
-    key="taskId"
-    cellData={
-      (rowData) => rowData.pendingTask.pendingTaskId.id
-    }
-    sortable={true}
-    className="keep-in-check"
   />
 );
 

--- a/SingularityUI/app/components/tasks/TaskFilters.jsx
+++ b/SingularityUI/app/components/tasks/TaskFilters.jsx
@@ -65,6 +65,10 @@ export default class TaskFilters extends React.Component {
     this.props.onFilterChange(_.extend({}, this.props.filter, {requestTypes: selected}));
   }
 
+  toggleShowResources(active) {
+    this.props.onFilterChange(_.extend({}, this.props.filter, {showResources: active}));
+  }
+
   renderStatusFilter() {
     const selectedIndex = _.findIndex(TaskFilters.TASK_STATES, (taskState) => taskState.filterVal === this.props.filter.taskStatus);
     const navItems = TaskFilters.TASK_STATES.map((taskState, index) => {
@@ -126,6 +130,21 @@ export default class TaskFilters extends React.Component {
     );
   }
 
+  renderShowResourcesToggle() {
+    const isActive = this.props.filter.showResources;
+    return (
+      <div className="requests-filter-container pull-right">
+        <ul className="nav nav-pills nav-pills-multi-select">
+          <li key='show-resources' className={isActive ? 'active' : ''}>
+          <a onClick={() => this.toggleShowResources(!isActive)}>
+            {isActive ? <Glyphicon glyph="ok" /> : <span className="icon-placeholder" />} Show Resources
+          </a>
+        </li>
+        </ul>
+      </div>
+    );
+  }
+
   render() {
     return (
       <div>
@@ -138,8 +157,11 @@ export default class TaskFilters extends React.Component {
           <div className="col-md-12">
             {this.renderSearchInput()}
           </div>
-          <div className="col-md-12">
+          <div className="col-md-9">
             {this.renderRequestTypeFilter()}
+          </div>
+          <div className="col-md-3">
+            {this.renderShowResourcesToggle()}
           </div>
         </div>
       </div>
@@ -150,6 +172,7 @@ export default class TaskFilters extends React.Component {
 TaskFilters.propTypes = {
   onFilterChange: React.PropTypes.func.isRequired,
   filter: React.PropTypes.shape({
+    showResources: React.PropTypes.bool.isRequired,
     taskStatus: React.PropTypes.string.isRequired,
     requestTypes: React.PropTypes.array.isRequired,
     filterText: React.PropTypes.string.isRequired

--- a/SingularityUI/app/components/tasks/TaskFilters.jsx
+++ b/SingularityUI/app/components/tasks/TaskFilters.jsx
@@ -135,7 +135,7 @@ export default class TaskFilters extends React.Component {
 
   renderShowResourcesToggle() {
     const isActive = this.props.filter.showResources;
-    return (
+    return this.props.displayRequestTypeFilters && (
       <div className="requests-filter-container pull-right">
         <ul className="nav nav-pills nav-pills-multi-select">
           <li key='show-resources' className={isActive ? 'active' : ''}>

--- a/SingularityUI/app/components/tasks/TaskFilters.jsx
+++ b/SingularityUI/app/components/tasks/TaskFilters.jsx
@@ -110,6 +110,9 @@ export default class TaskFilters extends React.Component {
   }
 
   renderRequestTypeFilter() {
+    if (!this.props.filter.showResources) {
+      return null;
+    }
     const filterItems = this.props.displayRequestTypeFilters && TaskFilters.REQUEST_TYPES.map((requestType, index) => {
       const isActive = _.contains(this.props.filter.requestTypes, requestType);
       return (

--- a/SingularityUI/app/components/tasks/TasksPage.jsx
+++ b/SingularityUI/app/components/tasks/TasksPage.jsx
@@ -72,8 +72,17 @@ class TasksPage extends React.Component {
     const requestTypes = filter.requestTypes.length === TaskFilters.REQUEST_TYPES.length ? 'all' : filter.requestTypes.join(',');
     this.props.router.push(`/tasks/${filter.taskStatus}/${requestTypes}/${filter.filterText}`);
 
+    if (this.props.filter.showResources && !filter.showResources) {
+      const newLocation = this.props.location;
+      newLocation.query.showResources = false;
+      this.props.router.push(newLocation);
+    } else if (!this.props.filter.showResources && filter.showResources) {
+      const location = this.props.location;
+      this.props.router.replace({ ...location, query: {...location.query, showResources: true }})
+    }
+
     if (lastFilterTaskStatus !== filter.taskStatus) {
-      this.props.fetchFilter(filter.taskStatus).then(() => {
+      this.props.fetchFilter(filter.taskStatus, false, filter.showResources).then(() => {
         this.setState({
           loading: false
         });
@@ -125,9 +134,13 @@ class TasksPage extends React.Component {
 
   render() {
     const displayRequestTypeFilters = this.props.filter.taskStatus === 'active';
+    let tasks = this.props.tasks;
+    if (this.props.filter.taskStatus === 'active' && !this.props.filter.showResources) {
+      tasks = tasks.map((t) => {task: {taskId: t}})
+    }
     const displayTasks = this.props.filter.taskStatus !== 'decommissioning' ?
-      _.sortBy(getFilteredTasks({tasks: this.props.tasks, filter: this.props.filter}), (task) => this.getDefaultSortAttribute(task)) :
-      _.sortBy(getDecomissioningTasks({tasks: this.props.tasks, cleanups: this.props.cleanups}), (task) => this.getDefaultSortAttribute(task));
+      _.sortBy(getFilteredTasks({tasks: tasks, filter: this.props.filter}), (task) => this.getDefaultSortAttribute(task)) :
+      _.sortBy(getDecomissioningTasks({tasks: tasks, cleanups: this.props.cleanups}), (task) => this.getDefaultSortAttribute(task));
     if (_.contains(['active', 'decommissioning'], this.props.filter.taskStatus)) displayTasks.reverse();
 
     let table;
@@ -157,6 +170,7 @@ class TasksPage extends React.Component {
 
 function mapStateToProps(state, ownProps) {
   const filter = {
+    showResources: ownProps.location.query.showResources == 'true',
     taskStatus: ownProps.params.state || 'active',
     requestTypes: !ownProps.params.requestsSubFilter || ownProps.params.requestsSubFilter === 'all' ? TaskFilters.REQUEST_TYPES : ownProps.params.requestsSubFilter.split(','),
     filterText: ownProps.params.searchFilter || ''
@@ -173,7 +187,7 @@ function mapStateToProps(state, ownProps) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    fetchFilter: (state) => dispatch(FetchTasksInState.trigger(state, true)),
+    fetchFilter: (state, showResources) => dispatch(FetchTasksInState.trigger(state, true, showResources)),
     fetchCleanups: () => dispatch(FetchTaskCleanups.trigger()),
     killTask: (taskId, data) => dispatch(KillTask.trigger(taskId, data)),
     runRequest: (requestId, data) => dispatch(RunRequest.trigger(requestId, data)),

--- a/SingularityUI/app/components/tasks/TasksPage.jsx
+++ b/SingularityUI/app/components/tasks/TasksPage.jsx
@@ -31,8 +31,7 @@ import {
   NextRun,
   PendingType,
   PendingDeployId,
-  ScheduledActions,
-  ScheduledTaskId,
+  RequestId,
   CleanupType,
   JSONAction,
   InstanceNumber
@@ -94,7 +93,7 @@ class TasksPage extends React.Component {
         columns.push(ActiveActions);
         return columns;
       case 'scheduled':
-        return [ScheduledTaskId, NextRun, PendingType, PendingDeployId, ScheduledActions];
+        return [RequestId, NextRun, PendingType, PendingDeployId];
       case 'cleaning':
         return [TaskIdShortened, CleanupType, JSONAction];
       case 'lbcleanup':
@@ -117,8 +116,8 @@ class TasksPage extends React.Component {
       case 'decommissioning':
         return task.taskId.startedAt;
       case 'scheduled':
-        if (!task.pendingTask) return null;
-        return task.pendingTask.pendingTaskId.nextRunAt;
+        if (!task.nextRunAt) return null;
+        return task.nextRunAt;
       default:
         return null;
     }
@@ -140,7 +139,7 @@ class TasksPage extends React.Component {
       table = (
         <UITable
           data={displayTasks}
-          keyGetter={(task) => (Utils.maybe(task, ['taskId', 'id']) || Utils.maybe(task, ['pendingTask', 'pendingTaskId', 'id']) || Utils.maybe(task, ['id']))}
+          keyGetter={(task) => (Utils.maybe(task, ['taskId', 'id']) || Utils.maybe(task, ['id']))}
         >
           {this.getColumns()}
         </UITable>

--- a/SingularityUI/app/selectors/tasks.es6
+++ b/SingularityUI/app/selectors/tasks.es6
@@ -32,6 +32,7 @@ export const getDecomissioningTasks = createSelector(
 );
 
 const getFilter = (state) => ({
+  showResources: state.filter.showResources,
   state: state.filter.taskStatus,
   requestTypes: state.filter.requestTypes,
   filterText: state.filter.filterText
@@ -41,7 +42,7 @@ export const getFilteredTasks = createSelector(
   [getTasks, getFilter],
   (tasks, filter) => {
     // Filter by requestType
-    if (filter.state === 'active') {
+    if (filter.state === 'active' && filter.showResources) {
       tasks = _.filter(tasks, (task) => {
         return task.taskRequest && _.contains(filter.requestTypes, task.taskRequest.request.requestType);
       });


### PR DESCRIPTION
Nothing major in terms of backend work, but I found while doing the caching work in another PR that our UI uses some more expensive endpoints than needed for the active and scheduled tasks pages. We can make these much faster by omitting a few columns and instead requiring an extra click to load the expensive data.