### PR TITLE
Automatically handle tasks that might be stuck in launching status

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -408,6 +408,8 @@ public class SingularityConfiguration extends Configuration {
   // high memory slave, based on cpu to memory ratio
   private double highMemorySlaveCutOff = 0.5; //TODO
 
+  private long reconcileLaunchAfterMillis = TimeUnit.MINUTES.toMillis(3);
+
   @JsonProperty("crashLoop")
   private CrashLoopConfiguration crashLoopConfiguration = new CrashLoopConfiguration();
 
@@ -1732,5 +1734,13 @@ public class SingularityConfiguration extends Configuration {
 
   public void setCrashLoopConfiguration(CrashLoopConfiguration crashLoopConfiguration) {
     this.crashLoopConfiguration = crashLoopConfiguration;
+  }
+
+  public long getReconcileLaunchAfterMillis() {
+    return reconcileLaunchAfterMillis;
+  }
+
+  public void setReconcileLaunchAfterMillis(long reconcileLaunchAfterMillis) {
+    this.reconcileLaunchAfterMillis = reconcileLaunchAfterMillis;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -712,6 +712,12 @@ public class TaskManager extends CuratorAsyncManager {
     return notExists("getNumLaunchingTasks", paths).size();
   }
 
+  public List<SingularityTaskId> getLaunchingTasks() {
+    return getActiveTaskIds().stream()
+        .filter((t) -> !exists(getUpdatePath(t, ExtendedTaskState.TASK_STARTING)))
+        .collect(Collectors.toList());
+  }
+
   public List<SingularityTaskId> filterInactiveTaskIds(List<SingularityTaskId> taskIds) {
     if (leaderCache.active()) {
       return leaderCache.getInactiveTaskIds(taskIds);

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/OfferCache.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/OfferCache.java
@@ -9,20 +9,21 @@ import com.hubspot.singularity.mesos.SingularityOfferCache.CachedOffer;
 
 public interface OfferCache {
 
-  public void cacheOffer(long timestamp, Offer offer);
+  void cacheOffer(long timestamp, Offer offer);
 
-  public void rescindOffer(OfferID offerId);
+  void rescindOffer(OfferID offerId);
 
-  public void useOffer(CachedOffer cachedOffer);
+  void useOffer(CachedOffer cachedOffer);
 
-  public List<CachedOffer> checkoutOffers();
+  List<CachedOffer> checkoutOffers();
 
-  public void returnOffer(CachedOffer cachedOffer);
+  void returnOffer(CachedOffer cachedOffer);
 
-  public List<Offer> peekOffers();
+  List<Offer> peekOffers();
 
-  public void disableOfferCache();
+  void disableOfferCache();
 
-  public void enableOfferCache();
+  void enableOfferCache();
 
+  void invalidateAll();
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerClient.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerClient.java
@@ -159,6 +159,7 @@ public class SingularityMesosSchedulerClient {
         .mesosUri(mesosMasterURI)
         .applicationUserAgentEntry(UserAgentEntries.userAgentEntryForMavenArtifact("com.hubspot.singularity", "SingularityService"))
         .onSendEventBackpressureBuffer()
+        .onSendErrorRetry()
         .onBackpressureBuffer(
             scheduler.getEventBufferSize(),
             () -> {

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerClient.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerClient.java
@@ -1,5 +1,6 @@
 package com.hubspot.singularity.mesos;
 
+import java.net.ConnectException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
@@ -233,6 +234,15 @@ public class SingularityMesosSchedulerClient {
 
       // This is the observable that is responsible for sending calls to mesos master.
       PublishSubject<Optional<SinkOperation<Call>>> p = PublishSubject.create();
+
+      // Retry any operations currently in the pipe if the mesos master temporarily stpos responding
+      p.retry((i, t) -> Throwables.getCausalChain(t).stream().anyMatch((th) -> th instanceof ConnectException));
+
+      // Don't let the publisher stop emitting if it hits an error
+      p.onErrorResumeNext((throwable -> {
+        LOG.error("Could not send call", throwable);
+        return Observable.empty();
+      }));
 
       // toSerialised handles the fact that we can add calls on different threads.
       publisher = p.toSerialized();

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerClient.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerClient.java
@@ -236,7 +236,7 @@ public class SingularityMesosSchedulerClient {
       // This is the observable that is responsible for sending calls to mesos master.
       PublishSubject<Optional<SinkOperation<Call>>> p = PublishSubject.create();
 
-      // Retry any operations currently in the pipe if the mesos master temporarily stpos responding
+      // Retry any operations currently in the pipe if the mesos master temporarily stops responding
       p.retry((i, t) -> Throwables.getCausalChain(t).stream().anyMatch((th) -> th instanceof ConnectException));
 
       // Don't let the publisher stop emitting if it hits an error

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerClient.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerClient.java
@@ -236,15 +236,6 @@ public class SingularityMesosSchedulerClient {
       // This is the observable that is responsible for sending calls to mesos master.
       PublishSubject<Optional<SinkOperation<Call>>> p = PublishSubject.create();
 
-      // Retry any operations currently in the pipe if the mesos master temporarily stops responding
-      p.retry((i, t) -> Throwables.getCausalChain(t).stream().anyMatch((th) -> th instanceof ConnectException));
-
-      // Don't let the publisher stop emitting if it hits an error
-      p.onErrorResumeNext((throwable -> {
-        LOG.error("Could not send call", throwable);
-        return Observable.empty();
-      }));
-
       // toSerialised handles the fact that we can add calls on different threads.
       publisher = p.toSerialized();
       return publisher.onBackpressureBuffer();

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
@@ -424,10 +424,13 @@ public class SingularityMesosSchedulerImpl extends SingularityMesosScheduler {
           .withStopStrategy(StopStrategies.stopAfterDelay(configuration.getMesosConfiguration().getReconnectTimeoutMillis(), TimeUnit.MILLISECONDS))
           .build();
       startRetryer.call(() -> {
+        reconnectException.set(null);
         AtomicBoolean connected = new AtomicBoolean();
         callWithStateLock(() -> connected.set(state.getMesosSchedulerState() == MesosSchedulerState.SUBSCRIBED), "reconnectMesosSync", false);
         if (connected.get()) {
           restartInProgress.set(false);
+          reconnectException.set(null);
+          LOG.info("Already connected, cancelling reconnect attempt");
           return true;
         }
         mesosSchedulerClient.close();

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
@@ -385,6 +385,7 @@ public class SingularityMesosSchedulerImpl extends SingularityMesosScheduler {
   public void reconnectMesos() {
     callWithStateLock(() -> {
       state.setMesosSchedulerState(MesosSchedulerState.PAUSED_FOR_MESOS_RECONNECT);
+      offerCache.invalidateAll();
       LOG.info("Paused scheduler actions, closing existing mesos connection");
       mesosSchedulerClient.close();
       LOG.info("Closed existing mesos connection");

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityNoOfferCache.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityNoOfferCache.java
@@ -46,6 +46,11 @@ public class SingularityNoOfferCache implements OfferCache {
   }
 
   @Override
+  public void invalidateAll() {
+    // no-op
+  }
+
+  @Override
   public List<Offer> peekOffers() {
     return Collections.emptyList();
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityOfferCache.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityOfferCache.java
@@ -75,7 +75,19 @@ public class SingularityOfferCache implements OfferCache, RemovalListener<String
 
   @Override
   public void rescindOffer(OfferID offerId) {
+    CachedOffer maybeCached = offerCache.getIfPresent(offerId.getValue());
+    if (maybeCached != null) {
+      maybeCached.expire();
+      LOG.info("Offer {} on {} rescinded", offerId.getValue(), maybeCached.getOffer().getHostname());
+    } else {
+      LOG.info("Offer {} rescinded (not in cache)", offerId.getValue());
+    }
     offerCache.invalidate(offerId.getValue());
+  }
+
+  @Override
+  public void invalidateAll() {
+    offerCache.invalidateAll();
   }
 
   @Override

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityOfferCache.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityOfferCache.java
@@ -77,7 +77,6 @@ public class SingularityOfferCache implements OfferCache, RemovalListener<String
   public void rescindOffer(OfferID offerId) {
     CachedOffer maybeCached = offerCache.getIfPresent(offerId.getValue());
     if (maybeCached != null) {
-      maybeCached.expire();
       LOG.info("Offer {} on {} rescinded", offerId.getValue(), maybeCached.getOffer().getHostname());
     } else {
       LOG.info("Offer {} rescinded (not in cache)", offerId.getValue());

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -1066,5 +1066,11 @@ public class SingularityScheduler {
             LOG.warn("Could not find full content for task {}", taskId);
           }
         });
+    Set<SingularityTaskId> toRemove = requestedReconciles.keySet()
+        .stream()
+        .filter((t) -> t.getStartedAt() < now - TimeUnit.MINUTES.toMillis(15))
+        .collect(Collectors.toSet());
+    toRemove.forEach(requestedReconciles::remove);
+
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -21,7 +22,10 @@ import java.util.stream.Collectors;
 import javax.inject.Singleton;
 
 import org.apache.mesos.v1.Protos;
+import org.apache.mesos.v1.Protos.AgentID;
+import org.apache.mesos.v1.Protos.TaskID;
 import org.apache.mesos.v1.Protos.TaskStatus.Reason;
+import org.apache.mesos.v1.scheduler.Protos.Call.Reconcile.Task;
 import org.dmfs.rfc5545.recur.InvalidRecurrenceRuleException;
 import org.quartz.CronExpression;
 import org.slf4j.Logger;
@@ -81,6 +85,7 @@ import com.hubspot.singularity.data.TaskRequestManager;
 import com.hubspot.singularity.expiring.SingularityExpiringBounce;
 import com.hubspot.singularity.helpers.RFC5545Schedule;
 import com.hubspot.singularity.helpers.RebalancingHelper;
+import com.hubspot.singularity.mesos.SingularityMesosSchedulerClient;
 import com.hubspot.singularity.mesos.SingularitySchedulerLock;
 import com.hubspot.singularity.smtp.SingularityMailer;
 
@@ -102,12 +107,16 @@ public class SingularityScheduler {
   private final SingularityLeaderCache leaderCache;
   private final SingularitySchedulerLock lock;
   private final ExecutorService schedulerExecutorService;
+  private final SingularityMesosSchedulerClient mesosSchedulerClient;
+
+  private final Map<SingularityTaskId, Long> requestedReconciles;
 
   @Inject
   public SingularityScheduler(TaskRequestManager taskRequestManager, SingularityConfiguration configuration, SingularityCrashLoops crashLoops, DeployManager deployManager,
                               TaskManager taskManager, RequestManager requestManager, SlaveManager slaveManager, RebalancingHelper rebalancingHelper,
                               RackManager rackManager, SingularityMailer mailer,
-                              SingularityLeaderCache leaderCache, SingularitySchedulerLock lock, SingularityManagedThreadPoolFactory threadPoolFactory) {
+                              SingularityLeaderCache leaderCache, SingularitySchedulerLock lock, SingularityManagedThreadPoolFactory threadPoolFactory,
+                              SingularityMesosSchedulerClient mesosSchedulerClient) {
     this.taskRequestManager = taskRequestManager;
     this.configuration = configuration;
     this.deployManager = deployManager;
@@ -121,6 +130,8 @@ public class SingularityScheduler {
     this.leaderCache = leaderCache;
     this.lock = lock;
     this.schedulerExecutorService = threadPoolFactory.get("scheduler", configuration.getCoreThreadpoolSize());
+    this.mesosSchedulerClient = mesosSchedulerClient;
+    this.requestedReconciles = new HashMap<>();
   }
 
   private void cleanupTaskDueToDecomission(final Map<String, Optional<String>> requestIdsToUserToReschedule, final Set<SingularityTaskId> matchingTaskIds, SingularityTask task,
@@ -1026,5 +1037,34 @@ public class SingularityScheduler {
     } else {
       return currentRequest.getRequest();
     }
+  }
+
+  public void checkForStalledTaskLaunches() {
+    long now = System.currentTimeMillis();
+    taskManager.getLaunchingTasks()
+        .stream()
+        .filter((t) -> {
+          if (t.getStartedAt() < now - configuration.getReconcileLaunchAfterMillis()) {
+            Long maybeLastReconcileTime = requestedReconciles.get(t);
+            // Don't overwhelm ourselves with status updates, only reconcile each task every 15s
+            return maybeLastReconcileTime == null || now - maybeLastReconcileTime > 15000;
+          } else {
+            return false;
+          }
+        })
+        .forEach((taskId) -> {
+          Optional<SingularityTask> maybeTask = taskManager.getTask(taskId);
+          if (maybeTask.isPresent()) {
+            mesosSchedulerClient.reconcile(Collections.singletonList(
+                Task.newBuilder()
+                    .setTaskId(TaskID.newBuilder().setValue(taskId.toString()).build())
+                    .setAgentId(AgentID.newBuilder().setValue(maybeTask.get().getAgentId().getValue()).build())
+                    .build()
+            ));
+            LOG.info("Requested explicit reconcile of task {}", taskId);
+          } else {
+            LOG.warn("Could not find full content for task {}", taskId);
+          }
+        });
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularitySchedulerPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularitySchedulerPoller.java
@@ -53,7 +53,7 @@ public class SingularitySchedulerPoller extends SingularityLeaderOnlyPoller {
       }
 
       scheduler.drainPendingQueue();
-
+      scheduler.checkForStalledTaskLaunches();
       // Check against only cached offers
       offerScheduler.resourceOffers(Collections.emptyList());
     }, "SingularitySchedulerPoller");

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <dep.junit.platform.version>1.5.0</dep.junit.platform.version>
     <dep.liquibase.version>3.6.3</dep.liquibase.version>
     <dep.logback.version>1.2.3</dep.logback.version>
-    <dep.mesos.rxjava.version>0.1.0</dep.mesos.rxjava.version>
+    <dep.mesos.rxjava.version>1.0-retry_sink_operation-SNAPSHOT</dep.mesos.rxjava.version>
     <dep.metrics-guice.version>3.1.3</dep.metrics-guice.version>
     <dep.mysql-connector-java.version>8.0.17</dep.mysql-connector-java.version>
     <dep.netty.version>4.1.27.Final</dep.netty.version>


### PR DESCRIPTION
After implementing mesos master failover handling we've seen a few cases where a task will make it to the master but not be propagated to the agent before the master shuts down. This leaves us with a task that is launched in Singularity, but has no state on the master or agent. To compound this, with our newer faster reconnect, it's possible that we trigger our reconciliation before the master has finished building its full state, so the initial reconcile cycle may not pick up on the missed task.

This adds a step to the scheduler poller that will trigger an explicit reconciliation for any task in a launching state for more than 3 minutes (configurable). It will then trigger a re-check every 15s until it gets a status from the master. These should move the tasks to LOST eventually if they have not actually been launched. It also adds some logging to the offer cache, which we were not properly cleaning up upon master restart

Still TODO:
- [x] fix tests
- [x] clean up the recent reconcile timestamps so it doesn't grown forever
