### PR TITLE
Periodically reconcile the list of metadata files

### DIFF
--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/config/SingularityS3UploaderConfiguration.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/config/SingularityS3UploaderConfiguration.java
@@ -32,6 +32,10 @@ public class SingularityS3UploaderConfiguration extends BaseRunnerConfiguration 
   @JsonProperty
   private long checkUploadsEverySeconds = 600;
 
+  @Min(60)
+  @JsonProperty
+  private long recheckFilesEverySeconds = 600;
+
   @Min(1)
   @JsonProperty
   private long stopCheckingAfterMillisWithoutNewFile = TimeUnit.HOURS.toMillis(168);
@@ -102,6 +106,14 @@ public class SingularityS3UploaderConfiguration extends BaseRunnerConfiguration 
 
   public void setCheckUploadsEverySeconds(long checkUploadsEverySeconds) {
     this.checkUploadsEverySeconds = checkUploadsEverySeconds;
+  }
+
+  public long getRecheckFilesEverySeconds() {
+    return recheckFilesEverySeconds;
+  }
+
+  public void setRecheckFilesEverySeconds(long recheckFilesEverySeconds) {
+    this.recheckFilesEverySeconds = recheckFilesEverySeconds;
   }
 
   public long getStopCheckingAfterMillisWithoutNewFile() {


### PR DESCRIPTION
This is the simplest fix I could think of for our longer-term uploader leak issue. The most likely case is that we are occasionally missing a file update or not handling ti properly, since we always end up with more files in the filesystem than in memory. So, this periodically rescans the directory just like on startup. For the most part it will be a no-op, but will also serve to clean up files we may have missed so that things don't grow out of control