### PR TITLE
Filter getRequestHistory queries by createdAt times

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestHistoryQuery.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestHistoryQuery.java
@@ -1,0 +1,99 @@
+package com.hubspot.singularity;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.ComparisonChain;
+import java.util.Comparator;
+import java.util.Optional;
+
+public class SingularityRequestHistoryQuery {
+  private final String requestId;
+  private final Optional<Long> createdBefore;
+  private final Optional<Long> createdAfter;
+  private final Optional<OrderDirection> orderDirection;
+
+  public SingularityRequestHistoryQuery(
+    String requestId,
+    Optional<Long> createdBefore,
+    Optional<Long> createdAfter,
+    Optional<OrderDirection> orderDirection
+  ) {
+    this.requestId = requestId;
+    this.createdBefore = createdBefore;
+    this.createdAfter = createdAfter;
+    this.orderDirection = orderDirection;
+  }
+
+  public String getRequestId() {
+    return requestId;
+  }
+
+  public Optional<Long> getCreatedBefore() {
+    return createdBefore;
+  }
+
+  public Optional<Long> getCreatedAfter() {
+    return createdAfter;
+  }
+
+  public Optional<OrderDirection> getOrderDirection() {
+    return orderDirection;
+  }
+
+  public Predicate<SingularityRequestHistory> getHistoryFilter() {
+    return new Predicate<SingularityRequestHistory>() {
+
+      @Override
+      public boolean apply(SingularityRequestHistory input) {
+        if (!requestId.equals(input.getRequest().getId())) {
+          return false;
+        }
+
+        if (createdAfter.isPresent() && createdAfter.get() >= input.getCreatedAt()) {
+          return false;
+        }
+
+        if (createdBefore.isPresent() && createdBefore.get() <= input.getCreatedAt()) {
+          return false;
+        }
+
+        return true;
+      }
+    };
+  }
+
+  public Comparator<SingularityRequestHistory> getComparator() {
+    final OrderDirection localOrderDirection = orderDirection.orElse(OrderDirection.DESC);
+
+    return new Comparator<SingularityRequestHistory>() {
+
+      @Override
+      public int compare(SingularityRequestHistory o1, SingularityRequestHistory o2) {
+        ComparisonChain chain = ComparisonChain.start();
+
+        if (localOrderDirection == OrderDirection.ASC) {
+          chain = chain.compare(o1.getCreatedAt(), o2.getCreatedAt());
+        } else {
+          chain = chain.compare(o2.getCreatedAt(), o1.getCreatedAt());
+        }
+
+        return chain.compare(o1.getRequest().getId(), o2.getRequest().getId()).result();
+      }
+    };
+  }
+
+  @Override
+  public String toString() {
+    return (
+      "SingularityTaskHistoryQuery{" +
+      "requestId=" +
+      requestId +
+      ", createdBefore=" +
+      createdBefore +
+      ", createdAfter=" +
+      createdAfter +
+      ", orderDirection=" +
+      orderDirection +
+      '}'
+    );
+  }
+}

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestHistoryQuery.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestHistoryQuery.java
@@ -84,7 +84,7 @@ public class SingularityRequestHistoryQuery {
   @Override
   public String toString() {
     return (
-      "SingularityTaskHistoryQuery{" +
+      "SingularityRequestHistoryQuery{" +
       "requestId=" +
       requestId +
       ", createdBefore=" +

--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
@@ -1682,14 +1682,14 @@ public class SingularityClient {
    *    A list of {@link SingularityRequestHistory}
    */
   public Collection<SingularityRequestHistory> getHistoryForRequest(
-      String requestId,
-      Optional<Long> createdBefore,
-      Optional<Long> createdAfter,
-      Optional<Integer> count,
-      Optional<Integer> page
+    String requestId,
+    Optional<Long> createdBefore,
+    Optional<Long> createdAfter,
+    Optional<Integer> count,
+    Optional<Integer> page
   ) {
     final Function<String, String> requestUri = host ->
-        String.format(REQUEST_HISTORY_FORMAT, getApiBase(host), requestId);
+      String.format(REQUEST_HISTORY_FORMAT, getApiBase(host), requestId);
 
     Optional<Map<String, Object>> maybeQueryParams = Optional.empty();
 
@@ -1717,10 +1717,10 @@ public class SingularityClient {
     }
 
     return getCollectionWithParams(
-        requestUri,
-        "request history",
-        maybeQueryParams,
-        REQUEST_HISTORY_COLLECTION
+      requestUri,
+      "request history",
+      maybeQueryParams,
+      REQUEST_HISTORY_COLLECTION
     );
   }
 
@@ -1729,7 +1729,13 @@ public class SingularityClient {
     Optional<Integer> count,
     Optional<Integer> page
   ) {
-    return getHistoryForRequest(requestId, Optional.empty(), Optional.empty(), count, page);
+    return getHistoryForRequest(
+      requestId,
+      Optional.empty(),
+      Optional.empty(),
+      count,
+      page
+    );
   }
 
   //

--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
@@ -47,6 +47,7 @@ import com.hubspot.singularity.SingularityRequestBatch;
 import com.hubspot.singularity.SingularityRequestCleanup;
 import com.hubspot.singularity.SingularityRequestGroup;
 import com.hubspot.singularity.SingularityRequestHistory;
+import com.hubspot.singularity.SingularityRequestHistoryQuery;
 import com.hubspot.singularity.SingularityRequestParent;
 import com.hubspot.singularity.SingularityRequestWithState;
 import com.hubspot.singularity.SingularityS3Log;
@@ -1669,6 +1670,10 @@ public class SingularityClient {
    *
    * @param requestId
    *    Request ID to look up
+   * @param createdBefore
+   *    Long millis to filter request histories created before
+   * @param createdAfter
+   *    Long millis to filter request histories created after
    * @param count
    *    Number of items to return per page
    * @param page
@@ -1677,16 +1682,26 @@ public class SingularityClient {
    *    A list of {@link SingularityRequestHistory}
    */
   public Collection<SingularityRequestHistory> getHistoryForRequest(
-    String requestId,
-    Optional<Integer> count,
-    Optional<Integer> page
+      String requestId,
+      Optional<Long> createdBefore,
+      Optional<Long> createdAfter,
+      Optional<Integer> count,
+      Optional<Integer> page
   ) {
     final Function<String, String> requestUri = host ->
-      String.format(REQUEST_HISTORY_FORMAT, getApiBase(host), requestId);
+        String.format(REQUEST_HISTORY_FORMAT, getApiBase(host), requestId);
 
     Optional<Map<String, Object>> maybeQueryParams = Optional.empty();
 
     ImmutableMap.Builder<String, Object> queryParamsBuilder = ImmutableMap.builder();
+
+    if (createdBefore.isPresent()) {
+      queryParamsBuilder.put("createdBefore", createdBefore.get());
+    }
+
+    if (createdAfter.isPresent()) {
+      queryParamsBuilder.put("createdAfter", createdAfter.get());
+    }
 
     if (count.isPresent()) {
       queryParamsBuilder.put("count", count.get());
@@ -1702,11 +1717,19 @@ public class SingularityClient {
     }
 
     return getCollectionWithParams(
-      requestUri,
-      "request history",
-      maybeQueryParams,
-      REQUEST_HISTORY_COLLECTION
+        requestUri,
+        "request history",
+        maybeQueryParams,
+        REQUEST_HISTORY_COLLECTION
     );
+  }
+
+  public Collection<SingularityRequestHistory> getHistoryForRequest(
+    String requestId,
+    Optional<Integer> count,
+    Optional<Integer> page
+  ) {
+    return getHistoryForRequest(requestId, Optional.empty(), Optional.empty(), count, page);
   }
 
   //

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/AbstractHistoryJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/AbstractHistoryJDBI.java
@@ -4,7 +4,6 @@ import com.hubspot.singularity.ExtendedTaskState;
 import com.hubspot.singularity.OrderDirection;
 import com.hubspot.singularity.SingularityRequestHistory;
 import com.hubspot.singularity.SingularityTaskIdHistory;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/AbstractHistoryJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/AbstractHistoryJDBI.java
@@ -2,7 +2,9 @@ package com.hubspot.singularity.data.history;
 
 import com.hubspot.singularity.ExtendedTaskState;
 import com.hubspot.singularity.OrderDirection;
+import com.hubspot.singularity.SingularityRequestHistory;
 import com.hubspot.singularity.SingularityTaskIdHistory;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -25,6 +27,32 @@ public interface AbstractHistoryJDBI extends HistoryJDBI {
       sqlBuilder.append(" WHERE ");
     } else {
       sqlBuilder.append(" AND ");
+    }
+  }
+
+  String getRequestHistoryBaseQuery();
+
+  default void applyRequestHistoryBaseQuery(
+    StringBuilder sqlBuilder,
+    Map<String, Object> binds,
+    String requestId,
+    Optional<Long> createdBefore,
+    Optional<Long> createdAfter
+  ) {
+    addWhereOrAnd(sqlBuilder, binds.isEmpty());
+    sqlBuilder.append("requestId = :requestId");
+    binds.put("requestId", requestId);
+
+    if (createdBefore.isPresent()) {
+      addWhereOrAnd(sqlBuilder, binds.isEmpty());
+      sqlBuilder.append("createdAt < :createdBefore");
+      binds.put("createdBefore", new Date(createdBefore.get()));
+    }
+
+    if (createdAfter.isPresent()) {
+      addWhereOrAnd(sqlBuilder, binds.isEmpty());
+      sqlBuilder.append("createdAt > :createdAfter");
+      binds.put("createdAfter", new Date(createdAfter.get()));
     }
   }
 
@@ -154,6 +182,47 @@ public interface AbstractHistoryJDBI extends HistoryJDBI {
     binds.forEach(query::bind);
 
     return query.mapTo(SingularityTaskIdHistory.class).list();
+  }
+
+  default List<SingularityRequestHistory> getRequestHistory(
+    String requestId,
+    Optional<Long> createdBefore,
+    Optional<Long> createdAfter,
+    String orderDirection,
+    Integer limitStart,
+    Integer limitCount
+  ) {
+    final Map<String, Object> binds = new HashMap<>();
+    final StringBuilder sqlBuilder = new StringBuilder(getRequestHistoryBaseQuery());
+
+    applyRequestHistoryBaseQuery(
+      sqlBuilder,
+      binds,
+      requestId,
+      createdBefore,
+      createdAfter
+    );
+
+    sqlBuilder.append(" ORDER BY createdAt ");
+    sqlBuilder.append(orderDirection);
+    if (limitCount != null) {
+      sqlBuilder.append(" LIMIT :limitCount");
+      binds.put("limitCount", limitCount);
+    }
+
+    if (limitStart != null) {
+      sqlBuilder.append(" OFFSET :limitStart ");
+      binds.put("limitStart", limitStart);
+    }
+
+    final String sql = sqlBuilder.toString();
+
+    LOG.trace("Generated sql for request history search: {}, binds: {}", sql, binds);
+
+    Query query = getHandle().createQuery(sql);
+    binds.forEach(query::bind);
+
+    return query.mapTo(SingularityRequestHistory.class).list();
   }
 
   default int getTaskIdHistoryCount(

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/HistoryJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/HistoryJDBI.java
@@ -62,6 +62,8 @@ public interface HistoryJDBI extends SqlObject {
 
   List<SingularityRequestHistory> getRequestHistory(
     String requestId,
+    Optional<Long> createdBefore,
+    Optional<Long> createdAfter,
     String orderDirection,
     Integer limitStart,
     Integer limitCount

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/HistoryManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/HistoryManager.java
@@ -61,6 +61,8 @@ public interface HistoryManager {
 
   List<SingularityRequestHistory> getRequestHistory(
     String requestId,
+    Optional<Long> createdBefore,
+    Optional<Long> createdAfter,
     Optional<OrderDirection> orderDirection,
     Integer limitStart,
     Integer limitCount

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/JDBIHistoryManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/JDBIHistoryManager.java
@@ -271,20 +271,26 @@ public class JDBIHistoryManager implements HistoryManager {
   @Override
   public List<SingularityRequestHistory> getRequestHistory(
     String requestId,
+    Optional<Long> createdBefore,
+    Optional<Long> createdAfter,
     Optional<OrderDirection> orderDirection,
     Integer limitStart,
     Integer limitCount
   ) {
     List<SingularityRequestHistory> singularityRequestHistoryList = history.getRequestHistory(
       requestId,
+      createdBefore,
+      createdAfter,
       getOrderDirection(orderDirection),
       limitStart,
       limitCount
     );
     if (LOG.isTraceEnabled()) {
       LOG.trace(
-        "getRequestHistory requestId {}, orderDirection {}, limitStart {} , limitCount {}, requestHistory{}",
+        "getRequestHistory requestId {}, createdBefore {}, createdAfter {}, orderDirection {}, limitStart {} , limitCount {}, requestHistory{}",
         requestId,
+        createdBefore,
+        createdAfter,
         orderDirection,
         limitStart,
         limitCount,

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/MySQLHistoryJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/MySQLHistoryJDBI.java
@@ -93,15 +93,15 @@ public interface MySQLHistoryJDBI extends AbstractHistoryJDBI {
   @SqlQuery("SELECT COUNT(*) FROM deployHistory WHERE requestId = :requestId")
   int getDeployHistoryForRequestCount(@Bind("requestId") String requestId);
 
-  @SqlQuery(
-    "SELECT json, request, createdAt, requestState, user, message FROM requestHistory WHERE requestId = :requestId ORDER BY createdAt <orderDirection> LIMIT :limitStart, :limitCount"
-  )
-  List<SingularityRequestHistory> getRequestHistory(
-    @Bind("requestId") String requestId,
-    @Define("orderDirection") String orderDirection,
-    @Bind("limitStart") Integer limitStart,
-    @Bind("limitCount") Integer limitCount
-  );
+  //  @SqlQuery(
+  //    "SELECT json, request, createdAt, requestState, user, message FROM requestHistory WHERE requestId = :requestId ORDER BY createdAt <orderDirection> LIMIT :limitStart, :limitCount"
+  //  )
+  //  List<SingularityRequestHistory> getRequestHistory(
+  //    @Bind("requestId") String requestId,
+  //    @Define("orderDirection") String orderDirection,
+  //    @Bind("limitStart") Integer limitStart,
+  //    @Bind("limitCount") Integer limitCount
+  //  );
 
   @SqlQuery("SELECT COUNT(*) FROM requestHistory WHERE requestId = :requestId")
   int getRequestHistoryCount(@Bind("requestId") String requestId);
@@ -252,6 +252,11 @@ public interface MySQLHistoryJDBI extends AbstractHistoryJDBI {
     @Bind("deployId") String deployId,
     @Bind("json") @Json SingularityDeployHistory deployHistory
   );
+
+  @Override
+  default String getRequestHistoryBaseQuery() {
+    return "SELECT json, request, createdAt, requestState, user, message FROM requestHistory";
+  }
 
   default void close() {}
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/MySQLHistoryJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/MySQLHistoryJDBI.java
@@ -2,7 +2,6 @@ package com.hubspot.singularity.data.history;
 
 import com.hubspot.singularity.SingularityDeployHistory;
 import com.hubspot.singularity.SingularityRequest;
-import com.hubspot.singularity.SingularityRequestHistory;
 import com.hubspot.singularity.SingularityTaskHistory;
 import com.hubspot.singularity.data.history.SingularityMappers.SingularityRequestIdCount;
 import java.util.Date;
@@ -10,7 +9,6 @@ import java.util.List;
 import org.jdbi.v3.json.Json;
 import org.jdbi.v3.sqlobject.SingleValue;
 import org.jdbi.v3.sqlobject.customizer.Bind;
-import org.jdbi.v3.sqlobject.customizer.Define;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 
@@ -92,16 +90,6 @@ public interface MySQLHistoryJDBI extends AbstractHistoryJDBI {
 
   @SqlQuery("SELECT COUNT(*) FROM deployHistory WHERE requestId = :requestId")
   int getDeployHistoryForRequestCount(@Bind("requestId") String requestId);
-
-  //  @SqlQuery(
-  //    "SELECT json, request, createdAt, requestState, user, message FROM requestHistory WHERE requestId = :requestId ORDER BY createdAt <orderDirection> LIMIT :limitStart, :limitCount"
-  //  )
-  //  List<SingularityRequestHistory> getRequestHistory(
-  //    @Bind("requestId") String requestId,
-  //    @Define("orderDirection") String orderDirection,
-  //    @Bind("limitStart") Integer limitStart,
-  //    @Bind("limitCount") Integer limitCount
-  //  );
 
   @SqlQuery("SELECT COUNT(*) FROM requestHistory WHERE requestId = :requestId")
   int getRequestHistoryCount(@Bind("requestId") String requestId);

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/NoopHistoryManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/NoopHistoryManager.java
@@ -105,6 +105,8 @@ public class NoopHistoryManager implements HistoryManager {
   @Override
   public List<SingularityRequestHistory> getRequestHistory(
     String requestId,
+    Optional<Long> createdBefore,
+    Optional<Long> createdAfter,
     Optional<OrderDirection> orderDirection,
     Integer limitStart,
     Integer limitCount

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/PostgresHistoryJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/PostgresHistoryJDBI.java
@@ -2,7 +2,6 @@ package com.hubspot.singularity.data.history;
 
 import com.hubspot.singularity.SingularityDeployHistory;
 import com.hubspot.singularity.SingularityRequest;
-import com.hubspot.singularity.SingularityRequestHistory;
 import com.hubspot.singularity.SingularityTaskHistory;
 import com.hubspot.singularity.data.history.SingularityMappers.SingularityRequestIdCount;
 import java.util.Date;
@@ -10,7 +9,6 @@ import java.util.List;
 import org.jdbi.v3.json.Json;
 import org.jdbi.v3.sqlobject.SingleValue;
 import org.jdbi.v3.sqlobject.customizer.Bind;
-import org.jdbi.v3.sqlobject.customizer.Define;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 
@@ -92,16 +90,6 @@ public interface PostgresHistoryJDBI extends AbstractHistoryJDBI {
 
   @SqlQuery("SELECT COUNT(*) FROM deployHistory WHERE requestId = :requestId")
   int getDeployHistoryForRequestCount(@Bind("requestId") String requestId);
-
-  //  @SqlQuery(
-  //    "SELECT json, request, createdAt, requestState, f_user, message FROM requestHistory WHERE requestId = :requestId ORDER BY createdAt <orderDirection> OFFSET :limitStart LIMIT :limitCount"
-  //  )
-  //  List<SingularityRequestHistory> getRequestHistory(
-  //    @Bind("requestId") String requestId,
-  //    @Define("orderDirection") String orderDirection,
-  //    @Bind("limitStart") Integer limitStart,
-  //    @Bind("limitCount") Integer limitCount
-  //  );
 
   @SqlQuery("SELECT COUNT(*) FROM requestHistory WHERE requestId = :requestId")
   int getRequestHistoryCount(@Bind("requestId") String requestId);

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/PostgresHistoryJDBI.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/PostgresHistoryJDBI.java
@@ -93,15 +93,15 @@ public interface PostgresHistoryJDBI extends AbstractHistoryJDBI {
   @SqlQuery("SELECT COUNT(*) FROM deployHistory WHERE requestId = :requestId")
   int getDeployHistoryForRequestCount(@Bind("requestId") String requestId);
 
-  @SqlQuery(
-    "SELECT json, request, createdAt, requestState, f_user, message FROM requestHistory WHERE requestId = :requestId ORDER BY createdAt <orderDirection> OFFSET :limitStart LIMIT :limitCount"
-  )
-  List<SingularityRequestHistory> getRequestHistory(
-    @Bind("requestId") String requestId,
-    @Define("orderDirection") String orderDirection,
-    @Bind("limitStart") Integer limitStart,
-    @Bind("limitCount") Integer limitCount
-  );
+  //  @SqlQuery(
+  //    "SELECT json, request, createdAt, requestState, f_user, message FROM requestHistory WHERE requestId = :requestId ORDER BY createdAt <orderDirection> OFFSET :limitStart LIMIT :limitCount"
+  //  )
+  //  List<SingularityRequestHistory> getRequestHistory(
+  //    @Bind("requestId") String requestId,
+  //    @Define("orderDirection") String orderDirection,
+  //    @Bind("limitStart") Integer limitStart,
+  //    @Bind("limitCount") Integer limitCount
+  //  );
 
   @SqlQuery("SELECT COUNT(*) FROM requestHistory WHERE requestId = :requestId")
   int getRequestHistoryCount(@Bind("requestId") String requestId);
@@ -252,6 +252,11 @@ public interface PostgresHistoryJDBI extends AbstractHistoryJDBI {
     @Bind("deployId") String deployId,
     @Bind("json") @Json SingularityDeployHistory deployHistory
   );
+
+  @Override
+  default String getRequestHistoryBaseQuery() {
+    return "SELECT json, request, createdAt, requestState, f_user, message FROM requestHistory";
+  }
 
   default void close() {}
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/RequestHistoryHelper.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/RequestHistoryHelper.java
@@ -1,10 +1,15 @@
 package com.hubspot.singularity.data.history;
 
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.hubspot.mesos.JavaUtils;
 import com.hubspot.singularity.OrderDirection;
 import com.hubspot.singularity.SingularityRequestHistory;
+import com.hubspot.singularity.SingularityRequestHistoryQuery;
+import com.hubspot.singularity.SingularityTaskHistoryQuery;
+import com.hubspot.singularity.SingularityTaskIdHistory;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.RequestManager;
 import java.util.Collections;
@@ -13,7 +18,7 @@ import java.util.Optional;
 
 @Singleton
 public class RequestHistoryHelper
-  extends BlendedHistoryHelper<SingularityRequestHistory, String> {
+  extends BlendedHistoryHelper<SingularityRequestHistory, SingularityRequestHistoryQuery> {
   private final RequestManager requestManager;
   private final HistoryManager historyManager;
 
@@ -29,25 +34,32 @@ public class RequestHistoryHelper
   }
 
   @Override
-  protected List<SingularityRequestHistory> getFromZk(String requestId) {
+  protected List<SingularityRequestHistory> getFromZk(
+    SingularityRequestHistoryQuery query
+  ) {
     List<SingularityRequestHistory> requestHistory = requestManager.getRequestHistory(
-      requestId
+      query.getRequestId()
+    );
+    final List<SingularityRequestHistory> filteredHistory = Lists.newArrayList(
+      Iterables.filter(requestHistory, query.getHistoryFilter())
     );
 
-    Collections.sort(requestHistory);
+    Collections.sort(filteredHistory, query.getComparator());
 
-    return requestHistory;
+    return filteredHistory;
   }
 
   @Override
   protected List<SingularityRequestHistory> getFromHistory(
-    String requestId,
+    SingularityRequestHistoryQuery query,
     int historyStart,
     int numFromHistory
   ) {
     return historyManager.getRequestHistory(
-      requestId,
-      Optional.of(OrderDirection.DESC),
+      query.getRequestId(),
+      query.getCreatedBefore(),
+      query.getCreatedAfter(),
+      query.getOrderDirection(),
       historyStart,
       numFromHistory
     );
@@ -55,19 +67,42 @@ public class RequestHistoryHelper
 
   public Optional<SingularityRequestHistory> getFirstHistory(String requestId) {
     Optional<SingularityRequestHistory> firstHistory = JavaUtils.getFirst(
-      historyManager.getRequestHistory(requestId, Optional.of(OrderDirection.ASC), 0, 1)
+      historyManager.getRequestHistory(
+        requestId,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.of(OrderDirection.ASC),
+        0,
+        1
+      )
     );
 
     if (firstHistory.isPresent()) {
       return firstHistory;
     }
 
-    return JavaUtils.getLast(getFromZk(requestId));
+    return JavaUtils.getLast(
+      getFromZk(
+        new SingularityRequestHistoryQuery(
+          requestId,
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty()
+        )
+      )
+    );
   }
 
   public Optional<SingularityRequestHistory> getLastHistory(String requestId) {
     Optional<SingularityRequestHistory> lastHistory = JavaUtils.getFirst(
-      getFromZk(requestId)
+      getFromZk(
+        new SingularityRequestHistoryQuery(
+          requestId,
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty()
+        )
+      )
     );
 
     if (lastHistory.isPresent()) {
@@ -75,19 +110,29 @@ public class RequestHistoryHelper
     }
 
     return JavaUtils.getFirst(
-      historyManager.getRequestHistory(requestId, Optional.of(OrderDirection.DESC), 0, 1)
+      historyManager.getRequestHistory(
+        requestId,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.of(OrderDirection.DESC),
+        0,
+        1
+      )
     );
   }
 
   @Override
-  protected Optional<Integer> getTotalCount(String requestId, boolean canSkipZk) {
+  protected Optional<Integer> getTotalCount(
+    SingularityRequestHistoryQuery query,
+    boolean canSkipZk
+  ) {
     int numFromZk;
     if (sqlEnabled && canSkipZk) {
       numFromZk = 0;
     } else {
-      numFromZk = requestManager.getRequestHistory(requestId).size();
+      numFromZk = requestManager.getRequestHistory(query.getRequestId()).size();
     }
-    int numFromHistory = historyManager.getRequestHistoryCount(requestId);
+    int numFromHistory = historyManager.getRequestHistoryCount(query.getRequestId());
 
     return Optional.of(numFromZk + numFromHistory);
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/HistoryResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/HistoryResource.java
@@ -12,6 +12,7 @@ import com.hubspot.singularity.SingularityDeployHistory;
 import com.hubspot.singularity.SingularityDeployKey;
 import com.hubspot.singularity.SingularityPaginatedResponse;
 import com.hubspot.singularity.SingularityRequestHistory;
+import com.hubspot.singularity.SingularityRequestHistoryQuery;
 import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.SingularityTaskHistory;
 import com.hubspot.singularity.SingularityTaskHistoryQuery;
@@ -759,6 +760,15 @@ public class HistoryResource extends AbstractHistoryResource {
     @Parameter(required = true, description = "Request ID to look up") @PathParam(
       "requestId"
     ) String requestId,
+    @Parameter(
+      description = "Optionally match request histories created before"
+    ) @QueryParam("createdBefore") Optional<Long> createdBefore,
+    @Parameter(
+      description = "Optionally match request histories created after"
+    ) @QueryParam("createdAfter") Optional<Long> createdAfter,
+    @Parameter(description = "Sort direction") @QueryParam(
+      "orderDirection"
+    ) Optional<OrderDirection> orderDirection,
     @Parameter(description = "Maximum number of items to return") @QueryParam(
       "count"
     ) Integer count,
@@ -777,9 +787,15 @@ public class HistoryResource extends AbstractHistoryResource {
 
     final Integer limitCount = getLimitCount(count);
     final Integer limitStart = getLimitStart(limitCount, page);
+    SingularityRequestHistoryQuery requestHistoryQuery = new SingularityRequestHistoryQuery(
+      requestId,
+      createdBefore,
+      createdAfter,
+      orderDirection
+    );
 
     return requestHistoryHelper.getBlendedHistory(
-      requestId,
+      requestHistoryQuery,
       limitStart,
       limitCount,
       skipZk
@@ -810,14 +826,20 @@ public class HistoryResource extends AbstractHistoryResource {
       SingularityAuthorizationScope.READ
     );
 
-    final Optional<Integer> dataCount = requestHistoryHelper.getBlendedHistoryCount(
+    SingularityRequestHistoryQuery requestHistoryQuery = new SingularityRequestHistoryQuery(
       requestId,
+      Optional.empty(),
+      Optional.empty(),
+      Optional.empty()
+    );
+    final Optional<Integer> dataCount = requestHistoryHelper.getBlendedHistoryCount(
+      requestHistoryQuery,
       skipZk
     );
     final Integer limitCount = getLimitCount(count);
     final Integer limitStart = getLimitStart(limitCount, page);
     final List<SingularityRequestHistory> data = requestHistoryHelper.getBlendedHistory(
-      requestId,
+      requestHistoryQuery,
       limitStart,
       limitCount,
       skipZk

--- a/SingularityService/src/test/java/com/hubspot/singularity/SingularityHistoryTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/SingularityHistoryTest.java
@@ -1252,6 +1252,8 @@ public class SingularityHistoryTest extends SingularitySchedulerTestBase {
 
     List<SingularityRequestHistory> history = historyManager.getRequestHistory(
       requestId,
+      Optional.empty(),
+      Optional.empty(),
       Optional.of(OrderDirection.DESC),
       0,
       100
@@ -1291,7 +1293,14 @@ public class SingularityHistoryTest extends SingularitySchedulerTestBase {
     );
     requestHistoryPersister.runActionOnPoll();
     SingularityRequestHistory history = historyManager
-      .getRequestHistory(requestId, Optional.of(OrderDirection.DESC), 0, 100)
+      .getRequestHistory(
+        requestId,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.of(OrderDirection.DESC),
+        0,
+        100
+      )
       .get(0);
     historyManager.saveRequestHistoryUpdate(history);
     // Should not throw exception
@@ -1375,7 +1384,14 @@ public class SingularityHistoryTest extends SingularitySchedulerTestBase {
 
       configuration.setSqlFallBackToBytesFields(true);
       SingularityRequestHistory requestHistoryBefore = historyManager
-        .getRequestHistory(request.getId(), Optional.empty(), 0, 1)
+        .getRequestHistory(
+          request.getId(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          0,
+          1
+        )
         .get(0);
       Assertions.assertNotNull(requestHistoryBefore);
       Assertions.assertEquals(
@@ -1400,7 +1416,14 @@ public class SingularityHistoryTest extends SingularitySchedulerTestBase {
       configuration.setSqlFallBackToBytesFields(false);
 
       SingularityRequestHistory requestHistoryAfter = historyManager
-        .getRequestHistory(request.getId(), Optional.empty(), 0, 1)
+        .getRequestHistory(
+          request.getId(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          0,
+          1
+        )
         .get(0);
       Assertions.assertNotNull(requestHistoryAfter);
       Assertions.assertEquals(


### PR DESCRIPTION
Instead of looping through the entire request history for some `requestId` to find the `SingularityRequestHistory`s in a specific time range, this change allows us to get the request history entries filtered by `createdBefore` and `createdAfter` times via [SingularityClient#getHistoryForRequest ](https://github.com/HubSpot/Singularity/compare/get-request-history-by-createAt-times?expand=1#diff-33d09d764454092917dadaf4d4f34cd6L1679)