### PR TITLE
Render page while fetching history tables

### DIFF
--- a/SingularityUI/app/components/requestDetail/DeployHistoryTable.jsx
+++ b/SingularityUI/app/components/requestDetail/DeployHistoryTable.jsx
@@ -31,6 +31,7 @@ const DeployHistoryTable = ({requestId, deploysAPI, fetchDeploys}) => {
         paginated={true}
         fetchDataFromApi={(page, numberPerPage) => fetchDeploys(requestId, numberPerPage, page)}
         isFetching={isFetching}
+        showPageLoaderWhenFetching={true}
         defaultSortBy={'timestamp'}
       >
         <Column

--- a/SingularityUI/app/components/requestDetail/RequestDetailPage.jsx
+++ b/SingularityUI/app/components/requestDetail/RequestDetailPage.jsx
@@ -84,7 +84,7 @@ const mapStateToProps = (state, ownProps) => {
   const history = Utils.maybe(state, ['api', 'requestHistory', ownProps.params.requestId, 'data']);
   return {
     notFound: statusCode === 404 && _.isEmpty(history),
-    deleted: statusCode === 404 && !_.isEmpty(history),
+    deleted: statusCode === 404,
     pathname: ownProps.location.pathname
   };
 };

--- a/SingularityUI/app/components/requestDetail/RequestHistoryTable.jsx
+++ b/SingularityUI/app/components/requestDetail/RequestHistoryTable.jsx
@@ -28,6 +28,7 @@ const RequestHistoryTable = ({requestId, requestEventsAPI, fetchRequestHistory})
         paginated={true}
         fetchDataFromApi={(page, numberPerPage) => fetchRequestHistory(requestId, numberPerPage, page)}
         isFetching={isFetching}
+        showPageLoaderWhenFetching={true}
         defaultSortBy={'createdAt'}
       >
         <Column

--- a/SingularityUI/app/components/requestDetail/TaskHistoryTable.jsx
+++ b/SingularityUI/app/components/requestDetail/TaskHistoryTable.jsx
@@ -131,6 +131,7 @@ class TaskHistoryTable extends Component {
           paginated={true}
           fetchDataFromApi={(page, numberPerPage) => fetchTaskHistoryForRequest(requestId, numberPerPage, page)}
           isFetching={isFetching}
+          showPageLoaderWhenFetching={true}
           initialPageNumber={this.props.initialPageNumber}
           onPageChange={this.props.onPageChange}
           defaultSortBy={'updatedAt'}


### PR DESCRIPTION
History tables can sometimes be slow to fetch, so we should wait to load the entire page.

My frontend knowledge here is minimal, but I think taking advantage of this should take care of the issue: https://github.com/HubSpot/Singularity/blob/timeout/SingularityUI/app/components/common/table/UITable.jsx#L439