### PR TITLE
Remount RequestDetailPage when jumping between requests

### DIFF
--- a/SingularityUI/app/router.jsx
+++ b/SingularityUI/app/router.jsx
@@ -38,7 +38,12 @@ const routes = (
     <Route path="requests(/:group)(/:state)(/:subFilter)(/:searchFilter)" component={RequestsPage} title="Requests" />
     <Route path="group/:groupId(/:requestId)" component={Group} title={(params) => `Group ${params.groupId}`} />
     <Route path="request">
-      <Route path=":requestId" component={RequestDetailPage} title={(params) => params.requestId} />
+      <Route path=":requestId"
+        component={props => (
+          <RequestDetailPage key={props.params.requestId} {...props} />
+        )}
+        title={(params) => params.requestId}
+      />
       <Route path=":requestId/task-search" component={TaskSearch} title="Task Search" />
       <Route path=":requestId/deploy" component={NewDeployForm} title="New Deploy" />
       <Route path=":requestId/deploy/:deployId" component={DeployDetail} title={(params) => `Deploy ${params.deployId}`} />


### PR DESCRIPTION
Users can jump between requests using the global search. React decides not to remount the RequestDetailPage component because only the route param changes.

Applying a `key` based on the `requestId` will force React to remount the component. Another way to fix this would be in the component itself, but I think it's better done here.