### PR TITLE
Slightly Smarter Task Shuffling

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularitySchedulerModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularitySchedulerModule.java
@@ -37,6 +37,7 @@ public class SingularitySchedulerModule extends AbstractModule {
     bind(SingularityPriorityKillPoller.class).in(Scopes.SINGLETON);
     bind(SingularityUsageCleanerPoller.class).in(Scopes.SINGLETON);
     bind(SingularityUsagePoller.class).in(Scopes.SINGLETON);
+    bind(SingularityTaskShuffler.class).in(Scopes.SINGLETON);
     bind(SingularityMesosTaskPrioritizer.class).in(Scopes.SINGLETON);
     bind(SingularityMesosOfferScheduler.class).in(Scopes.SINGLETON);
     bind(SingularityLeaderCache.class).in(Scopes.SINGLETON);

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityTaskShuffler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityTaskShuffler.java
@@ -1,20 +1,25 @@
 package com.hubspot.singularity.scheduler;
 
-import java.util.*;
-import java.util.stream.Collectors;
-
-import com.hubspot.singularity.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.inject.Inject;
+import com.hubspot.singularity.SingularityPendingRequest;
 import com.hubspot.singularity.SingularityPendingRequest.PendingType;
+import com.hubspot.singularity.SingularitySlaveUsage;
+import com.hubspot.singularity.SingularityTaskCleanup;
+import com.hubspot.singularity.TaskCleanupType;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.RequestManager;
 import com.hubspot.singularity.data.TaskManager;
 import com.hubspot.singularity.scheduler.SingularityTaskShuffler.OverusedResource.Type;
-
 import io.dropwizard.util.SizeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 public class SingularityTaskShuffler {
   private static final Logger LOG = LoggerFactory.getLogger(SingularityTaskShuffler.class);
@@ -33,7 +38,9 @@ public class SingularityTaskShuffler {
   }
 
   static class OverusedResource {
-    enum Type {MEMORY, CPU};
+    enum Type {MEMORY, CPU}
+
+    ;
 
     double overusage;
     Type resourceType;
@@ -93,7 +100,7 @@ public class SingularityTaskShuffler {
       long shufflingTasksOnSlave = 0;
       double cpuUsage = getSystemLoadForShuffle(slave.usage);
       double memUsageBytes = slave.usage.getMemoryBytesUsed();
-      
+
       TaskCleanupType shuffleCleanupType = slave.resource.toTaskCleanupType();
       List<TaskIdWithUsage> shuffleCandidates = getPrioritizedShuffleCandidates(slave);
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityTaskShuffler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityTaskShuffler.java
@@ -181,13 +181,15 @@ public class SingularityTaskShuffler {
   }
 
   private void bounce(TaskIdWithUsage task, TaskCleanupType cleanupType, Optional<String> message) {
+    String actionId = UUID.randomUUID().toString();
+
     taskManager.createTaskCleanup(new SingularityTaskCleanup(
         Optional.empty(),
         cleanupType,
         System.currentTimeMillis(),
         task.getTaskId(),
         message,
-        Optional.of(UUID.randomUUID().toString()),
+        Optional.of(actionId),
         Optional.empty(), Optional.empty()
     ));
 
@@ -201,7 +203,7 @@ public class SingularityTaskShuffler {
         Optional.empty(),
         Optional.empty(),
         message,
-        Optional.of(UUID.randomUUID().toString())
+        Optional.of(actionId)
     ));
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityTaskShuffler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityTaskShuffler.java
@@ -1,0 +1,384 @@
+package com.hubspot.singularity.scheduler;
+
+import java.util.*;
+import java.util.concurrent.ExecutorService;
+import java.util.stream.Collectors;
+
+import com.hubspot.singularity.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.Inject;
+import com.hubspot.singularity.SingularityPendingRequest.PendingType;
+import com.hubspot.singularity.config.SingularityConfiguration;
+import com.hubspot.singularity.data.DeployManager;
+import com.hubspot.singularity.data.DisasterManager;
+import com.hubspot.singularity.data.RequestManager;
+import com.hubspot.singularity.data.TaskManager;
+import com.hubspot.singularity.data.usage.UsageManager;
+import com.hubspot.singularity.scheduler.SingularityTaskShuffler.OverusedResource.Type;
+
+import io.dropwizard.util.SizeUnit;
+
+public class SingularityTaskShuffler {
+  private static final Logger LOG = LoggerFactory.getLogger(SingularityTaskShuffler.class);
+
+  private final SingularityConfiguration configuration;
+  private final RequestManager requestManager;
+  private final TaskManager taskManager;
+
+  @Inject
+  SingularityTaskShuffler(SingularityConfiguration configuration,
+                          RequestManager requestManager,
+                          TaskManager taskManager) {
+    this.configuration = configuration;
+    this.requestManager = requestManager;
+    this.taskManager = taskManager;
+  }
+
+  static class OverusedResource {
+    enum Type {MEMORY, CPU};
+
+    double overusage;
+    Type resourceType;
+
+    OverusedResource(double overusage, Type resourceType) {
+      this.overusage = overusage;
+      this.resourceType = resourceType;
+    }
+
+    public static int prioritize(OverusedResource r1, OverusedResource r2) {
+      if (r1.resourceType == r2.resourceType) {
+        return Double.compare(r2.overusage, r1.overusage);
+      } else if (r1.resourceType == Type.MEMORY) {
+        return -1;
+      } else {
+        return 1;
+      }
+    }
+
+    public TaskCleanupType toTaskCleanupType() {
+      if (resourceType == Type.CPU) {
+        return TaskCleanupType.REBALANCE_CPU_USAGE;
+      } else {
+        return TaskCleanupType.REBALANCE_MEMORY_USAGE;
+      }
+    }
+  }
+
+  static class OverusedSlave {
+    SingularitySlaveUsage usage;
+    List<TaskIdWithUsage> tasks;
+    OverusedResource resource;
+
+    OverusedSlave(SingularitySlaveUsage usage, List<TaskIdWithUsage> tasks, OverusedResource resource) {
+      this.usage = usage;
+      this.tasks = tasks;
+      this.resource = resource;
+    }
+  }
+
+  class Shuffle {
+    List<OverusedSlave> slaves;
+    long shuffledTasksOnCluster;
+    Set<String> shuffledRequests;
+
+    Shuffle(List<OverusedSlave> slaves) {
+      this.slaves = slaves;
+
+      List<SingularityTaskCleanup> shufflesInProgress = getInProgressShuffles();
+      this.shuffledTasksOnCluster = shufflesInProgress.size();
+      this.shuffledRequests = getAssociatedRequests(shufflesInProgress);
+    }
+
+    public void run() {
+      for (OverusedSlave slave : slaves) {
+        if (shuffledTasksOnCluster >= configuration.getMaxTasksToShuffleTotal()) {
+          LOG.debug("Not shuffling any more tasks (totalShuffleCleanups: {})", shuffledTasksOnCluster);
+          break;
+        }
+
+        shuffleSlave(slave);
+      }
+    }
+
+    private void shuffleSlave(OverusedSlave slave) {
+      long shuffledTasksOnSlave = 0;
+      double cpuUsage = getSystemLoadForShuffle(slave.usage);
+      double memUsageBytes = slave.usage.getMemoryBytesUsed();
+
+      TaskCleanupType cleanupType = slave.resource.toTaskCleanupType();
+
+      List<TaskIdWithUsage> shuffleCandidates = getShuffleCandidates(slave);
+
+      for (TaskIdWithUsage task : shuffleCandidates) {
+        if (shuffledRequests.contains(task.getTaskId().getRequestId())) {
+          LOG.debug("Request {} already has a shuffling task, skipping", task.getTaskId().getRequestId());
+          continue;
+        }
+
+        if (!isOverutilized(slave, cpuUsage, memUsageBytes) || isShufflingTooManyTasks(shuffledTasksOnSlave, shuffledTasksOnCluster)) {
+          LOG.debug("Not shuffling any more tasks on slave {} ({} overage : {}%, shuffledOnHost: {}, totalShuffleCleanups: {})", task.getTaskId().getSanitizedHost(), slave.resource.resourceType, slave.resource.overusage * 100, shuffledTasksOnSlave, shuffledTasksOnCluster);
+          break;
+        }
+
+        String message = getShuffleMessage(slave, task, cpuUsage, memUsageBytes);
+        bounce(task, cleanupType, Optional.of(message));
+
+        cpuUsage -= task.getUsage().getCpusUsed();
+        memUsageBytes -= task.getUsage().getMemoryTotalBytes();
+
+        shuffledTasksOnSlave++;
+        shuffledTasksOnCluster++;
+        shuffledRequests.add(task.getTaskId().getRequestId());
+      }
+    }
+
+    private boolean isOverutilized(OverusedSlave slave, double cpuUsage, double memUsageBytes) {
+      if (slave.resource.resourceType == Type.CPU) {
+        return cpuUsage > slave.usage.getSystemCpusTotal();
+      } else {
+        return memUsageBytes > getTargetMemoryUtilizationForHost(slave.usage);
+      }
+    }
+
+    private boolean isShufflingTooManyTasks(long shuffledOnSlave, long shuffledOnCluster) {
+      return shuffledOnSlave > configuration.getMaxTasksToShufflePerHost()
+          || shuffledOnCluster > configuration.getMaxTasksToShuffleTotal();
+    }
+
+    private String getShuffleMessage(OverusedSlave slave, TaskIdWithUsage task, double cpuUsage, double memUsageBytes) {
+      if (slave.resource.resourceType == Type.CPU) {
+        return String.format(
+            "Load on slave is %s / %s, shuffling task using %s / %s to less busy host",
+            cpuUsage,
+            slave.usage.getSystemCpusTotal(),
+            task.getUsage().getCpusUsed(),
+            task.getRequestedResources().getCpus()
+        );
+      } else {
+        return String.format(
+            "Mem usage on slave is %sMiB / %sMiB, shuffling task using %sMiB / %sMiB to less busy host",
+            SizeUnit.BYTES.toMegabytes(((long) memUsageBytes)),
+            SizeUnit.BYTES.toMegabytes(((long) slave.usage.getSystemMemTotalBytes())),
+            SizeUnit.BYTES.toMegabytes(task.getUsage().getMemoryTotalBytes()),
+            ((long) task.getRequestedResources().getMemoryMb())
+        );
+      }
+    }
+
+    private List<TaskIdWithUsage> getShuffleCandidates(OverusedSlave slave) {
+
+      // SingularityUsageHelper ensures that requests flagged as ineligible for shuffle have already been filtered out.
+      List<TaskIdWithUsage> out = slave.tasks.stream()
+          .filter((task) -> !shuffledRequests.contains(task.getTaskId().getRequestId()))
+          .collect(Collectors.toList());
+
+      if (slave.resource.resourceType == Type.CPU) {
+        out.sort((u1, u2) -> Double.compare(
+          u2.getUsage().getCpusUsed() / u2.getRequestedResources().getCpus(),
+          u1.getUsage().getCpusUsed() / u1.getRequestedResources().getCpus()
+        ));
+      } else {
+        out.sort((u1, u2) -> Double.compare(
+            getUtilizationScoreForMemoryShuffle(u1),
+            getUtilizationScoreForMemoryShuffle(u2)
+        ));
+      }
+
+      return out;
+    }
+  }
+
+  public void shuffle(Map<SingularitySlaveUsage, List<TaskIdWithUsage>> overloadedHosts) {
+    List<OverusedSlave> slavesToShuffle = overloadedHosts.entrySet().stream()
+        .map((entry) -> new OverusedSlave(entry.getKey(), entry.getValue(), getMostOverusedResource(entry.getKey())))
+        .sorted((s1, s2) -> OverusedResource.prioritize(s1.resource, s2.resource))
+        .collect(Collectors.toList());
+
+    List<SingularityTaskCleanup> shufflingTasks = getInProgressShuffles();
+    Set<String> shufflingRequests = getAssociatedRequests(shufflingTasks);
+    long shufflingTasksOnCluster = shufflingTasks.size();
+
+    for (OverusedSlave slave : slavesToShuffle) {
+      if (shufflingTasksOnCluster >= configuration.getMaxTasksToShuffleTotal()) {
+        LOG.debug("Not shuffling any more tasks (totalShuffleCleanups: {})", shufflingTasksOnCluster);
+        break;
+      }
+
+      long shufflingTasksOnSlave = 0;
+      double cpuUsage = getSystemLoadForShuffle(slave.usage);
+      double memUsageBytes = slave.usage.getMemoryBytesUsed();
+      
+      TaskCleanupType shuffleCleanupType = slave.resource.toTaskCleanupType();
+      List<TaskIdWithUsage> shuffleCandidates = getShuffleCandidates(slave);
+
+      for (TaskIdWithUsage task : shuffleCandidates) {
+        if (shufflingRequests.contains(task.getTaskId().getRequestId())) {
+          LOG.debug("Request {} already has a shuffling task, skipping", task.getTaskId().getRequestId());
+          continue;
+        }
+
+        boolean resourceNotOverused = !isOverutilized(slave, cpuUsage, memUsageBytes);
+        boolean tooManyShufflingTasks = isShufflingTooManyTasks(shufflingTasksOnSlave, shufflingTasksOnCluster);
+
+        if (resourceNotOverused || tooManyShufflingTasks) {
+          LOG.debug("Not shuffling any more tasks on slave {} ({} overage : {}%, shuffledOnHost: {}, totalShuffleCleanups: {})",
+              task.getTaskId().getSanitizedHost(),
+              slave.resource.resourceType,
+              slave.resource.overusage * 100,
+              shufflingTasksOnSlave,
+              shufflingTasksOnCluster
+          );
+          break;
+        }
+
+        String message = getShuffleMessage(slave, task, cpuUsage, memUsageBytes);
+        bounce(task, shuffleCleanupType, Optional.of(message));
+
+        cpuUsage -= task.getUsage().getCpusUsed();
+        memUsageBytes -= task.getUsage().getMemoryTotalBytes();
+
+        shufflingTasksOnSlave++;
+        shufflingTasksOnCluster++;
+        shufflingRequests.add(task.getTaskId().getRequestId());
+      }
+    }
+  }
+
+  private List<TaskIdWithUsage> getShuffleCandidates(OverusedSlave slave) {
+    // SingularityUsageHelper ensures that requests flagged as ineligible for shuffle have already been filtered out.
+    List<TaskIdWithUsage> out = slave.tasks;
+
+    if (slave.resource.resourceType == Type.CPU) {
+      out.sort((u1, u2) -> Double.compare(
+          u2.getUsage().getCpusUsed() / u2.getRequestedResources().getCpus(),
+          u1.getUsage().getCpusUsed() / u1.getRequestedResources().getCpus()
+      ));
+    } else {
+      out.sort((u1, u2) -> Double.compare(
+          getUtilizationScoreForMemoryShuffle(u1),
+          getUtilizationScoreForMemoryShuffle(u2)
+      ));
+    }
+
+    return out;
+  }
+
+  private double getUtilizationScoreForMemoryShuffle(TaskIdWithUsage task) {
+    double memoryUtilization = task.getUsage().getMemoryTotalBytes() / task.getRequestedResources().getMemoryMb();
+    double cpuUtilization = task.getUsage().getCpusUsed() / task.getRequestedResources().getCpus();
+
+    return (memoryUtilization + cpuUtilization) / 2;
+  }
+
+  private boolean isOverutilized(OverusedSlave slave, double cpuUsage, double memUsageBytes) {
+    if (slave.resource.resourceType == Type.CPU) {
+      return cpuUsage > slave.usage.getSystemCpusTotal();
+    } else {
+      return memUsageBytes > getTargetMemoryUtilizationForHost(slave.usage);
+    }
+  }
+
+  private boolean isShufflingTooManyTasks(long shuffledOnSlave, long shuffledOnCluster) {
+    return shuffledOnSlave > configuration.getMaxTasksToShufflePerHost()
+        || shuffledOnCluster > configuration.getMaxTasksToShuffleTotal();
+  }
+
+  private void bounce(TaskIdWithUsage task, TaskCleanupType cleanupType, Optional<String> message) {
+    taskManager.createTaskCleanup(new SingularityTaskCleanup(
+        Optional.empty(),
+        cleanupType,
+        System.currentTimeMillis(),
+        task.getTaskId(),
+        message,
+        Optional.of(UUID.randomUUID().toString()),
+        Optional.empty(), Optional.empty()
+    ));
+
+    requestManager.addToPendingQueue(new SingularityPendingRequest(
+        task.getTaskId().getRequestId(),
+        task.getTaskId().getDeployId(),
+        System.currentTimeMillis(),
+        Optional.empty(),
+        PendingType.TASK_BOUNCE,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        message,
+        Optional.of(UUID.randomUUID().toString())
+    ));
+  }
+
+  private String getShuffleMessage(OverusedSlave slave, TaskIdWithUsage task, double cpuUsage, double memUsageBytes) {
+    if (slave.resource.resourceType == Type.CPU) {
+      return String.format(
+          "Load on slave is %s / %s, shuffling task using %s / %s to less busy host",
+          cpuUsage,
+          slave.usage.getSystemCpusTotal(),
+          task.getUsage().getCpusUsed(),
+          task.getRequestedResources().getCpus()
+      );
+    } else {
+      return String.format(
+          "Mem usage on slave is %sMiB / %sMiB, shuffling task using %sMiB / %sMiB to less busy host",
+          SizeUnit.BYTES.toMegabytes(((long) memUsageBytes)),
+          SizeUnit.BYTES.toMegabytes(((long) slave.usage.getSystemMemTotalBytes())),
+          SizeUnit.BYTES.toMegabytes(task.getUsage().getMemoryTotalBytes()),
+          ((long) task.getRequestedResources().getMemoryMb())
+      );
+    }
+  }
+
+  private double getTargetMemoryUtilizationForHost(SingularitySlaveUsage usage) {
+    return configuration.getShuffleTasksWhenSlaveMemoryUtilizationPercentageExceeds() * usage.getSystemMemTotalBytes();
+  }
+
+  private OverusedResource getMostOverusedResource(SingularitySlaveUsage overloadedSlave) {
+    double currentCpuLoad = getSystemLoadForShuffle(overloadedSlave);
+    double currentMemUsageBytes = overloadedSlave.getMemoryBytesUsed();
+
+    double cpuOverage = currentCpuLoad - overloadedSlave.getSystemCpusTotal();
+    double cpuOverusage = cpuOverage / overloadedSlave.getSystemCpusTotal();
+
+    double targetMemUsageBytes = getTargetMemoryUtilizationForHost(overloadedSlave);
+    double memOverageBytes = currentMemUsageBytes - targetMemUsageBytes;
+    double memOverusage = memOverageBytes / targetMemUsageBytes;
+
+    if (cpuOverusage > memOverusage) {
+      return new OverusedResource(cpuOverusage, Type.CPU);
+    } else {
+      return new OverusedResource(memOverusage, Type.MEMORY);
+    }
+  }
+
+  private List<SingularityTaskCleanup> getInProgressShuffles() {
+    return taskManager.getCleanupTasks()
+        .stream()
+        .filter((taskCleanup) -> taskCleanup.getCleanupType() == TaskCleanupType.REBALANCE_CPU_USAGE || taskCleanup.getCleanupType() == TaskCleanupType.REBALANCE_MEMORY_USAGE)
+        .collect(Collectors.toList());
+  }
+
+  private static boolean isShuffle(SingularityTaskCleanup cleanup) {
+    TaskCleanupType type = cleanup.getCleanupType();
+    return type == TaskCleanupType.REBALANCE_CPU_USAGE || type == TaskCleanupType.REBALANCE_MEMORY_USAGE;
+  }
+
+  private Set<String> getAssociatedRequests(List<SingularityTaskCleanup> cleanups) {
+    return cleanups.stream()
+        .map((taskCleanup) -> taskCleanup.getTaskId().getRequestId())
+        .collect(Collectors.toSet());
+  }
+
+  private double getSystemLoadForShuffle(SingularitySlaveUsage usage) {
+    switch (configuration.getMesosConfiguration().getScoreUsingSystemLoad()) {
+      case LOAD_1:
+        return usage.getSystemLoad1Min();
+      case LOAD_5:
+        return usage.getSystemLoad5Min();
+      case LOAD_15:
+      default:
+        return usage.getSystemLoad15Min();
+    }
+  }
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityTaskShuffler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityTaskShuffler.java
@@ -103,6 +103,11 @@ public class SingularityTaskShuffler {
   }
 
   public void shuffle(Map<SingularitySlaveUsage, List<TaskIdWithUsage>> overloadedHosts) {
+    if (overloadedHosts.size() <= 0) {
+      return;
+    }
+
+    LOG.debug("Beginning task shuffle for {} slaves", overloadedHosts.size());
     List<OverusedSlave> slavesToShuffle = overloadedHosts.entrySet().stream()
         .map((entry) -> new OverusedSlave(entry.getKey(), entry.getValue(), getMostOverusedResource(entry.getKey())))
         .sorted((s1, s2) -> OverusedResource.prioritize(s1.resource, s2.resource))
@@ -111,7 +116,9 @@ public class SingularityTaskShuffler {
     List<SingularityTaskCleanup> shufflingTasks = getShufflingTasks();
     Set<String> shufflingRequests = getAssociatedRequestIds(shufflingTasks);
     Map<String, Long> shufflingTasksPerHost = getShufflingTaskCountPerHost(shufflingTasks);
+
     long shufflingTasksOnCluster = shufflingTasks.size();
+    LOG.debug("{} tasks currently shuffling on cluster", shufflingTasksOnCluster);
 
     for (OverusedSlave slave : slavesToShuffle) {
       if (shufflingTasksOnCluster >= configuration.getMaxTasksToShuffleTotal()) {
@@ -176,6 +183,8 @@ public class SingularityTaskShuffler {
         shufflingRequests.add(task.getTaskId().getRequestId());
       }
     }
+
+    LOG.debug("Completed task shuffle for {} slaves", overloadedHosts.size());
   }
 
   private List<TaskIdWithUsage> getPrioritizedShuffleCandidates(OverusedSlave slave) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityTaskShuffler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityTaskShuffler.java
@@ -176,8 +176,8 @@ public class SingularityTaskShuffler {
   }
 
   private boolean isShufflingTooManyTasks(long shuffledOnSlave, long shuffledOnCluster) {
-    return shuffledOnSlave > configuration.getMaxTasksToShufflePerHost()
-        || shuffledOnCluster > configuration.getMaxTasksToShuffleTotal();
+    return shuffledOnSlave >= configuration.getMaxTasksToShufflePerHost()
+        || shuffledOnCluster >= configuration.getMaxTasksToShuffleTotal();
   }
 
   private void bounce(TaskIdWithUsage task, TaskCleanupType cleanupType, Optional<String> message) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityTaskShuffler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityTaskShuffler.java
@@ -103,11 +103,12 @@ public class SingularityTaskShuffler {
   }
 
   public void shuffle(Map<SingularitySlaveUsage, List<TaskIdWithUsage>> overloadedHosts) {
+    LOG.debug("Beginning task shuffle for {} slaves", overloadedHosts.size());
+
     if (overloadedHosts.size() <= 0) {
       return;
     }
 
-    LOG.debug("Beginning task shuffle for {} slaves", overloadedHosts.size());
     List<OverusedSlave> slavesToShuffle = overloadedHosts.entrySet().stream()
         .map((entry) -> new OverusedSlave(entry.getKey(), entry.getValue(), getMostOverusedResource(entry.getKey())))
         .sorted((s1, s2) -> OverusedResource.prioritize(s1.resource, s2.resource))

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsageHelper.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsageHelper.java
@@ -198,8 +198,8 @@ public class SingularityUsageHelper {
         if (pastTaskUsages.isEmpty()) {
           Optional<SingularityTaskHistoryUpdate> maybeStartingUpdate = taskManager.getTaskHistoryUpdate(task, ExtendedTaskState.TASK_STARTING);
           if (maybeStartingUpdate.isPresent()) {
-            long startTimestampSeconds = TimeUnit.MILLISECONDS.toSeconds(maybeStartingUpdate.get().getTimestamp());
-            double usedCpusSinceStart = latestUsage.getCpuSeconds() / TimeUnit.MILLISECONDS.toSeconds(latestUsage.getTimestamp() - startTimestampSeconds);
+            long startTimestamp = maybeStartingUpdate.get().getTimestamp();
+            double usedCpusSinceStart = latestUsage.getCpuSeconds() / TimeUnit.MILLISECONDS.toSeconds(latestUsage.getTimestamp() - startTimestamp);
             currentUsage = new SingularityTaskCurrentUsage(latestUsage.getMemoryTotalBytes(), (long) taskUsage.getStatistics().getTimestamp() * 1000, usedCpusSinceStart, latestUsage.getDiskTotalBytes());
 
             cpusUsedOnSlave += usedCpusSinceStart;

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
@@ -1,11 +1,6 @@
 package com.hubspot.singularity.scheduler;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -196,11 +191,9 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
       } else {
         shufflingForCpu = false;
         possibleTasksToShuffle = overLoadedHosts.get(overloadedSlave);
-        possibleTasksToShuffle.sort((u1, u2) ->
-            Double.compare(
-                u2.getUsage().getMemoryTotalBytes() / u2.getRequestedResources().getMemoryMb(),
-                u1.getUsage().getMemoryTotalBytes() / u1.getRequestedResources().getMemoryMb()
-            ));
+        possibleTasksToShuffle.sort(Comparator.comparingDouble(
+            task -> task.getUsage().getMemoryTotalBytes() / task.getRequestedResources().getMemoryMb())
+        );
       }
 
       for (TaskIdWithUsage taskIdWithUsage : possibleTasksToShuffle) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
@@ -2,7 +2,12 @@ package com.hubspot.singularity.scheduler;
 
 import com.google.common.util.concurrent.AtomicDouble;
 import com.google.inject.Inject;
-import com.hubspot.singularity.*;
+import com.hubspot.singularity.RequestUtilization;
+import com.hubspot.singularity.SingularityAction;
+import com.hubspot.singularity.SingularityClusterUtilization;
+import com.hubspot.singularity.SingularityDeploy;
+import com.hubspot.singularity.SingularityManagedThreadPoolFactory;
+import com.hubspot.singularity.SingularitySlaveUsage;
 import com.hubspot.singularity.async.CompletableFutures;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.DeployManager;

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
@@ -92,7 +92,10 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
     utilizationPerRequestId.values().forEach(usageManager::saveRequestUtilization);
 
     if (configuration.isShuffleTasksForOverloadedSlaves() && !disasterManager.isDisabled(SingularityAction.TASK_SHUFFLE)) {
+      LOG.debug("Shuffling?");
       taskShuffler.shuffle(overLoadedHosts);
+    } else {
+      LOG.debug("Not shuffling?");
     }
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
@@ -92,10 +92,7 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
     utilizationPerRequestId.values().forEach(usageManager::saveRequestUtilization);
 
     if (configuration.isShuffleTasksForOverloadedSlaves() && !disasterManager.isDisabled(SingularityAction.TASK_SHUFFLE)) {
-      LOG.debug("Shuffling?");
       taskShuffler.shuffle(overLoadedHosts);
-    } else {
-      LOG.debug("Not shuffling?");
     }
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityUsagePoller.java
@@ -1,38 +1,25 @@
 package com.hubspot.singularity.scheduler;
 
-import java.util.*;
+import com.google.common.util.concurrent.AtomicDouble;
+import com.google.inject.Inject;
+import com.hubspot.singularity.*;
+import com.hubspot.singularity.async.CompletableFutures;
+import com.hubspot.singularity.config.SingularityConfiguration;
+import com.hubspot.singularity.data.DeployManager;
+import com.hubspot.singularity.data.DisasterManager;
+import com.hubspot.singularity.data.usage.UsageManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Collectors;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.common.util.concurrent.AtomicDouble;
-import com.google.inject.Inject;
-import com.hubspot.singularity.RequestUtilization;
-import com.hubspot.singularity.SingularityAction;
-import com.hubspot.singularity.SingularityClusterUtilization;
-import com.hubspot.singularity.SingularityDeploy;
-import com.hubspot.singularity.SingularityManagedThreadPoolFactory;
-import com.hubspot.singularity.SingularityPendingRequest;
-import com.hubspot.singularity.SingularityPendingRequest.PendingType;
-import com.hubspot.singularity.SingularitySlaveUsage;
-import com.hubspot.singularity.SingularityTaskCleanup;
-import com.hubspot.singularity.TaskCleanupType;
-import com.hubspot.singularity.async.CompletableFutures;
-import com.hubspot.singularity.config.SingularityConfiguration;
-import com.hubspot.singularity.data.DeployManager;
-import com.hubspot.singularity.data.DisasterManager;
-import com.hubspot.singularity.data.RequestManager;
-import com.hubspot.singularity.data.TaskManager;
-import com.hubspot.singularity.data.usage.UsageManager;
-import com.hubspot.singularity.scheduler.SingularityUsagePoller.OverusedResource.Type;
-
-import io.dropwizard.util.SizeUnit;
 
 public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
 
@@ -41,30 +28,27 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
   private final SingularityConfiguration configuration;
   private final UsageManager usageManager;
   private final SingularityUsageHelper usageHelper;
-  private final RequestManager requestManager;
   private final DeployManager deployManager;
-  private final TaskManager taskManager;
   private final DisasterManager disasterManager;
   private final ExecutorService usageExecutor;
+  private final SingularityTaskShuffler taskShuffler;
 
   @Inject
   SingularityUsagePoller(SingularityConfiguration configuration,
                          SingularityUsageHelper usageHelper,
                          UsageManager usageManager,
-                         RequestManager requestManager,
                          DeployManager deployManager,
-                         TaskManager taskManager,
                          DisasterManager disasterManager,
-                         SingularityManagedThreadPoolFactory threadPoolFactory) {
+                         SingularityManagedThreadPoolFactory threadPoolFactory,
+                         SingularityTaskShuffler taskShuffler) {
     super(configuration.getCheckUsageEveryMillis(), TimeUnit.MILLISECONDS);
 
     this.configuration = configuration;
     this.usageHelper = usageHelper;
     this.usageManager = usageManager;
-    this.requestManager = requestManager;
     this.deployManager = deployManager;
-    this.taskManager = taskManager;
     this.disasterManager = disasterManager;
+    this.taskShuffler = taskShuffler;
 
     this.usageExecutor = threadPoolFactory.get("usage-collection", configuration.getMaxConcurrentUsageCollections());
   }
@@ -103,194 +87,10 @@ public class SingularityUsagePoller extends SingularityLeaderOnlyPoller {
     utilizationPerRequestId.values().forEach(usageManager::saveRequestUtilization);
 
     if (configuration.isShuffleTasksForOverloadedSlaves() && !disasterManager.isDisabled(SingularityAction.TASK_SHUFFLE)) {
-      shuffleTasksOnOverloadedHosts(overLoadedHosts);
+      taskShuffler.shuffle(overLoadedHosts);
     }
   }
 
-  static class OverusedResource {
-    enum Type { MEMORY, CPU };
-
-    double overusage;
-    Type resourceType;
-
-    OverusedResource(double overusage, Type resourceType) {
-      this.overusage = overusage;
-      this.resourceType = resourceType;
-    }
-
-    public static int prioritize(OverusedResource r1, OverusedResource r2) {
-      if (r1.resourceType == r2.resourceType) {
-        return Double.compare(r2.overusage, r1.overusage);
-      } else if (r1.resourceType == Type.MEMORY) {
-        return -1;
-      } else {
-        return 1;
-      }
-    }
-  }
-
-  private double getTargetMemoryUtilizationForHost(SingularitySlaveUsage usage) {
-    return configuration.getShuffleTasksWhenSlaveMemoryUtilizationPercentageExceeds() * usage.getSystemMemTotalBytes();
-  }
-
-  private OverusedResource getMostOverusedResource(SingularitySlaveUsage overloadedSlave, double currentCpuLoad, double currentMemUsageBytes) {
-    double cpuOverage = currentCpuLoad - overloadedSlave.getSystemCpusTotal();
-
-    double cpuOverusage = cpuOverage / overloadedSlave.getSystemCpusTotal();
-
-    double targetMemUsageBytes = getTargetMemoryUtilizationForHost(overloadedSlave);
-    double memOverageBytes = currentMemUsageBytes - targetMemUsageBytes;
-    double memOverusage = memOverageBytes / targetMemUsageBytes;
-
-    if (cpuOverusage > memOverusage) {
-      return new OverusedResource(cpuOverusage, Type.CPU);
-    } else {
-      return new OverusedResource(memOverusage, Type.MEMORY);
-    }
-  }
-
-  private List<SingularityTaskCleanup> getInProgressShuffles() {
-    return taskManager.getCleanupTasks()
-        .stream()
-        .filter((taskCleanup) -> taskCleanup.getCleanupType() == TaskCleanupType.REBALANCE_CPU_USAGE || taskCleanup.getCleanupType() == TaskCleanupType.REBALANCE_MEMORY_USAGE)
-        .collect(Collectors.toList());
-  }
-
-  private Set<String> getAssociatedRequests(List<SingularityTaskCleanup> cleanups) {
-    return cleanups.stream()
-        .map((taskCleanup) -> taskCleanup.getTaskId().getRequestId())
-        .collect(Collectors.toSet());
-  }
-
-  private void shuffleTasksOnOverloadedHosts(Map<SingularitySlaveUsage, List<TaskIdWithUsage>> overLoadedHosts) {
-    List<SingularityTaskCleanup> shuffleCleanups = getInProgressShuffles();
-    long currentShuffleCleanupsTotal = shuffleCleanups.size();
-
-    Set<String> requestsWithShuffledTasks = getAssociatedRequests(shuffleCleanups);
-
-    List<SingularitySlaveUsage> overloadedSlavesByOverusage = overLoadedHosts.keySet().stream()
-        .sorted((usage1, usage2) -> {
-          OverusedResource mostOverusedResource1 = getMostOverusedResource(usage1, getSystemLoadForShuffle(usage1), usage1.getMemoryBytesUsed());
-          OverusedResource mostOverusedResource2 = getMostOverusedResource(usage2, getSystemLoadForShuffle(usage2), usage2.getMemoryBytesUsed());
-
-          return OverusedResource.prioritize(mostOverusedResource1, mostOverusedResource2);
-        })
-        .collect(Collectors.toList());
-
-    for (SingularitySlaveUsage overloadedSlave : overloadedSlavesByOverusage) {
-      if (currentShuffleCleanupsTotal >= configuration.getMaxTasksToShuffleTotal()) {
-        LOG.debug("Not shuffling any more tasks (totalShuffleCleanups: {})", currentShuffleCleanupsTotal);
-        break;
-      }
-      int shuffledTasksOnSlave = 0;
-
-      double currentCpuLoad = getSystemLoadForShuffle(overloadedSlave);
-      double currentMemUsageBytes = overloadedSlave.getMemoryBytesUsed();
-
-      OverusedResource mostOverusedResource = getMostOverusedResource(overloadedSlave, currentCpuLoad, currentMemUsageBytes);
-
-      List<TaskIdWithUsage> possibleTasksToShuffle;
-      boolean shufflingForCpu;
-
-      if (mostOverusedResource.resourceType == Type.CPU) {
-        shufflingForCpu = true;
-        possibleTasksToShuffle = overLoadedHosts.get(overloadedSlave);
-        possibleTasksToShuffle.sort((u1, u2) ->
-            Double.compare(
-                u2.getUsage().getCpusUsed() / u2.getRequestedResources().getCpus(),
-                u1.getUsage().getCpusUsed() / u1.getRequestedResources().getCpus()
-            ));
-      } else {
-        shufflingForCpu = false;
-
-        // prefer to shuffle low memory tasks, assuming they're doing less work
-        possibleTasksToShuffle = overLoadedHosts.get(overloadedSlave);
-        possibleTasksToShuffle.sort(Comparator.comparingDouble(
-            task -> task.getUsage().getMemoryTotalBytes() / task.getRequestedResources().getMemoryMb())
-        );
-      }
-
-      for (TaskIdWithUsage taskIdWithUsage : possibleTasksToShuffle) {
-        if (requestsWithShuffledTasks.contains(taskIdWithUsage.getTaskId().getRequestId())) {
-          LOG.debug("Request {} already has a shuffling task, skipping", taskIdWithUsage.getTaskId().getRequestId());
-          continue;
-        }
-
-        boolean resourceNoLongerOverutilized = (shufflingForCpu && currentCpuLoad <= overloadedSlave.getSystemCpusTotal()) || (!shufflingForCpu && currentMemUsageBytes <= getTargetMemoryUtilizationForHost(overloadedSlave));
-        boolean shufflingTooManyTasks = shuffledTasksOnSlave > configuration.getMaxTasksToShufflePerHost() || currentShuffleCleanupsTotal >= configuration.getMaxTasksToShuffleTotal();
-
-        if (resourceNoLongerOverutilized || shufflingTooManyTasks) {
-          LOG.debug("Not shuffling any more tasks on slave {} ({} overage : {}%, shuffledOnHost: {}, totalShuffleCleanups: {})", taskIdWithUsage.getTaskId().getSanitizedHost(), mostOverusedResource.resourceType, mostOverusedResource.overusage * 100, shuffledTasksOnSlave, currentShuffleCleanupsTotal);
-          break;
-        }
-
-        Optional<String> message;
-
-        if (shufflingForCpu) {
-          message = Optional.of(String.format(
-              "Load on slave is %s / %s, shuffling task using %s / %s to less busy host",
-              currentCpuLoad,
-              overloadedSlave.getSystemCpusTotal(),
-              taskIdWithUsage.getUsage().getCpusUsed(),
-              taskIdWithUsage.getRequestedResources().getCpus()));
-
-          currentCpuLoad -= taskIdWithUsage.getUsage().getCpusUsed();
-          LOG.debug("Cleaning up task {} to free up cpu on overloaded host (remaining cpu overage: {})", taskIdWithUsage.getTaskId(), currentCpuLoad - overloadedSlave.getSystemCpusTotal());
-
-          taskManager.createTaskCleanup(
-              new SingularityTaskCleanup(
-                  Optional.empty(),
-                  TaskCleanupType.REBALANCE_CPU_USAGE,
-                  System.currentTimeMillis(),
-                  taskIdWithUsage.getTaskId(),
-                  message,
-                  Optional.of(UUID.randomUUID().toString()),
-                  Optional.empty(), Optional.empty()));
-        } else {
-          message = Optional.of(String.format(
-              "Mem usage on slave is %sMiB / %sMiB, shuffling task using %sMiB / %sMiB to less busy host",
-              SizeUnit.BYTES.toMegabytes(((long) currentMemUsageBytes)),
-              SizeUnit.BYTES.toMegabytes(((long) overloadedSlave.getSystemMemTotalBytes())),
-              SizeUnit.BYTES.toMegabytes(taskIdWithUsage.getUsage().getMemoryTotalBytes()),
-              ((long) taskIdWithUsage.getRequestedResources().getMemoryMb())));
-
-          currentMemUsageBytes -= taskIdWithUsage.getUsage().getMemoryTotalBytes();
-
-          LOG.debug("Cleaning up task {} to free up mem on overloaded host (remaining mem overage: {}MiB)", taskIdWithUsage.getTaskId(), SizeUnit.BYTES.toMegabytes(((long) (currentMemUsageBytes - getTargetMemoryUtilizationForHost(overloadedSlave)))));
-
-          taskManager.createTaskCleanup(
-              new SingularityTaskCleanup(
-                  Optional.empty(),
-                  TaskCleanupType.REBALANCE_MEMORY_USAGE,
-                  System.currentTimeMillis(),
-                  taskIdWithUsage.getTaskId(),
-                  message,
-                  Optional.of(UUID.randomUUID().toString()),
-                  Optional.empty(), Optional.empty()));
-        }
-
-        requestManager.addToPendingQueue(new SingularityPendingRequest(taskIdWithUsage.getTaskId().getRequestId(), taskIdWithUsage.getTaskId()
-            .getDeployId(), System.currentTimeMillis(), Optional.empty(),
-            PendingType.TASK_BOUNCE, Optional.empty(), Optional.empty(), Optional.empty(), message, Optional.of(UUID.randomUUID().toString())));
-
-        shuffledTasksOnSlave++;
-        currentShuffleCleanupsTotal++;
-        requestsWithShuffledTasks.add(taskIdWithUsage.getTaskId().getRequestId());
-      }
-    }
-  }
-
-  private double getSystemLoadForShuffle(SingularitySlaveUsage usage) {
-    switch (configuration.getMesosConfiguration().getScoreUsingSystemLoad()) {
-      case LOAD_1:
-        return usage.getSystemLoad1Min();
-      case LOAD_5:
-        return usage.getSystemLoad5Min();
-      case LOAD_15:
-      default:
-        return usage.getSystemLoad15Min();
-    }
-  }
 
   private SingularityClusterUtilization getClusterUtilization(Map<String, RequestUtilization> utilizationPerRequestId,
                                                               long totalMemBytesUsed,

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityUsageTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityUsageTest.java
@@ -3,10 +3,24 @@ package com.hubspot.singularity.scheduler;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
+import com.hubspot.mesos.Resources;
+import com.hubspot.singularity.DeployState;
+import com.hubspot.singularity.RequestType;
+import com.hubspot.singularity.SingularityDeploy;
+import com.hubspot.singularity.SingularityDeployBuilder;
+import com.hubspot.singularity.SingularityDeployMarker;
+import com.hubspot.singularity.SingularityDeployResult;
+import com.hubspot.singularity.SingularityPendingRequest;
+import com.hubspot.singularity.SingularityRequest;
+import com.hubspot.singularity.SingularityRequestBuilder;
+import com.hubspot.singularity.SingularityRequestDeployState;
+import com.hubspot.singularity.SingularityRequestHistory;
 import org.apache.mesos.v1.Protos.TaskState;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -689,6 +703,249 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
     } finally {
       configuration.setShuffleTasksForOverloadedSlaves(false);
       configuration.setMaxTasksToShuffleTotal(6);
+    }
+  }
+
+  protected void scheduleTask(String rqid, double requiredCpus, double requiredMemoryMb) {
+    Resources rs = new Resources(requiredCpus, requiredMemoryMb, 0);
+    SingularityRequest rq = new SingularityRequestBuilder(rqid, RequestType.WORKER)
+        .setInstances(Optional.of(1))
+        .build();
+
+    SingularityDeploy dp = new SingularityDeployBuilder(rq.getId(), "deployId1")
+        .setCommand(Optional.of("sleep 100"))
+        .setResources(Optional.of(rs))
+        .build();
+
+    SingularityDeployMarker marker = new SingularityDeployMarker(dp.getRequestId(), dp.getId(), System.currentTimeMillis(), Optional.empty(), Optional.empty());
+    SingularityPendingRequest pending = new SingularityPendingRequest(
+        rq.getId(),
+        dp.getId(),
+        System.currentTimeMillis(),
+        Optional.empty(),
+        SingularityPendingRequest.PendingType.UPDATED_REQUEST,
+        Optional.empty(),
+        Optional.empty()
+    );
+
+    requestManager.activate(rq, SingularityRequestHistory.RequestHistoryType.CREATED, System.currentTimeMillis(), Optional.empty(), Optional.empty());
+    deployManager.saveDeploy(rq, marker, dp);
+    deployManager.deletePendingDeploy(marker.getRequestId());
+    deployManager.saveDeployResult(marker, Optional.of(dp), new SingularityDeployResult(DeployState.SUCCEEDED));
+    deployManager.saveNewRequestDeployState(new SingularityRequestDeployState(marker.getRequestId(), Optional.of(marker), Optional.empty()));
+
+    requestManager.addToPendingQueue(pending);
+    scheduler.drainPendingQueue();
+  }
+
+  protected void startTask(SingularityTaskId task) {
+    statusUpdate(taskManager.getTask(task).get(), TaskState.TASK_STARTING, Optional.of(task.getStartedAt()));
+  }
+
+  protected Map<String, Map<String, SingularityTaskId>> getTaskIdMapByHostByRequest() {
+    Map<String, Map<String, SingularityTaskId>> taskIdMap = new HashMap<>();
+    for (SingularityTaskId taskId : taskManager.getActiveTaskIds()) {
+      String host = taskId.getSanitizedHost();
+      taskIdMap.putIfAbsent(host, new HashMap<>());
+      taskIdMap.get(host).put(taskId.getRequestId(), taskId);
+    }
+
+    return taskIdMap;
+  }
+
+  @Test
+  public void itPrioritizesLowUtilizationTasksForMemoryShuffle() {
+    try {
+      configuration.setShuffleTasksForOverloadedSlaves(true);
+      configuration.setMinutesBeforeNewTaskEligibleForShuffle(0);
+      configuration.setMaxTasksToShufflePerHost(2);
+      configuration.setMaxTasksToShuffleTotal(5);
+      configuration.setShuffleTasksWhenSlaveMemoryUtilizationPercentageExceeds(0.90);
+
+      String t1id = "test-request-1";
+      String t2id = "test-request-2";
+      String t3id = "test-request-3";
+
+      scheduleTask(t1id, 1, 10);
+      scheduleTask(t2id, 1, 10);
+      scheduleTask(t3id, 1, 10);
+
+      sms.resourceOffers(ImmutableList.of(
+          createOffer(10, 100000, 100000, "slave1", "host1")
+      )).join();
+
+      System.out.println(taskManager.getActiveTaskIds());
+
+      Map<String, Map<String, SingularityTaskId>> taskIdMap = getTaskIdMapByHostByRequest();
+      SingularityTaskId task1 = taskIdMap.get("host1").get(t1id);
+      SingularityTaskId task2 = taskIdMap.get("host1").get(t2id);
+      SingularityTaskId task3 = taskIdMap.get("host1").get(t3id);
+
+      startTask(task1);
+      startTask(task2);
+      startTask(task3);
+
+      SingularitySlaveUsage highMemUsage = new SingularitySlaveUsage(1, 10, Optional.of(10.0), 1, 1, Optional.of(30L), 1, 1, Optional.of(1024L), 1, System.currentTimeMillis(), 100000, 9000, 10, 10, 10, 10, 0, 107374182);
+      usageManager.saveCurrentSlaveUsage(new SingularitySlaveUsageWithId(highMemUsage, "host1"));
+
+      MesosTaskMonitorObject t1u1 = getTaskMonitor(task1.getId(), 2, TimeUnit.MILLISECONDS.toSeconds(task1.getStartedAt()) + 5, 69000);
+      MesosTaskMonitorObject t2u1 = getTaskMonitor(task2.getId(), 2, TimeUnit.MILLISECONDS.toSeconds(task2.getStartedAt()) + 5, 19000);
+      MesosTaskMonitorObject t3u1 = getTaskMonitor(task3.getId(), 2, TimeUnit.MILLISECONDS.toSeconds(task3.getStartedAt()) + 5, 10000);
+
+      mesosClient.setSlaveResourceUsage("host1", Arrays.asList(t1u1, t2u1, t3u1));
+      mesosClient.setSlaveMetricsSnapshot(
+          "host1",
+          new MesosSlaveMetricsSnapshotObject(0, 0, 0, 10.0, 0, 0, 0, 0, 0, 0, 0, 0, 10.0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 100000, 0, 1000, 0, 0, 0, 10, 0, 0, 0, 0)
+      );
+
+      usagePoller.runActionOnPoll();
+
+      System.out.println(taskManager.getCleanupTaskIds().toString());
+
+      // First task is not cleaned up, due to relatively high utilization.
+      Assertions.assertFalse(taskManager.getTaskCleanup(task1.getId()).isPresent());
+
+      // Second task is not cleaned up, due to relatively high utilization.
+      Assertions.assertFalse(taskManager.getTaskCleanup(task2.getId()).isPresent());
+
+      // Third task is cleaned up, due to relatively low utilization, in order to reach desired memory usage.
+      Assertions.assertEquals(TaskCleanupType.REBALANCE_MEMORY_USAGE, taskManager.getTaskCleanup(task3.getId()).get().getCleanupType());
+    } finally {
+      configuration.setShuffleTasksForOverloadedSlaves(false);
+    }
+  }
+
+  @Test
+  public void itWillShuffleMultipleTasksIfNecessaryForMemoryShuffle() {
+    try {
+      configuration.setShuffleTasksForOverloadedSlaves(true);
+      configuration.setMinutesBeforeNewTaskEligibleForShuffle(0);
+      configuration.setMaxTasksToShufflePerHost(2);
+      configuration.setMaxTasksToShuffleTotal(5);
+      configuration.setShuffleTasksWhenSlaveMemoryUtilizationPercentageExceeds(0.90);
+
+      String t1id = "test-request-1";
+      String t2id = "test-request-2";
+      String t3id = "test-request-3";
+
+      scheduleTask(t1id, 1, 10);
+      scheduleTask(t2id, 1, 10);
+      scheduleTask(t3id, 1, 10);
+
+      sms.resourceOffers(ImmutableList.of(
+          createOffer(10, 100000, 100000, "slave1", "host1")
+      )).join();
+
+      System.out.println(taskManager.getActiveTaskIds());
+
+      Map<String, Map<String, SingularityTaskId>> taskIdMap = getTaskIdMapByHostByRequest();
+      SingularityTaskId task1 = taskIdMap.get("host1").get(t1id);
+      SingularityTaskId task2 = taskIdMap.get("host1").get(t2id);
+      SingularityTaskId task3 = taskIdMap.get("host1").get(t3id);
+
+      startTask(task1);
+      startTask(task2);
+      startTask(task3);
+
+      // not actually necessary to trigger shuffle, but worth leaving in case that changes
+      SingularitySlaveUsage highMemUsage = new SingularitySlaveUsage(1, 10, Optional.of(10.0), 1, 1, Optional.of(30L), 1, 1, Optional.of(1024L), 1, System.currentTimeMillis(), 100000, 1000, 10, 10, 10, 10, 0, 107374182);
+      usageManager.saveCurrentSlaveUsage(new SingularitySlaveUsageWithId(highMemUsage, "host1"));
+
+      MesosTaskMonitorObject t1u1 = getTaskMonitor(task1.getId(), 2, TimeUnit.MILLISECONDS.toSeconds(task1.getStartedAt()) + 5, 89000);
+      MesosTaskMonitorObject t2u1 = getTaskMonitor(task2.getId(), 2, TimeUnit.MILLISECONDS.toSeconds(task2.getStartedAt()) + 5, 9000);
+      MesosTaskMonitorObject t3u1 = getTaskMonitor(task3.getId(), 2, TimeUnit.MILLISECONDS.toSeconds(task3.getStartedAt()) + 5, 1000);
+
+      mesosClient.setSlaveResourceUsage("host1", Arrays.asList(t1u1, t2u1, t3u1));
+      mesosClient.setSlaveMetricsSnapshot(
+          "host1",
+          new MesosSlaveMetricsSnapshotObject(0, 0, 0, 10.0, 0, 0, 0, 0, 0, 0, 0, 0, 10.0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 100000, 0, 1000, 0, 0, 0, 10, 0, 0, 0, 0)
+      );
+
+      usagePoller.runActionOnPoll();
+
+      System.out.println(taskManager.getCleanupTaskIds().toString());
+
+      // First task is not cleaned up, due to relatively high utilization.
+      Assertions.assertFalse(taskManager.getTaskCleanup(task1.getId()).isPresent());
+
+      // Second task is cleaned up, due to relatively low utilization.
+      Assertions.assertEquals(TaskCleanupType.REBALANCE_MEMORY_USAGE, taskManager.getTaskCleanup(task2.getId()).get().getCleanupType());
+
+      // Third task is also cleaned up, in order to reach desired memory utilization.
+      Assertions.assertEquals(TaskCleanupType.REBALANCE_MEMORY_USAGE, taskManager.getTaskCleanup(task3.getId()).get().getCleanupType());
+    } finally {
+      configuration.setShuffleTasksForOverloadedSlaves(false);
+    }
+  }
+
+  @Test
+  public void itWillShuffleToDesiredMemoryThresholdIfPossibleForMemoryShuffle() {
+    try {
+      configuration.setShuffleTasksForOverloadedSlaves(true);
+      configuration.setMinutesBeforeNewTaskEligibleForShuffle(0);
+      configuration.setMaxTasksToShufflePerHost(2);
+      configuration.setMaxTasksToShuffleTotal(5);
+      configuration.setShuffleTasksWhenSlaveMemoryUtilizationPercentageExceeds(0.90);
+
+      String t1id = "test-request-1";
+      String t2id = "test-request-2";
+      String t3id = "test-request-3";
+      String t4id = "test-request-4";
+
+      scheduleTask(t1id, 1, 10);
+      scheduleTask(t2id, 1, 10);
+      scheduleTask(t3id, 1, 10);
+      scheduleTask(t4id, 1, 10);
+
+      sms.resourceOffers(ImmutableList.of(
+          createOffer(10, 100000, 100000, "slave1", "host1")
+      )).join();
+
+      System.out.println(taskManager.getActiveTaskIds());
+
+      Map<String, Map<String, SingularityTaskId>> taskIdMap = getTaskIdMapByHostByRequest();
+      SingularityTaskId task1 = taskIdMap.get("host1").get(t1id);
+      SingularityTaskId task2 = taskIdMap.get("host1").get(t2id);
+      SingularityTaskId task3 = taskIdMap.get("host1").get(t3id);
+      SingularityTaskId task4 = taskIdMap.get("host1").get(t4id);
+
+      startTask(task1);
+      startTask(task2);
+      startTask(task3);
+      startTask(task4);
+
+      // not actually necessary to trigger shuffle, but worth leaving in case that changes
+      SingularitySlaveUsage highMemUsage = new SingularitySlaveUsage(1, 10, Optional.of(10.0), 1, 1, Optional.of(30L), 1, 1, Optional.of(1024L), 1, System.currentTimeMillis(), 100000, 1000, 10, 10, 10, 10, 0, 107374182);
+      usageManager.saveCurrentSlaveUsage(new SingularitySlaveUsageWithId(highMemUsage, "host1"));
+
+      MesosTaskMonitorObject t1u1 = getTaskMonitor(task1.getId(), 2, TimeUnit.MILLISECONDS.toSeconds(task1.getStartedAt()) + 5, 87000);
+      MesosTaskMonitorObject t2u1 = getTaskMonitor(task2.getId(), 2, TimeUnit.MILLISECONDS.toSeconds(task2.getStartedAt()) + 5, 9000);
+      MesosTaskMonitorObject t3u1 = getTaskMonitor(task3.getId(), 2, TimeUnit.MILLISECONDS.toSeconds(task3.getStartedAt()) + 5, 1100);
+      MesosTaskMonitorObject t4u1 = getTaskMonitor(task4.getId(), 2, TimeUnit.MILLISECONDS.toSeconds(task3.getStartedAt()) + 5, 1000);
+
+      mesosClient.setSlaveResourceUsage("host1", Arrays.asList(t1u1, t2u1, t3u1, t4u1));
+      mesosClient.setSlaveMetricsSnapshot(
+          "host1",
+          new MesosSlaveMetricsSnapshotObject(0, 0, 0, 10.0, 0, 0, 0, 0, 0, 0, 0, 0, 10.0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 100000, 0, 1000, 0, 0, 0, 10, 0, 0, 0, 0)
+      );
+
+      usagePoller.runActionOnPoll();
+
+      System.out.println(taskManager.getCleanupTaskIds().toString());
+
+      // First task is not cleaned up, due to relatively high utilization.
+      Assertions.assertFalse(taskManager.getTaskCleanup(task1.getId()).isPresent());
+
+      // Second task is cleaned up, in order to reach desired memory threshold.
+      Assertions.assertEquals(TaskCleanupType.REBALANCE_MEMORY_USAGE, taskManager.getTaskCleanup(task2.getId()).get().getCleanupType());
+
+      // Third task is not cleaned up, as doing so will not reach the desired memory threshold given available shuffles.
+      Assertions.assertFalse(taskManager.getTaskCleanup(task3.getId()).isPresent());
+
+      // Fourth task is cleaned up, as it has the lowest utilization.
+      Assertions.assertEquals(TaskCleanupType.REBALANCE_MEMORY_USAGE, taskManager.getTaskCleanup(task4.getId()).get().getCleanupType());
+    } finally {
+      configuration.setShuffleTasksForOverloadedSlaves(false);
     }
   }
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityUsageTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityUsageTest.java
@@ -1013,16 +1013,16 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
       System.out.println(taskManager.getActiveTaskIds());
 
       Map<String, Map<String, SingularityTaskId>> taskIdMap = getTaskIdMapByHostByRequest();
+      SingularityTaskId task1 = taskIdMap.get("host1").get(t1id);
+      SingularityTaskId task2 = taskIdMap.get("host1").get(t2id);
+      SingularityTaskId task3 = taskIdMap.get("host1").get(t3id);
+      SingularityTaskId task4 = taskIdMap.get("host1").get(t4id);
+
       for (String host : taskIdMap.keySet()) {
         for (String request : taskIdMap.get(host).keySet()) {
           startTask(taskIdMap.get(host).get(request));
         }
       }
-
-      SingularityTaskId task1 = taskIdMap.get("host1").get(t1id);
-      SingularityTaskId task2 = taskIdMap.get("host1").get(t2id);
-      SingularityTaskId task3 = taskIdMap.get("host1").get(t3id);
-      SingularityTaskId task4 = taskIdMap.get("host1").get(t4id);
 
       // not actually necessary to trigger shuffle, but worth leaving in case that changes
       SingularitySlaveUsage highMemUsage = new SingularitySlaveUsage(1, 10, Optional.of(10.0), 1, 1, Optional.of(30L), 1, 1, Optional.of(1024L), 1, System.currentTimeMillis(), 100000, 1000, 10, 10, 10, 10, 0, 107374182);
@@ -1086,7 +1086,6 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
       )).join();
 
       taskIdMap = getTaskIdMapByHostByRequest();
-
       Assertions.assertNotNull(taskIdMap.get("host4").get(t1id));
       Assertions.assertNotNull(taskIdMap.get("host4").get(t4id));
     } finally {
@@ -1125,7 +1124,7 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
         Optional.empty()
     );
 
-    requestManager.activate(rq, SingularityRequestHistory.RequestHistoryType.CREATED, System.currentTimeMillis(), Optional.empty(), Optional.empty());
+    saveRequest(rq);
     deployManager.saveDeploy(rq, marker, dp);
     deployManager.deletePendingDeploy(marker.getRequestId());
     deployManager.saveDeployResult(marker, Optional.of(dp), new SingularityDeployResult(DeployState.SUCCEEDED));

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityUsageTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityUsageTest.java
@@ -529,9 +529,13 @@ public class SingularityUsageTest extends SingularitySchedulerTestBase {
 
       usagePoller.runActionOnPoll();
 
-      // First task is cleaned up
-      Assertions.assertEquals(TaskCleanupType.REBALANCE_MEMORY_USAGE, taskManager.getTaskCleanup(taskId1.getId()).get().getCleanupType());
-      // Second task is not cleaned up because it is from the same request as task 1
+      // First task is not cleaned up because it uses the most memory
+      Assertions.assertFalse(taskManager.getTaskCleanup(taskId1.getId()).isPresent());
+
+      // Third task is cleaned up because it uses the least memory
+      Assertions.assertEquals(TaskCleanupType.REBALANCE_MEMORY_USAGE, taskManager.getTaskCleanup(taskId3.getId()).get().getCleanupType());
+
+      // Second task is not cleaned up because it is from the same request as task 3
       Assertions.assertFalse(taskManager.getTaskCleanup(taskId2.getId()).isPresent());
     } finally {
       configuration.setShuffleTasksForOverloadedSlaves(false);


### PR DESCRIPTION
The current task shuffling/eviction logic used by Singularity prioritizes shuffling tasks with the highest resource utilization (memory or CPU, depending on which is most overused), on each overcommitted slave. Though this is a good way to ensure the shuffle succeeds at reducing load to acceptable levels, it is also much more likely to shuffle tasks performing large amounts of work or holding large amounts of in-memory state. This makes sense for high CPU tasks, but is undesirable for high memory ones - they'll likely return to their previous memory consumption and possibly trigger another shuffle on their new host.

To address these issues, this PR attempts to:
- Alter the shuffling logic for memory overusage to favor shuffling "low utilization" tasks.
- Create a simple scoring metric to identify "low utilization" tasks. Currently, this is just the average of a task's memory/CPU usage. Suggestions on whether to use max, min, or other methods would be welcome.
- Refactor shuffling logic from `SingularityUsagePoller` to a new `SingularityTaskShuffler` class, while preserving existing functionality/signatures.

Because of these changes, it is very likely that tasks that were not shuffled before will now be shuffled, which in turn has a fair chance of causing issues with these tasks in QA/prod. I don't think there's a good way to avoid this and also actually change the shuffling logic, though self-service shuffle opt-out may help mitigate things.

TODO:
- [ ] Add more complex shuffling unit tests.
- [ ] Evaluation in staging cluster.
- [ ] Ensure that enough resources are freed up while respecting shuffle limits in configuration.