### PR TITLE
Force index for task history requests by host and start/update times

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/AbstractHistoryJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/AbstractHistoryJDBI.java
@@ -41,7 +41,16 @@ public interface AbstractHistoryJDBI extends HistoryJDBI {
     Optional<Long> updatedBefore,
     Optional<Long> updatedAfter
   ) {
-    if (host.isPresent() && (updatedAfter.isPresent() || updatedBefore.isPresent()) && !(requestId.isPresent() || deployId.isPresent() || runId.isPresent() || lastTaskStatus.isPresent())) {
+    if (
+      host.isPresent() &&
+      (updatedAfter.isPresent() || updatedBefore.isPresent()) &&
+      !(
+        requestId.isPresent() ||
+        deployId.isPresent() ||
+        runId.isPresent() ||
+        lastTaskStatus.isPresent()
+      )
+    ) {
       sqlBuilder.append(" FORCE INDEX (hostUpdated) ");
     }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/AbstractHistoryJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/AbstractHistoryJDBI.java
@@ -41,6 +41,10 @@ public interface AbstractHistoryJDBI extends HistoryJDBI {
     Optional<Long> updatedBefore,
     Optional<Long> updatedAfter
   ) {
+    if (host.isPresent() && (updatedAfter.isPresent() || updatedBefore.isPresent()) && !(requestId.isPresent() || deployId.isPresent() || runId.isPresent() || lastTaskStatus.isPresent())) {
+      sqlBuilder.append(" FORCE INDEX (hostUpdated) ");
+    }
+
     if (requestId.isPresent()) {
       addWhereOrAnd(sqlBuilder, binds.isEmpty());
       sqlBuilder.append("requestId = :requestId");

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/AbstractHistoryJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/AbstractHistoryJDBI.java
@@ -28,6 +28,16 @@ public interface AbstractHistoryJDBI extends HistoryJDBI {
     }
   }
 
+  boolean shouldAddForceIndexClause(
+    Optional<String> requestId,
+    Optional<String> deployId,
+    Optional<String> runId,
+    Optional<String> host,
+    Optional<ExtendedTaskState> lastTaskStatus,
+    Optional<Long> updatedBefore,
+    Optional<Long> updatedAfter
+  );
+
   default void applyTaskIdHistoryBaseQuery(
     StringBuilder sqlBuilder,
     Map<String, Object> binds,
@@ -42,13 +52,14 @@ public interface AbstractHistoryJDBI extends HistoryJDBI {
     Optional<Long> updatedAfter
   ) {
     if (
-      host.isPresent() &&
-      (updatedAfter.isPresent() || updatedBefore.isPresent()) &&
-      !(
-        requestId.isPresent() ||
-        deployId.isPresent() ||
-        runId.isPresent() ||
-        lastTaskStatus.isPresent()
+      shouldAddForceIndexClause(
+        requestId,
+        deployId,
+        runId,
+        host,
+        lastTaskStatus,
+        updatedBefore,
+        updatedAfter
       )
     ) {
       sqlBuilder.append(" FORCE INDEX (hostUpdated) ");

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/PostgresHistoryJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/PostgresHistoryJDBI.java
@@ -1,5 +1,6 @@
 package com.hubspot.singularity.data.history;
 
+import com.hubspot.singularity.ExtendedTaskState;
 import com.hubspot.singularity.SingularityDeployHistory;
 import com.hubspot.singularity.SingularityRequest;
 import com.hubspot.singularity.SingularityRequestHistory;
@@ -7,6 +8,7 @@ import com.hubspot.singularity.SingularityTaskHistory;
 import com.hubspot.singularity.data.history.SingularityMappers.SingularityRequestIdCount;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import org.jdbi.v3.json.Json;
 import org.jdbi.v3.sqlobject.SingleValue;
 import org.jdbi.v3.sqlobject.customizer.Bind;
@@ -252,6 +254,20 @@ public interface PostgresHistoryJDBI extends AbstractHistoryJDBI {
     @Bind("deployId") String deployId,
     @Bind("json") @Json SingularityDeployHistory deployHistory
   );
+
+  //Postgres doesn't support index hinting
+  @Override
+  default boolean shouldAddForceIndexClause(
+    Optional<String> requestId,
+    Optional<String> deployId,
+    Optional<String> runId,
+    Optional<String> host,
+    Optional<ExtendedTaskState> lastTaskStatus,
+    Optional<Long> updatedBefore,
+    Optional<Long> updatedAfter
+  ) {
+    return false;
+  }
 
   default void close() {}
 }


### PR DESCRIPTION
Forces task history search queries to use the `hostUpadtedAt` index for requests that only specify `host` and `startedAt/updatedAt` fields. These queries currently timeout intermittently since the `hostUpdatedAt` index isn't consistently chosen by the optimizer.