### PR TITLE
Consistently compare memory in GB, not MB/B

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackHelper.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySlaveAndRackHelper.java
@@ -155,15 +155,15 @@ public class SingularitySlaveAndRackHelper {
   }
 
   private double getCpuMemoryRatioForSlave(SingularityOfferHolder offerHolder) {
-    double memory = MesosUtils.getMemory(offerHolder.getCurrentResources(), Optional.empty());
+    double memoryGB = MesosUtils.getMemory(offerHolder.getCurrentResources(), Optional.empty()) / 1024;
     double cpus = MesosUtils.getNumCpus(offerHolder.getCurrentResources(), Optional.empty());
-    return memory/cpus;
+    return cpus/memoryGB;
   }
 
   private double getCpuMemoryRatioForRequest(RequestUtilization requestUtilization) {
     double cpuUsageForRequest = getEstimatedCpuUsageForRequest(requestUtilization);
-    double memUsageForRequest = requestUtilization.getAvgMemBytesUsed();
-    return cpuUsageForRequest/memUsageForRequest;
+    double memUsageGBForRequest = requestUtilization.getAvgMemBytesUsed() / 1024 / 1024;
+    return cpuUsageForRequest/memUsageGBForRequest;
   }
 
   public double getEstimatedCpuUsageForRequest(RequestUtilization requestUtilization) {


### PR DESCRIPTION
Came across this when looking at other things. Looks like the cpu/mem ratio to determine if a slave/request was high mem or high cpu was comparing bytes in one spot and MB in another. This should compare everything in GB instead, which also makes the default cutoffs of 1.5 and 0.5 better. Should be the case that (for AWS at least) m5 is AVERAGE, r5 is high mem, c5 is high cpu