### PR TITLE
Only delay for status updates when many requests are delayed

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityMainModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityMainModule.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 import javax.inject.Inject;
@@ -113,7 +114,7 @@ public class SingularityMainModule implements Module {
 
   public static final String LOST_TASKS_METER = "singularity.lost.tasks.meter";
 
-  public static final String STATUS_UPDATE_DELTA_30S_AVERAGE = "singularity.status.update.delta.minute.average";
+  public static final String STATUS_UPDATE_SHORT_CIRCUIT = "singularity.status.update.delay.short.circuit";
   public static final String STATUS_UPDATE_DELTAS = "singularity.status.update.deltas";
   public static final String LAST_MESOS_MASTER_HEARTBEAT_TIME = "singularity.last.mesos.master.heartbeat.time";
 
@@ -395,15 +396,15 @@ public class SingularityMainModule implements Module {
 
   @Provides
   @Singleton
-  @Named(STATUS_UPDATE_DELTA_30S_AVERAGE)
-  public AtomicLong provideDeltasMap() {
-    return new AtomicLong(0);
+  @Named(STATUS_UPDATE_SHORT_CIRCUIT)
+  public AtomicBoolean provideDeltasMap() {
+    return new AtomicBoolean(false);
   }
 
   @Provides
   @Singleton
   @Named(STATUS_UPDATE_DELTAS)
-  public ConcurrentHashMap<Long, Long> provideUpdateDeltasMap() {
+  public Map<String, Map<Long, Long>> provideUpdateDeltasMap() {
     return new ConcurrentHashMap<>();
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -392,6 +392,8 @@ public class SingularityConfiguration extends Configuration {
 
   private long delayPollersWhenDeltaOverMs = 15000;
 
+  private double delayPollersWhenPercentOfRequestsOverUpdateDelta = 25;
+
   private boolean delayOfferProcessingForLargeStatusUpdateDelta = true;
 
   private int maxRunNowTaskLaunchDelayDays = 30;
@@ -1669,6 +1671,14 @@ public class SingularityConfiguration extends Configuration {
 
   public void setDelayOfferProcessingForLargeStatusUpdateDelta(boolean delayOfferProcessingForLargeStatusUpdateDelta) {
     this.delayOfferProcessingForLargeStatusUpdateDelta = delayOfferProcessingForLargeStatusUpdateDelta;
+  }
+
+  public double getDelayPollersWhenPercentOfRequestsOverUpdateDelta() {
+    return delayPollersWhenPercentOfRequestsOverUpdateDelta;
+  }
+
+  public void setDelayPollersWhenPercentOfRequestsOverUpdateDelta(double delayPollersWhenPercentOfRequestsOverUpdateDelta) {
+    this.delayPollersWhenPercentOfRequestsOverUpdateDelta = delayPollersWhenPercentOfRequestsOverUpdateDelta;
   }
 
   public int getMaxRunNowTaskLaunchDelayDays() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/StateManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/StateManager.java
@@ -64,7 +64,7 @@ public class StateManager extends CuratorManager {
   private final SingularityAuthDatastore authDatastore;
   private final Transcoder<SingularityTaskReconciliationStatistics> taskReconciliationStatisticsTranscoder;
   private final PriorityManager priorityManager;
-  private final AtomicLong statusUpdateDeltaAvg;
+  private final Map<String, Map<Long, Long>> statusUpdateDeltas;
   private final AtomicLong lastHeartbeatTime;
 
   @Inject
@@ -82,7 +82,7 @@ public class StateManager extends CuratorManager {
                       SingularityAuthDatastore authDatastore,
                       PriorityManager priorityManager,
                       Transcoder<SingularityTaskReconciliationStatistics> taskReconciliationStatisticsTranscoder,
-                      @Named(SingularityMainModule.STATUS_UPDATE_DELTA_30S_AVERAGE) AtomicLong statusUpdateDeltaAvg,
+                      @Named(SingularityMainModule.STATUS_UPDATE_DELTAS) Map<String, Map<Long, Long>> statusUpdateDeltas,
                       @Named(SingularityMainModule.LAST_MESOS_MASTER_HEARTBEAT_TIME) AtomicLong lastHeartbeatTime) {
     super(curatorFramework, configuration, metricRegistry);
 
@@ -97,7 +97,7 @@ public class StateManager extends CuratorManager {
     this.authDatastore = authDatastore;
     this.priorityManager = priorityManager;
     this.taskReconciliationStatisticsTranscoder = taskReconciliationStatisticsTranscoder;
-    this.statusUpdateDeltaAvg = statusUpdateDeltaAvg;
+    this.statusUpdateDeltas = statusUpdateDeltas;
     this.lastHeartbeatTime = lastHeartbeatTime;
   }
 
@@ -273,12 +273,20 @@ public class StateManager extends CuratorManager {
 
     final Optional<Double> minimumPriorityLevel = getMinimumPriorityLevel();
 
+    long statusUpdateDeltaAvg = (long) statusUpdateDeltas.entrySet().stream()
+        .flatMapToLong((e) -> e.getValue()
+            .values()
+            .stream()
+            .mapToLong(Long::longValue))
+        .average()
+        .orElse(0);
+
     return new SingularityState(activeTasks, launchingTasks, numActiveRequests, cooldownRequests, numPausedRequests, scheduledTasks, pendingRequests, lbCleanupTasks, lbCleanupRequests, cleaningRequests, activeSlaves,
         deadSlaves, decommissioningSlaves, activeRacks, deadRacks, decommissioningRacks, cleaningTasks, states, oldestDeploy, numDeploys, oldestDeployStep, activeDeploys, scheduledTasksInfo.getLateTasks().size(),
         scheduledTasksInfo.getLateTasks(), scheduledTasksInfo.getOnDemandLateTasks().size(), scheduledTasksInfo.getOnDemandLateTasks(),
         scheduledTasksInfo.getNumFutureTasks(), scheduledTasksInfo.getMaxTaskLag(), System.currentTimeMillis(), includeRequestIds ? overProvisionedRequestIds : null,
         includeRequestIds ? underProvisionedRequestIds : null, overProvisionedRequestIds.size(), underProvisionedRequestIds.size(), numFinishedRequests, unknownRacks, unknownSlaves, authDatastoreHealthy, minimumPriorityLevel,
-        statusUpdateDeltaAvg.get(), lastHeartbeatTime.get());
+        statusUpdateDeltaAvg, lastHeartbeatTime.get());
   }
 
   private SingularityScheduledTasksInfo getScheduledTasksInfo() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
@@ -103,7 +103,6 @@ public class SingularityMesosSchedulerImpl extends SingularityMesosScheduler {
                                 SingularityConfiguration configuration,
                                 TaskManager taskManager,
                                 Transcoder<SingularityTaskDestroyFrameworkMessage> transcoder,
-                                @Named(SingularityMainModule.STATUS_UPDATE_DELTA_30S_AVERAGE) AtomicLong statusUpdateDeltaAvg,
                                 @Named(SingularityMainModule.LAST_MESOS_MASTER_HEARTBEAT_TIME) AtomicLong lastHeartbeatTime) {
     this.exceptionNotifier = exceptionNotifier;
     this.startup = startup;

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderOnlyPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderOnlyPoller.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.curator.framework.recipes.leader.LeaderLatch;
 import org.slf4j.Logger;
@@ -19,7 +18,6 @@ import com.hubspot.singularity.SingularityAbort;
 import com.hubspot.singularity.SingularityAbort.AbortReason;
 import com.hubspot.singularity.SingularityMainModule;
 import com.hubspot.singularity.SingularityManagedScheduledExecutorServiceFactory;
-import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.mesos.SingularityMesosScheduler;
 import com.hubspot.singularity.sentry.SingularityExceptionNotifier;
 
@@ -37,8 +35,7 @@ public abstract class SingularityLeaderOnlyPoller {
   private SingularityExceptionNotifier exceptionNotifier;
   private SingularityAbort abort;
   private SingularityMesosScheduler mesosScheduler;
-  private long delayPollersWhenDeltaOverMs;
-  private AtomicLong statusUpdateDelta30sAverage;
+  private AtomicBoolean shortCircuitForStatusUpdateDelay;
 
   protected SingularityLeaderOnlyPoller(long pollDelay, TimeUnit pollTimeUnit) {
     this(pollDelay, pollTimeUnit, false);
@@ -56,15 +53,13 @@ public abstract class SingularityLeaderOnlyPoller {
                                 SingularityExceptionNotifier exceptionNotifier,
                                 SingularityAbort abort,
                                 SingularityMesosScheduler mesosScheduler,
-                                SingularityConfiguration configuration,
-                                @Named(SingularityMainModule.STATUS_UPDATE_DELTA_30S_AVERAGE) AtomicLong statusUpdateDelta30sAverage) {
+                                @Named(SingularityMainModule.STATUS_UPDATE_SHORT_CIRCUIT) AtomicBoolean shortCircuitForStatusUpdateDelay) {
     this.executorService = executorServiceFactory.get(getClass().getSimpleName());
     this.leaderLatch = checkNotNull(leaderLatch, "leaderLatch is null");
     this.exceptionNotifier = checkNotNull(exceptionNotifier, "exceptionNotifier is null");
     this.abort = checkNotNull(abort, "abort is null");
     this.mesosScheduler = checkNotNull(mesosScheduler, "mesosScheduler is null");
-    this.delayPollersWhenDeltaOverMs = configuration.getDelayPollersWhenDeltaOverMs();
-    this.statusUpdateDelta30sAverage = checkNotNull(statusUpdateDelta30sAverage, "statusUpdateDeltaAverage is null");
+    this.shortCircuitForStatusUpdateDelay = checkNotNull(shortCircuitForStatusUpdateDelay, "statusUpdateDeltaAverage is null");
   }
 
   public void start() {
@@ -109,7 +104,7 @@ public abstract class SingularityLeaderOnlyPoller {
       return;
     }
 
-    if (delayWhenLargeStatusUpdateDelta && statusUpdateDelta30sAverage.get() > delayPollersWhenDeltaOverMs) {
+    if (delayWhenLargeStatusUpdateDelta && shortCircuitForStatusUpdateDelay.get()) {
       LOG.info("Delaying run of {} until status updates have caught up", getClass().getSimpleName());
       return;
     }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityStatusUpdateDeltaPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityStatusUpdateDeltaPoller.java
@@ -1,39 +1,54 @@
 package com.hubspot.singularity.scheduler;
 
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
-import com.google.common.math.DoubleMath;
+import com.google.common.math.Stats;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.hubspot.singularity.SingularityMainModule;
+import com.hubspot.singularity.config.SingularityConfiguration;
 
 public class SingularityStatusUpdateDeltaPoller extends SingularityLeaderOnlyPoller {
-  private final ConcurrentHashMap<Long, Long> statusUpdateDeltas;
-  private final AtomicLong statusUpdateDelta30sAverage;
+  private final SingularityConfiguration configuration;
+  private final Map<String, Map<Long, Long>> statusUpdateDeltas;
+  private final AtomicBoolean shortCircuitForStatusUpdateDelay;
 
   @Inject
-  public SingularityStatusUpdateDeltaPoller(@Named(SingularityMainModule.STATUS_UPDATE_DELTAS) ConcurrentHashMap<Long, Long> statusUpdateDeltas,
-                                            @Named(SingularityMainModule.STATUS_UPDATE_DELTA_30S_AVERAGE) AtomicLong statusUpdateDelta30sAverage) {
+  public SingularityStatusUpdateDeltaPoller(SingularityConfiguration configuration,
+                                            @Named(SingularityMainModule.STATUS_UPDATE_DELTAS) Map<String, Map<Long, Long>> statusUpdateDeltas,
+                                            @Named(SingularityMainModule.STATUS_UPDATE_SHORT_CIRCUIT) AtomicBoolean shortCircuitForStatusUpdateDelay) {
     super(5L, TimeUnit.SECONDS);
+    this.configuration = configuration;
     this.statusUpdateDeltas = statusUpdateDeltas;
-    this.statusUpdateDelta30sAverage = statusUpdateDelta30sAverage;
+    this.shortCircuitForStatusUpdateDelay = shortCircuitForStatusUpdateDelay;
   }
 
   @Override
   public void runActionOnPoll() {
     long now = System.currentTimeMillis();
-    List<Long> toRemove = statusUpdateDeltas.keySet().stream()
-        .filter((e) -> e < now - 30000)
-        .collect(Collectors.toList());
-    toRemove.forEach(statusUpdateDeltas::remove);
-    if (statusUpdateDeltas.isEmpty()) {
-      statusUpdateDelta30sAverage.set(0L);
+    Set<String> requestIds = statusUpdateDeltas.keySet();
+    int overThreshold = 0;
+    for (String requestId : requestIds) {
+      Map<Long, Long> requestDeltas = statusUpdateDeltas.get(requestId);
+      List<Long> toRemove = requestDeltas.keySet()
+          .stream()
+          .filter((e) -> e < now - 30000)
+          .collect(Collectors.toList());
+      toRemove.forEach(requestDeltas::remove);
+      if (requestDeltas.size() > 0 && Stats.meanOf(requestDeltas.values()) > configuration.getDelayPollersWhenDeltaOverMs()) {
+        overThreshold++;
+      }
+    }
+
+    if ((overThreshold * 100.0 / requestIds.size()) > configuration.getDelayPollersWhenPercentOfRequestsOverUpdateDelta()) {
+      shortCircuitForStatusUpdateDelay.set(true);
     } else {
-      statusUpdateDelta30sAverage.set((long) DoubleMath.mean(statusUpdateDeltas.values()));
+      shortCircuitForStatusUpdateDelay.set(false);
     }
   }
 }


### PR DESCRIPTION
Attempt at fixing the delay issues for status updates. After the other current open PRs are merged, we still have one case where a particularly active request with many tasks being launched will have status updates delayed. Offer processing to launch 200+ tasks ma hold the request lock for a fair amount of time, delaying status updates for that particular request. Other request updates are fine, but the overall delay still looks high and can short circuit offer polling.

This changes the logic to only delay other pollers when a higher percentage of requests have delayed status updates. One or two requests with large piles of status updates will then not be able to slow down processing of everything else.