### PR TITLE
Don't mutate args in lb sync comparison

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUpstreamChecker.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUpstreamChecker.java
@@ -99,11 +99,12 @@ public class SingularityUpstreamChecker {
   }
 
   private List<UpstreamInfo> getExtraUpstreamsInLoadBalancer(Collection<UpstreamInfo> upstreamsInLoadBalancerForService, Collection<UpstreamInfo> upstreamsInSingularityForService) {
+    List<UpstreamInfo>  extraUpstreams = new ArrayList<>(upstreamsInLoadBalancerForService);
     for (UpstreamInfo upstreamInSingularity : upstreamsInSingularityForService) {
       final Collection<UpstreamInfo> matches = getEqualUpstreams(upstreamInSingularity, upstreamsInLoadBalancerForService);
-      upstreamsInLoadBalancerForService.removeAll(matches);
+      extraUpstreams.removeAll(matches);
     }
-    return new ArrayList<>(upstreamsInLoadBalancerForService);
+    return extraUpstreams;
   }
 
   private Collection<UpstreamInfo> getLoadBalancerUpstreamsForServiceHelper(SingularityCheckingUpstreamsUpdate singularityCheckingUpstreamsUpdate, Optional<String> loadBalancerUpstreamGroup) {


### PR DESCRIPTION
Didn't realize this was happening when the Pr went through. A check a few lines down later validates the size of the argument list against the one it is about to use for removal.