### PR TITLE
Fix updated request instance count

### DIFF
--- a/SingularityUI/app/components/requestDetail/header/RequestAlerts.jsx
+++ b/SingularityUI/app/components/requestDetail/header/RequestAlerts.jsx
@@ -40,8 +40,15 @@ const RequestAlerts = ({requestId, requestAPI, bounces, activeTasksForRequest, d
     const deployingInstanceCount = Utils.request.deployingInstanceCount(requestParent, activeTasksForRequest.data);
     const { pendingDeployState } = requestParent;
 
+    console.log('PAUL');
+    console.log(pendingDeployState);
+    console.log(pendingDeployState.updatedRequest);
+    console.log(pendingDeployState.updatedRequest.instances);
+    console.log(pendingDeployState.updatedRequest && pendingDeployState.updatedRequest.instances);
+    
     let instances = requestParent.request.instances;
     if (pendingDeployState.updatedRequest && pendingDeployState.updatedRequest.instances) {
+      console.log('Updating instances');
       instances = pendingDeployState.updatedRequest.instances
     }
     const pendingDeployProgress = (

--- a/SingularityUI/app/components/requestDetail/header/RequestAlerts.jsx
+++ b/SingularityUI/app/components/requestDetail/header/RequestAlerts.jsx
@@ -40,15 +40,8 @@ const RequestAlerts = ({requestId, requestAPI, bounces, activeTasksForRequest, d
     const deployingInstanceCount = Utils.request.deployingInstanceCount(requestParent, activeTasksForRequest.data);
     const { pendingDeployState } = requestParent;
 
-    console.log('PAUL');
-    console.log(pendingDeployState);
-    console.log(pendingDeployState.updatedRequest);
-    console.log(pendingDeployState.updatedRequest.instances);
-    console.log(pendingDeployState.updatedRequest && pendingDeployState.updatedRequest.instances);
-    
     let instances = requestParent.request.instances;
     if (pendingDeployState.updatedRequest && pendingDeployState.updatedRequest.instances) {
-      console.log('Updating instances');
       instances = pendingDeployState.updatedRequest.instances
     }
     const pendingDeployProgress = (
@@ -98,7 +91,7 @@ const RequestAlerts = ({requestId, requestAPI, bounces, activeTasksForRequest, d
           maybeDeployProgress = (
             <span>
               {
-                `Trying to deploy ${targetActiveInstances}
+                `Current deploy step trying to deploy ${targetActiveInstances} of ${instances}
                 instances, ${deployingInstanceCount} of
                 ${targetActiveInstances} new tasks are currently running.`
               }

--- a/SingularityUI/app/components/requestDetail/header/RequestAlerts.jsx
+++ b/SingularityUI/app/components/requestDetail/header/RequestAlerts.jsx
@@ -39,8 +39,8 @@ const RequestAlerts = ({requestId, requestAPI, bounces, activeTasksForRequest, d
   if (pendingDeploy) {
     const deployingInstanceCount = Utils.request.deployingInstanceCount(requestParent, activeTasksForRequest.data);
     let instances = requestParent.request.instances;
-    if (pendingDeploy.updatedRequest && pendingDeploy.updatedRequest.instances) {
-      instances = pendingDeploy.updatedRequest.instances
+    if (pendingDeployState.updatedRequest && pendingDeployState.updatedRequest.instances) {
+      instances = pendingDeployState.updatedRequest.instances
     }
     const pendingDeployProgress = (
       <span>{`${deployingInstanceCount} of ${instances} new tasks are currently running`}</span>

--- a/SingularityUI/app/components/requestDetail/header/RequestAlerts.jsx
+++ b/SingularityUI/app/components/requestDetail/header/RequestAlerts.jsx
@@ -38,6 +38,8 @@ const RequestAlerts = ({requestId, requestAPI, bounces, activeTasksForRequest, d
   const { pendingDeploy, activeDeploy } = requestParent;
   if (pendingDeploy) {
     const deployingInstanceCount = Utils.request.deployingInstanceCount(requestParent, activeTasksForRequest.data);
+    const { pendingDeployState } = requestParent;
+
     let instances = requestParent.request.instances;
     if (pendingDeployState.updatedRequest && pendingDeployState.updatedRequest.instances) {
       instances = pendingDeployState.updatedRequest.instances
@@ -49,7 +51,6 @@ const RequestAlerts = ({requestId, requestAPI, bounces, activeTasksForRequest, d
     let maybeDeployProgress;
     let maybeAdvanceDeploy;
 
-    const { pendingDeployState } = requestParent;
     if (pendingDeployState && pendingDeployState.deployProgress) {
       const { deployProgress, deployMarker } = pendingDeployState;
       const {


### PR DESCRIPTION
Instance counts in the UI are wrong when a deploy has an updated request because `updatedRequest` is a field of `pendingDeployState`, not of `pendingDeploy`.