### PR TITLE
Don't reactivate tasks on agent reregistration after lb removal

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosStatusUpdateHandler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosStatusUpdateHandler.java
@@ -14,8 +14,8 @@ import com.hubspot.singularity.ExtendedTaskState;
 import com.hubspot.singularity.InvalidSingularityTaskIdException;
 import com.hubspot.singularity.RequestType;
 import com.hubspot.singularity.SingularityCreateResult;
+import com.hubspot.singularity.SingularityLoadBalancerUpdate.LoadBalancerMethod;
 import com.hubspot.singularity.SingularityMainModule;
-import com.hubspot.singularity.SingularityManagedScheduledExecutorServiceFactory;
 import com.hubspot.singularity.SingularityManagedThreadPoolFactory;
 import com.hubspot.singularity.SingularityPendingDeploy;
 import com.hubspot.singularity.SingularityPendingRequest;
@@ -24,10 +24,12 @@ import com.hubspot.singularity.SingularityPendingRequestBuilder;
 import com.hubspot.singularity.SingularityPendingTask;
 import com.hubspot.singularity.SingularityRequestWithState;
 import com.hubspot.singularity.SingularityTask;
+import com.hubspot.singularity.SingularityTaskCleanup;
 import com.hubspot.singularity.SingularityTaskHistory;
 import com.hubspot.singularity.SingularityTaskHistoryUpdate;
 import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.SingularityTaskStatusHolder;
+import com.hubspot.singularity.TaskCleanupType;
 import com.hubspot.singularity.async.ExecutorAndQueue;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.DeployManager;
@@ -344,6 +346,35 @@ public class SingularityMesosStatusUpdateHandler {
           taskIdObj
         );
         return StatusUpdateResult.KILL_TASK;
+      } else if (
+        maybeTaskHistory.isPresent() &&
+        status.getReason() == Reason.REASON_AGENT_REREGISTERED
+      ) {
+        boolean lbRemovalStarted = maybeTaskHistory
+          .get()
+          .getLoadBalancerUpdates()
+          .stream()
+          .anyMatch(
+            lbUpdate ->
+              lbUpdate.getMethod() == LoadBalancerMethod.CANCEL ||
+              lbUpdate.getMethod() == LoadBalancerMethod.DELETE
+          );
+        if (lbRemovalStarted) {
+          taskManager.createTaskCleanup(
+            new SingularityTaskCleanup(
+              null,
+              TaskCleanupType.PRIORITY_KILL,
+              System.currentTimeMillis(),
+              taskIdObj,
+              Optional.of(
+                "Agent re-registered after load balancer removal started. Task cannot be reactivated."
+              ),
+              Optional.empty(),
+              Optional.empty()
+            )
+          );
+          return StatusUpdateResult.IGNORED;
+        }
       }
       boolean reactivated = taskManager.reactivateTask(
         taskIdObj,

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosStatusUpdateHandler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosStatusUpdateHandler.java
@@ -356,7 +356,7 @@ public class SingularityMesosStatusUpdateHandler {
         if (lbRemovalStarted) {
           taskManager.createTaskCleanup(
             new SingularityTaskCleanup(
-              null,
+              Optional.empty(),
               TaskCleanupType.DECOMISSIONING,
               System.currentTimeMillis(),
               taskIdObj,


### PR DESCRIPTION
If an agent re-registers with mesos, but the task has already started being removed from the load balancer, don't reactivate it. Instead, clean it gracefully.