### PR TITLE
Add a base timeout to executor healthchecks + make configurable in yaml

### DIFF
--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
@@ -236,6 +236,10 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
   @JsonProperty
   private int defaultHealthcheckMaxRetries = 6;
 
+  private int defaultHealthcheckBaseTimeoutSeconds = 30;
+
+  private int defaultHealthcheckInternvalSeconds = 5;
+
   private int defaultCfsPeriod = 100000;
 
   private String extraScriptContent = "";
@@ -743,6 +747,22 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
     this.verifyAssignedPorts = verifyAssignedPorts;
   }
 
+  public int getDefaultHealthcheckBaseTimeoutSeconds() {
+    return defaultHealthcheckBaseTimeoutSeconds;
+  }
+
+  public void setDefaultHealthcheckBaseTimeoutSeconds(int defaultHealthcheckBaseTimeoutSeconds) {
+    this.defaultHealthcheckBaseTimeoutSeconds = defaultHealthcheckBaseTimeoutSeconds;
+  }
+
+  public int getDefaultHealthcheckInternvalSeconds() {
+    return defaultHealthcheckInternvalSeconds;
+  }
+
+  public void setDefaultHealthcheckInternvalSeconds(int defaultHealthcheckInternvalSeconds) {
+    this.defaultHealthcheckInternvalSeconds = defaultHealthcheckInternvalSeconds;
+  }
+
   @Override
   public String toString() {
     return "SingularityExecutorConfiguration{" +
@@ -792,6 +812,7 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
         ", shellCommandUserPlaceholder='" + shellCommandUserPlaceholder + '\'' +
         ", shellCommandPidFile='" + shellCommandPidFile + '\'' +
         ", shellCommandPrefix=" + shellCommandPrefix +
+        ", runShellCommandBeforeKillDueToThreads=" + runShellCommandBeforeKillDueToThreads +
         ", dockerClientTimeLimitSeconds=" + dockerClientTimeLimitSeconds +
         ", dockerClientConnectionPoolSize=" + dockerClientConnectionPoolSize +
         ", maxDockerPullAttempts=" + maxDockerPullAttempts +
@@ -801,6 +822,8 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
         ", cronDirectory='" + cronDirectory + '\'' +
         ", useFileAttributes=" + useFileAttributes +
         ", defaultHealthcheckMaxRetries=" + defaultHealthcheckMaxRetries +
+        ", defaultHealthcheckBaseTimeoutSeconds=" + defaultHealthcheckBaseTimeoutSeconds +
+        ", defaultHealthcheckInternvalSeconds=" + defaultHealthcheckInternvalSeconds +
         ", defaultCfsPeriod=" + defaultCfsPeriod +
         ", extraScriptContent='" + extraScriptContent + '\'' +
         ", extraDockerScriptContent='" + extraDockerScriptContent + '\'' +

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskProcessCallable.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskProcessCallable.java
@@ -84,8 +84,8 @@ public class SingularityExecutorTaskProcessCallable extends SafeProcessManager i
     File fullHealthcheckPath = Paths.get(taskAppDirectory, expectedHealthcheckResultFilePath.get()).toFile();
 
     Integer healthcheckMaxRetries = maybeOptions.get().getMaxRetries().or(configuration.getDefaultHealthcheckMaxRetries());
-    Integer retryInterval = maybeOptions.get().getIntervalSeconds().or(5);
-    long maxDelay = retryInterval * healthcheckMaxRetries;
+    Integer retryInterval = maybeOptions.get().getIntervalSeconds().or(configuration.getDefaultHealthcheckInternvalSeconds());
+    long maxDelay = configuration.getDefaultHealthcheckBaseTimeoutSeconds() + (retryInterval * healthcheckMaxRetries);
 
     try {
       Retryer<HealthCheckResult> retryer = RetryerBuilder.<HealthCheckResult>newBuilder()


### PR DESCRIPTION
reverts functionality back to when we had the startup delay, but makes it configurable in executor yaml instead and continues polling at same interval instead of waiting first