### PR TITLE
Use leader cache first for launching check, also check staging

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -907,7 +907,8 @@ public class TaskManager extends CuratorAsyncManager {
           } else {
             return (
               !exists(getUpdatePath(t, ExtendedTaskState.TASK_STARTING)) &&
-              !exists(getUpdatePath(t, ExtendedTaskState.TASK_STAGING))
+              !exists(getUpdatePath(t, ExtendedTaskState.TASK_STAGING)) &&
+              !exists(getUpdatePath(t, ExtendedTaskState.TASK_RUNNING))
             );
           }
         }


### PR DESCRIPTION
Follow up to #2122 and #2123 , I think I was able to fix both issues:

1) The previous zk check for !exists... was actually correct. However, I realized that some mesos executors do not utilize the task starting state at all, only task staging or task running. So I added both of those to the check
2) This could be more efficient anyway since it should almost always run on the leading instance where the leader cache is already present. When running on the leader, this will now avoid those zk checks entirely and just use the list of history updates already in memory to determine what the most recent state is. This gives us a very simple comparison of == TASK_LAUNCHED to check, not having to worry about which states specific executors use

cc @relistan 