### PR TITLE
Add option for downloader to listen on unix socket

### DIFF
--- a/SingularityExecutor/pom.xml
+++ b/SingularityExecutor/pom.xml
@@ -123,6 +123,11 @@
 
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-http</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-unixsocket</artifactId>
     </dependency>
 

--- a/SingularityExecutor/pom.xml
+++ b/SingularityExecutor/pom.xml
@@ -117,6 +117,16 @@
     </dependency>
 
     <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-unixsocket</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.sun.activation</groupId>
       <artifactId>jakarta.activation</artifactId>
       <scope>runtime</scope>

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorRunner.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorRunner.java
@@ -10,6 +10,7 @@ import com.google.inject.name.Named;
 import com.hubspot.mesos.JavaUtils;
 import com.hubspot.singularity.executor.config.SingularityExecutorConfiguration;
 import com.hubspot.singularity.executor.config.SingularityExecutorModule;
+import com.hubspot.singularity.executor.task.LocalDownloadServiceFetcher;
 import com.hubspot.singularity.runner.base.config.SingularityRunnerBaseModule;
 import com.hubspot.singularity.runner.base.configuration.BaseRunnerConfiguration;
 import com.hubspot.singularity.s3.base.config.SingularityS3Configuration;
@@ -41,6 +42,10 @@ public class SingularityExecutorRunner {
       final SingularityExecutorRunner executorRunner = injector.getInstance(
         SingularityExecutorRunner.class
       );
+      final LocalDownloadServiceFetcher downloadServiceFetcher = injector.getInstance(
+        LocalDownloadServiceFetcher.class
+      );
+      downloadServiceFetcher.start();
 
       final Protos.Status driverStatus = executorRunner.run();
 
@@ -50,6 +55,7 @@ public class SingularityExecutorRunner {
         driverStatus
       );
 
+      downloadServiceFetcher.stop();
       stopLog();
 
       System.exit(driverStatus == Protos.Status.DRIVER_STOPPED ? 0 : 1);

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/CompletableFutureResponseListener.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/CompletableFutureResponseListener.java
@@ -1,0 +1,33 @@
+package com.hubspot.singularity.executor.task;
+
+import java.util.concurrent.CompletableFuture;
+import org.eclipse.jetty.client.HttpContentResponse;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.api.Result;
+import org.eclipse.jetty.client.util.BufferingResponseListener;
+
+public class CompletableFutureResponseListener extends BufferingResponseListener {
+  private final CompletableFuture<ContentResponse> completable;
+
+  public CompletableFutureResponseListener(
+    CompletableFuture<ContentResponse> completable
+  ) {
+    this.completable = completable;
+  }
+
+  @Override
+  public void onComplete(Result result) {
+    if (result.isFailed()) {
+      completable.completeExceptionally(result.getFailure());
+    } else {
+      completable.complete(
+        new HttpContentResponse(
+          result.getResponse(),
+          getContent(),
+          getMediaType(),
+          getEncoding()
+        )
+      );
+    }
+  }
+}

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/HttpLocalDownloadServiceFetcher.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/HttpLocalDownloadServiceFetcher.java
@@ -42,6 +42,11 @@ public class HttpLocalDownloadServiceFetcher implements LocalDownloadServiceFetc
   }
 
   @Override
+  public String getDownloadPath() {
+    return localDownloadUri;
+  }
+
+  @Override
   public void downloadFiles(
     List<? extends S3Artifact> s3Artifacts,
     SingularityExecutorTask task

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/HttpLocalDownloadServiceFetcher.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/HttpLocalDownloadServiceFetcher.java
@@ -88,7 +88,7 @@ public class HttpLocalDownloadServiceFetcher implements LocalDownloadServiceFetc
     }
 
     for (FutureHolder future : futures) {
-      Response response = future.getReponse();
+      Response response = future.getResponse();
 
       task
         .getLog()
@@ -120,7 +120,7 @@ public class HttpLocalDownloadServiceFetcher implements LocalDownloadServiceFetc
       this.s3Artifact = s3Artifact;
     }
 
-    public Response getReponse() throws InterruptedException {
+    public Response getResponse() throws InterruptedException {
       try {
         return future.get();
       } catch (ExecutionException e) {

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/HttpLocalDownloadServiceFetcher.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/HttpLocalDownloadServiceFetcher.java
@@ -1,0 +1,126 @@
+package com.hubspot.singularity.executor.task;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
+import com.hubspot.deploy.S3Artifact;
+import com.hubspot.mesos.JavaUtils;
+import com.hubspot.singularity.executor.config.SingularityExecutorConfiguration;
+import com.hubspot.singularity.s3.base.ArtifactDownloadRequest;
+import com.hubspot.singularity.s3.base.config.SingularityS3Configuration;
+import com.ning.http.client.AsyncHttpClient;
+import com.ning.http.client.AsyncHttpClient.BoundRequestBuilder;
+import com.ning.http.client.ListenableFuture;
+import com.ning.http.client.Response;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+
+public class HttpLocalDownloadServiceFetcher implements LocalDownloadServiceFetcher {
+  private static final String LOCAL_DOWNLOAD_STRING_FORMAT = "http://localhost:%s%s";
+
+  private final AsyncHttpClient httpClient;
+  private final ObjectMapper objectMapper;
+  private final SingularityExecutorConfiguration executorConfiguration;
+  private final String localDownloadUri;
+
+  public HttpLocalDownloadServiceFetcher(
+    AsyncHttpClient httpClient,
+    ObjectMapper objectMapper,
+    SingularityExecutorConfiguration executorConfiguration,
+    SingularityS3Configuration s3Configuration
+  ) {
+    this.httpClient = httpClient;
+    this.objectMapper = objectMapper;
+    this.executorConfiguration = executorConfiguration;
+    this.localDownloadUri =
+      String.format(
+        LOCAL_DOWNLOAD_STRING_FORMAT,
+        s3Configuration.getLocalDownloadHttpPort(),
+        s3Configuration.getLocalDownloadPath()
+      );
+  }
+
+  @Override
+  public void downloadFiles(
+    List<? extends S3Artifact> s3Artifacts,
+    SingularityExecutorTask task
+  )
+    throws InterruptedException {
+    final List<FutureHolder> futures = Lists.newArrayListWithCapacity(s3Artifacts.size());
+
+    for (S3Artifact s3Artifact : s3Artifacts) {
+      String destination = task
+        .getArtifactPath(s3Artifact, task.getTaskDefinition().getTaskDirectoryPath())
+        .toString();
+      ArtifactDownloadRequest artifactDownloadRequest = new ArtifactDownloadRequest(
+        destination,
+        s3Artifact,
+        Optional.of(executorConfiguration.getLocalDownloadServiceTimeoutMillis())
+      );
+
+      task
+        .getLog()
+        .debug("Requesting {} from {}", artifactDownloadRequest, localDownloadUri);
+
+      BoundRequestBuilder postRequestBldr = httpClient.preparePost(localDownloadUri);
+
+      try {
+        postRequestBldr.setBody(objectMapper.writeValueAsBytes(artifactDownloadRequest));
+      } catch (JsonProcessingException e) {
+        throw new RuntimeException(e);
+      }
+
+      try {
+        ListenableFuture<Response> future = httpClient.executeRequest(
+          postRequestBldr.build()
+        );
+
+        futures.add(new FutureHolder(future, System.currentTimeMillis(), s3Artifact));
+      } catch (Throwable t) {
+        throw new RuntimeException(t);
+      }
+    }
+
+    for (FutureHolder future : futures) {
+      Response response = future.getReponse();
+
+      task
+        .getLog()
+        .debug(
+          "Future for {} got status code {} after {}",
+          future.s3Artifact.getName(),
+          response.getStatusCode(),
+          JavaUtils.duration(future.start)
+        );
+
+      if (response.getStatusCode() != 200) {
+        throw new IllegalStateException("Got status code:" + response.getStatusCode());
+      }
+    }
+  }
+
+  private static class FutureHolder {
+    private final ListenableFuture<Response> future;
+    private final long start;
+    private final S3Artifact s3Artifact;
+
+    public FutureHolder(
+      ListenableFuture<Response> future,
+      long start,
+      S3Artifact s3Artifact
+    ) {
+      this.future = future;
+      this.start = start;
+      this.s3Artifact = s3Artifact;
+    }
+
+    public Response getReponse() throws InterruptedException {
+      try {
+        return future.get();
+      } catch (ExecutionException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+}

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/LocalDownloadServiceFetcher.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/LocalDownloadServiceFetcher.java
@@ -10,6 +10,8 @@ public interface LocalDownloadServiceFetcher {
   )
     throws InterruptedException;
 
+  String getDownloadPath();
+
   default void start() {}
 
   default void stop() {}

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/LocalDownloadServiceFetcher.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/LocalDownloadServiceFetcher.java
@@ -1,0 +1,16 @@
+package com.hubspot.singularity.executor.task;
+
+import com.hubspot.deploy.S3Artifact;
+import java.util.List;
+
+public interface LocalDownloadServiceFetcher {
+  void downloadFiles(
+    List<? extends S3Artifact> s3Artifacts,
+    SingularityExecutorTask task
+  )
+    throws InterruptedException;
+
+  default void start() {}
+
+  default void stop() {}
+}

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorArtifactFetcher.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorArtifactFetcher.java
@@ -115,9 +115,10 @@ public class SingularityExecutorArtifactFetcher {
         task
           .getLog()
           .info(
-            "Fetching {} (S3) artifacts and {} (S3) artifact signatures",
+            "Fetching {} (S3) artifacts and {} (S3) artifact signatures from {}",
             s3Artifacts.size(),
-            s3ArtifactsWithSignature.size()
+            s3ArtifactsWithSignature.size(),
+            localDownloadServiceFetcher.getDownloadPath()
           );
 
         try {

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskProcessBuilder.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskProcessBuilder.java
@@ -102,8 +102,7 @@ public class SingularityExecutorTaskProcessBuilder implements Callable<ProcessBu
       task.getLog()
     );
 
-    taskArtifactFetcher =
-      Optional.of(artifactFetcher.buildTaskFetcher(executorData, task));
+    taskArtifactFetcher = Optional.of(artifactFetcher.buildTaskFetcher(task));
 
     taskArtifactFetcher
       .get()

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/UnixLocalDownloadServiceFetcher.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/UnixLocalDownloadServiceFetcher.java
@@ -21,7 +21,7 @@ public class UnixLocalDownloadServiceFetcher implements LocalDownloadServiceFetc
   private final ObjectMapper objectMapper;
   private final HttpClient httpClient;
   private final SingularityExecutorConfiguration executorConfiguration;
-  private final String localDownloadUri;
+  private final SingularityS3Configuration s3Configuration;
 
   public UnixLocalDownloadServiceFetcher(
     HttpClient httpClient,
@@ -32,7 +32,7 @@ public class UnixLocalDownloadServiceFetcher implements LocalDownloadServiceFetc
     this.httpClient = httpClient;
     this.objectMapper = objectMapper;
     this.executorConfiguration = executorConfiguration;
-    this.localDownloadUri = s3Configuration.getLocalDownloadSocket().get();
+    this.s3Configuration = s3Configuration;
   }
 
   @Override
@@ -75,12 +75,16 @@ public class UnixLocalDownloadServiceFetcher implements LocalDownloadServiceFetc
 
       task
         .getLog()
-        .debug("Requesting {} from {}", artifactDownloadRequest, localDownloadUri);
+        .debug(
+          "Requesting {} from {}",
+          artifactDownloadRequest,
+          s3Configuration.getLocalDownloadSocket().get()
+        );
 
       try {
         CompletableFuture<ContentResponse> future = new CompletableFuture<>();
         httpClient
-          .newRequest(localDownloadUri)
+          .newRequest("http://localhost")
           .method(HttpMethod.POST)
           .content(
             new BytesContentProvider(

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/UnixLocalDownloadServiceFetcher.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/UnixLocalDownloadServiceFetcher.java
@@ -22,6 +22,7 @@ public class UnixLocalDownloadServiceFetcher implements LocalDownloadServiceFetc
   private final HttpClient httpClient;
   private final SingularityExecutorConfiguration executorConfiguration;
   private final SingularityS3Configuration s3Configuration;
+  private final String localDownloadPath;
 
   public UnixLocalDownloadServiceFetcher(
     HttpClient httpClient,
@@ -33,6 +34,8 @@ public class UnixLocalDownloadServiceFetcher implements LocalDownloadServiceFetc
     this.objectMapper = objectMapper;
     this.executorConfiguration = executorConfiguration;
     this.s3Configuration = s3Configuration;
+    this.localDownloadPath =
+      String.format("http://localhost%s", s3Configuration.getLocalDownloadPath());
   }
 
   @Override
@@ -84,7 +87,7 @@ public class UnixLocalDownloadServiceFetcher implements LocalDownloadServiceFetc
       try {
         CompletableFuture<ContentResponse> future = new CompletableFuture<>();
         httpClient
-          .newRequest("http://localhost")
+          .newRequest(localDownloadPath)
           .method(HttpMethod.POST)
           .content(
             new BytesContentProvider(

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/UnixLocalDownloadServiceFetcher.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/UnixLocalDownloadServiceFetcher.java
@@ -57,6 +57,11 @@ public class UnixLocalDownloadServiceFetcher implements LocalDownloadServiceFetc
   }
 
   @Override
+  public String getDownloadPath() {
+    return localDownloadPath;
+  }
+
+  @Override
   public void downloadFiles(
     List<? extends S3Artifact> s3Artifacts,
     SingularityExecutorTask task

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/UnixLocalDownloadServiceFetcher.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/UnixLocalDownloadServiceFetcher.java
@@ -110,7 +110,7 @@ public class UnixLocalDownloadServiceFetcher implements LocalDownloadServiceFetc
     }
 
     for (CompletableFutureHolder future : futures) {
-      ContentResponse response = future.getReponse();
+      ContentResponse response = future.getResponse();
 
       task
         .getLog()
@@ -142,7 +142,7 @@ public class UnixLocalDownloadServiceFetcher implements LocalDownloadServiceFetc
       this.s3Artifact = s3Artifact;
     }
 
-    public ContentResponse getReponse() throws InterruptedException {
+    public ContentResponse getResponse() throws InterruptedException {
       try {
         return future.get();
       } catch (ExecutionException e) {

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/UnixLocalDownloadServiceFetcher.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/UnixLocalDownloadServiceFetcher.java
@@ -1,0 +1,141 @@
+package com.hubspot.singularity.executor.task;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
+import com.hubspot.deploy.S3Artifact;
+import com.hubspot.mesos.JavaUtils;
+import com.hubspot.singularity.executor.config.SingularityExecutorConfiguration;
+import com.hubspot.singularity.s3.base.ArtifactDownloadRequest;
+import com.hubspot.singularity.s3.base.config.SingularityS3Configuration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.util.BytesContentProvider;
+import org.eclipse.jetty.http.HttpMethod;
+
+public class UnixLocalDownloadServiceFetcher implements LocalDownloadServiceFetcher {
+  private final ObjectMapper objectMapper;
+  private final HttpClient httpClient;
+  private final SingularityExecutorConfiguration executorConfiguration;
+  private final String localDownloadUri;
+
+  public UnixLocalDownloadServiceFetcher(
+    HttpClient httpClient,
+    ObjectMapper objectMapper,
+    SingularityExecutorConfiguration executorConfiguration,
+    SingularityS3Configuration s3Configuration
+  ) {
+    this.httpClient = httpClient;
+    this.objectMapper = objectMapper;
+    this.executorConfiguration = executorConfiguration;
+    this.localDownloadUri = s3Configuration.getLocalDownloadSocket().get();
+  }
+
+  @Override
+  public void start() {
+    try {
+      httpClient.start();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void stop() {
+    try {
+      httpClient.stop();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void downloadFiles(
+    List<? extends S3Artifact> s3Artifacts,
+    SingularityExecutorTask task
+  )
+    throws InterruptedException {
+    final List<CompletableFutureHolder> futures = Lists.newArrayListWithCapacity(
+      s3Artifacts.size()
+    );
+
+    for (S3Artifact s3Artifact : s3Artifacts) {
+      String destination = task
+        .getArtifactPath(s3Artifact, task.getTaskDefinition().getTaskDirectoryPath())
+        .toString();
+      ArtifactDownloadRequest artifactDownloadRequest = new ArtifactDownloadRequest(
+        destination,
+        s3Artifact,
+        Optional.of(executorConfiguration.getLocalDownloadServiceTimeoutMillis())
+      );
+
+      task
+        .getLog()
+        .debug("Requesting {} from {}", artifactDownloadRequest, localDownloadUri);
+
+      try {
+        CompletableFuture<ContentResponse> future = new CompletableFuture<>();
+        httpClient
+          .newRequest(localDownloadUri)
+          .method(HttpMethod.POST)
+          .content(
+            new BytesContentProvider(
+              objectMapper.writeValueAsBytes(artifactDownloadRequest)
+            ),
+            "application/json"
+          )
+          .send(new CompletableFutureResponseListener(future));
+        futures.add(
+          new CompletableFutureHolder(future, System.currentTimeMillis(), s3Artifact)
+        );
+      } catch (JsonProcessingException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    for (CompletableFutureHolder future : futures) {
+      ContentResponse response = future.getReponse();
+
+      task
+        .getLog()
+        .debug(
+          "Future for {} got status code {} after {}",
+          future.s3Artifact.getName(),
+          response.getStatus(),
+          JavaUtils.duration(future.start)
+        );
+
+      if (response.getStatus() != 200) {
+        throw new IllegalStateException("Got status code:" + response.getStatus());
+      }
+    }
+  }
+
+  private static class CompletableFutureHolder {
+    private final CompletableFuture<ContentResponse> future;
+    private final long start;
+    private final S3Artifact s3Artifact;
+
+    public CompletableFutureHolder(
+      CompletableFuture<ContentResponse> future,
+      long start,
+      S3Artifact s3Artifact
+    ) {
+      this.future = future;
+      this.start = start;
+      this.s3Artifact = s3Artifact;
+    }
+
+    public ContentResponse getReponse() throws InterruptedException {
+      try {
+        return future.get();
+      } catch (ExecutionException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+}

--- a/SingularityS3Base/src/main/java/com/hubspot/singularity/s3/base/config/SingularityS3Configuration.java
+++ b/SingularityS3Base/src/main/java/com/hubspot/singularity/s3/base/config/SingularityS3Configuration.java
@@ -46,11 +46,13 @@ public class SingularityS3Configuration extends BaseRunnerConfiguration {
 
   @Min(0)
   @JsonProperty
-  private int localDownloadHttpPort = 7070;
+  private Optional<Integer> localDownloadHttpPort = Optional.of(7070);
 
   @NotEmpty
   @JsonProperty
   private String localDownloadPath = "/download";
+
+  private Optional<String> localDownloadSocket = Optional.empty();
 
   @NotNull
   @JsonProperty
@@ -118,11 +120,11 @@ public class SingularityS3Configuration extends BaseRunnerConfiguration {
     this.s3DownloadTimeoutMillis = s3DownloadTimeoutMillis;
   }
 
-  public int getLocalDownloadHttpPort() {
+  public Optional<Integer> getLocalDownloadHttpPort() {
     return localDownloadHttpPort;
   }
 
-  public void setLocalDownloadHttpPort(int localDownloadHttpPort) {
+  public void setLocalDownloadHttpPort(Optional<Integer> localDownloadHttpPort) {
     this.localDownloadHttpPort = localDownloadHttpPort;
   }
 
@@ -174,6 +176,14 @@ public class SingularityS3Configuration extends BaseRunnerConfiguration {
 
   public void setMetricsFilePath(Optional<String> metricsFilePath) {
     this.metricsFilePath = metricsFilePath;
+  }
+
+  public Optional<String> getLocalDownloadSocket() {
+    return localDownloadSocket;
+  }
+
+  public void setLocalDownloadSocket(Optional<String> localDownloadSocket) {
+    this.localDownloadSocket = localDownloadSocket;
   }
 
   @Override

--- a/SingularityS3Downloader/pom.xml
+++ b/SingularityS3Downloader/pom.xml
@@ -86,6 +86,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-unixsocket</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/SingularityS3Downloader/src/main/java/com/hubspot/singularity/s3downloader/config/SingularityS3DownloaderConfiguration.java
+++ b/SingularityS3Downloader/src/main/java/com/hubspot/singularity/s3downloader/config/SingularityS3DownloaderConfiguration.java
@@ -28,6 +28,9 @@ public class SingularityS3DownloaderConfiguration extends BaseRunnerConfiguratio
   @JsonProperty
   private int numDownloaderThreads = 5;
 
+  @JsonProperty
+  private int unixAcceptQueueSize = 128;
+
   public SingularityS3DownloaderConfiguration() {
     super(Optional.of("singularity-s3downloader.log"));
   }
@@ -64,10 +67,19 @@ public class SingularityS3DownloaderConfiguration extends BaseRunnerConfiguratio
     this.numDownloaderThreads = numDownloaderThreads;
   }
 
+  public int getUnixAcceptQueueSize() {
+    return unixAcceptQueueSize;
+  }
+
+  public void setUnixAcceptQueueSize(int unixAcceptQueueSize) {
+    this.unixAcceptQueueSize = unixAcceptQueueSize;
+  }
+
   @Override
   public String toString() {
     return (
-      "SingularityS3DownloaderConfiguration [httpServerTimeout=" +
+      "SingularityS3DownloaderConfiguration{" +
+      "httpServerTimeout=" +
       httpServerTimeout +
       ", numEnqueueThreads=" +
       numEnqueueThreads +
@@ -75,7 +87,10 @@ public class SingularityS3DownloaderConfiguration extends BaseRunnerConfiguratio
       millisToWaitForReEnqueue +
       ", numDownloaderThreads=" +
       numDownloaderThreads +
-      "]"
+      ", unixAcceptQueueSize=" +
+      unixAcceptQueueSize +
+      "} " +
+      super.toString()
     );
   }
 }

--- a/SingularityS3Downloader/src/main/java/com/hubspot/singularity/s3downloader/server/SingularityS3DownloaderServer.java
+++ b/SingularityS3Downloader/src/main/java/com/hubspot/singularity/s3downloader/server/SingularityS3DownloaderServer.java
@@ -75,7 +75,7 @@ public class SingularityS3DownloaderServer implements SingularityDriver {
 
     if (s3Configuration.getLocalDownloadSocket().isPresent()) {
       UnixSocketConnector unix = new UnixSocketConnector(server);
-      unix.setAcceptQueueSize(128);
+      unix.setAcceptQueueSize(configuration.getUnixAcceptQueueSize());
       unix.setUnixSocket(s3Configuration.getLocalDownloadSocket().get());
       server.addConnector(unix);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,36 @@
       </dependency>
 
       <dependency>
+        <groupId>com.github.jnr</groupId>
+        <artifactId>jffi</artifactId>
+        <version>1.2.17</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.github.jnr</groupId>
+        <artifactId>jnr-enxio</artifactId>
+        <version>0.20</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.github.jnr</groupId>
+        <artifactId>jnr-ffi</artifactId>
+        <version>2.1.9</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.github.jnr</groupId>
+        <artifactId>jnr-posix</artifactId>
+        <version>3.0.47</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.github.jnr</groupId>
+        <artifactId>jnr-unixsocket</artifactId>
+        <version>0.22</version>
+      </dependency>
+
+      <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client</artifactId>
         <version>1.23.0</version>
@@ -305,7 +335,7 @@
       <dependency>
         <groupId>com.spotify</groupId>
         <artifactId>docker-client</artifactId>
-        <version>8.4.0</version>
+        <version>8.16.0</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -361,6 +361,10 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -565,6 +565,18 @@
       </dependency>
 
       <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-unixsocket</artifactId>
+        <version>${dep.jetty.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-unixsocket-http</artifactId>
+        <version>${dep.jetty.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-api</artifactId>
         <version>${dep.hk2.version}</version>


### PR DESCRIPTION
Gives the ability to better lock down the s3 downloader. If a unix socket is set in the base configuration, the downloader will listen on the given socket and the executor will use that to trigger downloads.

- The S3Downloader can listen on both http + unix socket
- Executor prefers unix socket if set

Still need to test