### PR TITLE
Fix `logrotateadditionalfiles` deletion.

### DIFF
--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTask.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTask.java
@@ -84,10 +84,11 @@ public class SingularityExecutorTask {
     ExtendedTaskState extendedTaskState = MesosUtils.fromTaskState(org.apache.mesos.v1.Protos.TaskState.valueOf(state.toString()));
 
     boolean cleanupAppTaskDirectory = !extendedTaskState.isFailed() && !taskDefinition.getExecutorData().getPreserveTaskSandboxAfterFinish().orElse(Boolean.FALSE);
+    boolean cleanupLogs = false; // Task has just died, so we don't want to delete logs yet.
 
     boolean isDocker = (taskInfo.hasContainer() && taskInfo.getContainer().hasDocker());
 
-    taskCleanup.cleanup(cleanupAppTaskDirectory, isDocker);
+    taskCleanup.cleanup(cleanupAppTaskDirectory, cleanupLogs, isDocker);
   }
 
   public Path getArtifactPath(Artifact artifact, Path defaultPath) {

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskCleanup.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskCleanup.java
@@ -1,21 +1,29 @@
 package com.hubspot.singularity.executor.task;
 
 import java.io.IOException;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
 import java.util.List;
 
 import org.slf4j.Logger;
 
 import com.google.common.collect.ImmutableList;
 import com.hubspot.singularity.executor.config.SingularityExecutorConfiguration;
+import com.hubspot.singularity.executor.config.SingularityExecutorLogrotateAdditionalFile;
 import com.hubspot.singularity.executor.utils.DockerUtils;
 import com.hubspot.singularity.runner.base.shared.ExceptionChainParser;
 import com.hubspot.singularity.runner.base.shared.SimpleProcessManager;
 import com.spotify.docker.client.exceptions.ContainerNotFoundException;
 import com.spotify.docker.client.exceptions.DockerException;
 import com.spotify.docker.client.messages.ContainerInfo;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class SingularityExecutorTaskCleanup {
 
@@ -33,7 +41,7 @@ public class SingularityExecutorTaskCleanup {
     this.dockerUtils = dockerUtils;
   }
 
-  public TaskCleanupResult cleanup(boolean cleanupTaskAppDirectory, boolean isDocker) {
+  public TaskCleanupResult cleanup(boolean cleanupTaskAppDirectory, boolean cleanupLogs, boolean isDocker) {
     final Path taskDirectory = Paths.get(taskDefinition.getTaskDirectory());
 
     boolean dockerCleanSuccess = true;
@@ -71,7 +79,13 @@ public class SingularityExecutorTaskCleanup {
       return TaskCleanupResult.WAITING;
     }
 
+    if (!cleanupLogs) {
+      log.info("Not finishing cleanup because log files have not been cleaned yet");
+      return TaskCleanupResult.WAITING;
+    }
+
     boolean cleanupTaskAppDirectorySuccess = cleanupTaskAppDirectory();
+    checkForLogrotateAdditionalFilesToDelete(taskDefinition);
 
     log.info("Cleaned up logs ({}) and task app directory ({})", logTearDownSuccess, cleanupTaskAppDirectorySuccess);
 
@@ -123,7 +137,7 @@ public class SingularityExecutorTaskCleanup {
           "rm",
           "-rf",
           pathToDelete
-          );
+      );
 
       new SimpleProcessManager(log).runCommand(cmd);
 
@@ -133,5 +147,48 @@ public class SingularityExecutorTaskCleanup {
     }
 
     return false;
+  }
+
+  private void checkForLogrotateAdditionalFilesToDelete(SingularityExecutorTaskDefinition taskDefinition) {
+    configuration.getLogrotateAdditionalFiles()
+        .stream()
+        .filter(SingularityExecutorLogrotateAdditionalFile::isDeleteInExecutorCleanup)
+        .forEach(toDelete -> {
+          String glob = String.format("glob:%s/%s", taskDefinition.getTaskDirectoryPath().toAbsolutePath(), toDelete.getFilename());
+
+          log.debug("Trying to delete {} for task {} using glob {}...", toDelete.getFilename(), taskDefinition.getTaskId(), glob);
+
+          try {
+            List<Path> matches = findGlob(taskDefinition.getTaskDirectoryPath().toAbsolutePath(), taskDefinition.getTaskDirectoryPath().getFileSystem().getPathMatcher(glob));
+            for (Path match : matches) {
+              Files.delete(match);
+              log.debug("Deleted {}", match);
+            }
+          } catch (IOException e) {
+            log.error("Unable to list files while trying to delete for {}", toDelete);
+          }
+        });
+  }
+
+  @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE", justification = "https://github.com/spotbugs/spotbugs/issues/259")
+  private List<Path> findGlob(Path path, PathMatcher matcher) throws IOException {
+    Deque<Path> stack = new ArrayDeque<>();
+    List<Path> matched = new ArrayList<>();
+
+    stack.push(path);
+
+    while (!stack.isEmpty()) {
+      try (DirectoryStream<Path> stream = Files.newDirectoryStream(stack.pop())) {
+        for (Path entry : stream) {
+          if (Files.isDirectory(entry)) {
+            stack.push(entry);
+          } else if (matcher.matches(entry)) {
+            matched.add(entry);
+          }
+        }
+      }
+    }
+
+    return matched;
   }
 }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskCleanup.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskCleanup.java
@@ -72,22 +72,25 @@ public class SingularityExecutorTaskCleanup {
       return finishTaskCleanup(dockerCleanSuccess);
     }
 
-    boolean logTearDownSuccess = taskLogManager.teardown();
 
     if (!cleanupTaskAppDirectory) {
       log.info("Not finishing cleanup because taskApp directory is being preserved");
       return TaskCleanupResult.WAITING;
     }
 
+    boolean cleanupTaskAppDirectorySuccess = cleanupTaskAppDirectory();
+
+    log.info("Cleaned up task app directory ({})", cleanupTaskAppDirectorySuccess);
+
     if (!cleanupLogs) {
-      log.info("Not finishing cleanup because log files have not been cleaned yet");
+      log.info("Not finishing cleanup because log files will be preserved for 15 minutes after task termination");
       return TaskCleanupResult.WAITING;
     }
 
-    boolean cleanupTaskAppDirectorySuccess = cleanupTaskAppDirectory();
+    boolean logTearDownSuccess = taskLogManager.teardown();
     checkForLogrotateAdditionalFilesToDelete(taskDefinition);
 
-    log.info("Cleaned up logs ({}) and task app directory ({})", logTearDownSuccess, cleanupTaskAppDirectorySuccess);
+    log.info("Cleaned up logs ({})", logTearDownSuccess);
 
     if (logTearDownSuccess && cleanupTaskAppDirectorySuccess) {
       return finishTaskCleanup(dockerCleanSuccess);

--- a/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/SingularityExecutorCleanup.java
+++ b/SingularityExecutorCleanup/src/main/java/com/hubspot/singularity/executor/cleanup/SingularityExecutorCleanup.java
@@ -351,7 +351,6 @@ public class SingularityExecutorCleanup {
       if (lastUpdate.isPresent()) {
         if (taskDefinition.getTaskDirectoryPath().toFile().exists() && lastUpdate.get().getTaskState().isDone() && System.currentTimeMillis() - lastUpdate.get().getTimestamp() > TimeUnit.MINUTES.toMillis(15)) {
           LOG.info("Task {} is done for > 15 minutes, removing logrotate files", taskDefinition.getTaskId());
-          taskCleanup.cleanUpLogs();
           checkForLogrotateAdditionalFilesToDelete(taskDefinition);
         }
         if (lastUpdate.get().getTaskState().isFailed()) {


### PR DESCRIPTION
This PR aims to fix a scenario whereby `logrotateAdditionalFiles` marked with `deleteInExecutorCleanup` would never actually be deleted. The scenario was:

- Task terminates successfully
- Executor runs the “immediate” cleanup logic
- `logrotateAdditionalFiles` deletion is skipped because it hasn't been 15 minutes since task termination
- Cleanup logic flows all the way through to https://github.com/HubSpot/Singularity/blob/4dea95764bdeee9f41046b4ad1c6a94a1e5dab8c/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskCleanup.java#L79
- Task definition file is deleted
- Scheduled executor cleanup will never be aware of this sandbox again

I’ve plumbed through some logic for log cleanup which is similar to the logic for the sandbox `app/` directory cleanup. Which is to say, if it hasn’t been 15 minutes since task termination, we return a `WAITING` state from the “immediate” cleanup process. This way, we allow scheduled cleanup to take another look at it later, and properly delete files which we had been logrotating for the lifetime of the task.
