### PR TITLE
Make crash loops resolve faster

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/config/CrashLoopConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/CrashLoopConfiguration.java
@@ -8,19 +8,22 @@ public class CrashLoopConfiguration {
   private int startupFailureThreshold = 5;
 
   private int evaluateOomsOverMinutes = 30;
-  private int oomFailureThreshold = 3;
+  private int oomFailureThreshold = 4;
 
   private int singleInstanceFailureBucketSizeMinutes = 3;
   private int singleInstanceFailureBuckets = 10;
   private double singleInstanceFailureThreshold = 0.25;
+  private int singleInstanceMinBucketIndexPercent = 75; // i.e. must have a failure in most recent 50% of bucket
 
   private int multiInstanceFailureBucketSizeMinutes = 3;
   private int multiInstanceFailureBuckets = 10;
   private double multiInstanceFailureThreshold = 0.4;
+  private int multiInstanceMinBucketIndexPercent = 75; // i.e. must have a failure in most recent 50% of bucket
 
   private int slowFailureBucketSizeMinutes = 30;
   private int slowFailureBuckets = 15;
   private double slowFailureThreshold = 0.7;
+  private int slowFailureMinBucketIndexPercent = 75; // i.e. must have a failure in most recent 70% of bucket
 
   public int getEvaluateCooldownOverMinutes() {
     return evaluateCooldownOverMinutes;
@@ -96,6 +99,16 @@ public class CrashLoopConfiguration {
     this.singleInstanceFailureThreshold = singleInstanceFailureThreshold;
   }
 
+  public int getSingleInstanceMinBucketIndexPercent() {
+    return singleInstanceMinBucketIndexPercent;
+  }
+
+  public void setSingleInstanceMinBucketIndexPercent(
+    int singleInstanceMinBucketIndexPercent
+  ) {
+    this.singleInstanceMinBucketIndexPercent = singleInstanceMinBucketIndexPercent;
+  }
+
   public int getMultiInstanceFailureBucketSizeMinutes() {
     return multiInstanceFailureBucketSizeMinutes;
   }
@@ -122,6 +135,16 @@ public class CrashLoopConfiguration {
     this.multiInstanceFailureThreshold = multiInstanceFailureThreshold;
   }
 
+  public int getMultiInstanceMinBucketIndexPercent() {
+    return multiInstanceMinBucketIndexPercent;
+  }
+
+  public void setMultiInstanceMinBucketIndexPercent(
+    int multiInstanceMinBucketIndexPercent
+  ) {
+    this.multiInstanceMinBucketIndexPercent = multiInstanceMinBucketIndexPercent;
+  }
+
   public int getSlowFailureBucketSizeMinutes() {
     return slowFailureBucketSizeMinutes;
   }
@@ -144,5 +167,13 @@ public class CrashLoopConfiguration {
 
   public void setSlowFailureThreshold(double slowFailureThreshold) {
     this.slowFailureThreshold = slowFailureThreshold;
+  }
+
+  public int getSlowFailureMinBucketIndexPercent() {
+    return slowFailureMinBucketIndexPercent;
+  }
+
+  public void setSlowFailureMinBucketIndexPercent(int slowFailureMinBucketIndexPercent) {
+    this.slowFailureMinBucketIndexPercent = slowFailureMinBucketIndexPercent;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/CrashLoopConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/CrashLoopConfiguration.java
@@ -13,17 +13,17 @@ public class CrashLoopConfiguration {
   private int singleInstanceFailureBucketSizeMinutes = 3;
   private int singleInstanceFailureBuckets = 10;
   private double singleInstanceFailureThreshold = 0.25;
-  private int singleInstanceMinBucketIndexPercent = 75; // i.e. must have a failure in most recent 50% of bucket
+  private int singleInstanceMinBucketIndexPercent = 75; // i.e. must have a failure in most recent 75% of bucket
 
   private int multiInstanceFailureBucketSizeMinutes = 3;
   private int multiInstanceFailureBuckets = 10;
   private double multiInstanceFailureThreshold = 0.4;
-  private int multiInstanceMinBucketIndexPercent = 75; // i.e. must have a failure in most recent 50% of bucket
+  private int multiInstanceMinBucketIndexPercent = 75; // i.e. must have a failure in most recent 75% of bucket
 
   private int slowFailureBucketSizeMinutes = 30;
   private int slowFailureBuckets = 15;
   private double slowFailureThreshold = 0.7;
-  private int slowFailureMinBucketIndexPercent = 75; // i.e. must have a failure in most recent 70% of bucket
+  private int slowFailureMinBucketIndexPercent = 75; // i.e. must have a failure in most recent 75% of bucket
 
   public int getEvaluateCooldownOverMinutes() {
     return evaluateCooldownOverMinutes;


### PR DESCRIPTION
Currently we bucket failures into time windows. For example:

|O|O|X|X|O|O|O|O|

and we take into account the number of overall buckets that have failures. However, the one piece I thought the code compensated well for, but does not is that there is a very big difference between:

|X|X|O|O|O|O|O|O|

and

|O|O|O|O|O|X|X|O|

If you imagine each of those buckets is a 3 minute window, that overall window can stretch 30mins. This PR adds an additional condition that the most recent failure timestamp must be in the most recent X% of buckets (e.g. one of the failures must be in the most recent 8 minutes). This should cover cases where something failed for a while then recovered on its own