### PR TITLE
Debounce UI Request/Task Search

### DIFF
--- a/SingularityUI/app/components/requests/RequestFilters.jsx
+++ b/SingularityUI/app/components/requests/RequestFilters.jsx
@@ -78,6 +78,16 @@ export default class RequestFilters extends React.Component {
     }
   ];
 
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      filter: _.extend({}, this.props.filter),
+    };
+
+    this.onFilterChange = _.debounce(this.props.onFilterChange, 250);
+  }
+
   handleStatusSelect(selectedKey) {
     this.props.onFilterChange(_.extend({}, this.props.filter, {state: RequestFilters.REQUEST_STATES[selectedKey].filterVal}));
   }
@@ -87,7 +97,9 @@ export default class RequestFilters extends React.Component {
   }
 
   handleSearchChange(event) {
-    this.props.onFilterChange(_.extend({}, this.props.filter, {searchFilter: event.target.value}));
+    const update = _.extend({}, this.props.filter, {searchFilter: event.target.value})
+    this.setState({ filter: update })
+    this.onFilterChange(update);
   }
 
   toggleRequestType(requestType) {
@@ -147,7 +159,7 @@ export default class RequestFilters extends React.Component {
           ref="search"
           className="big-search-box"
           placeholder="Filter requests"
-          value={this.props.filter.searchFilter}
+          value={this.state.filter.searchFilter}
           onChange={(...args) => this.handleSearchChange(...args)}
           maxLength="128"
           onFocus={function(e) {

--- a/SingularityUI/app/components/requests/RequestFilters.jsx
+++ b/SingularityUI/app/components/requests/RequestFilters.jsx
@@ -85,7 +85,7 @@ export default class RequestFilters extends React.Component {
       filter: _.extend({}, this.props.filter),
     };
 
-    this.onFilterChange = _.debounce(this.props.onFilterChange, 250);
+    this.debouncedOnFilterChange = _.debounce(this.props.onFilterChange, 250);
   }
 
   handleStatusSelect(selectedKey) {
@@ -99,7 +99,7 @@ export default class RequestFilters extends React.Component {
   handleSearchChange(event) {
     const update = _.extend({}, this.props.filter, {searchFilter: event.target.value})
     this.setState({ filter: update })
-    this.onFilterChange(update);
+    this.debouncedOnFilterChange(update);
   }
 
   toggleRequestType(requestType) {

--- a/SingularityUI/app/components/tasks/TaskFilters.jsx
+++ b/SingularityUI/app/components/tasks/TaskFilters.jsx
@@ -39,12 +39,24 @@ export default class TaskFilters extends React.Component {
     return ['SERVICE', 'WORKER', 'SCHEDULED', 'ON_DEMAND', 'RUN_ONCE'];
   }
 
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      filter: _.extend({}, this.props.filter),
+    };
+
+    this.debouncedOnFilterChange = _.debounce(this.props.onFilterChange, 250);
+  }
+
   handleStatusSelect(selectedKey) {
     this.props.onFilterChange(_.extend({}, this.props.filter, {taskStatus: TaskFilters.TASK_STATES[selectedKey].filterVal}));
   }
 
   handleSearchChange(event) {
-    this.props.onFilterChange(_.extend({}, this.props.filter, {filterText: event.target.value}));
+    const update = _.extend({}, this.props.filter, {filterText: event.target.value})
+    this.setState({ filter: update })
+    this.debouncedOnFilterChange(update);
   }
 
   clearSearch() {
@@ -100,7 +112,7 @@ export default class TaskFilters extends React.Component {
           ref="search"
           className="big-search-box"
           placeholder="Filter tasks"
-          value={this.props.filter.filterText}
+          value={this.state.filter.filterText}
           onChange={(...args) => this.handleSearchChange(...args)}
           maxLength="128"
         />

--- a/SingularityUI/gulpfile.js
+++ b/SingularityUI/gulpfile.js
@@ -72,6 +72,9 @@ gulp.task('static', ['clean'], function() {
 })
 
 gulp.task('debug-html', ['static'], function () {
+  templateData['appJsPath'] = 'js/app.bundle.js'
+  templateData['appCssPath'] = 'css/app.css'
+  templateData['vendorJsPath'] = 'js/vendor.bundle.js'
   templateData.isDebug = true;
   return gulp.src('app/assets/index.mustache')
     .pipe(mustache(templateData, {extension: '.html'}))


### PR DESCRIPTION
Should make the request/task search filters feel much snappier, though there's still occasionally perceptible amounts of lag for very short queries. I've tested it against the QA Singularity backend, can DM you a gif if you feel like it.

Tangential issue, seems like #2058 broke `gulp serve` - this PR fixes that as well, though I'm not proud of how long it took me to realize what was the issue.

cc - @ssalinas