### PR TITLE
offer executor needs at least 2 threads

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
@@ -134,7 +134,7 @@ public class SingularityMesosSchedulerImpl extends SingularityMesosScheduler {
     this.leaderCacheCoordinator = leaderCacheCoordinator;
     this.queuedUpdates = queuedUpdates;
     this.lock = lock;
-    this.offerExecutor = threadPoolFactory.getSingleThreaded("offer-scheduler");
+    this.offerExecutor = threadPoolFactory.get("offer-scheduler", 2);
     this.subscribeExecutor = threadPoolFactory.getSingleThreaded("subscribe-scheduler");
     this.state = new SchedulerState();
     this.configuration = configuration;


### PR DESCRIPTION
:faceplam: had this commit locally and never pushed. This makes the other piece of the newer thread model work, allowing subsequent offer traffic to come in, time out on the lock, and instead add to the cache. With a single thread it just gets queued instead