### PR TITLE
Subscribe on other thread for faster status updates

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityMainModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityMainModule.java
@@ -173,7 +173,7 @@ public class SingularityMainModule implements Module {
     binder.bindConstant().annotatedWith(Names.named(SERVER_ID_PROPERTY)).to(UUID.randomUUID().toString());
 
     binder.bind(SingularityManagedScheduledExecutorServiceFactory.class).in(Scopes.SINGLETON);
-    binder.bind(SingularityManagedCachedThreadPoolFactory.class).in(Scopes.SINGLETON);
+    binder.bind(SingularityManagedThreadPoolFactory.class).in(Scopes.SINGLETON);
 
     binder.bind(SingularityGraphiteReporter.class).in(Scopes.SINGLETON);
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityManagedThreadPoolFactory.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityManagedThreadPoolFactory.java
@@ -15,20 +15,27 @@ import com.google.inject.Singleton;
 import com.hubspot.singularity.config.SingularityConfiguration;
 
 @Singleton
-public class SingularityManagedCachedThreadPoolFactory {
+public class SingularityManagedThreadPoolFactory {
   private final AtomicBoolean stopped = new AtomicBoolean();
   private final List<ExecutorService> executorPools = new ArrayList<>();
 
   private final long timeoutInMillis;
 
   @Inject
-  public SingularityManagedCachedThreadPoolFactory(final SingularityConfiguration configuration) {
+  public SingularityManagedThreadPoolFactory(final SingularityConfiguration configuration) {
     this.timeoutInMillis = TimeUnit.SECONDS.toMillis(configuration.getThreadpoolShutdownDelayInSeconds());
   }
 
   public synchronized ExecutorService get(String name) {
     checkState(!stopped.get(), "already stopped");
     ExecutorService service = Executors.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat(name + "-%d").build());
+    executorPools.add(service);
+    return service;
+  }
+
+  public synchronized ExecutorService get(String name, int maxSize) {
+    checkState(!stopped.get(), "already stopped");
+    ExecutorService service = Executors.newFixedThreadPool(maxSize, new ThreadFactoryBuilder().setNameFormat(name + "-%d").build());
     executorPools.add(service);
     return service;
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/MesosConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/MesosConfiguration.java
@@ -71,6 +71,8 @@ public class MesosConfiguration {
   private double recheckMetricsLoad5Threshold = 0.8;
   private int agentReregisterTimeoutSeconds = 600;
 
+  private int subscriberThreads = 5;
+
   private Optional<String> mesosUsername = Optional.empty();
   private Optional<String> mesosPassword = Optional.empty();
 
@@ -384,6 +386,14 @@ public class MesosConfiguration {
 
   public void setAgentReregisterTimeoutSeconds(int agentReregisterTimeoutSeconds) {
     this.agentReregisterTimeoutSeconds = agentReregisterTimeoutSeconds;
+  }
+
+  public int getSubscriberThreads() {
+    return subscriberThreads;
+  }
+
+  public void setSubscriberThreads(int subscriberThreads) {
+    this.subscriberThreads = subscriberThreads;
   }
 
   public Optional<String> getMesosUsername() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/hooks/SnsWebhookManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/hooks/SnsWebhookManager.java
@@ -24,7 +24,7 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.hubspot.singularity.Singularity;
 import com.hubspot.singularity.SingularityDeployUpdate;
-import com.hubspot.singularity.SingularityManagedCachedThreadPoolFactory;
+import com.hubspot.singularity.SingularityManagedThreadPoolFactory;
 import com.hubspot.singularity.SingularityManagedScheduledExecutorServiceFactory;
 import com.hubspot.singularity.SingularityRequestHistory;
 import com.hubspot.singularity.SingularityTaskWebhook;
@@ -51,7 +51,7 @@ public class SnsWebhookManager {
   public SnsWebhookManager(@Singularity ObjectMapper objectMapper,
                            SingularityConfiguration configuration,
                            SingularityManagedScheduledExecutorServiceFactory executorServiceFactory,
-                           SingularityManagedCachedThreadPoolFactory managedCachedThreadPoolFactory,
+                           SingularityManagedThreadPoolFactory managedCachedThreadPoolFactory,
                            WebhookManager webhookManager) {
     this.objectMapper = objectMapper;
     this.webhookConf = configuration.getWebhookQueueConfiguration();

--- a/SingularityService/src/main/java/com/hubspot/singularity/managed/SingularityLifecycleManaged.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/managed/SingularityLifecycleManaged.java
@@ -14,7 +14,7 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.hubspot.mesos.JavaUtils;
 import com.hubspot.singularity.SingularityLeaderController;
-import com.hubspot.singularity.SingularityManagedCachedThreadPoolFactory;
+import com.hubspot.singularity.SingularityManagedThreadPoolFactory;
 import com.hubspot.singularity.SingularityManagedScheduledExecutorServiceFactory;
 import com.hubspot.singularity.data.ExecutorIdGenerator;
 import com.hubspot.singularity.mesos.SingularityMesosExecutorInfoSupport;
@@ -33,7 +33,7 @@ import io.dropwizard.lifecycle.Managed;
 public class SingularityLifecycleManaged implements Managed {
   private static final Logger LOG = LoggerFactory.getLogger(SingularityLifecycleManaged.class);
 
-  private final SingularityManagedCachedThreadPoolFactory cachedThreadPoolFactory;
+  private final SingularityManagedThreadPoolFactory cachedThreadPoolFactory;
   private final SingularityManagedScheduledExecutorServiceFactory scheduledExecutorServiceFactory;
   private final AsyncHttpClient asyncHttpClient;
   private final SingularityLeaderController leaderController;
@@ -48,7 +48,7 @@ public class SingularityLifecycleManaged implements Managed {
   private final AtomicBoolean stopped = new AtomicBoolean(false);
 
   @Inject
-  public SingularityLifecycleManaged(SingularityManagedCachedThreadPoolFactory cachedThreadPoolFactory,
+  public SingularityLifecycleManaged(SingularityManagedThreadPoolFactory cachedThreadPoolFactory,
                                      SingularityManagedScheduledExecutorServiceFactory scheduledExecutorServiceFactory,
                                      AsyncHttpClient asyncHttpClient,
                                      CuratorFramework curatorFramework,

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
@@ -36,7 +36,7 @@ import com.hubspot.singularity.SingularityAction;
 import com.hubspot.singularity.SingularityDeployKey;
 import com.hubspot.singularity.SingularityDeployStatistics;
 import com.hubspot.singularity.SingularityMainModule;
-import com.hubspot.singularity.SingularityManagedCachedThreadPoolFactory;
+import com.hubspot.singularity.SingularityManagedThreadPoolFactory;
 import com.hubspot.singularity.SingularityManagedScheduledExecutorServiceFactory;
 import com.hubspot.singularity.SingularityPendingTaskId;
 import com.hubspot.singularity.SingularitySlaveUsage;
@@ -116,7 +116,7 @@ public class SingularityMesosOfferScheduler {
                                         DeployManager deployManager,
                                         SingularitySchedulerLock lock,
                                         SingularityManagedScheduledExecutorServiceFactory executorServiceFactory,
-                                        SingularityManagedCachedThreadPoolFactory cachedThreadPoolFactory,
+                                        SingularityManagedThreadPoolFactory cachedThreadPoolFactory,
                                         DisasterManager disasterManager,
                                         SingularityMesosSchedulerClient mesosSchedulerClient,
                                         OfferCache offerCache,

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerClient.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerClient.java
@@ -39,6 +39,7 @@ import com.hubspot.mesos.rx.java.SinkOperation;
 import com.hubspot.mesos.rx.java.SinkOperations;
 import com.hubspot.mesos.rx.java.protobuf.ProtobufMesosClientBuilder;
 import com.hubspot.mesos.rx.java.util.UserAgentEntries;
+import com.hubspot.singularity.SingularityManagedThreadPoolFactory;
 import com.hubspot.singularity.config.MesosConfiguration;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.config.UIConfiguration;
@@ -47,6 +48,8 @@ import com.hubspot.singularity.resources.ui.UiResource;
 
 import rx.BackpressureOverflow;
 import rx.Observable;
+import rx.Scheduler;
+import rx.schedulers.Schedulers;
 import rx.subjects.PublishSubject;
 import rx.subjects.SerializedSubject;
 
@@ -62,6 +65,8 @@ public class SingularityMesosSchedulerClient {
   private final SingularityConfiguration configuration;
   private final MesosConfiguration mesosConfiguration;
   private final String singularityUriBase;
+  private final Scheduler statusUpdateScheduler;
+  private final Scheduler offerScheduler;
 
   private SerializedSubject<Optional<SinkOperation<Call>>, Optional<SinkOperation<Call>>> publisher;
   private FrameworkID frameworkId;
@@ -69,10 +74,14 @@ public class SingularityMesosSchedulerClient {
   private Thread subscriberThread;
 
   @Inject
-  public SingularityMesosSchedulerClient(SingularityConfiguration configuration, @Named(SingularityServiceUIModule.SINGULARITY_URI_BASE) final String singularityUriBase) {
+  public SingularityMesosSchedulerClient(SingularityConfiguration configuration,
+                                         @Named(SingularityServiceUIModule.SINGULARITY_URI_BASE) final String singularityUriBase,
+                                         SingularityManagedThreadPoolFactory threadPoolFactory) {
     this.configuration = configuration;
     this.mesosConfiguration = configuration.getMesosConfiguration();
     this.singularityUriBase = singularityUriBase;
+    this.statusUpdateScheduler = Schedulers.from(threadPoolFactory.get("mesos-rx-status-updates", configuration.getMesosConfiguration().getSubscriberThreads()));
+    this.offerScheduler = Schedulers.from(threadPoolFactory.get("mesos-rx-offers", 1));
   }
 
   /**
@@ -188,6 +197,7 @@ public class SingularityMesosSchedulerClient {
 
       events.filter(event -> event.getType() == Event.Type.INVERSE_OFFERS)
           .map(event -> event.getInverseOffers().getInverseOffersList())
+          .observeOn(offerScheduler)
           .subscribe(scheduler::inverseOffers, scheduler::onUncaughtException);
 
       events.filter(event -> event.getType() == Event.Type.MESSAGE)
@@ -196,14 +206,17 @@ public class SingularityMesosSchedulerClient {
 
       events.filter(event -> event.getType() == Event.Type.OFFERS)
           .map(event -> event.getOffers().getOffersList())
+          .observeOn(offerScheduler)
           .subscribe(scheduler::resourceOffers, scheduler::onUncaughtException);
 
       events.filter(event -> event.getType() == Event.Type.RESCIND)
           .map(event -> event.getRescind().getOfferId())
+          .observeOn(offerScheduler)
           .subscribe(scheduler::rescind, scheduler::onUncaughtException);
 
       events.filter(event -> event.getType() == Event.Type.RESCIND_INVERSE_OFFER)
           .map(event -> event.getRescindInverseOffer().getInverseOfferId())
+          .observeOn(offerScheduler)
           .subscribe(scheduler::rescindInverseOffer, scheduler::onUncaughtException);
 
       events.filter(event -> event.getType() == Event.Type.SUBSCRIBED)
@@ -224,6 +237,7 @@ public class SingularityMesosSchedulerClient {
               return true;
             }
           })
+          .observeOn(statusUpdateScheduler)
           .subscribe(scheduler::statusUpdate, scheduler::onUncaughtException);
 
       // This is the observable that is responsible for sending calls to mesos master.

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosStatusUpdateHandler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosStatusUpdateHandler.java
@@ -27,7 +27,7 @@ import com.hubspot.singularity.InvalidSingularityTaskIdException;
 import com.hubspot.singularity.RequestType;
 import com.hubspot.singularity.SingularityCreateResult;
 import com.hubspot.singularity.SingularityMainModule;
-import com.hubspot.singularity.SingularityManagedCachedThreadPoolFactory;
+import com.hubspot.singularity.SingularityManagedThreadPoolFactory;
 import com.hubspot.singularity.SingularityManagedScheduledExecutorServiceFactory;
 import com.hubspot.singularity.SingularityPendingDeploy;
 import com.hubspot.singularity.SingularityPendingRequest;
@@ -102,7 +102,7 @@ public class SingularityMesosStatusUpdateHandler {
                                              SingularityLeaderCache leaderCache,
                                              MesosProtosUtils mesosProtosUtils,
                                              SingularityManagedScheduledExecutorServiceFactory executorServiceFactory,
-                                             SingularityManagedCachedThreadPoolFactory cachedThreadPoolFactory,
+                                             SingularityManagedThreadPoolFactory cachedThreadPoolFactory,
                                              @Named(SingularityMesosModule.TASK_LOST_REASONS_COUNTER) Multiset<Protos.TaskStatus.Reason> taskLostReasons,
                                              @Named(SingularityMainModule.LOST_TASKS_METER) Meter lostTasksMeter,
                                              @Named(SingularityMainModule.STATUS_UPDATE_DELTAS) ConcurrentHashMap<Long, Long> statusUpdateDeltas) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
@@ -22,7 +22,7 @@ import com.hubspot.singularity.RequestUtilization;
 import com.hubspot.singularity.SingularityAction;
 import com.hubspot.singularity.SingularityClusterUtilization;
 import com.hubspot.singularity.SingularityDeploy;
-import com.hubspot.singularity.SingularityManagedCachedThreadPoolFactory;
+import com.hubspot.singularity.SingularityManagedThreadPoolFactory;
 import com.hubspot.singularity.SingularityManagedScheduledExecutorServiceFactory;
 import com.hubspot.singularity.SingularityPendingRequest;
 import com.hubspot.singularity.SingularityPendingRequest.PendingType;
@@ -65,7 +65,7 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
                          TaskManager taskManager,
                          DisasterManager disasterManager,
                          SingularityManagedScheduledExecutorServiceFactory executorServiceFactory,
-                         SingularityManagedCachedThreadPoolFactory cachedThreadPoolFactory) {
+                         SingularityManagedThreadPoolFactory cachedThreadPoolFactory) {
     super(configuration.getCheckUsageEveryMillis(), TimeUnit.MILLISECONDS);
 
     this.configuration = configuration;

--- a/SingularityService/src/test/java/com/hubspot/singularity/managed/SingularityLifecycleManagedTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/managed/SingularityLifecycleManagedTest.java
@@ -7,7 +7,7 @@ import org.apache.curator.framework.recipes.leader.LeaderLatch;
 
 import com.google.inject.Inject;
 import com.hubspot.singularity.SingularityLeaderController;
-import com.hubspot.singularity.SingularityManagedCachedThreadPoolFactory;
+import com.hubspot.singularity.SingularityManagedThreadPoolFactory;
 import com.hubspot.singularity.SingularityManagedScheduledExecutorServiceFactory;
 import com.hubspot.singularity.data.ExecutorIdGenerator;
 import com.hubspot.singularity.mesos.SingularityMesosExecutorInfoSupport;
@@ -18,16 +18,16 @@ import com.ning.http.client.AsyncHttpClient;
 public class SingularityLifecycleManagedTest extends SingularityLifecycleManaged {
 
   @Inject
-  public SingularityLifecycleManagedTest(SingularityManagedCachedThreadPoolFactory cachedThreadPoolFactory,
-                                     SingularityManagedScheduledExecutorServiceFactory scheduledExecutorServiceFactory,
-                                     AsyncHttpClient asyncHttpClient,
-                                     CuratorFramework curatorFramework,
-                                     SingularityLeaderController leaderController,
-                                     LeaderLatch leaderLatch,
-                                     SingularityMesosExecutorInfoSupport executorInfoSupport,
-                                     SingularityGraphiteReporter graphiteReporter,
-                                     ExecutorIdGenerator executorIdGenerator,
-                                     Set<SingularityLeaderOnlyPoller> leaderOnlyPollers) {
+  public SingularityLifecycleManagedTest(SingularityManagedThreadPoolFactory cachedThreadPoolFactory,
+                                         SingularityManagedScheduledExecutorServiceFactory scheduledExecutorServiceFactory,
+                                         AsyncHttpClient asyncHttpClient,
+                                         CuratorFramework curatorFramework,
+                                         SingularityLeaderController leaderController,
+                                         LeaderLatch leaderLatch,
+                                         SingularityMesosExecutorInfoSupport executorInfoSupport,
+                                         SingularityGraphiteReporter graphiteReporter,
+                                         ExecutorIdGenerator executorIdGenerator,
+                                         Set<SingularityLeaderOnlyPoller> leaderOnlyPollers) {
     super(cachedThreadPoolFactory, scheduledExecutorServiceFactory, asyncHttpClient, curatorFramework, leaderController, leaderLatch, executorInfoSupport, graphiteReporter, executorIdGenerator, leaderOnlyPollers);
   }
 


### PR DESCRIPTION
Found recently that most methods in SingularityMesosSchedulerImpl were all being processed on a single thread. For some things like status updates this is fine since they are then kicked over to another pool of threads. However for things like offers, we hog the thread for a while, making status updates very delayed. Let's use more than one thread....