### PR TITLE
Don't immediately clean all history items, let the history purger do it

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
@@ -523,9 +523,6 @@ public class SingularityCleaner {
     SingularityDeleteResult deletePendingDeployResult = deployManager.deletePendingDeploy(requestCleanup.getRequestId());
     SingularityDeleteResult deleteRequestDeployStateResult = deployManager.deleteRequestDeployState(requestCleanup.getRequestId());
     LOG.trace("Deleted pendingDeploy ({}) and requestDeployState ({}) due to {}", deletePendingDeployResult, deleteRequestDeployStateResult, requestCleanup);
-    taskManager.deleteRequestId(requestCleanup.getRequestId());
-    deployManager.deleteRequestId(requestCleanup.getRequestId());
-    LOG.trace("Deleted stale request data for {}", requestCleanup.getRequestId());
     usageManager.deleteRequestUtilization(requestCleanup.getRequestId());
     requestGroupManager.removeFromAllGroups(requestCleanup.getRequestId());
   }


### PR DESCRIPTION
Often we have cases where a request gets immediately recreated as a new type. We don't want to lose the history in these cases. Let the history purger do this later on instead