### PR TITLE
Track shutdown time in status message

### DIFF
--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorMonitor.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorMonitor.java
@@ -772,6 +772,7 @@ public class SingularityExecutorMonitor {
                 task.getExecutorData().getMaxTaskThreads().get()
               );
           } else if (task.wasKilled()) {
+            long shutdownTimeMs = System.currentTimeMillis() - task.getKilledAt();
             taskState = TaskState.TASK_KILLED;
 
             if (task.wasDestroyedAfterWaiting()) {
@@ -782,19 +783,32 @@ public class SingularityExecutorMonitor {
 
               message =
                 String.format(
-                  "Task killed forcibly after waiting at least %s",
-                  JavaUtils.durationFromMillis(millisWaited)
+                  "Task killed forcibly after waiting at least %s (shutdownTime: %dms)",
+                  JavaUtils.durationFromMillis(millisWaited),
+                  shutdownTimeMs
                 );
             } else if (task.wasForceDestroyed()) {
               if (maybeKilledBy.isPresent()) {
                 message =
-                  String.format("Task killed forcibly by %s", maybeKilledBy.get());
+                  String.format(
+                    "Task killed forcibly by %s (shutdownTime: %dms)",
+                    maybeKilledBy.get(),
+                    shutdownTimeMs
+                  );
               } else {
                 message =
-                  "Task killed forcibly after multiple kill requests from framework";
+                  String.format(
+                    "Task killed forcibly after multiple kill requests from framework, (shutdownTime: %dms)",
+                    shutdownTimeMs
+                  );
               }
             } else {
-              message = "Task killed. Process exited gracefully with code " + exitCode;
+              message =
+                String.format(
+                  "Task killed. Process exited gracefully with code %d (shutdownTime: %dms)",
+                  exitCode,
+                  shutdownTimeMs
+                );
             }
           } else if (task.isSuccessExitCode(exitCode)) {
             taskState = TaskState.TASK_FINISHED;

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTask.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTask.java
@@ -18,6 +18,7 @@ import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 import org.apache.mesos.ExecutorDriver;
@@ -29,7 +30,7 @@ public class SingularityExecutorTask {
   private final Protos.TaskInfo taskInfo;
   private final Logger log;
   private final ReentrantLock lock;
-  private final AtomicBoolean killed;
+  private final AtomicLong killed;
   private final AtomicInteger threadCountAtOverage;
   private final AtomicBoolean killedAfterThreadOverage;
   private final AtomicBoolean destroyedAfterWaiting;
@@ -62,7 +63,7 @@ public class SingularityExecutorTask {
     this.log = log;
 
     this.lock = new ReentrantLock();
-    this.killed = new AtomicBoolean(false);
+    this.killed = new AtomicLong(-1);
     this.destroyedAfterWaiting = new AtomicBoolean(false);
     this.forceDestroyed = new AtomicBoolean(false);
     this.killedBy = new AtomicReference<>(Optional.<String>empty());
@@ -183,11 +184,15 @@ public class SingularityExecutorTask {
   }
 
   public boolean wasKilled() {
+    return killed.get() != -1;
+  }
+
+  public long getKilledAt() {
     return killed.get();
   }
 
   public void markKilled(Optional<String> maybeUser) {
-    this.killed.set(true);
+    this.killed.set(System.currentTimeMillis());
     this.killedBy.set(maybeUser);
   }
 


### PR DESCRIPTION
Right now this data is only available in the executor logs, which disappear after being cleaned up by mesos. This adds the time between a kill being sent and the process shutting down in the status message for easier viewing