### PR TITLE
History endpoint

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAuthorizer.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAuthorizer.java
@@ -38,6 +38,8 @@ public abstract class SingularityAuthorizer {
 
   public abstract void checkAdminAuthorization(SingularityUser user);
 
+  public abstract void checkGlobalReadAuthorization(SingularityUser user);
+
   public abstract void checkReadAuthorization(SingularityUser user);
 
   public abstract void checkForAuthorization(

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityGroupsAuthorizer.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityGroupsAuthorizer.java
@@ -77,6 +77,11 @@ public class SingularityGroupsAuthorizer extends SingularityAuthorizer {
   }
 
   @Override
+  public void checkGlobalReadAuthorization(SingularityUser user) {
+    checkAdminAuthorization(user);
+  }
+
+  @Override
   public void checkReadAuthorization(SingularityUser user) {
     if (authEnabled) {
       checkForbidden(user.isAuthenticated(), "Not Authenticated!");

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityGroupsScopesAuthorizer.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityGroupsScopesAuthorizer.java
@@ -63,6 +63,26 @@ public class SingularityGroupsScopesAuthorizer extends SingularityAuthorizer {
   }
 
   @Override
+  public void checkGlobalReadAuthorization(SingularityUser user) {
+    if (!authEnabled || isAdmin(user)) {
+      return;
+    }
+    Set<String> allowedReadGroups = new HashSet<>(
+      authConfiguration.getGlobalReadWriteGroups()
+    );
+    allowedReadGroups.addAll(authConfiguration.getGlobalReadOnlyGroups());
+
+    checkForbidden(user.isAuthenticated(), "Not Authenticated!");
+    checkForbiddenForGroups(
+      user,
+      allowedReadGroups,
+      "all",
+      SingularityAuthorizationScope.READ
+    );
+    checkReadScope(user);
+  }
+
+  @Override
   public void checkForAuthorization(
     SingularityRequest request,
     SingularityUser user,

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/HistoryResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/HistoryResource.java
@@ -352,7 +352,7 @@ public class HistoryResource extends AbstractHistoryResource {
         SingularityAuthorizationScope.READ
       );
     } else {
-      authorizationHelper.checkAdminAuthorization(user);
+      authorizationHelper.checkGlobalReadAuthorization(user);
     }
 
     final Integer limitCount = getLimitCount(count);
@@ -429,7 +429,7 @@ public class HistoryResource extends AbstractHistoryResource {
         SingularityAuthorizationScope.READ
       );
     } else {
-      authorizationHelper.checkAdminAuthorization(user);
+      authorizationHelper.checkGlobalReadAuthorization(user);
     }
 
     final Optional<Integer> dataCount = taskHistoryHelper.getBlendedHistoryCount(


### PR DESCRIPTION
Built off of https://github.com/HubSpot/Singularity/pull/2092. Updates the history endpoint to allow the global groups to access history search with no request id specified

relevant diff https://github.com/HubSpot/Singularity/pull/2099/commits/172eb21b5803a3b41182744636f2fd182b6fa6eb