### PR TITLE
Update ProcessUtils to work with java11

### DIFF
--- a/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/shared/ProcessUtils.java
+++ b/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/shared/ProcessUtils.java
@@ -97,7 +97,8 @@ public class ProcessUtils {
   }
 
   public int getUnixPID(Process process) {
-    Preconditions.checkArgument(process.getClass().getName().equals("java.lang.UNIXProcess"));
+    // older java versions have UNIXProcess, newer have ProcessImpl. Both have a pid field we can access
+    Preconditions.checkArgument(process.getClass().getName().equals("java.lang.UNIXProcess") || process.getClass().getName().equals("java.lang.ProcessImpl"));
 
     Class<?> clazz = process.getClass();
 


### PR DESCRIPTION
Looks like in newer java versions (or at least in openjdk11) UNIXProcess is gone and replaced with ProcessImpl. There is only a public method to get the pid as of java 9, so we'll have to wait until we are fully upgraded to start using that. For now continue using reflections against either class