### PR TITLE
Fix typo on request utilization component

### DIFF
--- a/SingularityUI/app/components/requestDetail/RequestUtilization.jsx
+++ b/SingularityUI/app/components/requestDetail/RequestUtilization.jsx
@@ -39,7 +39,7 @@ const RequestUtilization = ({utilization}) => {
         </div>
         <div className="col-md-3">
           <UsageInfo
-            title="Averge % CPU Time Throttled"
+            title="Average % CPU Time Throttled"
             total={100}
             used={utilization.percentCpuTimeThrottled / utilization.numTasks}
             style={isCpuThrottled ? 'danger' : null}


### PR DESCRIPTION
The title of the `RequestUtilization` component has a typo; 'averge' should be 'average'. This PR corrects that typo.