### PR TITLE
Rework scheduler connect + reconnect logic

### DIFF
--- a/SingularityExecutor/pom.xml
+++ b/SingularityExecutor/pom.xml
@@ -117,6 +117,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.sun.activation</groupId>
+      <artifactId>jakarta.activation</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/SingularityService/pom.xml
+++ b/SingularityService/pom.xml
@@ -151,6 +151,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.squareup.tape2</groupId>
+      <artifactId>tape</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.sun.mail</groupId>
       <artifactId>javax.mail</artifactId>
     </dependency>

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityAbort.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityAbort.java
@@ -9,9 +9,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.framework.state.ConnectionState;
-import org.apache.curator.framework.state.ConnectionStateListener;
 import org.eclipse.jetty.server.Server;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
@@ -32,7 +29,7 @@ import com.hubspot.singularity.smtp.SingularitySmtpSender;
 import ch.qos.logback.classic.LoggerContext;
 
 @Singleton
-public class SingularityAbort implements ConnectionStateListener {
+public class SingularityAbort {
 
   private static final Logger LOG = LoggerFactory.getLogger(SingularityAbort.class);
 
@@ -58,14 +55,6 @@ public class SingularityAbort implements ConnectionStateListener {
     this.exceptionNotifier = exceptionNotifier;
     this.injector = injector;
     this.hostAndPort = hostAndPort;
-  }
-
-  @Override
-  public void stateChanged(CuratorFramework client, ConnectionState newState) {
-    if (newState == ConnectionState.LOST) {
-      LOG.error("Aborting due to new connection state received from ZooKeeper: {}", newState);
-      abort(AbortReason.LOST_ZK_CONNECTION, Optional.empty());
-    }
   }
 
   public enum AbortReason {
@@ -137,7 +126,7 @@ public class SingularityAbort implements ConnectionStateListener {
       StringWriter sw = new StringWriter();
       PrintWriter pw = new PrintWriter(sw);
       throwable.get().printStackTrace(pw);
-      body = throwable.get().getMessage() + "\n" + sw.toString();
+      body = "<pre>\n" + throwable.get().getMessage() + "\n" + sw.toString() + "\n</pre>";
     } else {
       body = "(no stack trace)";
     }

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityCuratorProvider.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityCuratorProvider.java
@@ -7,6 +7,7 @@ import javax.inject.Provider;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.state.SessionConnectionStateErrorPolicy;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,6 +29,7 @@ public class SingularityCuratorProvider implements Provider<CuratorFramework> {
 
     this.curatorFramework = CuratorFrameworkFactory.builder()
         .defaultData(null)
+        .connectionStateErrorPolicy(new SessionConnectionStateErrorPolicy())
         .sessionTimeoutMs(zookeeperConfig.getSessionTimeoutMillis())
         .connectionTimeoutMs(zookeeperConfig.getConnectTimeoutMillis())
         .connectString(zookeeperConfig.getQuorum())

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityCuratorProvider.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityCuratorProvider.java
@@ -2,14 +2,11 @@ package com.hubspot.singularity;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.Set;
-
 import javax.inject.Inject;
 import javax.inject.Provider;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
-import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,10 +20,9 @@ public class SingularityCuratorProvider implements Provider<CuratorFramework> {
   private final CuratorFramework curatorFramework;
 
   @Inject
-  public SingularityCuratorProvider(final SingularityConfiguration configuration, final Set<ConnectionStateListener> connectionStateListeners) {
+  public SingularityCuratorProvider(final SingularityConfiguration configuration) {
 
     checkNotNull(configuration, "configuration is null");
-    checkNotNull(connectionStateListeners, "connectionStateListeners is null");
 
     ZooKeeperConfiguration zookeeperConfig = configuration.getZooKeeperConfiguration();
 
@@ -37,10 +33,6 @@ public class SingularityCuratorProvider implements Provider<CuratorFramework> {
         .connectString(zookeeperConfig.getQuorum())
         .retryPolicy(new ExponentialBackoffRetry(zookeeperConfig.getRetryBaseSleepTimeMilliseconds(), zookeeperConfig.getRetryMaxTries()))
         .namespace(zookeeperConfig.getZkNamespace()).build();
-
-    for (ConnectionStateListener connectionStateListener : connectionStateListeners) {
-      curatorFramework.getConnectionStateListenable().addListener(connectionStateListener);
-    }
   }
 
   @Override

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityLeaderController.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityLeaderController.java
@@ -101,6 +101,10 @@ public class SingularityLeaderController implements LeaderLatchListener, Connect
           @Override
           public void run() {
             stateHandlerLock.lock();
+            if (scheduler.getState().getZkConnectionState().isConnected()) {
+              LOG.debug("Reconnected to zk, will not abort");
+              return;
+            }
             try {
               LOG.error("Aborting due to loss of zookeeper connection for {}ms. Current connection state {}",
                   configuration.getZooKeeperConfiguration().getAbortAfterConnectionLostForMillis(), newState);

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityLeaderController.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityLeaderController.java
@@ -49,7 +49,7 @@ public class SingularityLeaderController implements LeaderLatchListener, Connect
   private final OfferCache offerCache;
   private final SingularityConfiguration configuration;
 
-  private AtomicReference<ConnectionState> lastState;
+  private final AtomicReference<ConnectionState> lastState;
   private final ReentrantLock stateHandlerLock;
   private TimerTask lostConnectionStateChecker;
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityLeaderController.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityLeaderController.java
@@ -90,6 +90,8 @@ public class SingularityLeaderController implements LeaderLatchListener, Connect
     LOG.info("Received update for new zk connection state {}", newState);
     stateHandlerLock.lock();
     try {
+      // If the new state is not connected `setZkConnectionState` will effectively pause all pollers from
+      // continuing to process events. An explicit call to pauseForDatastoreReconnect is not needed here
       scheduler.setZkConnectionState(newState);
       if (!newState.isConnected()) {
         LOG.info("No longer connected to zk, pausing scheduler actions and waiting up to {}ms for reconnect",

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityLeaderController.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityLeaderController.java
@@ -80,6 +80,7 @@ public class SingularityLeaderController implements LeaderLatchListener, Connect
   }
 
   public void stop() {
+    scheduler.notifyStopping();
     statePoller.finish();
     TIMER.cancel();
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityMainModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityMainModule.java
@@ -21,7 +21,6 @@ import javax.servlet.http.HttpServletRequest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.leader.LeaderLatch;
 import org.apache.curator.framework.recipes.leader.LeaderLatchListener;
-import org.apache.curator.framework.state.ConnectionStateListener;
 
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3Client;
@@ -129,9 +128,6 @@ public class SingularityMainModule implements Module {
 
     binder.bind(LeaderLatch.class).to(SingularityLeaderLatch.class).in(Scopes.SINGLETON);
     binder.bind(CuratorFramework.class).toProvider(SingularityCuratorProvider.class).in(Scopes.SINGLETON);
-
-    Multibinder<ConnectionStateListener> connectionStateListeners = Multibinder.newSetBinder(binder, ConnectionStateListener.class);
-    connectionStateListeners.addBinding().to(SingularityAbort.class).in(Scopes.SINGLETON);
 
     Multibinder<LeaderLatchListener> leaderLatchListeners = Multibinder.newSetBinder(binder, LeaderLatchListener.class);
     leaderLatchListeners.addBinding().to(SingularityLeaderController.class).in(Scopes.SINGLETON);

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityMainModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityMainModule.java
@@ -68,6 +68,7 @@ import com.hubspot.singularity.mesos.OfferCache;
 import com.hubspot.singularity.mesos.SingularityMesosStatusUpdateHandler;
 import com.hubspot.singularity.mesos.SingularityNoOfferCache;
 import com.hubspot.singularity.mesos.SingularityOfferCache;
+import com.hubspot.singularity.mesos.StatusUpdateQueue;
 import com.hubspot.singularity.metrics.SingularityGraphiteReporter;
 import com.hubspot.singularity.resources.SingularityServiceUIModule;
 import com.hubspot.singularity.scheduler.SingularityLeaderOnlyPoller;
@@ -143,7 +144,7 @@ public class SingularityMainModule implements Module {
     binder.bind(SingularityExceptionNotifier.class).in(Scopes.SINGLETON);
     binder.bind(LoadBalancerClient.class).to(LoadBalancerClientImpl.class).in(Scopes.SINGLETON);
     binder.bind(SingularityMailRecordCleaner.class).in(Scopes.SINGLETON);
-
+    binder.bind(StatusUpdateQueue.class).in(Scopes.SINGLETON);
     binder.bind(SingularityWebhookPoller.class).in(Scopes.SINGLETON);
 
     binder.bind(SingularityAbort.class).in(Scopes.SINGLETON);

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityMainModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityMainModule.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 import javax.inject.Inject;
@@ -113,7 +114,7 @@ public class SingularityMainModule implements Module {
 
   public static final String LOST_TASKS_METER = "singularity.lost.tasks.meter";
 
-  public static final String STATUS_UPDATE_DELTA_30S_AVERAGE = "singularity.status.update.delta.minute.average";
+  public static final String STATUS_UPDATE_SHORT_CIRCUIT = "singularity.status.update.delay.short.circuit";
   public static final String STATUS_UPDATE_DELTAS = "singularity.status.update.deltas";
   public static final String LAST_MESOS_MASTER_HEARTBEAT_TIME = "singularity.last.mesos.master.heartbeat.time";
 
@@ -392,15 +393,15 @@ public class SingularityMainModule implements Module {
 
   @Provides
   @Singleton
-  @Named(STATUS_UPDATE_DELTA_30S_AVERAGE)
-  public AtomicLong provideDeltasMap() {
-    return new AtomicLong(0);
+  @Named(STATUS_UPDATE_SHORT_CIRCUIT)
+  public AtomicBoolean provideDeltasMap() {
+    return new AtomicBoolean(false);
   }
 
   @Provides
   @Singleton
   @Named(STATUS_UPDATE_DELTAS)
-  public ConcurrentHashMap<Long, Long> provideUpdateDeltasMap() {
+  public Map<String, Map<Long, Long>> provideUpdateDeltasMap() {
     return new ConcurrentHashMap<>();
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/MesosConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/MesosConfiguration.java
@@ -74,6 +74,8 @@ public class MesosConfiguration {
   private Optional<String> mesosUsername = Optional.empty();
   private Optional<String> mesosPassword = Optional.empty();
 
+  private long reconnectTimeoutMillis = 60000;
+
   public int getMaxNumInstancesPerRequest() {
     return maxNumInstancesPerRequest;
   }
@@ -400,5 +402,13 @@ public class MesosConfiguration {
 
   public void setMesosPassword(Optional<String> mesosPassword) {
     this.mesosPassword = mesosPassword;
+  }
+
+  public long getReconnectTimeoutMillis() {
+    return reconnectTimeoutMillis;
+  }
+
+  public void setReconnectTimeoutMillis(long reconnectTimeoutMillis) {
+    this.reconnectTimeoutMillis = reconnectTimeoutMillis;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -392,6 +392,8 @@ public class SingularityConfiguration extends Configuration {
 
   private long delayPollersWhenDeltaOverMs = 15000;
 
+  private double delayPollersWhenPercentOfRequestsOverUpdateDelta = 25;
+
   private boolean delayOfferProcessingForLargeStatusUpdateDelta = true;
 
   private int maxRunNowTaskLaunchDelayDays = 30;
@@ -1669,6 +1671,14 @@ public class SingularityConfiguration extends Configuration {
 
   public void setDelayOfferProcessingForLargeStatusUpdateDelta(boolean delayOfferProcessingForLargeStatusUpdateDelta) {
     this.delayOfferProcessingForLargeStatusUpdateDelta = delayOfferProcessingForLargeStatusUpdateDelta;
+  }
+
+  public double getDelayPollersWhenPercentOfRequestsOverUpdateDelta() {
+    return delayPollersWhenPercentOfRequestsOverUpdateDelta;
+  }
+
+  public void setDelayPollersWhenPercentOfRequestsOverUpdateDelta(double delayPollersWhenPercentOfRequestsOverUpdateDelta) {
+    this.delayPollersWhenPercentOfRequestsOverUpdateDelta = delayPollersWhenPercentOfRequestsOverUpdateDelta;
   }
 
   public int getMaxRunNowTaskLaunchDelayDays() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/ZooKeeperConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/ZooKeeperConfiguration.java
@@ -17,6 +17,8 @@ public class ZooKeeperConfiguration {
   @NotNull
   private String zkNamespace;
 
+  private long abortAfterConnectionLostForMillis = 30000;
+
   public String getQuorum() {
     return quorum;
   }
@@ -65,4 +67,11 @@ public class ZooKeeperConfiguration {
     this.zkNamespace = zkNamespace;
   }
 
+  public long getAbortAfterConnectionLostForMillis() {
+    return abortAfterConnectionLostForMillis;
+  }
+
+  public void setAbortAfterConnectionLostForMillis(long abortAfterConnectionLostForMillis) {
+    this.abortAfterConnectionLostForMillis = abortAfterConnectionLostForMillis;
+  }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/CuratorAsyncManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/CuratorAsyncManager.java
@@ -17,6 +17,8 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.BackgroundCallback;
 import org.apache.curator.framework.api.CuratorEvent;
 import org.apache.curator.utils.ZKPaths;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.KeeperException.Code;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -117,7 +119,10 @@ public abstract class CuratorAsyncManager extends CuratorManager {
 
   private void checkLatch(CountDownLatch latch, String path) throws InterruptedException {
     if (!latch.await(configuration.getZookeeperAsyncTimeout(), TimeUnit.MILLISECONDS)) {
-      throw new IllegalStateException(String.format("Timed out waiting response for objects from %s, waited %s millis", path, configuration.getZookeeperAsyncTimeout()));
+      throw new IllegalStateException(
+          String.format("Timed out waiting response for objects from %s, waited %s millis", path, configuration.getZookeeperAsyncTimeout()),
+          KeeperException.create(Code.OPERATIONTIMEOUT, path)
+      );
     }
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/StateManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/StateManager.java
@@ -64,7 +64,7 @@ public class StateManager extends CuratorManager {
   private final SingularityAuthDatastore authDatastore;
   private final Transcoder<SingularityTaskReconciliationStatistics> taskReconciliationStatisticsTranscoder;
   private final PriorityManager priorityManager;
-  private final AtomicLong statusUpdateDeltaAvg;
+  private final Map<String, Map<Long, Long>> statusUpdateDeltas;
   private final AtomicLong lastHeartbeatTime;
 
   @Inject
@@ -82,7 +82,7 @@ public class StateManager extends CuratorManager {
                       SingularityAuthDatastore authDatastore,
                       PriorityManager priorityManager,
                       Transcoder<SingularityTaskReconciliationStatistics> taskReconciliationStatisticsTranscoder,
-                      @Named(SingularityMainModule.STATUS_UPDATE_DELTA_30S_AVERAGE) AtomicLong statusUpdateDeltaAvg,
+                      @Named(SingularityMainModule.STATUS_UPDATE_DELTAS) Map<String, Map<Long, Long>> statusUpdateDeltas,
                       @Named(SingularityMainModule.LAST_MESOS_MASTER_HEARTBEAT_TIME) AtomicLong lastHeartbeatTime) {
     super(curatorFramework, configuration, metricRegistry);
 
@@ -97,7 +97,7 @@ public class StateManager extends CuratorManager {
     this.authDatastore = authDatastore;
     this.priorityManager = priorityManager;
     this.taskReconciliationStatisticsTranscoder = taskReconciliationStatisticsTranscoder;
-    this.statusUpdateDeltaAvg = statusUpdateDeltaAvg;
+    this.statusUpdateDeltas = statusUpdateDeltas;
     this.lastHeartbeatTime = lastHeartbeatTime;
   }
 
@@ -273,12 +273,20 @@ public class StateManager extends CuratorManager {
 
     final Optional<Double> minimumPriorityLevel = getMinimumPriorityLevel();
 
+    long statusUpdateDeltaAvg = (long) statusUpdateDeltas.entrySet().stream()
+        .flatMapToLong((e) -> e.getValue()
+            .values()
+            .stream()
+            .mapToLong(Long::longValue))
+        .average()
+        .orElse(0);
+
     return new SingularityState(activeTasks, launchingTasks, numActiveRequests, cooldownRequests, numPausedRequests, scheduledTasks, pendingRequests, lbCleanupTasks, lbCleanupRequests, cleaningRequests, activeSlaves,
         deadSlaves, decommissioningSlaves, activeRacks, deadRacks, decommissioningRacks, cleaningTasks, states, oldestDeploy, numDeploys, oldestDeployStep, activeDeploys, scheduledTasksInfo.getLateTasks().size(),
         scheduledTasksInfo.getLateTasks(), scheduledTasksInfo.getOnDemandLateTasks().size(), scheduledTasksInfo.getOnDemandLateTasks(),
         scheduledTasksInfo.getNumFutureTasks(), scheduledTasksInfo.getMaxTaskLag(), System.currentTimeMillis(), includeRequestIds ? overProvisionedRequestIds : null,
         includeRequestIds ? underProvisionedRequestIds : null, overProvisionedRequestIds.size(), underProvisionedRequestIds.size(), numFinishedRequests, unknownRacks, unknownSlaves, authDatastoreHealthy, minimumPriorityLevel,
-        statusUpdateDeltaAvg.get(), lastHeartbeatTime.get());
+        statusUpdateDeltaAvg, lastHeartbeatTime.get());
   }
 
   private SingularityScheduledTasksInfo getScheduledTasksInfo() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/managed/SingularityLifecycleManaged.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/managed/SingularityLifecycleManaged.java
@@ -18,7 +18,6 @@ import com.hubspot.singularity.SingularityManagedCachedThreadPoolFactory;
 import com.hubspot.singularity.SingularityManagedScheduledExecutorServiceFactory;
 import com.hubspot.singularity.data.ExecutorIdGenerator;
 import com.hubspot.singularity.mesos.SingularityMesosExecutorInfoSupport;
-import com.hubspot.singularity.mesos.SingularityMesosScheduler;
 import com.hubspot.singularity.metrics.SingularityGraphiteReporter;
 import com.hubspot.singularity.scheduler.SingularityLeaderOnlyPoller;
 import com.ning.http.client.AsyncHttpClient;
@@ -43,7 +42,6 @@ public class SingularityLifecycleManaged implements Managed {
   private final SingularityGraphiteReporter graphiteReporter;
   private final ExecutorIdGenerator executorIdGenerator;
   private final Set<SingularityLeaderOnlyPoller> leaderOnlyPollers;
-  private final SingularityMesosScheduler scheduler;
 
   private final CuratorFramework curatorFramework;
   private final AtomicBoolean started = new AtomicBoolean(false);
@@ -59,8 +57,7 @@ public class SingularityLifecycleManaged implements Managed {
                                      SingularityMesosExecutorInfoSupport executorInfoSupport,
                                      SingularityGraphiteReporter graphiteReporter,
                                      ExecutorIdGenerator executorIdGenerator,
-                                     Set<SingularityLeaderOnlyPoller> leaderOnlyPollers,
-                                     SingularityMesosScheduler scheduler) {
+                                     Set<SingularityLeaderOnlyPoller> leaderOnlyPollers) {
     this.cachedThreadPoolFactory = cachedThreadPoolFactory;
     this.scheduledExecutorServiceFactory = scheduledExecutorServiceFactory;
     this.asyncHttpClient = asyncHttpClient;

--- a/SingularityService/src/main/java/com/hubspot/singularity/managed/SingularityLifecycleManaged.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/managed/SingularityLifecycleManaged.java
@@ -18,6 +18,7 @@ import com.hubspot.singularity.SingularityManagedCachedThreadPoolFactory;
 import com.hubspot.singularity.SingularityManagedScheduledExecutorServiceFactory;
 import com.hubspot.singularity.data.ExecutorIdGenerator;
 import com.hubspot.singularity.mesos.SingularityMesosExecutorInfoSupport;
+import com.hubspot.singularity.mesos.SingularityMesosScheduler;
 import com.hubspot.singularity.metrics.SingularityGraphiteReporter;
 import com.hubspot.singularity.scheduler.SingularityLeaderOnlyPoller;
 import com.ning.http.client.AsyncHttpClient;
@@ -42,6 +43,7 @@ public class SingularityLifecycleManaged implements Managed {
   private final SingularityGraphiteReporter graphiteReporter;
   private final ExecutorIdGenerator executorIdGenerator;
   private final Set<SingularityLeaderOnlyPoller> leaderOnlyPollers;
+  private final SingularityMesosScheduler scheduler;
 
   private final CuratorFramework curatorFramework;
   private final AtomicBoolean started = new AtomicBoolean(false);
@@ -57,7 +59,8 @@ public class SingularityLifecycleManaged implements Managed {
                                      SingularityMesosExecutorInfoSupport executorInfoSupport,
                                      SingularityGraphiteReporter graphiteReporter,
                                      ExecutorIdGenerator executorIdGenerator,
-                                     Set<SingularityLeaderOnlyPoller> leaderOnlyPollers) {
+                                     Set<SingularityLeaderOnlyPoller> leaderOnlyPollers,
+                                     SingularityMesosScheduler scheduler) {
     this.cachedThreadPoolFactory = cachedThreadPoolFactory;
     this.scheduledExecutorServiceFactory = scheduledExecutorServiceFactory;
     this.asyncHttpClient = asyncHttpClient;

--- a/SingularityService/src/main/java/com/hubspot/singularity/managed/SingularityLifecycleManaged.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/managed/SingularityLifecycleManaged.java
@@ -179,6 +179,7 @@ public class SingularityLifecycleManaged implements Managed {
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
     }
+    curatorFramework.getConnectionStateListenable().addListener(leaderController);
 
     LOG.info("Connected to ZK after {}", JavaUtils.duration(start));
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SchedulerState.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SchedulerState.java
@@ -10,8 +10,8 @@ public class SchedulerState {
     PAUSED_FOR_MESOS_RECONNECT,
   }
 
-  private MesosSchedulerState mesosSchedulerState;
-  private ConnectionState zkConnectionState;
+  private MesosSchedulerState mesosSchedulerState = MesosSchedulerState.NOT_STARTED;
+  private ConnectionState zkConnectionState = ConnectionState.CONNECTED;
 
   public boolean isRunning() {
     return mesosSchedulerState != null &&

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SchedulerState.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SchedulerState.java
@@ -8,6 +8,7 @@ public class SchedulerState {
     SUBSCRIBED,
     STOPPED,
     PAUSED_FOR_MESOS_RECONNECT,
+    PAUSED_SUBSCRIBED,
   }
 
   private volatile MesosSchedulerState mesosSchedulerState = MesosSchedulerState.NOT_STARTED;

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SchedulerState.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SchedulerState.java
@@ -1,0 +1,38 @@
+package com.hubspot.singularity.mesos;
+
+import org.apache.curator.framework.state.ConnectionState;
+
+public class SchedulerState {
+  public enum MesosSchedulerState {
+    NOT_STARTED,
+    SUBSCRIBED,
+    STOPPED,
+    PAUSED_FOR_MESOS_RECONNECT,
+  }
+
+  private MesosSchedulerState mesosSchedulerState;
+  private ConnectionState zkConnectionState;
+
+  public boolean isRunning() {
+    return mesosSchedulerState != null &&
+        mesosSchedulerState == MesosSchedulerState.SUBSCRIBED &&
+        zkConnectionState != null &&
+        zkConnectionState.isConnected();
+  }
+
+  public MesosSchedulerState getMesosSchedulerState() {
+    return mesosSchedulerState;
+  }
+
+  public void setMesosSchedulerState(MesosSchedulerState mesosSchedulerState) {
+    this.mesosSchedulerState = mesosSchedulerState;
+  }
+
+  public ConnectionState getZkConnectionState() {
+    return zkConnectionState;
+  }
+
+  public void setZkConnectionState(ConnectionState zkConnectionState) {
+    this.zkConnectionState = zkConnectionState;
+  }
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SchedulerState.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SchedulerState.java
@@ -10,8 +10,8 @@ public class SchedulerState {
     PAUSED_FOR_MESOS_RECONNECT,
   }
 
-  private MesosSchedulerState mesosSchedulerState = MesosSchedulerState.NOT_STARTED;
-  private ConnectionState zkConnectionState = ConnectionState.CONNECTED;
+  private volatile MesosSchedulerState mesosSchedulerState = MesosSchedulerState.NOT_STARTED;
+  private volatile ConnectionState zkConnectionState = ConnectionState.CONNECTED;
 
   public boolean isRunning() {
     return mesosSchedulerState != null &&

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SchedulerState.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SchedulerState.java
@@ -36,4 +36,12 @@ public class SchedulerState {
   public void setZkConnectionState(ConnectionState zkConnectionState) {
     this.zkConnectionState = zkConnectionState;
   }
+
+  @Override
+  public String toString() {
+    return "SchedulerState{" +
+        "mesosSchedulerState=" + mesosSchedulerState +
+        ", zkConnectionState=" + zkConnectionState +
+        '}';
+  }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
@@ -153,6 +153,8 @@ public abstract class SingularityMesosScheduler {
 
   public abstract void notLeader();
 
+  public abstract void pauseForDatastoreReconnect();
+
   public abstract void setZkConnectionState(ConnectionState connectionState);
 
   public abstract void slaveLost(AgentID slaveId);

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
+import org.apache.curator.framework.state.ConnectionState;
 import org.apache.mesos.v1.Protos.AgentID;
 import org.apache.mesos.v1.Protos.InverseOffer;
 import org.apache.mesos.v1.Protos.MasterInfo;
@@ -18,10 +19,6 @@ import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.TaskCleanupType;
 
 public abstract class SingularityMesosScheduler {
-
-  public enum SchedulerState {
-    NOT_STARTED, SUBSCRIBED, STOPPED;
-  }
 
   /**
    * First event received when the scheduler subscribes. This contains the
@@ -151,6 +148,12 @@ public abstract class SingularityMesosScheduler {
   public abstract long getEventBufferSize();
 
   public abstract void notifyStopping();
+
+  public abstract void reconnectMesos();
+
+  public abstract void notLeader();
+
+  public abstract void setZkConnectionState(ConnectionState connectionState);
 
   public abstract void slaveLost(AgentID slaveId);
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerClient.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerClient.java
@@ -29,6 +29,7 @@ import org.apache.mesos.v1.scheduler.Protos.Event;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Throwables;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.google.protobuf.ByteString;
@@ -101,11 +102,14 @@ public class SingularityMesosSchedulerClient {
           try {
             connect(mesosMasterURI, frameworkInfo, scheduler);
           } catch (RuntimeException|URISyntaxException e) {
-            LOG.error("Could not connect: ", e);
-            scheduler.onConnectException(e);
+            if (!Throwables.getCausalChain(e).stream().anyMatch((t) -> t instanceof InterruptedException)) {
+              LOG.error("Could not connect: ", e);
+              scheduler.onConnectException(e);
+            } else {
+              LOG.warn("Interruped stream from mesos on subscriber thread, closing");
+            }
           }
         }
-
       };
       subscriberThread.start();
     }
@@ -239,8 +243,12 @@ public class SingularityMesosSchedulerClient {
     try {
       openStream.await();
     } catch (Throwable t) {
-      LOG.error("Observable was unexpectedly closed", t);
-      scheduler.onConnectException(t);
+      if (Throwables.getCausalChain(t).stream().anyMatch((throwable) -> throwable instanceof InterruptedException)) {
+        LOG.warn("Observable interrupted, closed stream from mesos");
+      } else {
+        LOG.error("Observable was unexpectedly closed", t);
+        scheduler.onUncaughtException(t);
+      }
     }
   }
 
@@ -250,8 +258,24 @@ public class SingularityMesosSchedulerClient {
   public void close() {
     if (openStream != null) {
       if (!openStream.isUnsubscribed()) {
+        // Causes a RuntimeException -> InterruptedException in the subscriberThread
         openStream.unsubscribe();
       }
+    }
+    if (subscriberThread != null) {
+      try {
+        if (!subscriberThread.isInterrupted()) {
+          subscriberThread.interrupt();
+        }
+        subscriberThread.join(10000);
+      } catch (InterruptedException ie) {
+        LOG.error("Interrupted waiting for subscriber thread to exit", ie);
+        throw new RuntimeException(ie);
+      }
+      if (subscriberThread.isAlive()) {
+        throw new RuntimeException("Unable to shut down current subscriber thread for mesos events");
+      }
+      subscriberThread = null;
     }
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
@@ -142,20 +143,16 @@ public class SingularityMesosSchedulerImpl extends SingularityMesosScheduler {
         heartbeatIntervalSeconds = Optional.of(advertisedHeartbeatIntervalSeconds);
       }
 
-      // Should be called before activation of leader cache or cache could be left empty
-      startup.checkMigrations();
-
-      leaderCacheCoordinator.activateLeaderCache();
+      if (state.getMesosSchedulerState() != MesosSchedulerState.PAUSED_FOR_MESOS_RECONNECT) {
+        // Should be called before activation of leader cache or cache could be left empty
+        startup.checkMigrations();
+        leaderCacheCoordinator.activateLeaderCache();
+      }
       MasterInfo newMasterInfo = subscribed.getMasterInfo();
       masterInfo.set(newMasterInfo);
       startup.startup(newMasterInfo);
       state.setMesosSchedulerState(MesosSchedulerState.SUBSCRIBED);
-      try {
-        queuedUpdates.iterate(this::handleStatusUpdateAsync);
-      } catch (Throwable t) {
-        LOG.error("Unable to process queued status updates", t);
-        throw new RuntimeException(t);
-      }
+      handleQueuedStatusUpdates();
     }, "subscribed", false);
   }
 
@@ -289,12 +286,7 @@ public class SingularityMesosSchedulerImpl extends SingularityMesosScheduler {
       } else if (currentState == MesosSchedulerState.PAUSED_SUBSCRIBED) {
         LOG.info("Already subscribed, restarting scheduler actions");
         state.setMesosSchedulerState(MesosSchedulerState.SUBSCRIBED);
-        try {
-          queuedUpdates.iterate(this::handleStatusUpdateAsync);
-        } catch (Throwable t) {
-          LOG.error("Unable to process queued status updates", t);
-          throw new RuntimeException(t);
-        }
+        handleQueuedStatusUpdates();
         return;
       }
 
@@ -521,5 +513,33 @@ public class SingularityMesosSchedulerImpl extends SingularityMesosScheduler {
           }
           LOG.debug("Handled status update for {} in {}", status.getTaskId().getValue(), JavaUtils.duration(start));
         });
+  }
+
+  private void handleQueuedStatusUpdates() {
+    try {
+      Iterator<TaskStatus> diskQueueIterator = queuedUpdates.diskQueueIterator();
+      while (diskQueueIterator.hasNext()) {
+        while (!statusUpdateHandler.hasRoomForMoreUpdates()) {
+          LOG.debug("Status update queue is full, waiting before processing additional updates");
+          Thread.sleep(2000);
+        }
+        TaskStatus status = diskQueueIterator.next();
+        handleStatusUpdateAsync(status);
+        diskQueueIterator.remove();
+      }
+
+      TaskStatus nextInMemory = queuedUpdates.nextInMemory();
+      while (nextInMemory != null) {
+        while (!statusUpdateHandler.hasRoomForMoreUpdates()) {
+          LOG.debug("Status update queue is full, waiting before processing additional updates");
+          Thread.sleep(2000);
+        }
+        handleStatusUpdateAsync(nextInMemory);
+        nextInMemory = queuedUpdates.nextInMemory();
+      }
+    } catch (Throwable t) {
+      LOG.error("Unable to process queued status updates", t);
+      throw new RuntimeException(t);
+    }
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
@@ -159,12 +159,12 @@ public class SingularityMesosSchedulerImpl extends SingularityMesosScheduler {
   @Timed
   @Override
   public void resourceOffers(List<Offer> offers) {
+    lastOfferTimestamp = Optional.of(System.currentTimeMillis());
     if (!isRunning()) {
       LOG.info("Scheduler is in state {}, declining {} offer(s)", state.getMesosSchedulerState(), offers.size());
       mesosSchedulerClient.decline(offers.stream().map(Offer::getId).collect(Collectors.toList()));
       return;
     }
-    lastOfferTimestamp = Optional.of(System.currentTimeMillis());
     try {
       lock.runWithOffersLock(() -> offerScheduler.resourceOffers(offers), "SingularityMesosScheduler");
     } catch (Throwable t) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosStatusUpdateHandler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosStatusUpdateHandler.java
@@ -355,6 +355,10 @@ public class SingularityMesosStatusUpdateHandler {
     scheduler.handleCompletedTask(task, taskIdObj, timestamp, taskState, taskHistoryUpdateCreateResult, status);
   }
 
+  public boolean hasRoomForMoreUpdates() {
+    return statusUpdatesSemaphore.getQueueSize() < configuration.getMesosConfiguration().getMaxStatusUpdateQueueSize();
+  }
+
   public CompletableFuture<StatusUpdateResult> processStatusUpdateAsync(Protos.TaskStatus status) {
     return statusUpdatesSemaphore.call(() -> CompletableFuture.supplyAsync(() -> {
         final String taskId = status.getTaskId().getValue();

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/StatusUpdateQueue.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/StatusUpdateQueue.java
@@ -4,10 +4,9 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
+import java.util.Iterator;
 import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Function;
 
 import org.apache.mesos.v1.Protos.TaskStatus;
 
@@ -67,10 +66,11 @@ public class StatusUpdateQueue {
     }
   }
 
-  public synchronized void iterate(Function<TaskStatus, CompletableFuture<StatusUpdateResult>> function) throws IOException {
-    onDiskQueue.forEach(function::apply);
-    onDiskQueue.clear();
-    inMemoryQueue.forEach(function::apply);
-    inMemoryQueue.clear();
+  public Iterator<TaskStatus> diskQueueIterator() {
+    return onDiskQueue.iterator();
+  }
+
+  public TaskStatus nextInMemory() {
+    return inMemoryQueue.poll();
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/StatusUpdateQueue.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/StatusUpdateQueue.java
@@ -1,0 +1,76 @@
+package com.hubspot.singularity.mesos;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+import org.apache.mesos.v1.Protos.TaskStatus;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.hubspot.singularity.Singularity;
+import com.hubspot.singularity.config.SingularityConfiguration;
+import com.squareup.tape2.ObjectQueue;
+import com.squareup.tape2.ObjectQueue.Converter;
+import com.squareup.tape2.QueueFile;
+
+@Singleton
+public class StatusUpdateQueue {
+  private final SingularityConfiguration configuration;
+  private final File queueFile;
+  private final Queue<TaskStatus> inMemoryQueue;
+  private final ObjectQueue<TaskStatus> onDiskQueue;
+
+  @Inject
+  public StatusUpdateQueue(SingularityConfiguration configuration,
+                           @Singularity ObjectMapper objectMapper) throws IOException {
+    this.configuration = configuration;
+    this.inMemoryQueue = new ArrayBlockingQueue<>(configuration.getMesosConfiguration().getMaxStatusUpdateQueueSize());
+    File parent = Files.createTempDirectory("queues").toFile();
+    this.queueFile = new File(parent, "queue-file");
+    this.onDiskQueue = ObjectQueue.create(new QueueFile.Builder(queueFile).build(), new Converter<TaskStatus>() {
+      @Override
+      public TaskStatus from(byte[] source) throws IOException {
+        return objectMapper.readValue(source, TaskStatus.class);
+      }
+
+      @Override
+      public void toStream(TaskStatus value, OutputStream sink) throws IOException {
+        objectMapper.writeValue(sink, value);
+      }
+    });
+  }
+
+  public int onDiskSize() {
+    return onDiskQueue.size();
+  }
+
+  public int inMemorySize() {
+    return inMemoryQueue.size();
+  }
+
+  public int size() {
+    return onDiskQueue.size() + inMemoryQueue.size();
+  }
+
+  public void add(TaskStatus update) throws IOException {
+    if (inMemoryQueue.size() < configuration.getMesosConfiguration().getMaxStatusUpdateQueueSize()) {
+      inMemoryQueue.add(update);
+    } else {
+      onDiskQueue.add(update);
+    }
+  }
+
+  public void iterate(Function<TaskStatus, CompletableFuture<StatusUpdateResult>> function) throws IOException {
+    onDiskQueue.forEach(function::apply);
+    onDiskQueue.clear();
+    inMemoryQueue.forEach(function::apply);
+    inMemoryQueue.clear();
+  }
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/StatusUpdateQueue.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/StatusUpdateQueue.java
@@ -59,7 +59,7 @@ public class StatusUpdateQueue {
     return onDiskQueue.size() + inMemoryQueue.size();
   }
 
-  public void add(TaskStatus update) throws IOException {
+  public synchronized void add(TaskStatus update) throws IOException {
     if (inMemoryQueue.size() < configuration.getMesosConfiguration().getMaxStatusUpdateQueueSize()) {
       inMemoryQueue.add(update);
     } else {
@@ -67,7 +67,7 @@ public class StatusUpdateQueue {
     }
   }
 
-  public void iterate(Function<TaskStatus, CompletableFuture<StatusUpdateResult>> function) throws IOException {
+  public synchronized void iterate(Function<TaskStatus, CompletableFuture<StatusUpdateResult>> function) throws IOException {
     onDiskQueue.forEach(function::apply);
     onDiskQueue.clear();
     inMemoryQueue.forEach(function::apply);

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/TestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/TestResource.java
@@ -212,4 +212,17 @@ public class TestResource {
     checkForbidden(configuration.isAllowTestResourceCalls(), "Test resource calls are disabled (set isAllowTestResourceCalls to true in configuration)");
     historyManager.purgeDeployHistory();
   }
+
+  @POST
+  @Path("/reconnect-mesos")
+  @Operation(
+      summary = "Trigger a reconnect to the mesos master",
+      responses = {
+          @ApiResponse(responseCode = "403", description = "Test resource calls are currently not enabled, set `allowTestResourceCalls` to `true` in config yaml to enable")
+      }
+  )
+  public void reconnectMesos() {
+    checkForbidden(configuration.isAllowTestResourceCalls(), "Test resource calls are disabled (set isAllowTestResourceCalls to true in configuration)");
+    scheduler.reconnectMesos();
+  }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCache.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCache.java
@@ -153,6 +153,7 @@ public class SingularityLeaderCache {
   public void cacheRacks(List<SingularityRack> racks) {
     this.racks = racks.stream().collect(Collectors.toConcurrentMap(SingularityRack::getId, Function.identity()));
   }
+
   public void stop() {
     active = false;
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCacheCoordinator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCacheCoordinator.java
@@ -51,4 +51,7 @@ public class SingularityLeaderCacheCoordinator {
     leaderCache.stop();
   }
 
+  public void clear() {
+    leaderCache.clear();
+  }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderOnlyPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderOnlyPoller.java
@@ -124,6 +124,7 @@ public abstract class SingularityLeaderOnlyPoller {
       LOG.error("Caught an exception while running {}", getClass().getSimpleName(), t);
       exceptionNotifier.notify(String.format("Caught an exception while running %s", getClass().getSimpleName()), t);
       if (abortsOnError()) {
+        // TODO catch zk errors differently here
         abort.abort(AbortReason.ERROR_IN_LEADER_ONLY_POLLER, Optional.of(t));
       }
     } finally {

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderOnlyPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderOnlyPoller.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.curator.framework.recipes.leader.LeaderLatch;
 import org.apache.zookeeper.KeeperException;
@@ -21,7 +20,6 @@ import com.hubspot.singularity.SingularityAbort;
 import com.hubspot.singularity.SingularityAbort.AbortReason;
 import com.hubspot.singularity.SingularityMainModule;
 import com.hubspot.singularity.SingularityManagedScheduledExecutorServiceFactory;
-import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.mesos.SingularityMesosScheduler;
 import com.hubspot.singularity.sentry.SingularityExceptionNotifier;
 
@@ -39,8 +37,7 @@ public abstract class SingularityLeaderOnlyPoller {
   private SingularityExceptionNotifier exceptionNotifier;
   private SingularityAbort abort;
   private SingularityMesosScheduler mesosScheduler;
-  private long delayPollersWhenDeltaOverMs;
-  private AtomicLong statusUpdateDelta30sAverage;
+  private AtomicBoolean shortCircuitForStatusUpdateDelay;
 
   protected SingularityLeaderOnlyPoller(long pollDelay, TimeUnit pollTimeUnit) {
     this(pollDelay, pollTimeUnit, false);
@@ -58,15 +55,13 @@ public abstract class SingularityLeaderOnlyPoller {
                                 SingularityExceptionNotifier exceptionNotifier,
                                 SingularityAbort abort,
                                 SingularityMesosScheduler mesosScheduler,
-                                SingularityConfiguration configuration,
-                                @Named(SingularityMainModule.STATUS_UPDATE_DELTA_30S_AVERAGE) AtomicLong statusUpdateDelta30sAverage) {
+                                @Named(SingularityMainModule.STATUS_UPDATE_SHORT_CIRCUIT) AtomicBoolean shortCircuitForStatusUpdateDelay) {
     this.executorService = executorServiceFactory.get(getClass().getSimpleName());
     this.leaderLatch = checkNotNull(leaderLatch, "leaderLatch is null");
     this.exceptionNotifier = checkNotNull(exceptionNotifier, "exceptionNotifier is null");
     this.abort = checkNotNull(abort, "abort is null");
     this.mesosScheduler = checkNotNull(mesosScheduler, "mesosScheduler is null");
-    this.delayPollersWhenDeltaOverMs = configuration.getDelayPollersWhenDeltaOverMs();
-    this.statusUpdateDelta30sAverage = checkNotNull(statusUpdateDelta30sAverage, "statusUpdateDeltaAverage is null");
+    this.shortCircuitForStatusUpdateDelay = checkNotNull(shortCircuitForStatusUpdateDelay, "statusUpdateDeltaAverage is null");
   }
 
   public void start() {
@@ -111,7 +106,7 @@ public abstract class SingularityLeaderOnlyPoller {
       return;
     }
 
-    if (delayWhenLargeStatusUpdateDelta && statusUpdateDelta30sAverage.get() > delayPollersWhenDeltaOverMs) {
+    if (delayWhenLargeStatusUpdateDelta && shortCircuitForStatusUpdateDelay.get()) {
       LOG.info("Delaying run of {} until status updates have caught up", getClass().getSimpleName());
       return;
     }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityMesosHeartbeatChecker.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityMesosHeartbeatChecker.java
@@ -8,7 +8,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
-import com.hubspot.singularity.SingularityAbort;
 import com.hubspot.singularity.SingularityMainModule;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.mesos.SingularityMesosScheduler;
@@ -18,18 +17,15 @@ public class SingularityMesosHeartbeatChecker extends SingularityLeaderOnlyPolle
 
   private final SingularityConfiguration configuration;
   private final SingularityMesosScheduler mesosScheduler;
-  private final SingularityAbort abort;
   private final AtomicLong lastHeartbeatTime;
 
   @Inject
   public SingularityMesosHeartbeatChecker(SingularityConfiguration configuration,
                                           SingularityMesosScheduler mesosScheduler,
-                                          SingularityAbort abort,
                                           @Named(SingularityMainModule.LAST_MESOS_MASTER_HEARTBEAT_TIME) AtomicLong lastHeartbeatTime) {
     super(configuration.getCheckMesosMasterHeartbeatEverySeconds(), TimeUnit.SECONDS);
     this.configuration = configuration;
     this.mesosScheduler = mesosScheduler;
-    this.abort = abort;
     this.lastHeartbeatTime = lastHeartbeatTime;
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityMesosHeartbeatChecker.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityMesosHeartbeatChecker.java
@@ -1,6 +1,5 @@
 package com.hubspot.singularity.scheduler;
 
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -10,7 +9,6 @@ import org.slf4j.LoggerFactory;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.hubspot.singularity.SingularityAbort;
-import com.hubspot.singularity.SingularityAbort.AbortReason;
 import com.hubspot.singularity.SingularityMainModule;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.mesos.SingularityMesosScheduler;
@@ -50,9 +48,8 @@ public class SingularityMesosHeartbeatChecker extends SingularityLeaderOnlyPolle
     double missedHeartbeats = millisSinceLastHeartbeat / (mesosScheduler.getHeartbeatIntervalSeconds().get() * 1000);
 
     if (missedHeartbeats > configuration.getMaxMissedMesosMasterHeartbeats()) {
-      LOG.error("I haven't received a Mesos heartbeat in {}ms! Aborting Singularity...", millisSinceLastHeartbeat);
-      mesosScheduler.notifyStopping();
-      abort.abort(AbortReason.LOST_MESOS_CONNECTION, Optional.of(new RuntimeException(String.format("Didn't receive a heartbeat from the Mesos Master for %dms", millisSinceLastHeartbeat))));
+      LOG.error("I haven't received a Mesos heartbeat in {}ms! Restarting mesos connection", millisSinceLastHeartbeat);
+      mesosScheduler.reconnectMesos();
     }
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityStatusUpdateDeltaPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityStatusUpdateDeltaPoller.java
@@ -1,39 +1,51 @@
 package com.hubspot.singularity.scheduler;
 
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
-import com.google.common.math.DoubleMath;
+import com.google.common.math.Stats;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.hubspot.singularity.SingularityMainModule;
+import com.hubspot.singularity.config.SingularityConfiguration;
 
 public class SingularityStatusUpdateDeltaPoller extends SingularityLeaderOnlyPoller {
-  private final ConcurrentHashMap<Long, Long> statusUpdateDeltas;
-  private final AtomicLong statusUpdateDelta30sAverage;
+  private final SingularityConfiguration configuration;
+  private final Map<String, Map<Long, Long>> statusUpdateDeltas;
+  private final AtomicBoolean shortCircuitForStatusUpdateDelay;
 
   @Inject
-  public SingularityStatusUpdateDeltaPoller(@Named(SingularityMainModule.STATUS_UPDATE_DELTAS) ConcurrentHashMap<Long, Long> statusUpdateDeltas,
-                                            @Named(SingularityMainModule.STATUS_UPDATE_DELTA_30S_AVERAGE) AtomicLong statusUpdateDelta30sAverage) {
+  public SingularityStatusUpdateDeltaPoller(SingularityConfiguration configuration,
+                                            @Named(SingularityMainModule.STATUS_UPDATE_DELTAS) Map<String, Map<Long, Long>> statusUpdateDeltas,
+                                            @Named(SingularityMainModule.STATUS_UPDATE_SHORT_CIRCUIT) AtomicBoolean shortCircuitForStatusUpdateDelay) {
     super(5L, TimeUnit.SECONDS);
+    this.configuration = configuration;
     this.statusUpdateDeltas = statusUpdateDeltas;
-    this.statusUpdateDelta30sAverage = statusUpdateDelta30sAverage;
+    this.shortCircuitForStatusUpdateDelay = shortCircuitForStatusUpdateDelay;
   }
 
   @Override
   public void runActionOnPoll() {
     long now = System.currentTimeMillis();
-    List<Long> toRemove = statusUpdateDeltas.keySet().stream()
-        .filter((e) -> e < now - 10000)
-        .collect(Collectors.toList());
-    toRemove.forEach(statusUpdateDeltas::remove);
-    if (statusUpdateDeltas.isEmpty()) {
-      statusUpdateDelta30sAverage.set(0L);
+    int overThreshold = 0;
+    for (Map<Long, Long> deltas : statusUpdateDeltas.values()) {
+      List<Long> toRemove = deltas.keySet()
+          .stream()
+          .filter((e) -> e < now - 30000)
+          .collect(Collectors.toList());
+      toRemove.forEach(deltas::remove);
+      if (deltas.size() > 0 && Stats.meanOf(deltas.values()) > configuration.getDelayPollersWhenDeltaOverMs()) {
+        overThreshold++;
+      }
+    }
+
+    if ((overThreshold * 100.0 / statusUpdateDeltas.keySet().size()) > configuration.getDelayPollersWhenPercentOfRequestsOverUpdateDelta()) {
+      shortCircuitForStatusUpdateDelay.set(true);
     } else {
-      statusUpdateDelta30sAverage.set((long) DoubleMath.mean(statusUpdateDeltas.values()));
+      shortCircuitForStatusUpdateDelay.set(false);
     }
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityStatusUpdateDeltaPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityStatusUpdateDeltaPoller.java
@@ -27,7 +27,7 @@ public class SingularityStatusUpdateDeltaPoller extends SingularityLeaderOnlyPol
   public void runActionOnPoll() {
     long now = System.currentTimeMillis();
     List<Long> toRemove = statusUpdateDeltas.keySet().stream()
-        .filter((e) -> e < now - 30000)
+        .filter((e) -> e < now - 10000)
         .collect(Collectors.toList());
     toRemove.forEach(statusUpdateDeltas::remove);
     if (statusUpdateDeltas.isEmpty()) {

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityStatusUpdateQueueTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityStatusUpdateQueueTest.java
@@ -1,0 +1,38 @@
+package com.hubspot.singularity.mesos;
+
+import org.apache.mesos.v1.Protos.TaskState;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.google.inject.Inject;
+import com.hubspot.singularity.SingularityTask;
+import com.hubspot.singularity.scheduler.SingularitySchedulerTestBase;
+
+public class SingularityStatusUpdateQueueTest extends SingularitySchedulerTestBase {
+
+  @Inject
+  StatusUpdateQueue statusUpdateQueue;
+
+  public SingularityStatusUpdateQueueTest() {
+    super(false);
+  }
+
+  @Test
+  public void testUsesDiskOverflowToProcessStatusUpdates() throws Exception {
+    try {
+      configuration.getMesosConfiguration().setMaxStatusUpdateQueueSize(1);
+      initRequest();
+      initFirstDeploy();
+      SingularityTask firstTask = launchTask(request, firstDeploy, 1, TaskState.TASK_RUNNING);
+      sms.pauseForDatastoreReconnect();
+      statusUpdate(firstTask, TaskState.TASK_RUNNING);
+      statusUpdate(firstTask, TaskState.TASK_FINISHED);
+      Assertions.assertEquals(1, statusUpdateQueue.inMemorySize());
+      Assertions.assertEquals(1, statusUpdateQueue.onDiskSize());
+      sms.start();
+      Assertions.assertEquals(0, statusUpdateQueue.size());
+    } finally {
+      configuration.getMesosConfiguration().setMaxStatusUpdateQueueSize(5000);
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <dep.hk2.version>2.5.0-b63</dep.hk2.version>
     <dep.httpclient.version>4.5.5</dep.httpclient.version>
     <dep.httpcore.version>4.4.9</dep.httpcore.version>
-    <dep.jackson-databind.version>2.9.9</dep.jackson-databind.version>
+    <dep.jackson-databind.version>2.9.9.3</dep.jackson-databind.version>
     <dep.jackson.version>2.9.9</dep.jackson.version>
     <dep.javassist.version>3.24.1-GA</dep.javassist.version>
     <dep.jboss-logging.version>3.3.0.Final</dep.jboss-logging.version>
@@ -281,7 +281,7 @@
       <dependency>
         <groupId>com.hubspot.jackson</groupId>
         <artifactId>jackson-jaxrs-propertyfiltering</artifactId>
-        <version>0.8.1</version>
+        <version>0.8.4</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
     <dep.logback.version>1.2.3</dep.logback.version>
     <dep.mesos.rxjava.version>0.1.0</dep.mesos.rxjava.version>
     <dep.metrics-guice.version>3.1.3</dep.metrics-guice.version>
+    <dep.mysql-connector-java.version>8.0.17</dep.mysql-connector-java.version>
     <dep.netty.version>4.1.27.Final</dep.netty.version>
     <dep.netty3.version>3.10.6.Final</dep.netty3.version>
     <dep.plugin.surefire.version>2.22.1</dep.plugin.surefire.version>

--- a/pom.xml
+++ b/pom.xml
@@ -341,6 +341,12 @@
       </dependency>
 
       <dependency>
+        <groupId>com.sun.activation</groupId>
+        <artifactId>jakarta.activation</artifactId>
+        <version>1.2.1</version>
+      </dependency>
+
+      <dependency>
         <groupId>de.neuland-bfi</groupId>
         <artifactId>jade4j</artifactId>
         <version>1.2.7</version>

--- a/pom.xml
+++ b/pom.xml
@@ -387,6 +387,12 @@
       </dependency>
 
       <dependency>
+        <groupId>com.squareup.tape2</groupId>
+        <artifactId>tape</artifactId>
+        <version>2.0.0-beta1</version>
+      </dependency>
+
+      <dependency>
         <groupId>io.swagger.core.v3</groupId>
         <artifactId>swagger-annotations</artifactId>
         <version>${dep.swagger.version}</version>


### PR DESCRIPTION
Goals of this PR:
- Don't require an abort/restart when mesos connection is lost. Try to reconnect for up to 60s first
- Don't require an abort/restart when losing zk connection. Wait up to 30s for reconnect first
  - When regaining zk connection, as long as we did not also lose mesos connection, don't re-run reconciliation
- When losing leadership, don't immediately abort, stop the pollers, clear leader cache and continue running as a hot standby

TODOs:
- [x] fix up unit tests. Need some newer guice magic to change how the unit test version of the scheduler works
- [x] Should we retry forever on mesos/zk connection? Wondering if there is a downside to spinning forever versus restarting. I _think_ as long as we've properly stopped all our leader pollers and leader cache, that it should be safe to continue waiting. Need to verify
- [x] Figure out what to do about buffering status updates while we are in a state where we have mesos connection but not zk. Should we reject these? Eventually buffer to disk? Status updates need zk to finish processing so we either have to buffer, or re-run reconciliation when restarting.

cc @jkebinger @baconmania @jschlather 