### PR TITLE
Add warning about override and lb updates

### DIFF
--- a/SingularityUI/app/components/common/modalButtons/KillTaskModal.jsx
+++ b/SingularityUI/app/components/common/modalButtons/KillTaskModal.jsx
@@ -93,6 +93,9 @@ class KillTaskModal extends Component {
               to run in the future depending on whether or not the request
               has <code>numRetriesOnFailure</code> set.
           </p>
+          {this.props.destroy && (<p>
+              Note, a kill -9 of this task will bypass any load balancer cleanup operations that may still be in progress.
+          </p>)}
         </span>
       </FormModal>
     );

--- a/SingularityUI/app/components/common/modalButtons/KillTaskModal.jsx
+++ b/SingularityUI/app/components/common/modalButtons/KillTaskModal.jsx
@@ -93,9 +93,9 @@ class KillTaskModal extends Component {
               to run in the future depending on whether or not the request
               has <code>numRetriesOnFailure</code> set.
           </p>
-          {this.props.destroy && (<p>
+          {this.props.destroy && (<strong>
               Note, a kill -9 of this task will bypass any load balancer cleanup operations that may still be in progress.
-          </p>)}
+          </strong>)}
         </span>
       </FormModal>
     );


### PR DESCRIPTION
The kill -9 bypasses LB updates, which was a surprise to some users. Making it more obvious in the modal