### PR TITLE
Expose host sandbox path

### DIFF
--- a/SingularityExecutor/src/main/resources/docker.sh.hbs
+++ b/SingularityExecutor/src/main/resources/docker.sh.hbs
@@ -116,6 +116,7 @@ DOCKER_OPTIONS+=( -v "$CURRENT_DIR:/mnt/mesos/sandbox" )
 echo "MESOS_SANDBOX=/mnt/mesos/sandbox" >> docker.env
 echo "LOG_HOME=/mnt/mesos/sandbox/logs" >> docker.env
 echo "MESOS_TASK_ID={{{bashEscaped runContext.taskId}}}" >> docker.env
+echo "HOST_SANDBOX_DIR=$CURRENT_DIR" >> docker.env
 {{#each envContext.containerVolumes}}
 {{#if mode}}raw_mode{{@index}}={{{ mode }}}{{/if}}
 DOCKER_OPTIONS+=( -v "{{#if hostPath}}{{{ hostPath }}}:{{{ containerPath }}}{{else}}{{{ containerPath }}}:{{{ containerPath }}}{{/if}}{{#if mode}}:${raw_mode{{@index}},,}{{/if}}" )


### PR DESCRIPTION
Needed for communication with s3uploader from docker tasks. The uploader needs to know the full path to the sandbox, not a relative path within the container