### PR TITLE
Pin xterm versions to avoid compatibility issues

### DIFF
--- a/SingularityUI/package.json
+++ b/SingularityUI/package.json
@@ -63,11 +63,11 @@
     "typeahead.js": "^0.11.1",
     "underscore": "~1.8.0",
     "uuid": "^3.0.0",
-    "xterm": "^4.4.0",
-    "xterm-addon-attach": "^0.5.0",
-    "xterm-addon-fit": "^0.3.0",
-    "xterm-addon-webgl": "^0.6.0",
-    "xterm-addon-web-links": "^0.2.1"
+    "xterm": "4.6.0",
+    "xterm-addon-attach": "0.6.0",
+    "xterm-addon-fit": "0.4.0",
+    "xterm-addon-web-links": "0.4.0",
+    "xterm-addon-webgl": "0.7.0"
   },
   "license": "Apache-2.0",
   "devDependencies": {


### PR DESCRIPTION
Avoid issues by specifying the set of versions from https://github.com/xtermjs/xterm.js/releases/tag/4.6.0.

cc - @ssalinas 