### PR TITLE
Task history ui updates for sort

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskHistoryQuery.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskHistoryQuery.java
@@ -143,9 +143,9 @@ public class SingularityTaskHistoryQuery {
         ComparisonChain chain = ComparisonChain.start();
 
         if (localOrderDirection == OrderDirection.ASC) {
-          chain = chain.compare(o1.getTaskId().getStartedAt(), o2.getTaskId().getStartedAt());
+          chain = chain.compare(o1.getUpdatedAt(), o2.getUpdatedAt());
         } else {
-          chain = chain.compare(o2.getTaskId().getStartedAt(), o1.getTaskId().getStartedAt());
+          chain = chain.compare(o2.getUpdatedAt(), o1.getUpdatedAt());
         }
 
         return chain.compare(o1.getTaskId().getRequestId(), o2.getTaskId().getRequestId()).result();

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/AbstractHistoryJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/AbstractHistoryJDBI.java
@@ -104,7 +104,7 @@ public interface AbstractHistoryJDBI extends HistoryJDBI {
 
     applyTaskIdHistoryBaseQuery(sqlBuilder, binds, requestId, deployId, runId, host, lastTaskStatus, startedBefore, startedAfter, updatedBefore, updatedAfter);
 
-    sqlBuilder.append(" ORDER BY startedAt ");
+    sqlBuilder.append(" ORDER BY updatedAt ");
     sqlBuilder.append(orderDirection.orElse(OrderDirection.DESC).name());
 
     if (!requestId.isPresent()) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/TaskHistoryHelper.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/TaskHistoryHelper.java
@@ -52,6 +52,13 @@ public class TaskHistoryHelper extends BlendedHistoryHelper<SingularityTaskIdHis
   }
 
   @Override
+  public List<SingularityTaskIdHistory> getBlendedHistory(SingularityTaskHistoryQuery query, Integer limitStart, Integer limitCount, boolean canSkipZk) {
+    List<SingularityTaskIdHistory> results = super.getBlendedHistory(query, limitStart, limitCount, canSkipZk);
+    Collections.sort(results, query.getComparator());
+    return results;
+  }
+
+  @Override
   protected List<SingularityTaskIdHistory> getFromZk(SingularityTaskHistoryQuery query) {
     final List<SingularityTaskIdHistory> filteredHistory = Lists.newArrayList(Iterables.filter(getFromZk(getRequestIds(query)), query.getHistoryFilter()));
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/SingularityHistoryTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/SingularityHistoryTest.java
@@ -269,13 +269,13 @@ public class SingularityHistoryTest extends SingularitySchedulerTestBase {
 
     match(taskHistoryHelper.getBlendedHistory(new SingularityTaskHistoryQuery(Optional.<String>empty(), Optional.<String>empty(), Optional.<String>empty(), Optional.<String>empty(),
         Optional.<ExtendedTaskState>empty(), Optional.<Long>empty(), Optional.<Long>empty(), Optional.<Long>empty(), Optional.<Long>empty(), Optional.<OrderDirection>empty()), 0, 3), 3,
-        taskSeven, taskSix, taskFive);
+        taskSeven, taskFive, taskThree);
 
     taskHistoryPersister.runActionOnPoll();
 
     match(taskHistoryHelper.getBlendedHistory(new SingularityTaskHistoryQuery(Optional.<String>empty(), Optional.<String>empty(), Optional.<String>empty(), Optional.<String>empty(),
         Optional.<ExtendedTaskState>empty(), Optional.of(70000L), Optional.of(20000L), Optional.<Long>empty(), Optional.<Long>empty(), Optional.of(OrderDirection.ASC)), 0, 3), 3,
-        taskFour, taskFive, taskSix);
+        taskSix, taskFour, taskFive);
   }
 
   @Test
@@ -306,7 +306,7 @@ public class SingularityHistoryTest extends SingularitySchedulerTestBase {
 
     match(taskHistoryHelper.getBlendedHistory(new SingularityTaskHistoryQuery(Optional.of(requestId), Optional.<String>empty(), Optional.<String>empty(), Optional.<String>empty(),
         Optional.<ExtendedTaskState>empty(), Optional.<Long>empty(), Optional.<Long>empty(), Optional.<Long>empty(), Optional.<Long>empty(), Optional.<OrderDirection>empty()), 0, 3), 3,
-        taskSeven, taskSix, taskFive);
+        taskSeven, taskFive, taskThree);
 
     match(taskHistoryHelper.getBlendedHistory(new SingularityTaskHistoryQuery(Optional.of(requestId), Optional.of(secondDeployId), Optional.<String>empty(), Optional.of("host4"),
         Optional.<ExtendedTaskState>empty(), Optional.<Long>empty(), Optional.<Long>empty(), Optional.<Long>empty(), Optional.<Long>empty(), Optional.<OrderDirection>empty()), 0, 3), 1,
@@ -322,19 +322,19 @@ public class SingularityHistoryTest extends SingularitySchedulerTestBase {
 
     match(taskHistoryHelper.getBlendedHistory(new SingularityTaskHistoryQuery(Optional.of(requestId), Optional.<String>empty(), Optional.<String>empty(), Optional.<String>empty(),
         Optional.<ExtendedTaskState>empty(), Optional.of(7L), Optional.of(2L), Optional.<Long>empty(), Optional.<Long>empty(), Optional.of(OrderDirection.ASC)), 0, 3), 3,
-        taskThree, taskFour, taskFive);
+        taskSix, taskFour, taskThree);
 
     match(taskHistoryHelper.getBlendedHistory(new SingularityTaskHistoryQuery(Optional.of(requestId), Optional.<String>empty(), Optional.<String>empty(), Optional.<String>empty(),
         Optional.<ExtendedTaskState>empty(), Optional.of(7L), Optional.of(2L), Optional.<Long>empty(), Optional.<Long>empty(), Optional.of(OrderDirection.ASC)), 1, 3), 3,
-        taskFour, taskFive, taskSix);
+        taskFour, taskThree, taskFive);
 
     match(taskHistoryHelper.getBlendedHistory(new SingularityTaskHistoryQuery(Optional.of(requestId), Optional.<String>empty(), Optional.<String>empty(), Optional.<String>empty(),
         Optional.<ExtendedTaskState>empty(), Optional.<Long>empty(), Optional.<Long>empty(), Optional.of(26000L), Optional.of(21000L), Optional.of(OrderDirection.ASC)), 0, 3), 3,
-      taskThree, taskFour, taskFive);
+      taskSix, taskFour, taskThree);
 
     match(taskHistoryHelper.getBlendedHistory(new SingularityTaskHistoryQuery(Optional.of(requestId), Optional.<String>empty(), Optional.<String>empty(), Optional.<String>empty(),
         Optional.<ExtendedTaskState>empty(), Optional.<Long>empty(), Optional.<Long>empty(), Optional.of(26000L), Optional.of(21000L), Optional.of(OrderDirection.ASC)), 1, 3), 3,
-      taskFour, taskFive, taskSix);
+      taskFour, taskThree, taskFive);
   }
 
   @Test

--- a/SingularityService/src/test/java/com/hubspot/singularity/SingularityHistoryTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/SingularityHistoryTest.java
@@ -379,17 +379,17 @@ public class SingularityHistoryTest extends SingularitySchedulerTestBase {
 
     match(taskHistoryHelper.getBlendedHistory(new SingularityTaskHistoryQuery(Optional.of(requestId), Optional.<String>empty(), Optional.<String>empty(), Optional.<String>empty(),
         Optional.<ExtendedTaskState>empty(), Optional.of(70000L), Optional.of(20000L), Optional.<Long>empty(), Optional.<Long>empty(), Optional.of(OrderDirection.DESC)), 0, 3), 3,
-        taskSix, taskFive, taskFour);
+        taskFive, taskThree, taskFour);
 
     taskHistoryPersister.runActionOnPoll();
 
     match(taskHistoryHelper.getBlendedHistory(new SingularityTaskHistoryQuery(Optional.of(requestId), Optional.<String>empty(), Optional.<String>empty(), Optional.<String>empty(),
         Optional.<ExtendedTaskState>empty(), Optional.<Long>empty(), Optional.<Long>empty(), Optional.<Long>empty(), Optional.<Long>empty(), Optional.<OrderDirection>empty()), 0, 3), 3,
-        taskSeven, taskSix, taskFive);
+        taskSeven, taskFive, taskThree);
 
     match(taskHistoryHelper.getBlendedHistory(new SingularityTaskHistoryQuery(Optional.of(requestId), Optional.<String>empty(), Optional.<String>empty(), Optional.<String>empty(),
         Optional.<ExtendedTaskState>empty(), Optional.<Long>empty(), Optional.<Long>empty(), Optional.<Long>empty(), Optional.<Long>empty(), Optional.<OrderDirection>empty()), 2, 1), 1,
-        taskFive);
+        taskThree);
 
     match(taskHistoryHelper.getBlendedHistory(new SingularityTaskHistoryQuery(Optional.of(requestId), Optional.of(secondDeployId), Optional.<String>empty(), Optional.of("host4"),
         Optional.<ExtendedTaskState>empty(), Optional.<Long>empty(), Optional.<Long>empty(), Optional.<Long>empty(), Optional.<Long>empty(), Optional.<OrderDirection>empty()), 0, 3), 1,
@@ -405,19 +405,19 @@ public class SingularityHistoryTest extends SingularitySchedulerTestBase {
 
     match(taskHistoryHelper.getBlendedHistory(new SingularityTaskHistoryQuery(Optional.of(requestId), Optional.<String>empty(), Optional.<String>empty(), Optional.<String>empty(),
         Optional.<ExtendedTaskState>empty(), Optional.of(70000L), Optional.of(20000L), Optional.<Long>empty(), Optional.<Long>empty(), Optional.of(OrderDirection.ASC)), 0, 3), 3,
-        taskThree, taskFour, taskFive);
+        taskSix, taskFour, taskThree);
 
     match(taskHistoryHelper.getBlendedHistory(new SingularityTaskHistoryQuery(Optional.of(requestId), Optional.<String>empty(), Optional.<String>empty(), Optional.<String>empty(),
         Optional.<ExtendedTaskState>empty(), Optional.of(70000L), Optional.of(20000L), Optional.<Long>empty(), Optional.<Long>empty(), Optional.of(OrderDirection.ASC)), 1, 3), 3,
-        taskFour, taskFive, taskSix);
+        taskFour, taskThree, taskFive);
 
     match(taskHistoryHelper.getBlendedHistory(new SingularityTaskHistoryQuery(Optional.of(requestId), Optional.<String>empty(), Optional.<String>empty(), Optional.<String>empty(),
         Optional.<ExtendedTaskState>empty(), Optional.<Long>empty(), Optional.<Long>empty(), Optional.of(140000L), Optional.of(90000L), Optional.of(OrderDirection.ASC)), 0, 3), 3,
-      taskThree, taskFour, taskFive);
+      taskSix, taskFour, taskThree);
 
     match(taskHistoryHelper.getBlendedHistory(new SingularityTaskHistoryQuery(Optional.of(requestId), Optional.<String>empty(), Optional.<String>empty(), Optional.<String>empty(),
         Optional.<ExtendedTaskState>empty(), Optional.<Long>empty(), Optional.<Long>empty(), Optional.of(140000L), Optional.of(90000L), Optional.of(OrderDirection.ASC)), 1, 3), 3,
-      taskFour, taskFive, taskSix);
+      taskFour, taskThree, taskFive);
 
     match(taskHistoryHelper.getBlendedHistory(new SingularityTaskHistoryQuery(Optional.of(requestId), Optional.<String>empty(), Optional.of("test-run-id-1"), Optional.<String>empty(),
         Optional.<ExtendedTaskState>empty(), Optional.<Long>empty(), Optional.<Long>empty(), Optional.<Long>empty(), Optional.<Long>empty(), Optional.of(OrderDirection.ASC)), 0, 1), 1,
@@ -435,7 +435,7 @@ public class SingularityHistoryTest extends SingularitySchedulerTestBase {
       SingularityTaskIdHistory idHistory = history.get(i);
       SingularityTask task = tasks[i];
 
-      Assertions.assertEquals(task.getTaskId(), idHistory.getTaskId());
+      Assertions.assertEquals(idHistory.getTaskId(), task.getTaskId());
     }
   }
 

--- a/SingularityUI/.blazar.yaml
+++ b/SingularityUI/.blazar.yaml
@@ -19,6 +19,7 @@ after:
       commands:
         - /bin/bash custom-build-config/publish-ui.sh
 
+buildType: GENERIC_SINGULARITY
 
 stepActivation:
   publish:

--- a/SingularityUI/app/components/common/table/Column.jsx
+++ b/SingularityUI/app/components/common/table/Column.jsx
@@ -12,6 +12,7 @@ class Column extends Component {
     sortable: PropTypes.bool,
     sortData: PropTypes.func, // (cellData, object) -> any
     sortFunc: PropTypes.func,
+    forceSortHeader: PropTypes.bool,
     className: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.func

--- a/SingularityUI/app/components/common/table/UITable.jsx
+++ b/SingularityUI/app/components/common/table/UITable.jsx
@@ -417,7 +417,7 @@ class UITable extends Component {
       }, col.props.headerClassName);
 
       const sortIndicator = this.sortIndicator(
-        col.props.sortable,
+        col.props.sortable || col.props.forceSortHeader,
         thisColumnSorted,
         this.state.sortDirection
       );

--- a/SingularityUI/app/components/requestDetail/DeployHistoryTable.jsx
+++ b/SingularityUI/app/components/requestDetail/DeployHistoryTable.jsx
@@ -31,6 +31,7 @@ const DeployHistoryTable = ({requestId, deploysAPI, fetchDeploys}) => {
         paginated={true}
         fetchDataFromApi={(page, numberPerPage) => fetchDeploys(requestId, numberPerPage, page)}
         isFetching={isFetching}
+        defaultSortBy={'timestamp'}
       >
         <Column
           label="Deploy ID"
@@ -58,6 +59,7 @@ const DeployHistoryTable = ({requestId, deploysAPI, fetchDeploys}) => {
           label="Timestamp"
           id="timestamp"
           key="timestamp"
+          forceSortHeader={true}
           cellData={(deploy) => Utils.timestampFromNow(deploy.deployMarker.timestamp)}
         />
         <Column

--- a/SingularityUI/app/components/requestDetail/RequestHistoryTable.jsx
+++ b/SingularityUI/app/components/requestDetail/RequestHistoryTable.jsx
@@ -28,6 +28,7 @@ const RequestHistoryTable = ({requestId, requestEventsAPI, fetchRequestHistory})
         paginated={true}
         fetchDataFromApi={(page, numberPerPage) => fetchRequestHistory(requestId, numberPerPage, page)}
         isFetching={isFetching}
+        defaultSortBy={'createdAt'}
       >
         <Column
           label="State"
@@ -43,8 +44,9 @@ const RequestHistoryTable = ({requestId, requestEventsAPI, fetchRequestHistory})
         />
         <Column
           label="Timestamp"
-          id="timestamp"
-          key="timestamp"
+          id="createdAt"
+          key="createdAt"
+          forceSortHeader={true}
           cellData={(requestEvent) => Utils.timestampFromNow(requestEvent.createdAt)}
         />
         <Column

--- a/SingularityUI/app/components/requestDetail/TaskHistoryTable.jsx
+++ b/SingularityUI/app/components/requestDetail/TaskHistoryTable.jsx
@@ -127,6 +127,7 @@ class TaskHistoryTable extends Component {
           isFetching={isFetching}
           initialPageNumber={this.props.initialPageNumber}
           onPageChange={this.props.onPageChange}
+          defaultSortBy={'updatedAt'}
         >
           <Column
             label="Instance"
@@ -166,8 +167,9 @@ class TaskHistoryTable extends Component {
           />
           <Column
             label="Updated At"
-            id="updated"
-            key="updated"
+            id="updatedAt"
+            key="updatedAt"
+            forceSortHeader={true}
             cellData={(task) => Utils.timestampFromNow(task.updatedAt)}
           />
           <Column


### PR DESCRIPTION
- Make the backend sort correctly when combining zk + sql data. Most times this is already sorted correctly, but other times it is not, depending on history persister times
- Make the sort more obvious (but still not currently editable) in the UI