### PR TITLE
Properly reconnect after losing mesos master connection

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/config/MesosConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/MesosConfiguration.java
@@ -77,7 +77,7 @@ public class MesosConfiguration {
   private Optional<String> mesosUsername = Optional.empty();
   private Optional<String> mesosPassword = Optional.empty();
 
-  private long reconnectTimeoutMillis = 60000;
+  private long reconnectTimeoutMillis = 120000;
   // Set to a value at least a few seconds below the configured mesos offer timeout
   private long offerTimeout = 45000;
   private long offerLockTimeout = 1000;

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosScheduler.java
@@ -137,7 +137,7 @@ public abstract class SingularityMesosScheduler {
   /**
    * Called when an uncaught exception occurs while attempting to connect to the mesos master
    */
-  public abstract void onConnectException(Throwable t);
+  public abstract void onSubscribeException(Throwable t);
 
   /**
    * Singularity-specific methods used elsewhere in the code to determine scheduler

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerClient.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerClient.java
@@ -276,6 +276,7 @@ public class SingularityMesosSchedulerClient {
     if (subscriberThread != null) {
       try {
         if (!subscriberThread.isInterrupted()) {
+          LOG.info("Interrupting current subscriber thread");
           subscriberThread.interrupt();
         }
         subscriberThread.join(10000);

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
@@ -292,6 +292,8 @@ public class SingularityMesosSchedulerImpl extends SingularityMesosScheduler {
   public void onUncaughtException(Throwable t) {
     if (t instanceof PrematureChannelClosureException) {
       LOG.warn("PrematureChannelClosureException, will attempt restart");
+    } else if (t instanceof IllegalStateException && restartInProgress.get()) {
+      onSubscribeException(t);
     } else {
       LOG.error("uncaught exception", t);
     }
@@ -419,7 +421,7 @@ public class SingularityMesosSchedulerImpl extends SingularityMesosScheduler {
         start();
         long start = System.currentTimeMillis();
         while (!state.isRunning() && System.currentTimeMillis() - start < 30000) {
-          Thread.sleep(500);
+          Thread.sleep(50);
           if (reconnectException.get() != null) {
             LOG.warn("Exception during reconnect", reconnectException.getAndSet(null));
             return false;


### PR DESCRIPTION
This will fix reconnects in a situation where all masters are temporarily unavailable. Currently if the reconnect ends up throwing a ConnectException in the subscriber thread, that calls onConnectException which, correctly, starts the process over again. However, because this is still synchronously called on the subscriber thread, when the reconnect tries to interrupt that thread, waiting for the join then throws an InterruptedException (because it is called from the same thread being interrupted)

Moving the reconnect to a separate thread should solve this problem. It is currently a single thread, as no more than one of them should be running at a time anyway