### PR TITLE
Enable authz checks when creating requests

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -154,12 +154,13 @@ public class RequestResource extends AbstractRequestResource {
       authorizationHelper.checkForAuthorizedChanges(request, oldRequest.get(), user);
       validator.checkActionEnabled(SingularityAction.UPDATE_REQUEST);
     } else {
+      authorizationHelper.checkForAuthorization(user, request.getReadWriteGroups().orElse(Collections.emptySet()), request.getReadOnlyGroups().orElse(Collections.emptySet()), SingularityAuthorizationScope.WRITE, Optional.empty());
       validator.checkActionEnabled(SingularityAction.CREATE_REQUEST);
     }
 
     if (request.getSlavePlacement().isPresent() && request.getSlavePlacement().get() == SlavePlacement.SPREAD_ALL_SLAVES) {
       checkBadRequest(validator.isSpreadAllSlavesEnabled(), "You must enabled spread to all slaves in order to use the SPREAD_ALL_SLAVES request type");
-      int currentActiveSlaveCount =  slaveManager.getNumObjectsAtState(MachineState.ACTIVE);
+      int currentActiveSlaveCount = slaveManager.getNumObjectsAtState(MachineState.ACTIVE);
       request = request.toBuilder().setInstances(Optional.of(currentActiveSlaveCount)).build();
     }
 


### PR DESCRIPTION
Currently anyone can create a request, even for a group they're not in.
This means that they could create a request configured to run as another
team, but not with the permission of that team.


I'm not positive this is the only place that needs updating, but I think its the only place. 