### PR TITLE
More efficient use of state data

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityLeaderController.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityLeaderController.java
@@ -203,6 +203,9 @@ public class SingularityLeaderController implements LeaderLatchListener {
           final SingularityHostState state = getHostState();
           LOG.trace("Saving state in ZK: " + state);
           stateManager.save(state);
+          if (master) {
+            stateManager.saveNewState();
+          }
         } catch (InterruptedException e) {
           LOG.trace("Caught interrupted exception, running the loop");
         } catch (Throwable t) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -54,6 +54,7 @@ public class SingularityConfiguration extends Configuration {
 
   private long cacheDeploysForMillis = TimeUnit.DAYS.toMillis(5);
 
+  @Deprecated
   private long cacheStateForMillis = TimeUnit.SECONDS.toMillis(60);
 
   private long checkDeploysEverySeconds = 5;
@@ -280,7 +281,7 @@ public class SingularityConfiguration extends Configuration {
 
   private long sandboxHttpTimeoutMillis = TimeUnit.SECONDS.toMillis(2);
 
-  private long saveStateEverySeconds = 60;
+  private long saveStateEverySeconds = 30;
 
   @JsonProperty("sentry")
   @Valid
@@ -416,6 +417,7 @@ public class SingularityConfiguration extends Configuration {
     return askDriverToKillTasksAgainAfterMillis;
   }
 
+  @Deprecated
   public long getCacheStateForMillis() {
     return cacheStateForMillis;
   }


### PR DESCRIPTION
Right now when we restart/redeploy singulairty, we slam zk with a ton of requests from startup as well as regenerating state on every instance at once. This updates the state manager to prefer pulling the existing state from zk. The state will be updated async by the leading Singularity instance. This makes the endpoint respond much faster as well as lessening the load on zk when several instances try to generate state at once