### PR TITLE
Prevent request action modals from closing upon regaining focus

### DIFF
--- a/SingularityUI/app/actions/ui/requestDetail.es6
+++ b/SingularityUI/app/actions/ui/requestDetail.es6
@@ -11,6 +11,21 @@ export const refresh = (requestId) => (dispatch, getState) => {
   const requiredPromises = Promise.all([
     dispatch(FetchRequest.trigger(requestId)),
     dispatch(FetchRequestHistory.trigger(requestId, 5, 1)),
+  ])
+
+  dispatch(FetchActiveTasksForRequest.trigger(requestId));
+  dispatch(FetchTaskCleanups.trigger());
+  dispatch(FetchDeploysForRequest.trigger(requestId, 5, 1));
+  dispatch(FetchScheduledTasksForRequest.trigger(requestId));
+  dispatch(FetchRequestUtilization.trigger(requestId, [404]))
+
+  return requiredPromises;
+}
+
+export const initialize = (requestId) => (dispatch, getState) => {
+  const requiredPromises = Promise.all([
+    dispatch(FetchRequest.trigger(requestId)),
+    dispatch(FetchRequestHistory.trigger(requestId, 5, 1)),
     dispatch(FetchRequestShuffleOptOut.trigger(requestId)),
   ])
 

--- a/SingularityUI/app/components/common/modal/FormModal.jsx
+++ b/SingularityUI/app/components/common/modal/FormModal.jsx
@@ -29,8 +29,6 @@ export default class FormModal extends React.Component {
   constructor(props) {
     super(props);
 
-    console.log('blame1')
-
     this.state = {
       visible: false,
       formState: getDefaultFormState(props),
@@ -69,7 +67,6 @@ export default class FormModal extends React.Component {
   };
 
   hide() {
-    console.log('blame2')
     this.setState({
       visible: false
     });
@@ -151,7 +148,6 @@ export default class FormModal extends React.Component {
           formState[formElement.name] = formElement.defaultValue;
         });
       }
-      console.log('blame3')
       this.setState({
         visible: false,
         errors: {},
@@ -461,10 +457,6 @@ export default class FormModal extends React.Component {
         {inputs}
       </form>
     );
-  }
-
-  componentWillUnmount() {
-    console.log('will unmount');
   }
 
   render() {

--- a/SingularityUI/app/components/common/modal/FormModal.jsx
+++ b/SingularityUI/app/components/common/modal/FormModal.jsx
@@ -29,6 +29,8 @@ export default class FormModal extends React.Component {
   constructor(props) {
     super(props);
 
+    console.log('blame1')
+
     this.state = {
       visible: false,
       formState: getDefaultFormState(props),
@@ -67,6 +69,7 @@ export default class FormModal extends React.Component {
   };
 
   hide() {
+    console.log('blame2')
     this.setState({
       visible: false
     });
@@ -148,6 +151,7 @@ export default class FormModal extends React.Component {
           formState[formElement.name] = formElement.defaultValue;
         });
       }
+      console.log('blame3')
       this.setState({
         visible: false,
         errors: {},
@@ -457,6 +461,10 @@ export default class FormModal extends React.Component {
         {inputs}
       </form>
     );
+  }
+
+  componentWillUnmount() {
+    console.log('will unmount');
   }
 
   render() {

--- a/SingularityUI/app/components/requestDetail/RequestDetailPage.jsx
+++ b/SingularityUI/app/components/requestDetail/RequestDetailPage.jsx
@@ -27,8 +27,7 @@ import RequestUtilization from './RequestUtilization';
 
 import Utils from '../../utils';
 
-import { refresh } from '../../actions/ui/requestDetail';
-import { FetchRequestShuffleOptOut } from '../../actions/api/requests.es6';
+import { refresh, initialize } from '../../actions/ui/requestDetail';
 
 class RequestDetailPage extends Component {
   componentDidMount() {
@@ -124,4 +123,6 @@ export default withRouter(connect(
   RequestDetailPage,
   (props) => refresh(props.params.requestId),
   true,
+  true,
+  (props) => initialize(props.params.requestId),
 )));


### PR DESCRIPTION
Fixes a bug introduced by #2060, which caused all action modals to close when a user regained focus on the request detail page. TLDR - the shuffle opt out status for a request should only be fetched on initialization of the details page, not as part of the existing refresh process, to avoid forcing reconstruction (which resets modal visibility) of the request action buttons and their child modals.

cc - @ssalinas 