### PR TITLE
Only keep the most recent 50 failure events

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeployStatisticsBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityDeployStatisticsBuilder.java
@@ -2,8 +2,10 @@ package com.hubspot.singularity;
 
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ListMultimap;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class SingularityDeployStatisticsBuilder {
   private final String requestId;
@@ -170,6 +172,16 @@ public class SingularityDeployStatisticsBuilder {
     TaskFailureEvent taskFailureEvent
   ) {
     taskFailureEvents.add(taskFailureEvent);
+    return this;
+  }
+
+  public SingularityDeployStatisticsBuilder trimTaskFailureEvents(int countToKeep) {
+    this.taskFailureEvents =
+      taskFailureEvents
+        .stream()
+        .sorted(Comparator.comparingLong(TaskFailureEvent::getTimestamp).reversed())
+        .limit(countToKeep)
+        .collect(Collectors.toList());
     return this;
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -1372,6 +1372,7 @@ public class SingularityScheduler {
       bldr.setNumSequentialRetries(0);
     }
 
+    bldr.trimTaskFailureEvents(50);
     final SingularityDeployStatistics newStatistics = bldr.build();
 
     LOG.trace("Saving new deploy statistics {}", newStatistics);


### PR DESCRIPTION
For very long lived deploys in a constant crash loop, the statistics node can essentially grow out of control, which will eventually cause Singularity to reach its jute buffer limit. This will trim it to the most recent 50, which is more than enough for the cooldown and crash loop checks