### PR TITLE
Add a cheaper endpoint to return the counts of tasks for a request

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskCounts.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskCounts.java
@@ -1,0 +1,90 @@
+package com.hubspot.singularity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Objects;
+
+@Schema(
+  description = "The number of tasks in each state for a particular request. Cleaning tasks are also included in active (i.e. total task count = active + pending)"
+)
+public class SingularityTaskCounts {
+  private final String requestId;
+  private final int active;
+  private final int pending;
+  private final int cleaning;
+
+  @JsonCreator
+  public SingularityTaskCounts(
+    @JsonProperty("requestId") String requestId,
+    @JsonProperty("active") int active,
+    @JsonProperty("pending") int pending,
+    @JsonProperty("cleaning") int cleaning
+  ) {
+    this.requestId = requestId;
+    this.active = active;
+    this.pending = pending;
+    this.cleaning = cleaning;
+  }
+
+  @Schema(description = "Request id")
+  public String getRequestId() {
+    return requestId;
+  }
+
+  @Schema(description = "The number of actively running tasks")
+  public int getActive() {
+    return active;
+  }
+
+  @Schema(description = "The number of tasks that have not yet launched")
+  public int getPending() {
+    return pending;
+  }
+
+  @Schema(
+    description = "The number of tasks in a cleaning state. Note these are also counted under 'active'"
+  )
+  public int getCleaning() {
+    return cleaning;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SingularityTaskCounts that = (SingularityTaskCounts) o;
+    return (
+      active == that.active &&
+      pending == that.pending &&
+      cleaning == that.cleaning &&
+      Objects.equals(requestId, that.requestId)
+    );
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(requestId, active, pending, cleaning);
+  }
+
+  @Override
+  public String toString() {
+    return (
+      "SingularityTaskCounts{" +
+      "requestId='" +
+      requestId +
+      '\'' +
+      ", active=" +
+      active +
+      ", pending=" +
+      pending +
+      ", cleaning=" +
+      cleaning +
+      '}'
+    );
+  }
+}

--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
@@ -57,6 +57,7 @@ import com.hubspot.singularity.SingularitySlave;
 import com.hubspot.singularity.SingularityState;
 import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.SingularityTaskCleanup;
+import com.hubspot.singularity.SingularityTaskCounts;
 import com.hubspot.singularity.SingularityTaskHistory;
 import com.hubspot.singularity.SingularityTaskHistoryUpdate;
 import com.hubspot.singularity.SingularityTaskId;
@@ -156,6 +157,8 @@ public class SingularityClient {
   private static final String TASKS_GET_SCHEDULED_IDS_FORMAT =
     TASKS_GET_SCHEDULED_FORMAT + "/ids";
   private static final String TASKS_BY_STATE_FORMAT = TASKS_FORMAT + "/ids/request/%s";
+  private static final String TASK_COUNTS_BY_STATE_FORMAT =
+    TASKS_FORMAT + "/counts/request/%s";
 
   private static final String SHELL_COMMAND_FORMAT = TASKS_FORMAT + "/task/%s/command";
   private static final String SHELL_COMMAND_UPDATES_FORMAT =
@@ -1452,6 +1455,20 @@ public class SingularityClient {
       "task ids by state",
       requestId,
       SingularityTaskIdsByStatus.class
+    );
+  }
+
+  public Optional<SingularityTaskCounts> getTaskCountsByStatusForRequest(
+    String requestId
+  ) {
+    final Function<String, String> requestUri = host ->
+      String.format(TASK_COUNTS_BY_STATE_FORMAT, getApiBase(host), requestId);
+
+    return getSingle(
+      requestUri,
+      "task counts by state",
+      requestId,
+      SingularityTaskCounts.class
     );
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -336,6 +336,20 @@ public class TaskManager extends CuratorAsyncManager {
     return getNumChildren(LB_CLEANUP_PATH_ROOT);
   }
 
+  public int getNumActiveTasks(String requestId) {
+    if (leaderCache.active()) {
+      return leaderCache.getNumActiveTasks(requestId);
+    }
+    return getNumChildren(getLastActiveTaskParent(requestId));
+  }
+
+  public int getNumScheduledTasks(String requestId) {
+    if (leaderCache.active()) {
+      return leaderCache.getNumPendingTasks(requestId);
+    }
+    return getNumChildren(getPendingForRequestPath(requestId));
+  }
+
   public int getNumActiveTasks() {
     if (leaderCache.active()) {
       return leaderCache.getNumActiveTasks();
@@ -468,6 +482,17 @@ public class TaskManager extends CuratorAsyncManager {
     }
 
     return getChildrenAsIds(CLEANUP_PATH_ROOT, taskIdTranscoder);
+  }
+
+  public int getNumCleanupTaskIds(String requestId) {
+    if (leaderCache.active()) {
+      return leaderCache.getNumCleaningTasks(requestId);
+    }
+
+    return (int) getChildrenAsIds(CLEANUP_PATH_ROOT, taskIdTranscoder)
+      .stream()
+      .filter(t -> t.getRequestId().equals(requestId))
+      .count();
   }
 
   public List<SingularityTaskCleanup> getCleanupTasks(boolean useWebCache) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/helpers/RequestHelper.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/helpers/RequestHelper.java
@@ -19,6 +19,7 @@ import com.hubspot.singularity.SingularityRequestHistory;
 import com.hubspot.singularity.SingularityRequestHistory.RequestHistoryType;
 import com.hubspot.singularity.SingularityRequestParent;
 import com.hubspot.singularity.SingularityRequestWithState;
+import com.hubspot.singularity.SingularityTaskCounts;
 import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.SingularityTaskIdsByStatus;
 import com.hubspot.singularity.SingularityUser;
@@ -490,6 +491,15 @@ public class RequestHelper {
       requestId
     );
     return JavaUtils.getFirst(requestHistory);
+  }
+
+  public SingularityTaskCounts getTaskCountsForRequest(String requestId) {
+    return new SingularityTaskCounts(
+      requestId,
+      taskManager.getNumActiveTasks(requestId),
+      taskManager.getNumScheduledTasks(requestId),
+      taskManager.getNumCleanupTaskIds(requestId)
+    );
   }
 
   public Optional<SingularityTaskIdsByStatus> getTaskIdsByStatusForRequest(

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
@@ -30,6 +30,7 @@ import com.hubspot.singularity.SingularityRequestWithState;
 import com.hubspot.singularity.SingularityShellCommand;
 import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.SingularityTaskCleanup;
+import com.hubspot.singularity.SingularityTaskCounts;
 import com.hubspot.singularity.SingularityTaskHistoryUpdate;
 import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.SingularityTaskIdsByStatus;
@@ -390,6 +391,33 @@ public class TaskResource extends AbstractLeaderAwareResource {
     );
 
     return requestHelper.getTaskIdsByStatusForRequest(requestId);
+  }
+
+  @GET
+  @Path("/counts/request/{requestId}")
+  @Operation(
+    summary = "Retrieve a list of task counts separated by status",
+    description = "Includes pending, active, and cleaning tasks",
+    responses = {
+      @ApiResponse(
+        responseCode = "404",
+        description = "A request with the specified id was not found"
+      )
+    }
+  )
+  public SingularityTaskCounts getTaskCountsByStatusForRequest(
+    @Parameter(hidden = true) @Auth SingularityUser user,
+    @Parameter(description = "The request id to retrieve tasks for") @PathParam(
+      "requestId"
+    ) String requestId
+  ) {
+    authorizationHelper.checkForAuthorizationByRequestId(
+      requestId,
+      user,
+      SingularityAuthorizationScope.READ
+    );
+
+    return requestHelper.getTaskCountsForRequest(requestId);
   }
 
   @GET

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCache.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCache.java
@@ -300,8 +300,23 @@ public class SingularityLeaderCache {
     return activeTaskIds.size();
   }
 
+  public int getNumActiveTasks(String requestId) {
+    return (int) activeTaskIds
+      .stream()
+      .filter(t -> t.getRequestId().equals(requestId))
+      .count();
+  }
+
   public int getNumPendingTasks() {
     return pendingTaskIdToPendingTask.size();
+  }
+
+  public int getNumPendingTasks(String requestId) {
+    return (int) pendingTaskIdToPendingTask
+      .keySet()
+      .stream()
+      .filter(t -> t.getRequestId().equals(requestId))
+      .count();
   }
 
   public boolean isActiveTask(SingularityTaskId taskId) {
@@ -349,6 +364,14 @@ public class SingularityLeaderCache {
 
   public List<SingularityTaskId> getCleanupTaskIds() {
     return new ArrayList<>(cleanupTasks.keySet());
+  }
+
+  public int getNumCleaningTasks(String requestId) {
+    return (int) cleanupTasks
+      .keySet()
+      .stream()
+      .filter(t -> t.getRequestId().equals(requestId))
+      .count();
   }
 
   public Optional<SingularityTaskCleanup> getTaskCleanup(SingularityTaskId taskId) {


### PR DESCRIPTION
For cases of large counts or where the actual task ids aren't needed. This is much cheaper and faster.