### PR TITLE
Better exposure of LB status in UI

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskIdsByStatus.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskIdsByStatus.java
@@ -33,13 +33,6 @@ public class SingularityTaskIdsByStatus {
     this.killed = killed != null ? killed : Collections.emptyList();
   }
 
-  public SingularityTaskIdsByStatus(List<SingularityTaskId> healthy,
-                                    List<SingularityTaskId> notYetHealthy,
-                                    List<SingularityPendingTaskId> pending,
-                                    List<SingularityTaskId> cleaning) {
-    this(healthy, notYetHealthy, pending, cleaning, Collections.emptyList(), Collections.emptyList());
-  }
-
   @Schema(description = "Active tasks whose healthchecks and load balancer updates (when applicable) have finished successfully")
   public List<SingularityTaskId> getHealthy() {
     return healthy;
@@ -71,23 +64,43 @@ public class SingularityTaskIdsByStatus {
   }
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
+  public boolean equals(Object o) {
+    if (this == o) {
       return true;
     }
-    if (obj instanceof SingularityTaskIdsByStatus) {
-      final SingularityTaskIdsByStatus that = (SingularityTaskIdsByStatus) obj;
-      return Objects.equals(this.healthy, that.healthy) &&
-          Objects.equals(this.notYetHealthy, that.notYetHealthy) &&
-          Objects.equals(this.pending, that.pending) &&
-          Objects.equals(this.cleaning, that.cleaning);
+    if (o == null || getClass() != o.getClass()) {
+      return false;
     }
-    return false;
+
+    SingularityTaskIdsByStatus that = (SingularityTaskIdsByStatus) o;
+
+    if (healthy != null ? !healthy.equals(that.healthy) : that.healthy != null) {
+      return false;
+    }
+    if (notYetHealthy != null ? !notYetHealthy.equals(that.notYetHealthy) : that.notYetHealthy != null) {
+      return false;
+    }
+    if (pending != null ? !pending.equals(that.pending) : that.pending != null) {
+      return false;
+    }
+    if (cleaning != null ? !cleaning.equals(that.cleaning) : that.cleaning != null) {
+      return false;
+    }
+    if (loadBalanced != null ? !loadBalanced.equals(that.loadBalanced) : that.loadBalanced != null) {
+      return false;
+    }
+    return killed != null ? killed.equals(that.killed) : that.killed == null;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(healthy, notYetHealthy, pending, cleaning);
+    int result = healthy != null ? healthy.hashCode() : 0;
+    result = 31 * result + (notYetHealthy != null ? notYetHealthy.hashCode() : 0);
+    result = 31 * result + (pending != null ? pending.hashCode() : 0);
+    result = 31 * result + (cleaning != null ? cleaning.hashCode() : 0);
+    result = 31 * result + (loadBalanced != null ? loadBalanced.hashCode() : 0);
+    result = 31 * result + (killed != null ? killed.hashCode() : 0);
+    return result;
   }
 
   @Override
@@ -97,6 +110,8 @@ public class SingularityTaskIdsByStatus {
         ", notYetHealthy=" + notYetHealthy +
         ", pending=" + pending +
         ", cleaning=" + cleaning +
+        ", loadBalanced=" + loadBalanced +
+        ", killed=" + killed +
         '}';
   }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskIdsByStatus.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskIdsByStatus.java
@@ -16,25 +16,28 @@ public class SingularityTaskIdsByStatus {
   private List<SingularityPendingTaskId> pending;
   private List<SingularityTaskId> cleaning;
   private List<SingularityTaskId> loadBalanced;
+  private List<SingularityTaskId> killed;
 
   @JsonCreator
   public SingularityTaskIdsByStatus(@JsonProperty("healthy") List<SingularityTaskId> healthy,
                                     @JsonProperty("notYetHealthy") List<SingularityTaskId> notYetHealthy,
                                     @JsonProperty("pending") List<SingularityPendingTaskId> pending,
                                     @JsonProperty("cleaning") List<SingularityTaskId> cleaning,
-                                    @JsonProperty("loadBalanced") List<SingularityTaskId> loadBalanced) {
+                                    @JsonProperty("loadBalanced") List<SingularityTaskId> loadBalanced,
+                                    @JsonProperty("killed") List<SingularityTaskId> killed) {
     this.healthy = healthy;
     this.notYetHealthy = notYetHealthy;
     this.pending = pending;
     this.cleaning = cleaning;
     this.loadBalanced = loadBalanced != null ? loadBalanced : Collections.emptyList();
+    this.killed = killed != null ? killed : Collections.emptyList();
   }
 
   public SingularityTaskIdsByStatus(List<SingularityTaskId> healthy,
                                     List<SingularityTaskId> notYetHealthy,
                                     List<SingularityPendingTaskId> pending,
                                     List<SingularityTaskId> cleaning) {
-    this(healthy, notYetHealthy, pending, cleaning, Collections.emptyList());
+    this(healthy, notYetHealthy, pending, cleaning, Collections.emptyList(), Collections.emptyList());
   }
 
   @Schema(description = "Active tasks whose healthchecks and load balancer updates (when applicable) have finished successfully")
@@ -60,6 +63,11 @@ public class SingularityTaskIdsByStatus {
   @Schema(description = "Tasks that are currently active in the load balancer")
   public List<SingularityTaskId> getLoadBalanced() {
     return loadBalanced;
+  }
+
+  @Schema(description = "Tasks which have been sent a kill signal")
+  public List<SingularityTaskId> getKilled() {
+    return killed;
   }
 
   @Override

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskIdsByStatus.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskIdsByStatus.java
@@ -1,5 +1,6 @@
 package com.hubspot.singularity;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -14,16 +15,26 @@ public class SingularityTaskIdsByStatus {
   private List<SingularityTaskId> notYetHealthy;
   private List<SingularityPendingTaskId> pending;
   private List<SingularityTaskId> cleaning;
+  private List<SingularityTaskId> loadBalanced;
 
   @JsonCreator
   public SingularityTaskIdsByStatus(@JsonProperty("healthy") List<SingularityTaskId> healthy,
                                     @JsonProperty("notYetHealthy") List<SingularityTaskId> notYetHealthy,
                                     @JsonProperty("pending") List<SingularityPendingTaskId> pending,
-                                    @JsonProperty("cleaning") List<SingularityTaskId> cleaning) {
+                                    @JsonProperty("cleaning") List<SingularityTaskId> cleaning,
+                                    @JsonProperty("loadBalanced") List<SingularityTaskId> loadBalanced) {
     this.healthy = healthy;
     this.notYetHealthy = notYetHealthy;
     this.pending = pending;
     this.cleaning = cleaning;
+    this.loadBalanced = loadBalanced != null ? loadBalanced : Collections.emptyList();
+  }
+
+  public SingularityTaskIdsByStatus(List<SingularityTaskId> healthy,
+                                    List<SingularityTaskId> notYetHealthy,
+                                    List<SingularityPendingTaskId> pending,
+                                    List<SingularityTaskId> cleaning) {
+    this(healthy, notYetHealthy, pending, cleaning, Collections.emptyList());
   }
 
   @Schema(description = "Active tasks whose healthchecks and load balancer updates (when applicable) have finished successfully")
@@ -44,6 +55,11 @@ public class SingularityTaskIdsByStatus {
   @Schema(description = "Active tasks in a cleaning state")
   public List<SingularityTaskId> getCleaning() {
     return cleaning;
+  }
+
+  @Schema(description = "Tasks that are currently active in the load balancer")
+  public List<SingularityTaskId> getLoadBalanced() {
+    return loadBalanced;
   }
 
   @Override

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -364,24 +364,6 @@ public class TaskManager extends CuratorAsyncManager {
     return getChildrenAsIdsForParents("getAllTaskIds", paths, taskIdTranscoder);
   }
 
-  private List<SingularityTaskId> getTaskIds(String root) {
-    return getChildrenAsIds(root, taskIdTranscoder);
-  }
-
-  public List<String> getActiveTaskIdsAsStrings() {
-    if (leaderCache.active()) {
-      return leaderCache.getActiveTaskIdsAsStrings();
-    }
-
-    List<String> results = new ArrayList<>();
-
-    for (String requestId : getChildren(LAST_ACTIVE_TASK_STATUSES_PATH_ROOT)) {
-      results.addAll(getChildren(getLastActiveTaskParent(requestId)));
-    }
-
-    return results;
-  }
-
   public List<SingularityTaskId> getActiveTaskIds() {
     return getActiveTaskIds(false);
   }
@@ -1033,6 +1015,13 @@ public class TaskManager extends CuratorAsyncManager {
     return save(getKilledPath(killedTaskIdRecord.getTaskId()), killedTaskIdRecord, killedTaskIdRecordTranscoder);
   }
 
+  public boolean isKilledTask(SingularityTaskId taskId) {
+    if (leaderCache.active()) {
+      return leaderCache.getKilledTaskRecord(taskId).isPresent();
+    }
+    return exists(getKilledPath(taskId));
+  }
+
   public List<SingularityKilledTaskIdRecord> getKilledTaskIdRecords() {
     if (leaderCache.active()) {
       return leaderCache.getKilledTasks();
@@ -1189,10 +1178,6 @@ public class TaskManager extends CuratorAsyncManager {
         }
       }
     }
-  }
-
-  public SingularityDeleteResult deleteRequestId(String requestId) {
-    return delete(getRequestPath(requestId));
   }
 
   public long getTaskStatusBytes() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -822,8 +822,7 @@ public class TaskManager extends CuratorAsyncManager {
     if (exists(getLoadBalancerStatePath(taskId, LoadBalancerRequestType.REMOVE))) {
       return false;
     }
-    return exists(getLoadBalancerStatePath(taskId, LoadBalancerRequestType.ADD))
-        || exists(getLoadBalancerStatePath(taskId, LoadBalancerRequestType.DEPLOY));
+    return exists(getLoadBalancerStatePath(taskId, LoadBalancerRequestType.ADD));
   }
 
   public Optional<SingularityPendingTask> getPendingTask(SingularityPendingTaskId pendingTaskId) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -836,6 +836,14 @@ public class TaskManager extends CuratorAsyncManager {
     return getData(getLoadBalancerStatePath(taskId, requestType), taskLoadBalancerUpdateTranscoder);
   }
 
+  public boolean isInLoadBalancer(SingularityTaskId taskId) {
+    if (exists(getLoadBalancerStatePath(taskId, LoadBalancerRequestType.REMOVE))) {
+      return false;
+    }
+    return exists(getLoadBalancerStatePath(taskId, LoadBalancerRequestType.ADD))
+        || exists(getLoadBalancerStatePath(taskId, LoadBalancerRequestType.DEPLOY));
+  }
+
   public Optional<SingularityPendingTask> getPendingTask(SingularityPendingTaskId pendingTaskId) {
     if (leaderCache.active()) {
       return leaderCache.getPendingTask(pendingTaskId);

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCache.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCache.java
@@ -395,6 +395,10 @@ public class SingularityLeaderCache {
     return new ArrayList<>(killedTasks.values());
   }
 
+  public Optional<SingularityKilledTaskIdRecord> getKilledTaskRecord(SingularityTaskId taskId) {
+    return Optional.ofNullable(killedTasks.get(taskId));
+  }
+
   public void addKilledTask(SingularityKilledTaskIdRecord killedTask) {
     if (!active) {
       LOG.warn("addKilledTask {}, but not active", killedTask.getTaskId().getId());

--- a/SingularityUI/app/components/requestDetail/ActiveTasksTable.jsx
+++ b/SingularityUI/app/components/requestDetail/ActiveTasksTable.jsx
@@ -45,7 +45,7 @@ const ActiveTasksTable = ({request, requestId, tasksAPI, healthyTaskIds, cleanin
 
   const tasksWithHealth = _.map(tasks, (task) => {
     let health;
-    if (request.loadBalanced) {
+    if (request.request.loadBalanced) {
       if (_.contains(healthyTaskIds, task.taskId.id)) {
         if (_.contains(loadBalancedTaskIds, task.taskId.id)) {
           health = 'healthy, in load balancer';

--- a/SingularityUI/app/components/requestDetail/ActiveTasksTable.jsx
+++ b/SingularityUI/app/components/requestDetail/ActiveTasksTable.jsx
@@ -25,7 +25,7 @@ import { FetchTaskHistoryForRequest } from '../../actions/api/history';
 
 import TaskStateBreakdown from './TaskStateBreakdown';
 
-const ActiveTasksTable = ({request, requestId, tasksAPI, healthyTaskIds, cleaningTaskIds,loadBalancedTaskIds, fetchTaskHistoryForRequest}) => {
+const ActiveTasksTable = ({request, requestId, tasksAPI, healthyTaskIds, cleaningTaskIds,loadBalancedTaskIds, killedTaskIds, fetchTaskHistoryForRequest}) => {
   const tasks = tasksAPI ? tasksAPI.data : [];
   const emptyTableMessage = (Utils.api.isFirstLoad(tasksAPI)
     ? <p>Loading...</p>
@@ -58,6 +58,8 @@ const ActiveTasksTable = ({request, requestId, tasksAPI, healthyTaskIds, cleanin
         } else {
           health = 'cleaning, removed from load balancer';
         }
+      } else if (_.contains(killedTaskIds, task.taskId.id)) {
+        health = 'terminating'
       } else {
         health = 'not yet healthy'
       }
@@ -66,6 +68,8 @@ const ActiveTasksTable = ({request, requestId, tasksAPI, healthyTaskIds, cleanin
         health = 'healthy';
       } else if (_.contains(cleaningTaskIds, task.taskId.id)) {
         health = 'cleaning';
+      } else if (_.contains(killedTaskIds, task.taskId.id)) {
+        health = 'terminating'
       } else {
         health = 'not yet healthy'
       }
@@ -105,6 +109,7 @@ ActiveTasksTable.propTypes = {
   healthyTaskIds: PropTypes.array.isRequired,
   cleaningTaskIds: PropTypes.array.isRequired,
   loadBalancedTaskIds: PropTypes.array.isRequired,
+  killedTaskIds: PropTypes.array.isRequired,
   fetchTaskHistoryForRequest: PropTypes.func.isRequired
 };
 
@@ -123,6 +128,9 @@ const mapStateToProps = (state, ownProps) => {
     return task.id;
   }),
   loadBalancedTaskIds: _.map(Utils.maybe(request, ['taskIds', 'loadBalanced'], []), (task) => {
+    return task.id;
+  }),
+  killedTaskIds: _.map(Utils.maybe(request, ['taskIds', 'killed'], []), (task) => {
     return task.id;
   })
 }};

--- a/SingularityUI/app/components/requestDetail/ActiveTasksTable.jsx
+++ b/SingularityUI/app/components/requestDetail/ActiveTasksTable.jsx
@@ -11,6 +11,7 @@ import Utils from '../../utils';
 import UITable from '../common/table/UITable';
 import {
   Health,
+  LoadBalancerState,
   InstanceNumberWithHostname,
   Host,
   LastTaskState,
@@ -45,38 +46,19 @@ const ActiveTasksTable = ({request, requestId, tasksAPI, healthyTaskIds, cleanin
 
   const tasksWithHealth = _.map(tasks, (task) => {
     let health;
-    if (request.request.loadBalanced) {
-      if (_.contains(healthyTaskIds, task.taskId.id)) {
-        if (_.contains(loadBalancedTaskIds, task.taskId.id)) {
-          health = 'healthy, in load balancer';
-        } else {
-          health = 'healthy, awaiting load balancer';
-        }
-      } else if (_.contains(cleaningTaskIds, task.taskId.id)) {
-        if (_.contains(loadBalancedTaskIds, task.taskId.id)) {
-          health = 'cleaning, in load balancer';
-        } else {
-          health = 'cleaning, removed from load balancer';
-        }
-      } else if (_.contains(killedTaskIds, task.taskId.id)) {
-        health = 'terminating'
-      } else {
-        health = 'not yet healthy'
-      }
+    if (_.contains(healthyTaskIds, task.taskId.id)) {
+      health = 'healthy';
+    } else if (_.contains(cleaningTaskIds, task.taskId.id)) {
+      health = 'cleaning';
+    } else if (_.contains(killedTaskIds, task.taskId.id)) {
+      health = 'terminating'
     } else {
-      if (_.contains(healthyTaskIds, task.taskId.id)) {
-        health = 'healthy';
-      } else if (_.contains(cleaningTaskIds, task.taskId.id)) {
-        health = 'cleaning';
-      } else if (_.contains(killedTaskIds, task.taskId.id)) {
-        health = 'terminating'
-      } else {
-        health = 'not yet healthy'
-      }
+      health = 'not yet healthy'
     }
     return {
       ...task,
       health: health
+      activeInLb: _.contains(loadBalancedTaskIds, task.taskId.id)
     }
   });
   const title = <span>Running instances {maybeAggregateTailButton}</span>;
@@ -91,6 +73,7 @@ const ActiveTasksTable = ({request, requestId, tasksAPI, healthyTaskIds, cleanin
         triggerOnDataSizeChange={fetchTaskHistoryForRequest}
       >
         {Health}
+        {request.request.loadBalanced && LoadBalancerState}
         {InstanceNumberWithHostname}
         {LastTaskState}
         {DeployId}

--- a/SingularityUI/app/components/requestDetail/ActiveTasksTable.jsx
+++ b/SingularityUI/app/components/requestDetail/ActiveTasksTable.jsx
@@ -57,7 +57,7 @@ const ActiveTasksTable = ({request, requestId, tasksAPI, healthyTaskIds, cleanin
     }
     return {
       ...task,
-      health: health
+      health: health,
       activeInLb: _.contains(loadBalancedTaskIds, task.taskId.id)
     }
   });

--- a/SingularityUI/app/components/tasks/Columns.jsx
+++ b/SingularityUI/app/components/tasks/Columns.jsx
@@ -522,7 +522,7 @@ export const LoadBalancerState = (
         } else {
           glyph = "minus";
           colorClass = "color-info";
-          message = "not serving traffic"
+          message = "not serving traffic";
         }
         const tooltip = (
           <ToolTip id="view-lb-state">

--- a/SingularityUI/app/components/tasks/Columns.jsx
+++ b/SingularityUI/app/components/tasks/Columns.jsx
@@ -470,14 +470,30 @@ export const Health = (
       (cellData) => {
         let glyph;
         let colorClass;
-        if (cellData === "healthy" || cellData === "cleaning") {
+
+        if (cellData === "healthy, awaiting load balancer") {
+          glyph = "heart";
+          colorClass = "color-success";
+        } else if (cellData === "healthy, in load balancer") {
+          glyph = "check";
+          colorClass = "color-success";
+        } else if (cellData === "healthy") {
           glyph = "ok";
           colorClass = "color-success";
-        } else if (cellData === "pending") {
-          glyph = "question-sign";
-        } else {
+        } else if (cellData === "not yet healthy") {
           glyph = "hourglass";
           colorClass = "color-info"
+        } else if (cellData === "cleaning, in load balancer") {
+          glyph = "check";
+          colorClass = "color-info";
+        } else if (cellData === "cleaning, removed from load balancer") {
+          glyph = "stop";
+          colorClass = "color-info";
+        } else if (cellData === "cleaning") {
+          glyph = "stop";
+          colorClass = "color-info";
+        } else {
+          glyph = "question-sign";
         }
         const tooltip = (
           <ToolTip id="view-task-health">

--- a/SingularityUI/app/components/tasks/Columns.jsx
+++ b/SingularityUI/app/components/tasks/Columns.jsx
@@ -514,16 +514,19 @@ export const LoadBalancerState = (
       (cellData) => {
         let glyph;
         let colorClass;
+        let message;
         if (cellData) {
           glyph = "ok";
           colorClass = "color-success";
+          message = "active and serving traffic";
         } else {
           glyph = "minus";
           colorClass = "color-info";
+          message = "not serving traffic"
         }
         const tooltip = (
           <ToolTip id="view-lb-state">
-            {cellData}
+            {message}
           </ToolTip>
         )
         return (

--- a/SingularityUI/app/components/tasks/Columns.jsx
+++ b/SingularityUI/app/components/tasks/Columns.jsx
@@ -487,11 +487,14 @@ export const Health = (
           glyph = "check";
           colorClass = "color-info";
         } else if (cellData === "cleaning, removed from load balancer") {
-          glyph = "stop";
+          glyph = "minus";
           colorClass = "color-info";
         } else if (cellData === "cleaning") {
-          glyph = "stop";
+          glyph = "minus";
           colorClass = "color-info";
+        } else if (cellData === "terminating") {
+          glyph = "stop";
+          colorClass = "color-warning";
         } else {
           glyph = "question-sign";
         }

--- a/SingularityUI/app/components/tasks/Columns.jsx
+++ b/SingularityUI/app/components/tasks/Columns.jsx
@@ -460,7 +460,7 @@ export const InstanceNumberWithHostname = (
 
 export const Health = (
   <Column
-    label=""
+    label="Health"
     id="health"
     key="health"
     cellData={
@@ -471,24 +471,12 @@ export const Health = (
         let glyph;
         let colorClass;
 
-        if (cellData === "healthy, awaiting load balancer") {
-          glyph = "heart";
-          colorClass = "color-success";
-        } else if (cellData === "healthy, in load balancer") {
-          glyph = "check";
-          colorClass = "color-success";
-        } else if (cellData === "healthy") {
+        if (cellData === "healthy") {
           glyph = "ok";
           colorClass = "color-success";
         } else if (cellData === "not yet healthy") {
           glyph = "hourglass";
           colorClass = "color-info"
-        } else if (cellData === "cleaning, in load balancer") {
-          glyph = "check";
-          colorClass = "color-info";
-        } else if (cellData === "cleaning, removed from load balancer") {
-          glyph = "minus";
-          colorClass = "color-info";
         } else if (cellData === "cleaning") {
           glyph = "minus";
           colorClass = "color-info";
@@ -511,5 +499,39 @@ export const Health = (
       }
     }
     sortable={true}
+  />
+);
+
+export const LoadBalancerState = (
+  <Column
+    label="In Load Balancer"
+    id="lbState"
+    key="lbState"
+    cellData={
+      (rowData) => rowData.activeInLb
+    }
+    cellRender={
+      (cellData) => {
+        let glyph;
+        let colorClass;
+        if (cellData) {
+          glyph = "ok";
+          colorClass = "color-success";
+        } else {
+          glyph = "minus";
+          colorClass = "color-info";
+        }
+        const tooltip = (
+          <ToolTip id="view-lb-state">
+            {cellData}
+          </ToolTip>
+        )
+        return (
+          <OverlayTrigger placement="top" id="view-lb-state-overlay" overlay={tooltip}>
+            <Glyphicon className={colorClass} glyph={glyph} />
+          </OverlayTrigger>
+        );
+      }
+    }
   />
 );


### PR DESCRIPTION
The Singularity backend knows if a task has been added to the load balancer or not. We should better expose this in the health icon in the UI to show if a task is currently serving traffic or not. Still debating if this should be a separate column. Didn't want to make the active tasks table too much wider, so for the moment I've tried to see if we can encode this all into the existing health icon in a way that is easy enough to understand