### PR TITLE
Add ability to auth to mesos http endpoints

### DIFF
--- a/SingularityMesosClient/src/main/java/com/hubspot/mesos/client/SingularityMesosClientModule.java
+++ b/SingularityMesosClient/src/main/java/com/hubspot/mesos/client/SingularityMesosClientModule.java
@@ -15,6 +15,16 @@ public class SingularityMesosClientModule extends AbstractModule {
     "singularity.mesos.client.object.mapper";
   private static final int MESOS_CLIENT_HTTP_SHORT_TIMEOUT_SECONDS = 5;
 
+  private final UserAndPassword credentials;
+
+  public SingularityMesosClientModule(UserAndPassword credentials) {
+    this.credentials = credentials;
+  }
+
+  public SingularityMesosClientModule() {
+    this.credentials = UserAndPassword.empty();
+  }
+
   @Override
   protected void configure() {
     ObjectMapper objectMapper = JavaUtils.newObjectMapper();
@@ -26,6 +36,9 @@ public class SingularityMesosClientModule extends AbstractModule {
     bind(HttpClient.class)
       .annotatedWith(Names.named(SingularityMesosClient.DEFAULT_HTTP_CLIENT_NAME))
       .toInstance(new NingHttpClient(httpConfigBuilder.build()));
+    bind(UserAndPassword.class)
+      .annotatedWith(Names.named(SingularityMesosClient.MESOS_CREDENTIALS))
+      .toInstance(credentials);
 
     bind(HttpClient.class)
       .annotatedWith(Names.named(SingularityMesosClient.SHORT_TIMEOUT_HTTP_CLIENT_NAME))

--- a/SingularityMesosClient/src/main/java/com/hubspot/mesos/client/UserAndPassword.java
+++ b/SingularityMesosClient/src/main/java/com/hubspot/mesos/client/UserAndPassword.java
@@ -1,0 +1,27 @@
+package com.hubspot.mesos.client;
+
+public class UserAndPassword {
+  private final String user;
+  private final String password;
+
+  public static UserAndPassword empty() {
+    return new UserAndPassword(null, null);
+  }
+
+  public UserAndPassword(String user, String password) {
+    this.user = user;
+    this.password = password;
+  }
+
+  public String getUser() {
+    return user;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public boolean hasCredentials() {
+    return user != null && password != null;
+  }
+}


### PR DESCRIPTION
Ability to still hit mesos master api endpoints when authenticate_http_readonly and authenticate_http_readwrite flags are set. Uses the same credentials as specified in MesosConfiguration that are used to register the framework (e.g. Singularity just needs a single principal with ability to register and to hit the read/write apis)