### PR TITLE
Make task history persister not use the request level lock

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -270,8 +270,6 @@ public class SingularityConfiguration extends Configuration {
 
   private long persistHistoryEverySeconds = TimeUnit.MINUTES.toSeconds(2);
 
-  private long maxTaskHistoryPersisterLockTimeMillis = 10000;
-
   private int maxPendingImmediatePersists = 200;
 
   private long reconcileSlavesEveryMinutes = TimeUnit.HOURS.toMinutes(1);
@@ -836,14 +834,6 @@ public class SingularityConfiguration extends Configuration {
 
   public long getPersistHistoryEverySeconds() {
     return persistHistoryEverySeconds;
-  }
-
-  public long getMaxTaskHistoryPersisterLockTimeMillis() {
-    return maxTaskHistoryPersisterLockTimeMillis;
-  }
-
-  public void setMaxTaskHistoryPersisterLockTimeMillis(long maxTaskHistoryPersisterLockTimeMillis) {
-    this.maxTaskHistoryPersisterLockTimeMillis = maxTaskHistoryPersisterLockTimeMillis;
   }
 
   @JsonIgnore

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityTaskHistoryPersister.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityTaskHistoryPersister.java
@@ -1,9 +1,11 @@
 package com.hubspot.singularity.data.history;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
@@ -76,7 +78,7 @@ public class SingularityTaskHistoryPersister extends SingularityHistoryPersister
   }
 
   private Map<String, List<SingularityTaskId>> getInactiveTaskIdsByRequest() {
-    final List<SingularityTaskId> taskIds = new ArrayList<>(taskManager.getAllTaskIds());
+    final Set<SingularityTaskId> taskIds = new HashSet<>(taskManager.getAllTaskIds());
     taskIds.removeAll(taskManager.getActiveTaskIds());
     taskIds.removeAll(taskManager.getLBCleanupTasks());
     List<SingularityPendingDeploy> pendingDeploys = deployManager.getPendingDeploys();


### PR DESCRIPTION
This was added when we attempted to work on immediate persisting of task history items. However, when looking through more recent changes to the code, the request level lock should no longer be needed here, since data persisted here is not part of the active task set. This will free up the lock during scheduling for further improvements to scheduling efficiency