### PR TITLE
Convert to string

### DIFF
--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
@@ -1707,7 +1707,7 @@ public class SingularityClient {
     }
 
     if (orderDirection.isPresent()) {
-      queryParamsBuilder.put("orderDirection", orderDirection.get());
+      queryParamsBuilder.put("orderDirection", orderDirection.get().toString());
     }
 
     if (count.isPresent()) {


### PR DESCRIPTION
Fixing my mistake on https://github.com/HubSpot/Singularity/pull/2119 here. orderDirection should be converted to String due to https://github.com/HubSpot/Singularity/blob/7d53ef8460c8ad0687c0a4389fb2d3f9f9e518ed/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java#L581