### PR TITLE
Additional deploy validation

### DIFF
--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutor.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutor.java
@@ -4,6 +4,7 @@ import com.google.inject.Inject;
 import com.hubspot.singularity.executor.SingularityExecutorMonitor.KillState;
 import com.hubspot.singularity.executor.SingularityExecutorMonitor.SubmitState;
 import com.hubspot.singularity.executor.config.SingularityExecutorTaskBuilder;
+import com.hubspot.singularity.executor.task.ArtifactVerificationException;
 import com.hubspot.singularity.executor.task.SingularityExecutorTask;
 import com.hubspot.singularity.executor.utils.ExecutorUtils;
 import com.hubspot.singularity.executor.utils.MesosUtils;
@@ -128,11 +129,13 @@ public class SingularityExecutor implements Executor {
       }
     } catch (Throwable t) {
       LOG.error("Unexpected exception starting task {}", taskId, t);
-
+      TaskState state = t instanceof ArtifactVerificationException
+        ? TaskState.TASK_FAILED
+        : TaskState.TASK_LOST;
       executorUtils.sendStatusUpdate(
         executorDriver,
         taskInfo.getTaskId(),
-        TaskState.TASK_LOST,
+        state,
         String.format(
           "Unexpected exception while launching task %s - %s",
           taskId,

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorMonitor.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorMonitor.java
@@ -16,6 +16,7 @@ import com.hubspot.singularity.SingularityTaskExecutorData;
 import com.hubspot.singularity.executor.config.SingularityExecutorConfiguration;
 import com.hubspot.singularity.executor.config.SingularityExecutorLogging;
 import com.hubspot.singularity.executor.config.SingularityExecutorModule;
+import com.hubspot.singularity.executor.task.ArtifactVerificationException;
 import com.hubspot.singularity.executor.task.SingularityExecutorTask;
 import com.hubspot.singularity.executor.task.SingularityExecutorTaskProcessCallable;
 import com.hubspot.singularity.executor.utils.ExecutorUtils;
@@ -464,11 +465,15 @@ public class SingularityExecutorMonitor {
           try {
             onSuccessThrows(processBuilder);
           } catch (Throwable t) {
+            TaskState state = t instanceof ArtifactVerificationException
+              ? TaskState.TASK_FAILED
+              : TaskState.TASK_LOST;
             finishTask(
               task,
-              TaskState.TASK_LOST,
+              state,
               String.format(
-                "Task lost while transitioning due to: %s",
+                "%s while transitioning due to: %s",
+                state,
                 t.getClass().getSimpleName()
               ),
               Optional.of("While submitting process task"),

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
@@ -261,6 +261,8 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
   @JsonProperty
   private boolean verifyAssignedPorts = false;
 
+  private boolean failOnSignatureWithNoMatchingArtifact = false;
+
   public SingularityExecutorConfiguration() {
     super(Optional.of("singularity-executor.log"));
   }
@@ -810,6 +812,20 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
     int defaultHealthcheckInternvalSeconds
   ) {
     this.defaultHealthcheckInternvalSeconds = defaultHealthcheckInternvalSeconds;
+  }
+
+  public void setLogrotateHourlyConfDirectory(String logrotateHourlyConfDirectory) {
+    this.logrotateHourlyConfDirectory = logrotateHourlyConfDirectory;
+  }
+
+  public boolean isFailOnSignatureWithNoMatchingArtifact() {
+    return failOnSignatureWithNoMatchingArtifact;
+  }
+
+  public void setFailOnSignatureWithNoMatchingArtifact(
+    boolean failOnSignatureWithNoMatchingArtifact
+  ) {
+    this.failOnSignatureWithNoMatchingArtifact = failOnSignatureWithNoMatchingArtifact;
   }
 
   @Override

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorTaskBuilder.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorTaskBuilder.java
@@ -18,6 +18,7 @@ import com.hubspot.singularity.executor.utils.MesosUtils;
 import com.hubspot.singularity.runner.base.config.SingularityRunnerBaseModule;
 import com.hubspot.singularity.runner.base.configuration.SingularityRunnerBaseConfiguration;
 import com.hubspot.singularity.runner.base.shared.JsonObjectFileHelper;
+import com.hubspot.singularity.s3.base.config.SingularityS3Configuration;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.nio.file.Path;
@@ -38,7 +39,7 @@ public class SingularityExecutorTaskBuilder {
   private final SingularityExecutorConfiguration executorConfiguration;
   private final SingularityExecutorArtifactFetcher artifactFetcher;
   private final DockerUtils dockerUtils;
-
+  private final SingularityS3Configuration s3Configuration;
   private final SingularityExecutorLogging executorLogging;
   private final ExecutorUtils executorUtils;
 
@@ -57,7 +58,8 @@ public class SingularityExecutorTaskBuilder {
     @Named(SingularityRunnerBaseModule.PROCESS_NAME) String executorPid,
     ExecutorUtils executorUtils,
     SingularityExecutorArtifactFetcher artifactFetcher,
-    DockerUtils dockerUtils
+    DockerUtils dockerUtils,
+    SingularityS3Configuration s3Configuration
   ) {
     this.jsonObjectFileHelper = jsonObjectFileHelper;
     this.jsonObjectMapper = jsonObjectMapper;
@@ -69,6 +71,7 @@ public class SingularityExecutorTaskBuilder {
     this.dockerUtils = dockerUtils;
     this.executorPid = executorPid;
     this.executorUtils = executorUtils;
+    this.s3Configuration = s3Configuration;
   }
 
   public Logger buildTaskLogger(String taskId, String executorId) {
@@ -132,7 +135,8 @@ public class SingularityExecutorTaskBuilder {
       log,
       jsonObjectFileHelper,
       dockerUtils,
-      jsonObjectMapper
+      jsonObjectMapper,
+      s3Configuration
     );
   }
 

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorTaskBuilder.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorTaskBuilder.java
@@ -18,7 +18,6 @@ import com.hubspot.singularity.executor.utils.MesosUtils;
 import com.hubspot.singularity.runner.base.config.SingularityRunnerBaseModule;
 import com.hubspot.singularity.runner.base.configuration.SingularityRunnerBaseConfiguration;
 import com.hubspot.singularity.runner.base.shared.JsonObjectFileHelper;
-import com.hubspot.singularity.s3.base.config.SingularityS3Configuration;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.nio.file.Path;
@@ -37,7 +36,6 @@ public class SingularityExecutorTaskBuilder {
 
   private final SingularityRunnerBaseConfiguration baseConfiguration;
   private final SingularityExecutorConfiguration executorConfiguration;
-  private final SingularityS3Configuration s3Configuration;
   private final SingularityExecutorArtifactFetcher artifactFetcher;
   private final DockerUtils dockerUtils;
 
@@ -59,8 +57,7 @@ public class SingularityExecutorTaskBuilder {
     @Named(SingularityRunnerBaseModule.PROCESS_NAME) String executorPid,
     ExecutorUtils executorUtils,
     SingularityExecutorArtifactFetcher artifactFetcher,
-    DockerUtils dockerUtils,
-    SingularityS3Configuration s3Configuration
+    DockerUtils dockerUtils
   ) {
     this.jsonObjectFileHelper = jsonObjectFileHelper;
     this.jsonObjectMapper = jsonObjectMapper;
@@ -72,7 +69,6 @@ public class SingularityExecutorTaskBuilder {
     this.dockerUtils = dockerUtils;
     this.executorPid = executorPid;
     this.executorUtils = executorUtils;
-    this.s3Configuration = s3Configuration;
   }
 
   public Logger buildTaskLogger(String taskId, String executorId) {
@@ -136,7 +132,6 @@ public class SingularityExecutorTaskBuilder {
       log,
       jsonObjectFileHelper,
       dockerUtils,
-      s3Configuration,
       jsonObjectMapper
     );
   }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/ArtifactVerificationException.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/ArtifactVerificationException.java
@@ -1,0 +1,8 @@
+package com.hubspot.singularity.executor.task;
+
+public class ArtifactVerificationException extends RuntimeException {
+
+  public ArtifactVerificationException(String message) {
+    super(message);
+  }
+}

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorArtifactVerifier.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorArtifactVerifier.java
@@ -68,15 +68,15 @@ public class SingularityExecutorArtifactVerifier {
     S3Artifact s3Artifact,
     S3ArtifactSignature s3ArtifactSignature
   ) {
-    final Path artifactPath = task.getArtifactPath(
-      s3Artifact,
-      task.getTaskDefinition().getTaskDirectoryPath()
-    );
-    final Path artifactSignaturePath = task.getArtifactPath(
-      s3ArtifactSignature,
-      task.getTaskDefinition().getTaskDirectoryPath()
-    );
-
+    final Path artifactPath = task
+      .getArtifactPath(s3Artifact, task.getTaskDefinition().getTaskDirectoryPath())
+      .resolve(s3Artifact.getFilename());
+    final Path artifactSignaturePath = task
+      .getArtifactPath(
+        s3ArtifactSignature,
+        task.getTaskDefinition().getTaskDirectoryPath()
+      )
+      .resolve(s3ArtifactSignature.getFilename());
     if (!Files.exists(artifactPath)) {
       log.warn(
         "Artifact {} not found for signature {}",

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorArtifactVerifier.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorArtifactVerifier.java
@@ -52,7 +52,7 @@ public class SingularityExecutorArtifactVerifier {
       } else {
         log.warn("No matching artifact found for signature {}", s3ArtifactSignature);
         if (executorConfiguration.isFailOnSignatureWithNoMatchingArtifact()) {
-          throw new RuntimeException(
+          throw new ArtifactVerificationException(
             String.format(
               "No matching artifact found for signature %s",
               s3ArtifactSignature.getFilename()
@@ -118,7 +118,7 @@ public class SingularityExecutorArtifactVerifier {
         );
 
         if (executorConfiguration.isFailTaskOnInvalidArtifactSignature()) {
-          throw new RuntimeException(
+          throw new ArtifactVerificationException(
             String.format("Failed to validate signature for artifact %s", artifactPath)
           );
         }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorArtifactVerifier.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorArtifactVerifier.java
@@ -51,6 +51,14 @@ public class SingularityExecutorArtifactVerifier {
         );
       } else {
         log.warn("No matching artifact found for signature {}", s3ArtifactSignature);
+        if (executorConfiguration.isFailOnSignatureWithNoMatchingArtifact()) {
+          throw new RuntimeException(
+            String.format(
+              "No matching artifact found for signature %s",
+              s3ArtifactSignature.getFilename()
+            )
+          );
+        }
       }
     }
   }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTask.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTask.java
@@ -12,6 +12,7 @@ import com.hubspot.singularity.executor.utils.ExecutorUtils;
 import com.hubspot.singularity.executor.utils.MesosUtils;
 import com.hubspot.singularity.runner.base.configuration.SingularityRunnerBaseConfiguration;
 import com.hubspot.singularity.runner.base.shared.JsonObjectFileHelper;
+import com.hubspot.singularity.s3.base.config.SingularityS3Configuration;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
@@ -53,7 +54,8 @@ public class SingularityExecutorTask {
     Logger log,
     JsonObjectFileHelper jsonObjectFileHelper,
     DockerUtils dockerUtils,
-    ObjectMapper objectMapper
+    ObjectMapper objectMapper,
+    SingularityS3Configuration s3Configuration
   ) {
     this.driver = driver;
     this.taskInfo = taskInfo;
@@ -100,7 +102,12 @@ public class SingularityExecutorTask {
         objectMapper
       );
     this.artifactVerifier =
-      new SingularityExecutorArtifactVerifier(taskDefinition, log, executorConfiguration);
+      new SingularityExecutorArtifactVerifier(
+        taskDefinition,
+        log,
+        executorConfiguration,
+        s3Configuration
+      );
   }
 
   public void cleanup(TaskState state) {

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTask.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTask.java
@@ -12,7 +12,6 @@ import com.hubspot.singularity.executor.utils.ExecutorUtils;
 import com.hubspot.singularity.executor.utils.MesosUtils;
 import com.hubspot.singularity.runner.base.configuration.SingularityRunnerBaseConfiguration;
 import com.hubspot.singularity.runner.base.shared.JsonObjectFileHelper;
-import com.hubspot.singularity.s3.base.config.SingularityS3Configuration;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
@@ -54,7 +53,6 @@ public class SingularityExecutorTask {
     Logger log,
     JsonObjectFileHelper jsonObjectFileHelper,
     DockerUtils dockerUtils,
-    SingularityS3Configuration s3Configuration,
     ObjectMapper objectMapper
   ) {
     this.driver = driver;
@@ -102,12 +100,7 @@ public class SingularityExecutorTask {
         objectMapper
       );
     this.artifactVerifier =
-      new SingularityExecutorArtifactVerifier(
-        taskDefinition,
-        log,
-        executorConfiguration,
-        s3Configuration
-      );
+      new SingularityExecutorArtifactVerifier(taskDefinition, log, executorConfiguration);
   }
 
   public void cleanup(TaskState state) {

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskProcessBuilder.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskProcessBuilder.java
@@ -115,7 +115,11 @@ public class SingularityExecutorTaskProcessBuilder implements Callable<ProcessBu
       );
     task
       .getArtifactVerifier()
-      .checkSignatures(executorData.getS3ArtifactSignaturesOrEmpty());
+      .checkSignatures(
+        task,
+        executorData.getS3Artifacts(),
+        executorData.getS3ArtifactSignaturesOrEmpty()
+      );
 
     List<ArtifactList> artifactLists = new ArrayList<>();
     artifactLists.addAll(checkArtifactsForArtifactLists(executorData.getS3Artifacts()));
@@ -157,7 +161,7 @@ public class SingularityExecutorTaskProcessBuilder implements Callable<ProcessBu
           s3ArtifactSignatures,
           externalArtifacts
         );
-      task.getArtifactVerifier().checkSignatures(s3ArtifactSignatures);
+      task.getArtifactVerifier().checkSignatures(task, s3Artifacts, s3ArtifactSignatures);
     }
 
     ProcessBuilder processBuilder = buildProcessBuilder(

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskProcessBuilder.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskProcessBuilder.java
@@ -116,7 +116,6 @@ public class SingularityExecutorTaskProcessBuilder implements Callable<ProcessBu
     task
       .getArtifactVerifier()
       .checkSignatures(
-        task,
         executorData.getS3Artifacts(),
         executorData.getS3ArtifactSignaturesOrEmpty()
       );
@@ -161,7 +160,7 @@ public class SingularityExecutorTaskProcessBuilder implements Callable<ProcessBu
           s3ArtifactSignatures,
           externalArtifacts
         );
-      task.getArtifactVerifier().checkSignatures(task, s3Artifacts, s3ArtifactSignatures);
+      task.getArtifactVerifier().checkSignatures(s3Artifacts, s3ArtifactSignatures);
     }
 
     ProcessBuilder processBuilder = buildProcessBuilder(

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -422,6 +422,9 @@ public class SingularityConfiguration extends Configuration {
   @JsonProperty("crashLoop")
   private CrashLoopConfiguration crashLoopConfiguration = new CrashLoopConfiguration();
 
+  // If true, only allow artifacts with an attached signature. This disallows embedded + external artifacts, only allowing lists + s3
+  private boolean enforceSignedArtifacts = false;
+
   public long getAskDriverToKillTasksAgainAfterMillis() {
     return askDriverToKillTasksAgainAfterMillis;
   }
@@ -1862,5 +1865,13 @@ public class SingularityConfiguration extends Configuration {
 
   public void setReconcileLaunchAfterMillis(long reconcileLaunchAfterMillis) {
     this.reconcileLaunchAfterMillis = reconcileLaunchAfterMillis;
+  }
+
+  public boolean isEnforceSignedArtifacts() {
+    return enforceSignedArtifacts;
+  }
+
+  public void setEnforceSignedArtifacts(boolean enforceSignedArtifacts) {
+    this.enforceSignedArtifacts = enforceSignedArtifacts;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -425,6 +425,9 @@ public class SingularityConfiguration extends Configuration {
   // If true, only allow artifacts with an attached signature. This disallows embedded + external artifacts, only allowing lists + s3
   private boolean enforceSignedArtifacts = false;
 
+  // If not empty, disallow docker images in deploys unless they are in this list
+  private Set<String> validDockerRegistries = Collections.emptySet();
+
   public long getAskDriverToKillTasksAgainAfterMillis() {
     return askDriverToKillTasksAgainAfterMillis;
   }
@@ -1873,5 +1876,13 @@ public class SingularityConfiguration extends Configuration {
 
   public void setEnforceSignedArtifacts(boolean enforceSignedArtifacts) {
     this.enforceSignedArtifacts = enforceSignedArtifacts;
+  }
+
+  public Set<String> getValidDockerRegistries() {
+    return validDockerRegistries;
+  }
+
+  public void setValidDockerRegistries(Set<String> validDockerRegistries) {
+    this.validDockerRegistries = validDockerRegistries;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
@@ -683,7 +683,11 @@ public class SingularityValidator {
         String image = deploy.getContainerInfo().get().getDocker().get().getImage();
         checkBadRequest(
           validDockerRegistries.contains(URI.create(image).getHost()),
-          String.format("%s does not point to an allowed docker registry", image)
+          String.format(
+            "%s does not point to an allowed docker registry. Must be one of: %s",
+            image,
+            validDockerRegistries
+          )
         );
       }
     }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
@@ -105,6 +105,7 @@ public class SingularityValidator {
   private final int deployIdLength;
   private final boolean allowBounceToSameHost;
   private final boolean enforceSignedArtifacts;
+  private final Set<String> validDockerRegistries;
   private final UIConfiguration uiConfiguration;
   private final SlavePlacement defaultSlavePlacement;
   private final DeployHistoryHelper deployHistoryHelper;
@@ -173,6 +174,7 @@ public class SingularityValidator {
     this.maxDecommissioningSlaves = configuration.getMaxDecommissioningSlaves();
     this.spreadAllSlavesEnabled = configuration.isSpreadAllSlavesEnabled();
     this.enforceSignedArtifacts = configuration.isEnforceSignedArtifacts();
+    this.validDockerRegistries = configuration.getValidDockerRegistries();
 
     this.uiConfiguration = uiConfiguration;
 
@@ -669,6 +671,19 @@ public class SingularityValidator {
               }
             ),
           "Only signed artifacts are allowed"
+        );
+      }
+    }
+
+    if (!validDockerRegistries.isEmpty()) {
+      if (
+        deploy.getContainerInfo().isPresent() &&
+        deploy.getContainerInfo().get().getDocker().isPresent()
+      ) {
+        String image = deploy.getContainerInfo().get().getDocker().get().getImage();
+        checkBadRequest(
+          validDockerRegistries.contains(URI.create(image).getHost()),
+          String.format("%s does not point to an allowed docker registry", image)
         );
       }
     }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
@@ -49,6 +49,7 @@ import com.hubspot.singularity.config.shell.ShellCommandDescriptor;
 import com.hubspot.singularity.config.shell.ShellCommandOptionDescriptor;
 import com.hubspot.singularity.data.history.DeployHistoryHelper;
 import com.hubspot.singularity.expiring.SingularityExpiringMachineState;
+import com.hubspot.singularity.helpers.ImageName;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -680,9 +681,11 @@ public class SingularityValidator {
         deploy.getContainerInfo().isPresent() &&
         deploy.getContainerInfo().get().getDocker().isPresent()
       ) {
-        String image = deploy.getContainerInfo().get().getDocker().get().getImage();
+        ImageName image = new ImageName(
+          deploy.getContainerInfo().get().getDocker().get().getImage()
+        );
         checkBadRequest(
-          validDockerRegistries.contains(URI.create(image).getHost()),
+          validDockerRegistries.contains(image.getRegistry()),
           String.format(
             "%s does not point to an allowed docker registry. Must be one of: %s",
             image,

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
@@ -13,6 +13,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.hash.Hashing;
 import com.google.inject.Inject;
+import com.hubspot.deploy.ExecutorData;
 import com.hubspot.deploy.HealthcheckOptions;
 import com.hubspot.mesos.Resources;
 import com.hubspot.mesos.SingularityContainerInfo;
@@ -30,13 +31,11 @@ import com.hubspot.singularity.SingularityDeploy;
 import com.hubspot.singularity.SingularityDeployBuilder;
 import com.hubspot.singularity.SingularityPendingRequest;
 import com.hubspot.singularity.SingularityPendingRequest.PendingType;
-import com.hubspot.singularity.SingularityPendingTaskId;
 import com.hubspot.singularity.SingularityPriorityFreezeParent;
 import com.hubspot.singularity.SingularityRequest;
 import com.hubspot.singularity.SingularityRequestGroup;
 import com.hubspot.singularity.SingularityRunNowRequestBuilder;
 import com.hubspot.singularity.SingularityShellCommand;
-import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.SingularityWebhook;
 import com.hubspot.singularity.SlavePlacement;
 import com.hubspot.singularity.WebExceptions;
@@ -105,6 +104,7 @@ public class SingularityValidator {
   private final boolean createDeployIds;
   private final int deployIdLength;
   private final boolean allowBounceToSameHost;
+  private final boolean enforceSignedArtifacts;
   private final UIConfiguration uiConfiguration;
   private final SlavePlacement defaultSlavePlacement;
   private final DeployHistoryHelper deployHistoryHelper;
@@ -170,9 +170,9 @@ public class SingularityValidator {
     this.defaultHealthcheckResponseTimeoutSeconds =
       configuration.getHealthcheckTimeoutSeconds();
     this.maxRunNowTaskLaunchDelay = configuration.getMaxRunNowTaskLaunchDelayDays();
-
     this.maxDecommissioningSlaves = configuration.getMaxDecommissioningSlaves();
     this.spreadAllSlavesEnabled = configuration.isSpreadAllSlavesEnabled();
+    this.enforceSignedArtifacts = configuration.isEnforceSignedArtifacts();
 
     this.uiConfiguration = uiConfiguration;
 
@@ -384,9 +384,7 @@ public class SingularityValidator {
   @SuppressFBWarnings("NP_NULL_ON_SOME_PATH") // false positive on deployId which is already checked for null
   public SingularityDeploy checkDeploy(
     SingularityRequest request,
-    SingularityDeploy deploy,
-    List<SingularityTaskId> activeTasks,
-    List<SingularityPendingTaskId> pendingTasks
+    SingularityDeploy deploy
   ) {
     checkNotNull(request, "request is null");
     checkNotNull(deploy, "deploy is null");
@@ -638,20 +636,50 @@ public class SingularityValidator {
       }
     }
 
+    if (enforceSignedArtifacts) {
+      checkBadRequest(
+        !deploy.getUris().isPresent() || deploy.getUris().get().isEmpty(),
+        "Only signed artifacts are allowed, cannot specify artifact uri"
+      );
+      if (deploy.getExecutorData().isPresent()) {
+        ExecutorData executorData = deploy.getExecutorData().get();
+        checkBadRequest(
+          executorData.getEmbeddedArtifacts().isEmpty(),
+          "Only signed artifacts are allowed, cannot specify embedded artifacts"
+        );
+        checkBadRequest(
+          executorData.getExternalArtifacts().isEmpty(),
+          "Only signed artifacts are allowed, cannot specify external artifacts"
+        );
+        checkBadRequest(
+          executorData
+            .getS3Artifacts()
+            .stream()
+            .noneMatch(
+              a -> {
+                if (!executorData.getS3ArtifactSignatures().isPresent()) {
+                  return false;
+                } else {
+                  return executorData
+                    .getS3ArtifactSignatures()
+                    .get()
+                    .stream()
+                    .anyMatch(s -> s.getArtifactFilename().equals(a.getFilename()));
+                }
+              }
+            ),
+          "Only signed artifacts are allowed"
+        );
+      }
+    }
+
     checkBadRequest(
       deployHistoryHelper.isDeployIdAvailable(request.getId(), deployId),
       "Can not deploy a deploy that has already been deployed"
     );
 
     if (deploy.getRunImmediately().isPresent()) {
-      deploy =
-        checkImmediateRunDeploy(
-          request,
-          deploy,
-          deploy.getRunImmediately().get(),
-          activeTasks,
-          pendingTasks
-        );
+      deploy = checkImmediateRunDeploy(request, deploy, deploy.getRunImmediately().get());
     }
 
     if (request.isDeployable()) {
@@ -664,9 +692,7 @@ public class SingularityValidator {
   private SingularityDeploy checkImmediateRunDeploy(
     SingularityRequest request,
     SingularityDeploy deploy,
-    SingularityRunNowRequest runNowRequest,
-    List<SingularityTaskId> activeTasks,
-    List<SingularityPendingTaskId> pendingTasks
+    SingularityRunNowRequest runNowRequest
   ) {
     if (!request.isScheduled() && !request.isOneOff()) {
       throw badRequest(

--- a/SingularityService/src/main/java/com/hubspot/singularity/helpers/ImageName.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/helpers/ImageName.java
@@ -1,0 +1,307 @@
+package com.hubspot.singularity.helpers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Helper class for parsing docker repository/image names:
+ *
+ */
+public class ImageName {
+  private String repository;
+  private String registry;
+  private String tag;
+  private String digest;
+  private String user;
+
+  /**
+   * Create an image name
+   *
+   * @param fullName The fullname of the image in Docker format.
+   */
+  public ImageName(String fullName) {
+    this(fullName, null);
+  }
+
+  /**
+   * Create an image name with a tag. If a tag is provided (i.e. is not null) then this tag is used.
+   * Otherwise the tag of the provided name is used (if any).
+   *
+   * @param fullName The fullname of the image in Docker format. I
+   * @param givenTag tag to use. Can be null in which case the tag specified in fullName is used.
+   */
+  public ImageName(String fullName, String givenTag) {
+    if (fullName == null) {
+      throw new NullPointerException("Image name must not be null");
+    }
+
+    // set digest to null as default
+    digest = null;
+    // check if digest is part of fullName, if so -> extract it
+    if (fullName.contains("@sha256")) { // Of it contains digest
+      String[] digestParts = fullName.split("@");
+      digest = digestParts[1];
+      fullName = digestParts[0];
+    }
+
+    // check for tag
+    Pattern tagPattern = Pattern.compile("^(.+?)(?::([^:/]+))?$");
+    Matcher matcher = tagPattern.matcher(fullName);
+    if (!matcher.matches()) {
+      throw new IllegalArgumentException(
+        fullName + " is not a proper image name ([registry/][repo][:port]"
+      );
+    }
+    // extract tag if it exists
+    tag = givenTag != null ? givenTag : matcher.group(2);
+    String rest = matcher.group(1);
+
+    // extract registry, repository, user
+    parseComponentsBeforeTag(rest);
+
+    /*
+     * set tag to latest if tag AND digest are null
+     * if digest is not null but tag is -> leave it!
+     *  -> in case of "image_name@sha256" it is not required to get resolved to "latest"
+     */
+    if (tag == null && digest == null) {
+      tag = "latest";
+    }
+
+    doValidate();
+  }
+
+  public String getRepository() {
+    return repository;
+  }
+
+  public String getRegistry() {
+    return registry;
+  }
+
+  public String getTag() {
+    return tag;
+  }
+
+  public String getDigest() {
+    return digest;
+  }
+
+  public boolean hasRegistry() {
+    return registry != null && registry.length() > 0;
+  }
+
+  private String joinTail(String[] parts) {
+    StringBuilder builder = new StringBuilder();
+    for (int i = 1; i < parts.length; i++) {
+      builder.append(parts[i]);
+      if (i < parts.length - 1) {
+        builder.append("/");
+      }
+    }
+    return builder.toString();
+  }
+
+  private boolean isRegistry(String part) {
+    return part.contains(".") || part.contains(":");
+  }
+
+  /**
+   * Get the full name of this image, including the registry but without
+   * any tag (e.g. <code>privateregistry:fabric8io/java</code>)
+   *
+   * @return full name with the original registry
+   */
+  public String getNameWithoutTag() {
+    return getNameWithoutTag(null);
+  }
+
+  /**
+   * Get the full name of this image like {@link #getNameWithoutTag()} does, but allow
+   * an optional registry. This registry is used when this image does not already
+   * contain a registry.
+   *
+   * @param optionalRegistry optional registry to use when this image does not provide
+   *                         a registry. Can be null in which case no optional registry is used*
+   * @return full name with original registry (if set) or optional registry (if not <code>null</code>)
+   */
+  public String getNameWithoutTag(String optionalRegistry) {
+    StringBuilder ret = new StringBuilder();
+    if (registry != null || optionalRegistry != null) {
+      ret.append(registry != null ? registry : optionalRegistry).append("/");
+    }
+    ret.append(repository);
+    return ret.toString();
+  }
+
+  /**
+   * Get the full name of this image, including the registry and tag
+   * (e.g. <code>privateregistry:fabric8io/java:7u53</code>)
+   *
+   * @return full name with the original registry and the original tag given (if any).
+   */
+  public String getFullName() {
+    return getFullName(null);
+  }
+
+  /**
+   * Get the full name of this image like {@link #getFullName(String)} does, but allow
+   * an optional registry. This registry is used when this image does not already
+   * contain a registry. If no tag was provided in the initial name, <code>latest</code> is used.
+   *
+   * @param optionalRegistry optional registry to use when this image does not provide
+   *                         a registry. Can be null in which case no optional registry is used*
+   * @return full name with original registry (if set) or optional registry (if not <code>null</code>).
+   */
+  public String getFullName(String optionalRegistry) {
+    String fullName = getNameWithoutTag(optionalRegistry);
+    if (tag != null) {
+      fullName = fullName + ":" + tag;
+    }
+    if (digest != null) {
+      fullName = fullName + "@" + digest;
+    }
+    return fullName;
+  }
+
+  /**
+   * Get the user (or "project") part of the image name. This is the part after the registry and before
+   * the image name
+   *
+   * @return user part or <code>null</code> if no user is present in the name
+   */
+  public String getUser() {
+    return user;
+  }
+
+  /**
+   * Get the simple name of the image, which is the repository sans the user parts.
+   *
+   * @return simple name of the image
+   */
+  public String getSimpleName() {
+    String prefix = user + "/";
+    return repository.startsWith(prefix)
+      ? repository.substring(prefix.length())
+      : repository;
+  }
+
+  /**
+   * Check whether the given name validates agains the Docker rules for names
+   *
+   * @param image image name to validate
+   * d@throws IllegalArgumentException if the name doesnt validate
+   */
+  public static void validate(String image) {
+    // Validation will be triggered during construction
+    new ImageName(image);
+  }
+
+  // Validate parts and throw an IllegalArgumentException if a part is not valid
+  private void doValidate() {
+    List<String> errors = new ArrayList<>();
+    // Strip off user from repository name
+    String image = user != null ? repository.substring(user.length() + 1) : repository;
+    Object[] checks = new Object[] {
+      "registry",
+      DOMAIN_REGEXP,
+      registry,
+      "image",
+      IMAGE_NAME_REGEXP,
+      image,
+      "user",
+      NAME_COMP_REGEXP,
+      user,
+      "tag",
+      TAG_REGEXP,
+      tag,
+      "digest",
+      DIGEST_REGEXP,
+      digest
+    };
+    for (int i = 0; i < checks.length; i += 3) {
+      String value = (String) checks[i + 2];
+      Pattern checkPattern = (Pattern) checks[i + 1];
+      if (value != null && !checkPattern.matcher(value).matches()) {
+        errors.add(
+          String.format(
+            "%s part '%s' doesn't match allowed pattern '%s'",
+            checks[i],
+            value,
+            checkPattern.pattern()
+          )
+        );
+      }
+    }
+    if (errors.size() > 0) {
+      StringBuilder buf = new StringBuilder();
+      buf.append(String.format("Given Docker name '%s' is invalid:\n", getFullName()));
+      for (String error : errors) {
+        buf.append(String.format("   * %s\n", error));
+      }
+      buf.append("See http://bit.ly/docker_image_fmt for more details");
+      throw new IllegalArgumentException(buf.toString());
+    }
+  }
+
+  private void parseComponentsBeforeTag(String rest) {
+    String[] parts = rest.split("\\s*/\\s*");
+    if (parts.length == 1) {
+      registry = null;
+      user = null;
+      repository = parts[0];
+    } else if (parts.length >= 2) {
+      if (isRegistry(parts[0])) {
+        registry = parts[0];
+        if (parts.length > 2) {
+          user = parts[1];
+          repository = joinTail(parts);
+        } else {
+          user = null;
+          repository = parts[1];
+        }
+      } else {
+        registry = null;
+        user = parts[0];
+        repository = rest;
+      }
+    }
+  }
+
+  // ================================================================================================
+
+  // Validations patterns, taken directly from the docker source -->
+  // https://github.com/docker/docker/blob/04da4041757370fb6f85510c8977c5a18ddae380/vendor/github.com/docker/distribution/reference/regexp.go
+  // https://github.com/docker/docker/blob/04da4041757370fb6f85510c8977c5a18ddae380/vendor/github.com/docker/distribution/reference/reference.go
+
+  // ---------------------------------------------------------------------
+  // https://github.com/docker/docker/blob/04da4041757370fb6f85510c8977c5a18ddae380/vendor/github.com/docker/distribution/reference/regexp.go#L18
+  private final String nameComponentRegexp =
+    "[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?";
+
+  // https://github.com/docker/docker/blob/04da4041757370fb6f85510c8977c5a18ddae380/vendor/github.com/docker/distribution/reference/regexp.go#L25
+  private final String domainComponentRegexp =
+    "(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])";
+
+  // ==========================================================
+
+  // https://github.com/docker/docker/blob/04da4041757370fb6f85510c8977c5a18ddae380/vendor/github.com/docker/distribution/reference/regexp.go#L18
+  private final Pattern NAME_COMP_REGEXP = Pattern.compile(nameComponentRegexp);
+
+  // https://github.com/docker/docker/blob/04da4041757370fb6f85510c8977c5a18ddae380/vendor/github.com/docker/distribution/reference/regexp.go#L53
+  private final Pattern IMAGE_NAME_REGEXP = Pattern.compile(
+    nameComponentRegexp + "(?:(?:/" + nameComponentRegexp + ")+)?"
+  );
+
+  // https://github.com/docker/docker/blob/04da4041757370fb6f85510c8977c5a18ddae380/vendor/github.com/docker/distribution/reference/regexp.go#L31
+  private final Pattern DOMAIN_REGEXP = Pattern.compile(
+    "^" + domainComponentRegexp + "(?:\\." + domainComponentRegexp + ")*(?::[0-9]+)?$"
+  );
+
+  // https://github.com/docker/docker/blob/04da4041757370fb6f85510c8977c5a18ddae380/vendor/github.com/docker/distribution/reference/regexp.go#L37
+  private final Pattern TAG_REGEXP = Pattern.compile("^[\\w][\\w.-]{0,127}$");
+
+  private final Pattern DIGEST_REGEXP = Pattern.compile("^sha256:[a-z0-9]{32,}$");
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/DeployResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/DeployResource.java
@@ -201,13 +201,7 @@ public class DeployResource extends AbstractRequestResource {
       );
     }
 
-    deploy =
-      validator.checkDeploy(
-        request,
-        deploy,
-        taskManager.getActiveTaskIdsForRequest(requestId),
-        taskManager.getPendingTaskIdsForRequest(requestId)
-      );
+    deploy = validator.checkDeploy(request, deploy);
 
     final long now = System.currentTimeMillis();
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/data/ValidatorTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/data/ValidatorTest.java
@@ -112,13 +112,7 @@ public class ValidatorTest extends SingularitySchedulerTestBase {
 
     Assertions.assertThrows(
       WebApplicationException.class,
-      () ->
-        validator.checkDeploy(
-          singularityRequest,
-          singularityDeploy,
-          Collections.emptyList(),
-          Collections.emptyList()
-        )
+      () -> validator.checkDeploy(singularityRequest, singularityDeploy)
     );
   }
 
@@ -137,12 +131,7 @@ public class ValidatorTest extends SingularitySchedulerTestBase {
 
     boolean thrown = false;
     try {
-      validator.checkDeploy(
-        singularityRequest,
-        singularityDeploy,
-        Collections.emptyList(),
-        Collections.emptyList()
-      );
+      validator.checkDeploy(singularityRequest, singularityDeploy);
     } catch (WebApplicationException exn) {
       Assertions.assertTrue(
         ((String) exn.getResponse().getEntity()).contains("[a-zA-Z0-9_.]")
@@ -167,13 +156,7 @@ public class ValidatorTest extends SingularitySchedulerTestBase {
 
     Assertions.assertThrows(
       WebApplicationException.class,
-      () ->
-        validator.checkDeploy(
-          request,
-          deploy,
-          Collections.emptyList(),
-          Collections.emptyList()
-        )
+      () -> validator.checkDeploy(request, deploy)
     );
   }
 
@@ -318,12 +301,7 @@ public class ValidatorTest extends SingularitySchedulerTestBase {
       .setRunImmediately(runNowRequest)
       .build();
 
-    SingularityDeploy result = validator.checkDeploy(
-      request,
-      deploy,
-      Collections.emptyList(),
-      Collections.emptyList()
-    );
+    SingularityDeploy result = validator.checkDeploy(request, deploy);
     Assertions.assertTrue(result.getRunImmediately().isPresent());
     Assertions.assertTrue(result.getRunImmediately().get().getRunId().isPresent());
   }
@@ -349,13 +327,7 @@ public class ValidatorTest extends SingularitySchedulerTestBase {
 
     Assertions.assertThrows(
       WebApplicationException.class,
-      () ->
-        validator.checkDeploy(
-          request,
-          deploy,
-          Collections.emptyList(),
-          Collections.emptyList()
-        )
+      () -> validator.checkDeploy(request, deploy)
     );
   }
 
@@ -378,13 +350,7 @@ public class ValidatorTest extends SingularitySchedulerTestBase {
 
     Assertions.assertThrows(
       WebApplicationException.class,
-      () ->
-        validator.checkDeploy(
-          request,
-          deploy,
-          Collections.emptyList(),
-          Collections.emptyList()
-        )
+      () -> validator.checkDeploy(request, deploy)
     );
   }
 
@@ -430,12 +396,7 @@ public class ValidatorTest extends SingularitySchedulerTestBase {
 
     boolean thrown = false;
     try {
-      validator.checkDeploy(
-        request,
-        deploy,
-        Collections.emptyList(),
-        Collections.emptyList()
-      );
+      validator.checkDeploy(request, deploy);
     } catch (WebApplicationException exn) {
       thrown = true;
       Assertions.assertTrue(
@@ -474,12 +435,7 @@ public class ValidatorTest extends SingularitySchedulerTestBase {
 
     boolean thrown = false;
     try {
-      validator.checkDeploy(
-        request,
-        deploy,
-        Collections.emptyList(),
-        Collections.emptyList()
-      );
+      validator.checkDeploy(request, deploy);
     } catch (WebApplicationException exn) {
       thrown = true;
       Assertions.assertTrue(


### PR DESCRIPTION
Two main pieces:
- Add the ability to lock down artifact specification to only signed artifacts (s3 + signature file). This does not validate everything within a list, assuming that if the list is signed, the things within the list are valid
- Add valid docker registry list so Singularity can lock usage down to only an internal docker registry if needed