### PR TITLE
Fix run now modal not being able to tail task launch

### DIFF
--- a/SingularityUI/app/components/common/modalButtons/RunNowModal.jsx
+++ b/SingularityUI/app/components/common/modalButtons/RunNowModal.jsx
@@ -59,7 +59,10 @@ class RunNowModal extends Component {
       data.runAt = runAt;
     }
 
-    if (data.afterTrigger === RunNowModal.AFTER_TRIGGER.TAIL.value) localStorage.setItem(LOCAL_STORAGE_TAIL_AFTER_TRIGGER_FILENAME, data.fileToTail);
+    if (data.afterTrigger === RunNowModal.AFTER_TRIGGER.TAIL.value) {
+      localStorage.setItem(LOCAL_STORAGE_TAIL_AFTER_TRIGGER_FILENAME, data.fileToTail);
+    }
+
     this.props.runNow(data).then((response) => {
       let requestFetchResponse = response || {};
       if (_.isArray(response) && response.length > 0) {
@@ -156,5 +159,5 @@ export default connect(
   null,
   mapDispatchToProps,
   null,
-  { withRef: true }
+  { withRef: true, forwardRef: true }
 )(RunNowModal);

--- a/SingularityUI/app/components/requestDetail/header/RequestActionButtons.jsx
+++ b/SingularityUI/app/components/requestDetail/header/RequestActionButtons.jsx
@@ -32,7 +32,6 @@ const RequestActionButtons = ({requestParent, fetchingShuffleOptOut, fetchReques
       fetchRequest(),
       fetchActiveTasks(),
       fetchRequestHistory(5, 1),
-      fetchRequestShuffleOptOut(),
     ]);
   }
 
@@ -40,7 +39,6 @@ const RequestActionButtons = ({requestParent, fetchingShuffleOptOut, fetchReques
     return Promise.all([
       fetchRequest(),
       fetchRequestHistory(5, 1),
-      fetchRequestShuffleOptOut(),
     ]);
   }
 
@@ -164,7 +162,7 @@ const RequestActionButtons = ({requestParent, fetchingShuffleOptOut, fetchReques
   }
 
   const shuffleOptOutButton = (
-    <ShuffleOptOutButton requestId={request.id} then={fetchRequestAndHistory} />
+    <ShuffleOptOutButton requestId={request.id} then={fetchRequestShuffleOptOut} />
   );
 
   const removeButton = (


### PR DESCRIPTION
More fun caused by Redux, seems like the run now modal was being re-rendered due to a transitive dependency on the shuffle opt out fetch. This PR removes that dependency, and should prevent similar issues for other modals.

cc - @ssalinas 