### PR TITLE
S3 uploader + executor cleanup efficiency improvements

### DIFF
--- a/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/shared/JsonObjectFileHelper.java
+++ b/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/shared/JsonObjectFileHelper.java
@@ -30,7 +30,7 @@ public class JsonObjectFileHelper {
   public <T> Optional<T> read(Path file, Logger log, Class<T> clazz) throws IOException {
     final long start = System.currentTimeMillis();
 
-    log.info("Reading {}", file);
+    log.trace("Reading {}", file);
 
     byte[] bytes = new byte[0];
 

--- a/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/shared/WatchServiceHelper.java
+++ b/SingularityRunnerBase/src/main/java/com/hubspot/singularity/runner/base/shared/WatchServiceHelper.java
@@ -111,7 +111,7 @@ public abstract class WatchServiceHelper implements Closeable {
       WatchEvent.Kind<?> kind = event.kind();
 
       if (!watchEvents.contains(kind)) {
-        LOG.trace("Ignoring an {} event to {}", event.context());
+        LOG.trace("Ignoring an {} event to {}", event.kind(), event.context());
         continue;
       }
 

--- a/SingularityS3Downloader/src/main/java/com/hubspot/singularity/s3downloader/server/SingularityS3DownloaderAsyncHandler.java
+++ b/SingularityS3Downloader/src/main/java/com/hubspot/singularity/s3downloader/server/SingularityS3DownloaderAsyncHandler.java
@@ -47,10 +47,10 @@ public class SingularityS3DownloaderAsyncHandler implements Runnable {
   }
 
   private boolean download() throws Exception {
-    LOG.info("Beginning download {} after {}", artifactDownloadRequest, JavaUtils.duration(start));
+    LOG.trace("Beginning download {} after {}", artifactDownloadRequest, JavaUtils.duration(start));
 
     if (continuation.isExpired()) {
-      LOG.info("Continuation expired for {}, aborting...", artifactDownloadRequest.getTargetDirectory());
+      LOG.trace("Continuation expired for {}, aborting...", artifactDownloadRequest.getTargetDirectory());
       return false;
     }
 
@@ -71,7 +71,7 @@ public class SingularityS3DownloaderAsyncHandler implements Runnable {
       artifactManager.copy(fetched, targetDirectory, artifactDownloadRequest.getS3Artifact().getFilename());
     }
 
-    LOG.info("Finishing request {} after {}", artifactDownloadRequest.getTargetDirectory(), JavaUtils.duration(start));
+    LOG.debug("Finishing request {} after {}", artifactDownloadRequest.getTargetDirectory(), JavaUtils.duration(start));
 
     getResponse().getOutputStream().close();
 

--- a/SingularityS3Downloader/src/main/java/com/hubspot/singularity/s3downloader/server/SingularityS3DownloaderCoordinator.java
+++ b/SingularityS3Downloader/src/main/java/com/hubspot/singularity/s3downloader/server/SingularityS3DownloaderCoordinator.java
@@ -111,7 +111,7 @@ public class SingularityS3DownloaderCoordinator implements DownloadListener {
         return false;
       }
 
-      LOG.info("Queing new downloader for {} ({} handlers, {} active threads, {} queue size, {} max) after {}", artifactDownloadRequest, downloadRequestToHandler.size(),
+      LOG.trace("Queing new downloader for {} ({} handlers, {} active threads, {} queue size, {} max) after {}", artifactDownloadRequest, downloadRequestToHandler.size(),
           downloadService.getActiveCount(), downloadService.getQueue().size(), configuration.getNumDownloaderThreads(), JavaUtils.duration(start));
 
       ListenableFuture<?> future = listeningDownloadWrapper.submit(newHandler);

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3UploaderDriver.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3UploaderDriver.java
@@ -306,7 +306,7 @@ public class SingularityS3UploaderDriver extends WatchServiceHelper implements S
       futures.put(uploader, CompletableFuture.supplyAsync(performUploadSupplier(uploader, isFinished, false), executorService));
     }
 
-    LOG.info("Waiting on {} future(s)", futures.size());
+    LOG.debug("Waiting on {} future(s)", futures.size());
 
     final long now = System.currentTimeMillis();
     final Set<SingularityUploader> expiredUploaders = Sets.newHashSetWithExpectedSize(initialExpectedSize);

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityUploader.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityUploader.java
@@ -1,12 +1,14 @@
 package com.hubspot.singularity.s3uploader;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
@@ -114,7 +116,7 @@ public abstract class SingularityUploader {
           context.stop();
         }
       } else {
-        LOG.info("{} is in use by another process, will retry upload later", file);
+        LOG.debug("{} is in use by another process, will retry upload later", file);
       }
     }
 
@@ -156,6 +158,8 @@ public abstract class SingularityUploader {
           throw new RuntimeException(ioe);
         }
       });
+    } catch (UncheckedIOException|NoSuchFileException nsfe) {
+      LOG.debug("Parent file {} did not exist, skipping", directory);
     }
     return toUpload;
   }


### PR DESCRIPTION
In looking through the code, there was a path that could cause us to build up an unnecessary amount of open uploaders if a large count of failed tasks ended up on the same host. In the current cleanup setup, because we were preserving the task app directory, we would short circuit before hitting any lines that finalized uploaders, allowing them to run to completion in the S3Uploader. Since the task is finished, there is no reason to keep the uploader files open

This also cleans up a few noisier exceptions and log statements that aren't adding a ton of value across the different runnables