### PR TITLE
Log lock hold times at debug level if too long

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderOnlyPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderOnlyPoller.java
@@ -127,7 +127,7 @@ public abstract class SingularityLeaderOnlyPoller {
         abort.abort(AbortReason.ERROR_IN_LEADER_ONLY_POLLER, Optional.of(t));
       }
     } finally {
-      LOG.debug("Ran {} in {}", getClass().getSimpleName(), JavaUtils.duration(start));
+      LOG.debug("Ran poller {} in {}", getClass().getSimpleName(), JavaUtils.duration(start));
     }
   }
 


### PR DESCRIPTION
Additional logs to make finding them easier so we can search out the cause of scheduling slowness