### PR TITLE
Sandbox permissions update should be recursive

### DIFF
--- a/SingularityExecutor/src/main/resources/runner.sh.hbs
+++ b/SingularityExecutor/src/main/resources/runner.sh.hbs
@@ -8,7 +8,7 @@ export MESOS_TASK_ID=$TASK_ID
 
 # MESOS-8322 changed this directory to 0750, chown owner since we can switch user either in mesos or the executor.
 # Otherwise, when switching user in the executor only, the non-root user can no longer traverse the sandbox
-chown {{{ user }}} $MESOS_SANDBOX
+chown -R {{{ user }}} $MESOS_SANDBOX
 
 {{#if cfsQuota }}
 # Outputs the path of the deepest cgroup the current process is in.


### PR DESCRIPTION
At the moment we do a chown of `$MESOS_SANDBOX`. This is set by mesos agent to the root of the sandbox. However, most operations on the sandbox are in the directory named after the task id, and that ends up still owned by root. This will make all directories under the sandbox owned by the correct user