### PR TITLE
Fix api reference docs link

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -34,5 +34,5 @@
   * [Slave Extras](Docs/reference/slave-extras.md)
   * [Deploy Defaults](Docs/reference/deploy-defaults.md)
   * [Health Checks](Docs/reference/healthchecks.md)
-  * [API Reference](http://getsingularity.com/Docs/reference/api.html)
+  * [API Reference](Docs/reference/api.html)
     * [OpenAPI JSON](Docs/reference/openapi.json)


### PR DESCRIPTION
Something weird with the gitbook here. It doesn't like if I give it a full url, but also seems to weirdly hang if I use the relative one. Navigating directly to api.html works though