### PR TITLE
Fix missing extension for additional logrotate file

### DIFF
--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/models/LogrotateTemplateContext.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/models/LogrotateTemplateContext.java
@@ -109,7 +109,7 @@ public class LogrotateTemplateContext {
       transformed.add(
           new LogrotateAdditionalFile(
               taskDefinition.getTaskDirectoryPath().resolve(additionalFile.getFilename()).toString(),
-              additionalFile.getExtension().or(Strings.emptyToNull(Files.getFileExtension(additionalFile.getFilename()))),
+              additionalFile.getExtension().isPresent() ? additionalFile.getExtension().get() : Strings.emptyToNull(Files.getFileExtension(additionalFile.getFilename())), // Can't have possible null in .or()
               dateformat,
               additionalFile.getLogrotateFrequencyOverride()
           ));


### PR DESCRIPTION
In cases where the file name is like `stdout` there will be no extension. the Optional.or(null) will throw an error in that case, but we need the null value to differentiate things properly in the template