### PR TITLE
fix mismatch in http/https protocol

### DIFF
--- a/Docs/reference/api.html
+++ b/Docs/reference/api.html
@@ -16,7 +16,7 @@
     window.onload = function() {
         // Build a system
         const ui = SwaggerUIBundle({
-            url: "http://getsingularity.com/Docs/reference/openapi.json",
+            url: "//getsingularity.com/Docs/reference/openapi.json",
             dom_id: '#swagger-ui',
             deepLinking: true,
             presets: [


### PR DESCRIPTION
This should fix issues where API reference page will not load when there's a protocol mismatch when this page is accessed with https and the swagger ui JS loads the swagger reference page using http.

I've not been able to get the public API reference page for months now due to this error