### PR TITLE
Timing-related fixes

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/hooks/LoadBalancerClientImpl.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/hooks/LoadBalancerClientImpl.java
@@ -48,6 +48,7 @@ public class LoadBalancerClientImpl implements LoadBalancerClient {
 
   private static final String CONTENT_TYPE_JSON = "application/json";
   private static final String HEADER_CONTENT_TYPE = "Content-Type";
+  private static final String ALREADY_ENQUEUED_ERROR = "is already enqueued with different parameters";
 
   private final String loadBalancerUri;
   private final Optional<Map<String, String>> loadBalancerQueryParams;
@@ -133,7 +134,7 @@ public class LoadBalancerClientImpl implements LoadBalancerClient {
 
     if ((method != LoadBalancerMethod.CHECK_STATE && method != LoadBalancerMethod.PRE_ENQUEUE) &&
         result.state == BaragonRequestState.FAILED
-        && result.message.orElse("").contains("is already enqueued with different parameters")) {
+        && result.message.orElse("").contains(ALREADY_ENQUEUED_ERROR)) {
       LOG.info("Baragon request {} already in the queue, will fetch current state instead", loadBalancerRequestId.getId());
       return sendRequestWrapper(loadBalancerRequestId, LoadBalancerMethod.CHECK_STATE, request, onFailure);
     }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityDeployChecker.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityDeployChecker.java
@@ -640,6 +640,15 @@ public class SingularityDeployChecker {
       return new SingularityDeployResult(DeployState.SUCCEEDED, "Request not deployable");
     }
 
+    if (!deploy.isPresent()) {
+      // Check for abandoned pending deploy
+      Optional<SingularityDeployResult> result = deployManager.getDeployResult(request.getId(), pendingDeploy.getDeployMarker().getDeployId());
+      if (result.isPresent() && result.get().getDeployState().isDeployFinished()) {
+        LOG.info("Deploy was already finished, running cleanup of pending data for {}", pendingDeploy.getDeployMarker());
+        return result.get();
+      }
+    }
+
     if (!pendingDeploy.getDeployProgress().isPresent()) {
       return new SingularityDeployResult(DeployState.FAILED, "No deploy progress data present in Zookeeper. Please reattempt your deploy");
     }


### PR DESCRIPTION
Few that will be in this PR
- [x] When skip healthchecks expires, any tasks that were initially marked healthy due to that should remain as healthy. Accomplishing this with a dummy healthcheck result, since pulling in request history to check at the time of startup would pull a dep on mysql on the critical scheduling path
- [x] Fix handling of baragon request already in queue with different params. This should not result in zero upstreams when rolling back a deploy (odd failover race condition)
- [x] Fix race condition where pending deploy gets stuck even though it already has a result in zk (odd failover mode)