### PR TITLE
Process a reconciliation for all tasks with missing state in zk

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityTaskHistoryPersister.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityTaskHistoryPersister.java
@@ -1,6 +1,5 @@
 package com.hubspot.singularity.data.history;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -64,6 +63,7 @@ public class SingularityTaskHistoryPersister extends SingularityHistoryPersister
         int transferred = 0;
         for (SingularityTaskId taskId : entry.getValue()) {
           if (moveToHistoryOrCheckForPurge(taskId, forRequest)) {
+            LOG.debug("Transferred task {}", taskId);
             transferred++;
           }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosStatusUpdateHandler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosStatusUpdateHandler.java
@@ -128,8 +128,7 @@ public class SingularityMesosStatusUpdateHandler {
     if (!previousTaskStatusHolder.isPresent() // Task was already removed from the active list
         && !taskState.isDone()
         && newTaskStatusHolder.getTaskStatus().isPresent()
-        && ACTIVE_STATES.contains(newTaskStatusHolder.getTaskStatus().get().getState())
-        && reason == Reason.REASON_AGENT_REREGISTERED) {
+        && ACTIVE_STATES.contains(newTaskStatusHolder.getTaskStatus().get().getState())) {
       LOG.warn("Task {} recovered but may have already been replaced", newTaskStatusHolder.getTaskId());
       return true;
     }
@@ -245,7 +244,7 @@ public class SingularityMesosStatusUpdateHandler {
       LOG.info("Found recovery status update with reason {} for task {}", status.getReason(), taskId);
       final Optional<SingularityTaskHistory> maybeTaskHistory = taskManager.getTaskHistory(taskIdObj);
       if (!maybeTaskHistory.isPresent() || !maybeTaskHistory.get().getLastTaskUpdate().isPresent()) {
-        LOG.warn("Task {} not found to recover, it may have already been persisted. Triggering a kill via mesos");
+        LOG.warn("Task {} not found to recover, it may have already been persisted. Triggering a kill via mesos", taskIdObj);
         return StatusUpdateResult.KILL_TASK;
       }
       boolean reactivated = taskManager.reactivateTask(taskIdObj, taskState, newTaskStatusHolder, Optional.ofNullable(status.getMessage()), status.hasReason() ? Optional.of(status.getReason().name()) : Optional.<String>empty());


### PR DESCRIPTION
We've had a few orphaned tasks recently. It seems the mesos master still knew about them but we weren't marking them as active. I'm still not certain how they got into that state, but this will at least reconcile it afterwards so they get cleaned up properly

one possibility for how they got there is a bug in the persister, so adding logging there as well