### PR TITLE
Add actions to group/scope auth

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityAuthorizationScope.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityAuthorizationScope.java
@@ -4,5 +4,6 @@ public enum SingularityAuthorizationScope {
   READ,
   WRITE,
   ADMIN,
-  DEPLOY
+  DEPLOY,
+  EXEC // run, bounce, kill, pause, scale
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityAuthorizationScope.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityAuthorizationScope.java
@@ -3,7 +3,5 @@ package com.hubspot.singularity;
 public enum SingularityAuthorizationScope {
   READ,
   WRITE,
-  ADMIN,
-  DEPLOY,
-  EXEC // run, bounce, kill, pause, scale
+  ADMIN
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
@@ -42,6 +42,7 @@ public class SingularityRequest {
   private final Optional<String> requiredRole;
   private final Optional<Set<String>> readWriteGroups;
   private final Optional<Set<String>> readOnlyGroups;
+  private final Optional<Map<String, List<SingularityAuthorizationScope>>> groupPermissionOverrides;
   private final Optional<Boolean> bounceAfterScale;
   private final Optional<Map<SingularityEmailType, List<SingularityEmailDestination>>> emailConfigurationOverrides;
   private final Optional<Boolean> hideEvenNumberAcrossRacksHint;
@@ -93,6 +94,9 @@ public class SingularityRequest {
     @JsonProperty("group") Optional<String> group,
     @JsonProperty("readWriteGroups") Optional<Set<String>> readWriteGroups,
     @JsonProperty("readOnlyGroups") Optional<Set<String>> readOnlyGroups,
+    @JsonProperty(
+      "groupPermissionOverrides"
+    ) Optional<Map<String, List<SingularityAuthorizationScope>>> groupPermissionOverrides,
     @JsonProperty("bounceAfterScale") Optional<Boolean> bounceAfterScale,
     @JsonProperty("skipHealthchecks") Optional<Boolean> skipHealthchecks,
     @JsonProperty(
@@ -155,6 +159,7 @@ public class SingularityRequest {
     this.requiredRole = requiredRole;
     this.readWriteGroups = readWriteGroups;
     this.readOnlyGroups = readOnlyGroups;
+    this.groupPermissionOverrides = groupPermissionOverrides;
     this.bounceAfterScale = bounceAfterScale;
     this.emailConfigurationOverrides = emailConfigurationOverrides;
     this.skipHealthchecks = skipHealthchecks;
@@ -199,6 +204,7 @@ public class SingularityRequest {
       .setGroup(group)
       .setReadWriteGroups(readWriteGroups)
       .setReadOnlyGroups(readOnlyGroups)
+      .setGroupPermissionOverrides(groupPermissionOverrides)
       .setBounceAfterScale(bounceAfterScale)
       .setEmailConfigurationOverrides(emailConfigurationOverrides)
       .setSkipHealthchecks(skipHealthchecks)
@@ -502,6 +508,11 @@ public class SingularityRequest {
     return readOnlyGroups;
   }
 
+  @Schema(nullable = true, description = "Permissions for specific groups")
+  public Optional<Map<String, List<SingularityAuthorizationScope>>> getGroupPermissionOverrides() {
+    return groupPermissionOverrides;
+  }
+
   @Schema(
     nullable = true,
     description = "Used for SingularityUI. If true, automatically trigger a bounce after changing the request's instance count"
@@ -605,6 +616,7 @@ public class SingularityRequest {
       Objects.equals(requiredRole, that.requiredRole) &&
       Objects.equals(readWriteGroups, that.readWriteGroups) &&
       Objects.equals(readOnlyGroups, that.readOnlyGroups) &&
+      Objects.equals(groupPermissionOverrides, that.groupPermissionOverrides) &&
       Objects.equals(bounceAfterScale, that.bounceAfterScale) &&
       Objects.equals(emailConfigurationOverrides, that.emailConfigurationOverrides) &&
       Objects.equals(hideEvenNumberAcrossRacksHint, that.hideEvenNumberAcrossRacksHint) &&
@@ -648,6 +660,7 @@ public class SingularityRequest {
       requiredRole,
       readWriteGroups,
       readOnlyGroups,
+      groupPermissionOverrides,
       bounceAfterScale,
       emailConfigurationOverrides,
       hideEvenNumberAcrossRacksHint,
@@ -715,6 +728,8 @@ public class SingularityRequest {
       readWriteGroups +
       ", readOnlyGroups=" +
       readOnlyGroups +
+      ", groupPermissionOverrides=" +
+      groupPermissionOverrides +
       ", bounceAfterScale=" +
       bounceAfterScale +
       ", emailConfigurationOverrides=" +

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
@@ -42,7 +42,7 @@ public class SingularityRequest {
   private final Optional<String> requiredRole;
   private final Optional<Set<String>> readWriteGroups;
   private final Optional<Set<String>> readOnlyGroups;
-  private final Optional<Map<String, Set<SingularityAuthorizationScope>>> groupPermissionOverrides;
+  private final Optional<Map<String, Set<SingularityAuthorizationScope>>> groupScopeOverrides;
   private final Optional<Boolean> bounceAfterScale;
   private final Optional<Map<SingularityEmailType, List<SingularityEmailDestination>>> emailConfigurationOverrides;
   private final Optional<Boolean> hideEvenNumberAcrossRacksHint;
@@ -95,8 +95,8 @@ public class SingularityRequest {
     @JsonProperty("readWriteGroups") Optional<Set<String>> readWriteGroups,
     @JsonProperty("readOnlyGroups") Optional<Set<String>> readOnlyGroups,
     @JsonProperty(
-      "groupPermissionOverrides"
-    ) Optional<Map<String, Set<SingularityAuthorizationScope>>> groupPermissionOverrides,
+      "groupScopeOverrides"
+    ) Optional<Map<String, Set<SingularityAuthorizationScope>>> groupScopeOverrides,
     @JsonProperty("bounceAfterScale") Optional<Boolean> bounceAfterScale,
     @JsonProperty("skipHealthchecks") Optional<Boolean> skipHealthchecks,
     @JsonProperty(
@@ -159,7 +159,7 @@ public class SingularityRequest {
     this.requiredRole = requiredRole;
     this.readWriteGroups = readWriteGroups;
     this.readOnlyGroups = readOnlyGroups;
-    this.groupPermissionOverrides = groupPermissionOverrides;
+    this.groupScopeOverrides = groupScopeOverrides;
     this.bounceAfterScale = bounceAfterScale;
     this.emailConfigurationOverrides = emailConfigurationOverrides;
     this.skipHealthchecks = skipHealthchecks;
@@ -204,7 +204,7 @@ public class SingularityRequest {
       .setGroup(group)
       .setReadWriteGroups(readWriteGroups)
       .setReadOnlyGroups(readOnlyGroups)
-      .setGroupPermissionOverrides(groupPermissionOverrides)
+      .setGroupScopeOverrides(groupScopeOverrides)
       .setBounceAfterScale(bounceAfterScale)
       .setEmailConfigurationOverrides(emailConfigurationOverrides)
       .setSkipHealthchecks(skipHealthchecks)
@@ -509,8 +509,8 @@ public class SingularityRequest {
   }
 
   @Schema(nullable = true, description = "Permissions for specific groups")
-  public Optional<Map<String, Set<SingularityAuthorizationScope>>> getGroupPermissionOverrides() {
-    return groupPermissionOverrides;
+  public Optional<Map<String, Set<SingularityAuthorizationScope>>> getGroupScopeOverrides() {
+    return groupScopeOverrides;
   }
 
   @Schema(
@@ -616,7 +616,7 @@ public class SingularityRequest {
       Objects.equals(requiredRole, that.requiredRole) &&
       Objects.equals(readWriteGroups, that.readWriteGroups) &&
       Objects.equals(readOnlyGroups, that.readOnlyGroups) &&
-      Objects.equals(groupPermissionOverrides, that.groupPermissionOverrides) &&
+      Objects.equals(groupScopeOverrides, that.groupScopeOverrides) &&
       Objects.equals(bounceAfterScale, that.bounceAfterScale) &&
       Objects.equals(emailConfigurationOverrides, that.emailConfigurationOverrides) &&
       Objects.equals(hideEvenNumberAcrossRacksHint, that.hideEvenNumberAcrossRacksHint) &&
@@ -660,7 +660,7 @@ public class SingularityRequest {
       requiredRole,
       readWriteGroups,
       readOnlyGroups,
-      groupPermissionOverrides,
+      groupScopeOverrides,
       bounceAfterScale,
       emailConfigurationOverrides,
       hideEvenNumberAcrossRacksHint,
@@ -728,8 +728,8 @@ public class SingularityRequest {
       readWriteGroups +
       ", readOnlyGroups=" +
       readOnlyGroups +
-      ", groupPermissionOverrides=" +
-      groupPermissionOverrides +
+      ", groupScopeOverrides=" +
+      groupScopeOverrides +
       ", bounceAfterScale=" +
       bounceAfterScale +
       ", emailConfigurationOverrides=" +

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
@@ -42,7 +42,7 @@ public class SingularityRequest {
   private final Optional<String> requiredRole;
   private final Optional<Set<String>> readWriteGroups;
   private final Optional<Set<String>> readOnlyGroups;
-  private final Optional<Map<String, Set<SingularityAuthorizationScope>>> groupScopeOverrides;
+  private final Optional<Map<String, Set<SingularityUserFacingAction>>> actionPermissions;
   private final Optional<Boolean> bounceAfterScale;
   private final Optional<Map<SingularityEmailType, List<SingularityEmailDestination>>> emailConfigurationOverrides;
   private final Optional<Boolean> hideEvenNumberAcrossRacksHint;
@@ -95,8 +95,8 @@ public class SingularityRequest {
     @JsonProperty("readWriteGroups") Optional<Set<String>> readWriteGroups,
     @JsonProperty("readOnlyGroups") Optional<Set<String>> readOnlyGroups,
     @JsonProperty(
-      "groupScopeOverrides"
-    ) Optional<Map<String, Set<SingularityAuthorizationScope>>> groupScopeOverrides,
+      "actionPermissions"
+    ) Optional<Map<String, Set<SingularityUserFacingAction>>> actionPermissions,
     @JsonProperty("bounceAfterScale") Optional<Boolean> bounceAfterScale,
     @JsonProperty("skipHealthchecks") Optional<Boolean> skipHealthchecks,
     @JsonProperty(
@@ -159,7 +159,7 @@ public class SingularityRequest {
     this.requiredRole = requiredRole;
     this.readWriteGroups = readWriteGroups;
     this.readOnlyGroups = readOnlyGroups;
-    this.groupScopeOverrides = groupScopeOverrides;
+    this.actionPermissions = actionPermissions;
     this.bounceAfterScale = bounceAfterScale;
     this.emailConfigurationOverrides = emailConfigurationOverrides;
     this.skipHealthchecks = skipHealthchecks;
@@ -204,7 +204,7 @@ public class SingularityRequest {
       .setGroup(group)
       .setReadWriteGroups(readWriteGroups)
       .setReadOnlyGroups(readOnlyGroups)
-      .setGroupScopeOverrides(groupScopeOverrides)
+      .setActionPermissions(actionPermissions)
       .setBounceAfterScale(bounceAfterScale)
       .setEmailConfigurationOverrides(emailConfigurationOverrides)
       .setSkipHealthchecks(skipHealthchecks)
@@ -509,8 +509,8 @@ public class SingularityRequest {
   }
 
   @Schema(nullable = true, description = "Permissions for specific groups")
-  public Optional<Map<String, Set<SingularityAuthorizationScope>>> getGroupScopeOverrides() {
-    return groupScopeOverrides;
+  public Optional<Map<String, Set<SingularityUserFacingAction>>> getActionPermissions() {
+    return actionPermissions;
   }
 
   @Schema(
@@ -616,7 +616,7 @@ public class SingularityRequest {
       Objects.equals(requiredRole, that.requiredRole) &&
       Objects.equals(readWriteGroups, that.readWriteGroups) &&
       Objects.equals(readOnlyGroups, that.readOnlyGroups) &&
-      Objects.equals(groupScopeOverrides, that.groupScopeOverrides) &&
+      Objects.equals(actionPermissions, that.actionPermissions) &&
       Objects.equals(bounceAfterScale, that.bounceAfterScale) &&
       Objects.equals(emailConfigurationOverrides, that.emailConfigurationOverrides) &&
       Objects.equals(hideEvenNumberAcrossRacksHint, that.hideEvenNumberAcrossRacksHint) &&
@@ -660,7 +660,7 @@ public class SingularityRequest {
       requiredRole,
       readWriteGroups,
       readOnlyGroups,
-      groupScopeOverrides,
+      actionPermissions,
       bounceAfterScale,
       emailConfigurationOverrides,
       hideEvenNumberAcrossRacksHint,
@@ -728,8 +728,8 @@ public class SingularityRequest {
       readWriteGroups +
       ", readOnlyGroups=" +
       readOnlyGroups +
-      ", groupScopeOverrides=" +
-      groupScopeOverrides +
+      ", actionPermissions=" +
+      actionPermissions +
       ", bounceAfterScale=" +
       bounceAfterScale +
       ", emailConfigurationOverrides=" +

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
@@ -42,7 +42,7 @@ public class SingularityRequest {
   private final Optional<String> requiredRole;
   private final Optional<Set<String>> readWriteGroups;
   private final Optional<Set<String>> readOnlyGroups;
-  private final Optional<Map<String, List<SingularityAuthorizationScope>>> groupPermissionOverrides;
+  private final Optional<Map<String, Set<SingularityAuthorizationScope>>> groupPermissionOverrides;
   private final Optional<Boolean> bounceAfterScale;
   private final Optional<Map<SingularityEmailType, List<SingularityEmailDestination>>> emailConfigurationOverrides;
   private final Optional<Boolean> hideEvenNumberAcrossRacksHint;
@@ -96,7 +96,7 @@ public class SingularityRequest {
     @JsonProperty("readOnlyGroups") Optional<Set<String>> readOnlyGroups,
     @JsonProperty(
       "groupPermissionOverrides"
-    ) Optional<Map<String, List<SingularityAuthorizationScope>>> groupPermissionOverrides,
+    ) Optional<Map<String, Set<SingularityAuthorizationScope>>> groupPermissionOverrides,
     @JsonProperty("bounceAfterScale") Optional<Boolean> bounceAfterScale,
     @JsonProperty("skipHealthchecks") Optional<Boolean> skipHealthchecks,
     @JsonProperty(
@@ -509,7 +509,7 @@ public class SingularityRequest {
   }
 
   @Schema(nullable = true, description = "Permissions for specific groups")
-  public Optional<Map<String, List<SingularityAuthorizationScope>>> getGroupPermissionOverrides() {
+  public Optional<Map<String, Set<SingularityAuthorizationScope>>> getGroupPermissionOverrides() {
     return groupPermissionOverrides;
   }
 

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestBuilder.java
@@ -42,7 +42,7 @@ public class SingularityRequestBuilder {
   private Optional<String> group;
   private Optional<Set<String>> readWriteGroups;
   private Optional<Set<String>> readOnlyGroups;
-  private Optional<Map<String, List<SingularityAuthorizationScope>>> groupPermissionOverrides;
+  private Optional<Map<String, Set<SingularityAuthorizationScope>>> groupPermissionOverrides;
   private Optional<Boolean> bounceAfterScale;
   private Optional<Map<SingularityEmailType, List<SingularityEmailDestination>>> emailConfigurationOverrides;
   private Optional<Boolean> hideEvenNumberAcrossRacksHint;
@@ -355,12 +355,12 @@ public class SingularityRequestBuilder {
     return this;
   }
 
-  public Optional<Map<String, List<SingularityAuthorizationScope>>> getGroupPermissionOverrides() {
+  public Optional<Map<String, Set<SingularityAuthorizationScope>>> getGroupPermissionOverrides() {
     return groupPermissionOverrides;
   }
 
   public SingularityRequestBuilder setGroupPermissionOverrides(
-    Optional<Map<String, List<SingularityAuthorizationScope>>> groupPermissionOverrides
+    Optional<Map<String, Set<SingularityAuthorizationScope>>> groupPermissionOverrides
   ) {
     this.groupPermissionOverrides = groupPermissionOverrides;
     return this;

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestBuilder.java
@@ -42,6 +42,7 @@ public class SingularityRequestBuilder {
   private Optional<String> group;
   private Optional<Set<String>> readWriteGroups;
   private Optional<Set<String>> readOnlyGroups;
+  private Optional<Map<String, List<SingularityAuthorizationScope>>> groupPermissionOverrides;
   private Optional<Boolean> bounceAfterScale;
   private Optional<Map<SingularityEmailType, List<SingularityEmailDestination>>> emailConfigurationOverrides;
   private Optional<Boolean> hideEvenNumberAcrossRacksHint;
@@ -78,6 +79,7 @@ public class SingularityRequestBuilder {
     this.group = Optional.empty();
     this.readWriteGroups = Optional.empty();
     this.readOnlyGroups = Optional.empty();
+    this.groupPermissionOverrides = Optional.empty();
     this.bounceAfterScale = Optional.empty();
     this.emailConfigurationOverrides = Optional.empty();
     this.skipHealthchecks = Optional.empty();
@@ -116,6 +118,7 @@ public class SingularityRequestBuilder {
       group,
       readWriteGroups,
       readOnlyGroups,
+      groupPermissionOverrides,
       bounceAfterScale,
       skipHealthchecks,
       emailConfigurationOverrides,
@@ -352,6 +355,17 @@ public class SingularityRequestBuilder {
     return this;
   }
 
+  public Optional<Map<String, List<SingularityAuthorizationScope>>> getGroupPermissionOverrides() {
+    return groupPermissionOverrides;
+  }
+
+  public SingularityRequestBuilder setGroupPermissionOverrides(
+    Optional<Map<String, List<SingularityAuthorizationScope>>> groupPermissionOverrides
+  ) {
+    this.groupPermissionOverrides = groupPermissionOverrides;
+    return this;
+  }
+
   public SingularityRequestBuilder setRequiredAgentAttributes(
     Optional<Map<String, String>> requiredAgentAttributes
   ) {
@@ -551,6 +565,7 @@ public class SingularityRequestBuilder {
       Objects.equals(group, that.group) &&
       Objects.equals(readWriteGroups, that.readWriteGroups) &&
       Objects.equals(readOnlyGroups, that.readOnlyGroups) &&
+      Objects.equals(groupPermissionOverrides, that.groupPermissionOverrides) &&
       Objects.equals(bounceAfterScale, that.bounceAfterScale) &&
       Objects.equals(emailConfigurationOverrides, that.emailConfigurationOverrides) &&
       Objects.equals(hideEvenNumberAcrossRacksHint, that.hideEvenNumberAcrossRacksHint) &&
@@ -594,6 +609,7 @@ public class SingularityRequestBuilder {
       group,
       readWriteGroups,
       readOnlyGroups,
+      groupPermissionOverrides,
       bounceAfterScale,
       emailConfigurationOverrides,
       hideEvenNumberAcrossRacksHint,
@@ -661,6 +677,8 @@ public class SingularityRequestBuilder {
       readWriteGroups +
       ", readOnlyGroups=" +
       readOnlyGroups +
+      ", groupPermissionOverrides=" +
+      groupPermissionOverrides +
       ", bounceAfterScale=" +
       bounceAfterScale +
       ", emailConfigurationOverrides=" +

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestBuilder.java
@@ -42,7 +42,7 @@ public class SingularityRequestBuilder {
   private Optional<String> group;
   private Optional<Set<String>> readWriteGroups;
   private Optional<Set<String>> readOnlyGroups;
-  private Optional<Map<String, Set<SingularityAuthorizationScope>>> groupPermissionOverrides;
+  private Optional<Map<String, Set<SingularityAuthorizationScope>>> groupScopeOverrides;
   private Optional<Boolean> bounceAfterScale;
   private Optional<Map<SingularityEmailType, List<SingularityEmailDestination>>> emailConfigurationOverrides;
   private Optional<Boolean> hideEvenNumberAcrossRacksHint;
@@ -79,7 +79,7 @@ public class SingularityRequestBuilder {
     this.group = Optional.empty();
     this.readWriteGroups = Optional.empty();
     this.readOnlyGroups = Optional.empty();
-    this.groupPermissionOverrides = Optional.empty();
+    this.groupScopeOverrides = Optional.empty();
     this.bounceAfterScale = Optional.empty();
     this.emailConfigurationOverrides = Optional.empty();
     this.skipHealthchecks = Optional.empty();
@@ -118,7 +118,7 @@ public class SingularityRequestBuilder {
       group,
       readWriteGroups,
       readOnlyGroups,
-      groupPermissionOverrides,
+      groupScopeOverrides,
       bounceAfterScale,
       skipHealthchecks,
       emailConfigurationOverrides,
@@ -355,14 +355,14 @@ public class SingularityRequestBuilder {
     return this;
   }
 
-  public Optional<Map<String, Set<SingularityAuthorizationScope>>> getGroupPermissionOverrides() {
-    return groupPermissionOverrides;
+  public Optional<Map<String, Set<SingularityAuthorizationScope>>> getGroupScopeOverrides() {
+    return groupScopeOverrides;
   }
 
-  public SingularityRequestBuilder setGroupPermissionOverrides(
-    Optional<Map<String, Set<SingularityAuthorizationScope>>> groupPermissionOverrides
+  public SingularityRequestBuilder setGroupScopeOverrides(
+    Optional<Map<String, Set<SingularityAuthorizationScope>>> groupScopeOverrides
   ) {
-    this.groupPermissionOverrides = groupPermissionOverrides;
+    this.groupScopeOverrides = groupScopeOverrides;
     return this;
   }
 
@@ -565,7 +565,7 @@ public class SingularityRequestBuilder {
       Objects.equals(group, that.group) &&
       Objects.equals(readWriteGroups, that.readWriteGroups) &&
       Objects.equals(readOnlyGroups, that.readOnlyGroups) &&
-      Objects.equals(groupPermissionOverrides, that.groupPermissionOverrides) &&
+      Objects.equals(groupScopeOverrides, that.groupScopeOverrides) &&
       Objects.equals(bounceAfterScale, that.bounceAfterScale) &&
       Objects.equals(emailConfigurationOverrides, that.emailConfigurationOverrides) &&
       Objects.equals(hideEvenNumberAcrossRacksHint, that.hideEvenNumberAcrossRacksHint) &&
@@ -609,7 +609,7 @@ public class SingularityRequestBuilder {
       group,
       readWriteGroups,
       readOnlyGroups,
-      groupPermissionOverrides,
+      groupScopeOverrides,
       bounceAfterScale,
       emailConfigurationOverrides,
       hideEvenNumberAcrossRacksHint,
@@ -677,8 +677,8 @@ public class SingularityRequestBuilder {
       readWriteGroups +
       ", readOnlyGroups=" +
       readOnlyGroups +
-      ", groupPermissionOverrides=" +
-      groupPermissionOverrides +
+      ", groupScopeOverrides=" +
+      groupScopeOverrides +
       ", bounceAfterScale=" +
       bounceAfterScale +
       ", emailConfigurationOverrides=" +

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestBuilder.java
@@ -42,7 +42,7 @@ public class SingularityRequestBuilder {
   private Optional<String> group;
   private Optional<Set<String>> readWriteGroups;
   private Optional<Set<String>> readOnlyGroups;
-  private Optional<Map<String, Set<SingularityAuthorizationScope>>> groupScopeOverrides;
+  private Optional<Map<String, Set<SingularityUserFacingAction>>> actionPermissions;
   private Optional<Boolean> bounceAfterScale;
   private Optional<Map<SingularityEmailType, List<SingularityEmailDestination>>> emailConfigurationOverrides;
   private Optional<Boolean> hideEvenNumberAcrossRacksHint;
@@ -79,7 +79,7 @@ public class SingularityRequestBuilder {
     this.group = Optional.empty();
     this.readWriteGroups = Optional.empty();
     this.readOnlyGroups = Optional.empty();
-    this.groupScopeOverrides = Optional.empty();
+    this.actionPermissions = Optional.empty();
     this.bounceAfterScale = Optional.empty();
     this.emailConfigurationOverrides = Optional.empty();
     this.skipHealthchecks = Optional.empty();
@@ -118,7 +118,7 @@ public class SingularityRequestBuilder {
       group,
       readWriteGroups,
       readOnlyGroups,
-      groupScopeOverrides,
+      actionPermissions,
       bounceAfterScale,
       skipHealthchecks,
       emailConfigurationOverrides,
@@ -355,14 +355,14 @@ public class SingularityRequestBuilder {
     return this;
   }
 
-  public Optional<Map<String, Set<SingularityAuthorizationScope>>> getGroupScopeOverrides() {
-    return groupScopeOverrides;
+  public Optional<Map<String, Set<SingularityUserFacingAction>>> getActionPermissions() {
+    return actionPermissions;
   }
 
-  public SingularityRequestBuilder setGroupScopeOverrides(
-    Optional<Map<String, Set<SingularityAuthorizationScope>>> groupScopeOverrides
+  public SingularityRequestBuilder setActionPermissions(
+    Optional<Map<String, Set<SingularityUserFacingAction>>> getActionPermissions
   ) {
-    this.groupScopeOverrides = groupScopeOverrides;
+    this.actionPermissions = getActionPermissions;
     return this;
   }
 
@@ -565,7 +565,7 @@ public class SingularityRequestBuilder {
       Objects.equals(group, that.group) &&
       Objects.equals(readWriteGroups, that.readWriteGroups) &&
       Objects.equals(readOnlyGroups, that.readOnlyGroups) &&
-      Objects.equals(groupScopeOverrides, that.groupScopeOverrides) &&
+      Objects.equals(actionPermissions, that.actionPermissions) &&
       Objects.equals(bounceAfterScale, that.bounceAfterScale) &&
       Objects.equals(emailConfigurationOverrides, that.emailConfigurationOverrides) &&
       Objects.equals(hideEvenNumberAcrossRacksHint, that.hideEvenNumberAcrossRacksHint) &&
@@ -609,7 +609,7 @@ public class SingularityRequestBuilder {
       group,
       readWriteGroups,
       readOnlyGroups,
-      groupScopeOverrides,
+      actionPermissions,
       bounceAfterScale,
       emailConfigurationOverrides,
       hideEvenNumberAcrossRacksHint,
@@ -677,8 +677,8 @@ public class SingularityRequestBuilder {
       readWriteGroups +
       ", readOnlyGroups=" +
       readOnlyGroups +
-      ", groupScopeOverrides=" +
-      groupScopeOverrides +
+      ", actionPermissions=" +
+      actionPermissions +
       ", bounceAfterScale=" +
       bounceAfterScale +
       ", emailConfigurationOverrides=" +

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityUserFacingAction.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityUserFacingAction.java
@@ -1,0 +1,12 @@
+package com.hubspot.singularity;
+
+public enum SingularityUserFacingAction {
+  RUN_REQUEST,
+  BOUNCE_REQUEST,
+  PAUSE_REQUEST,
+  SCALE_REQUEST,
+  KILL_TASK,
+  BOUNCE_TASK,
+  RUN_SHELL_COMMAND,
+  DELETE_SCHEDULED_TASK
+}

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityUserFacingAction.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityUserFacingAction.java
@@ -1,12 +1,11 @@
 package com.hubspot.singularity;
 
 public enum SingularityUserFacingAction {
-  RUN_REQUEST,
-  BOUNCE_REQUEST,
-  PAUSE_REQUEST,
-  SCALE_REQUEST,
+  EXEC,
+  BOUNCE,
+  PAUSE,
+  SCALE,
   KILL_TASK,
-  BOUNCE_TASK,
-  RUN_SHELL_COMMAND,
-  DELETE_SCHEDULED_TASK
+  DELETE_SCHEDULED_TASK,
+  RUN_SHELL_COMMAND
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityUpdateGroupsRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityUpdateGroupsRequest.java
@@ -2,7 +2,7 @@ package com.hubspot.singularity.api;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.hubspot.singularity.SingularityAuthorizationScope;
+import com.hubspot.singularity.SingularityUserFacingAction;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Collections;
 import java.util.Map;
@@ -15,7 +15,7 @@ public class SingularityUpdateGroupsRequest {
   private final Optional<String> group;
   private final Set<String> readWriteGroups;
   private final Set<String> readOnlyGroups;
-  private final Optional<Map<String, Set<SingularityAuthorizationScope>>> groupScopeOverrides;
+  private final Optional<Map<String, Set<SingularityUserFacingAction>>> actionPermissions;
   private final Optional<String> message;
 
   @JsonCreator
@@ -24,8 +24,8 @@ public class SingularityUpdateGroupsRequest {
     @JsonProperty("readWriteGroups") Set<String> readWriteGroups,
     @JsonProperty("readOnlyGroups") Set<String> readOnlyGroups,
     @JsonProperty(
-      "groupScopeOverrides"
-    ) Optional<Map<String, Set<SingularityAuthorizationScope>>> groupScopeOverrides,
+      "actionPermissions"
+    ) Optional<Map<String, Set<SingularityUserFacingAction>>> actionPermissions,
     @JsonProperty("message") Optional<String> message
   ) {
     this.group = group;
@@ -33,7 +33,7 @@ public class SingularityUpdateGroupsRequest {
       readWriteGroups != null ? readWriteGroups : Collections.emptySet();
     this.readOnlyGroups =
       readOnlyGroups != null ? readOnlyGroups : Collections.emptySet();
-    this.groupScopeOverrides = groupScopeOverrides;
+    this.actionPermissions = actionPermissions;
     this.message = message;
   }
 
@@ -53,8 +53,8 @@ public class SingularityUpdateGroupsRequest {
   }
 
   @Schema(description = "Overidden scopes for specific groups")
-  public Optional<Map<String, Set<SingularityAuthorizationScope>>> getGroupScopeOverrides() {
-    return groupScopeOverrides;
+  public Optional<Map<String, Set<SingularityUserFacingAction>>> getActionPermissions() {
+    return actionPermissions;
   }
 
   @Schema(
@@ -76,7 +76,7 @@ public class SingularityUpdateGroupsRequest {
         Objects.equals(this.group, that.group) &&
         Objects.equals(this.readWriteGroups, that.readWriteGroups) &&
         Objects.equals(this.readOnlyGroups, that.readOnlyGroups) &&
-        Objects.equals(this.groupScopeOverrides, that.groupScopeOverrides) &&
+        Objects.equals(this.actionPermissions, that.actionPermissions) &&
         Objects.equals(this.message, that.message)
       );
     }
@@ -89,7 +89,7 @@ public class SingularityUpdateGroupsRequest {
       group,
       readWriteGroups,
       readOnlyGroups,
-      groupScopeOverrides,
+      actionPermissions,
       message
     );
   }
@@ -105,7 +105,7 @@ public class SingularityUpdateGroupsRequest {
       ", readOnlyGroups=" +
       readOnlyGroups +
       ", groupScopeOverrides=" +
-      groupScopeOverrides +
+      actionPermissions +
       ", message=" +
       message +
       '}'

--- a/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityUpdateGroupsRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/api/SingularityUpdateGroupsRequest.java
@@ -2,8 +2,10 @@ package com.hubspot.singularity.api;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.hubspot.singularity.SingularityAuthorizationScope;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -13,6 +15,7 @@ public class SingularityUpdateGroupsRequest {
   private final Optional<String> group;
   private final Set<String> readWriteGroups;
   private final Set<String> readOnlyGroups;
+  private final Optional<Map<String, Set<SingularityAuthorizationScope>>> groupScopeOverrides;
   private final Optional<String> message;
 
   @JsonCreator
@@ -20,6 +23,9 @@ public class SingularityUpdateGroupsRequest {
     @JsonProperty("group") Optional<String> group,
     @JsonProperty("readWriteGroups") Set<String> readWriteGroups,
     @JsonProperty("readOnlyGroups") Set<String> readOnlyGroups,
+    @JsonProperty(
+      "groupScopeOverrides"
+    ) Optional<Map<String, Set<SingularityAuthorizationScope>>> groupScopeOverrides,
     @JsonProperty("message") Optional<String> message
   ) {
     this.group = group;
@@ -27,6 +33,7 @@ public class SingularityUpdateGroupsRequest {
       readWriteGroups != null ? readWriteGroups : Collections.emptySet();
     this.readOnlyGroups =
       readOnlyGroups != null ? readOnlyGroups : Collections.emptySet();
+    this.groupScopeOverrides = groupScopeOverrides;
     this.message = message;
   }
 
@@ -43,6 +50,11 @@ public class SingularityUpdateGroupsRequest {
   @Schema(description = "Groups allowed read only access to a request")
   public Set<String> getReadOnlyGroups() {
     return readOnlyGroups;
+  }
+
+  @Schema(description = "Overidden scopes for specific groups")
+  public Optional<Map<String, Set<SingularityAuthorizationScope>>> getGroupScopeOverrides() {
+    return groupScopeOverrides;
   }
 
   @Schema(
@@ -64,6 +76,7 @@ public class SingularityUpdateGroupsRequest {
         Objects.equals(this.group, that.group) &&
         Objects.equals(this.readWriteGroups, that.readWriteGroups) &&
         Objects.equals(this.readOnlyGroups, that.readOnlyGroups) &&
+        Objects.equals(this.groupScopeOverrides, that.groupScopeOverrides) &&
         Objects.equals(this.message, that.message)
       );
     }
@@ -72,7 +85,13 @@ public class SingularityUpdateGroupsRequest {
 
   @Override
   public int hashCode() {
-    return Objects.hash(group, readWriteGroups, readOnlyGroups, message);
+    return Objects.hash(
+      group,
+      readWriteGroups,
+      readOnlyGroups,
+      groupScopeOverrides,
+      message
+    );
   }
 
   @Override
@@ -85,6 +104,8 @@ public class SingularityUpdateGroupsRequest {
       readWriteGroups +
       ", readOnlyGroups=" +
       readOnlyGroups +
+      ", groupScopeOverrides=" +
+      groupScopeOverrides +
       ", message=" +
       message +
       '}'

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAuthorizer.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAuthorizer.java
@@ -14,6 +14,7 @@ import com.hubspot.singularity.SingularityRequest;
 import com.hubspot.singularity.SingularityRequestWithState;
 import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.SingularityUser;
+import com.hubspot.singularity.SingularityUserFacingAction;
 import com.hubspot.singularity.data.RequestManager;
 import java.util.List;
 import java.util.Map;
@@ -42,16 +43,52 @@ public abstract class SingularityAuthorizer {
 
   public abstract void checkReadAuthorization(SingularityUser user);
 
-  public abstract void checkForAuthorization(
+  public void checkForAuthorization(
     SingularityRequest request,
     SingularityUser user,
     SingularityAuthorizationScope scope
+  ) {
+    checkForAuthorization(request, user, scope, Optional.empty());
+  }
+
+  public void checkForAuthorization(
+    SingularityRequest request,
+    SingularityUser user,
+    SingularityAuthorizationScope scope,
+    SingularityUserFacingAction action
+  ) {
+    checkForAuthorization(request, user, scope, Optional.of(action));
+  }
+
+  protected abstract void checkForAuthorization(
+    SingularityRequest request,
+    SingularityUser user,
+    SingularityAuthorizationScope scope,
+    Optional<SingularityUserFacingAction> action
   );
 
-  public abstract boolean isAuthorizedForRequest(
+  public boolean isAuthorizedForRequest(
     SingularityRequest request,
     SingularityUser user,
     SingularityAuthorizationScope scope
+  ) {
+    return isAuthorizedForRequest(request, user, scope, Optional.empty());
+  }
+
+  public boolean isAuthorizedForRequest(
+    SingularityRequest request,
+    SingularityUser user,
+    SingularityAuthorizationScope scope,
+    SingularityUserFacingAction action
+  ) {
+    return isAuthorizedForRequest(request, user, scope, Optional.of(action));
+  }
+
+  protected abstract boolean isAuthorizedForRequest(
+    SingularityRequest request,
+    SingularityUser user,
+    SingularityAuthorizationScope scope,
+    Optional<SingularityUserFacingAction> action
   );
 
   public abstract void checkForAuthorizedChanges(
@@ -65,6 +102,24 @@ public abstract class SingularityAuthorizer {
     SingularityUser user,
     SingularityAuthorizationScope scope
   ) {
+    checkForAuthorizationByTaskId(taskId, user, scope, Optional.empty());
+  }
+
+  public void checkForAuthorizationByTaskId(
+    String taskId,
+    SingularityUser user,
+    SingularityAuthorizationScope scope,
+    SingularityUserFacingAction action
+  ) {
+    checkForAuthorizationByTaskId(taskId, user, scope, Optional.of(action));
+  }
+
+  private void checkForAuthorizationByTaskId(
+    String taskId,
+    SingularityUser user,
+    SingularityAuthorizationScope scope,
+    Optional<SingularityUserFacingAction> action
+  ) {
     if (authEnabled) {
       checkForbidden(user.isAuthenticated(), "Not Authenticated!");
       try {
@@ -76,7 +131,12 @@ public abstract class SingularityAuthorizer {
 
         maybeRequest.ifPresent(
           singularityRequestWithState ->
-            checkForAuthorization(singularityRequestWithState.getRequest(), user, scope)
+            checkForAuthorization(
+              singularityRequestWithState.getRequest(),
+              user,
+              scope,
+              action
+            )
         );
       } catch (InvalidSingularityTaskIdException e) {
         badRequest(e.getMessage());
@@ -89,6 +149,24 @@ public abstract class SingularityAuthorizer {
     SingularityUser user,
     SingularityAuthorizationScope scope
   ) {
+    checkForAuthorizationByRequestId(requestId, user, scope, Optional.empty());
+  }
+
+  public void checkForAuthorizationByRequestId(
+    String requestId,
+    SingularityUser user,
+    SingularityAuthorizationScope scope,
+    SingularityUserFacingAction action
+  ) {
+    checkForAuthorizationByRequestId(requestId, user, scope, Optional.of(action));
+  }
+
+  public void checkForAuthorizationByRequestId(
+    String requestId,
+    SingularityUser user,
+    SingularityAuthorizationScope scope,
+    Optional<SingularityUserFacingAction> action
+  ) {
     if (authEnabled) {
       final Optional<SingularityRequestWithState> maybeRequest = requestManager.getRequest(
         requestId
@@ -96,7 +174,12 @@ public abstract class SingularityAuthorizer {
 
       maybeRequest.ifPresent(
         singularityRequestWithState ->
-          checkForAuthorization(singularityRequestWithState.getRequest(), user, scope)
+          checkForAuthorization(
+            singularityRequestWithState.getRequest(),
+            user,
+            scope,
+            action
+          )
       );
     }
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityDualAuthorizer.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityDualAuthorizer.java
@@ -11,10 +11,12 @@ import com.hubspot.singularity.SingularityAuthorizationScope;
 import com.hubspot.singularity.SingularityRequest;
 import com.hubspot.singularity.SingularityRequestWithState;
 import com.hubspot.singularity.SingularityUser;
+import com.hubspot.singularity.SingularityUserFacingAction;
 import com.hubspot.singularity.config.AuthConfiguration;
 import com.hubspot.singularity.data.RequestManager;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.ws.rs.WebApplicationException;
@@ -151,7 +153,8 @@ public class SingularityDualAuthorizer extends SingularityAuthorizer {
   public void checkForAuthorization(
     SingularityRequest request,
     SingularityUser user,
-    SingularityAuthorizationScope scope
+    SingularityAuthorizationScope scope,
+    Optional<SingularityUserFacingAction> action
   ) {
     boolean grantedByScopes = checkGrantedByScopes(
       () -> groupsScopesAuthorizer.checkForAuthorization(request, user, scope)
@@ -183,7 +186,8 @@ public class SingularityDualAuthorizer extends SingularityAuthorizer {
   public boolean isAuthorizedForRequest(
     SingularityRequest request,
     SingularityUser user,
-    SingularityAuthorizationScope scope
+    SingularityAuthorizationScope scope,
+    Optional<SingularityUserFacingAction> action
   ) {
     boolean result = groupsAuthorizer.isAuthorizedForRequest(
       request,

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityGroupsAuthorizer.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityGroupsAuthorizer.java
@@ -12,6 +12,7 @@ import com.hubspot.mesos.JavaUtils;
 import com.hubspot.singularity.SingularityAuthorizationScope;
 import com.hubspot.singularity.SingularityRequest;
 import com.hubspot.singularity.SingularityUser;
+import com.hubspot.singularity.SingularityUserFacingAction;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.RequestManager;
 import java.util.Collections;
@@ -112,7 +113,8 @@ public class SingularityGroupsAuthorizer extends SingularityAuthorizer {
   public boolean isAuthorizedForRequest(
     SingularityRequest request,
     SingularityUser user,
-    SingularityAuthorizationScope scope
+    SingularityAuthorizationScope scope,
+    Optional<SingularityUserFacingAction> action
   ) {
     if (!authEnabled) {
       return true; // no auth == no rules!
@@ -164,7 +166,8 @@ public class SingularityGroupsAuthorizer extends SingularityAuthorizer {
   public void checkForAuthorization(
     SingularityRequest request,
     SingularityUser user,
-    SingularityAuthorizationScope scope
+    SingularityAuthorizationScope scope,
+    Optional<SingularityUserFacingAction> action
   ) {
     if (!authEnabled) {
       return;
@@ -235,10 +238,7 @@ public class SingularityGroupsAuthorizer extends SingularityAuthorizer {
           Iterables.concat(readOnlyGroups, readWriteGroups, jitaGroups)
         )
       );
-    } else if (
-      scope == SingularityAuthorizationScope.WRITE ||
-      scope == SingularityAuthorizationScope.DEPLOY
-    ) {
+    } else if (scope == SingularityAuthorizationScope.WRITE) {
       checkForbidden(
         userIsReadWriteUser || userIsJITA,
         "%s must be a member of one or more groups to %s %s: %s",

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityGroupsScopesAuthorizer.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityGroupsScopesAuthorizer.java
@@ -2,6 +2,7 @@ package com.hubspot.singularity.auth;
 
 import static com.hubspot.singularity.WebExceptions.checkForbidden;
 
+import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.hubspot.singularity.SingularityAuthorizationScope;
@@ -10,6 +11,7 @@ import com.hubspot.singularity.SingularityUser;
 import com.hubspot.singularity.config.AuthConfiguration;
 import com.hubspot.singularity.config.ScopesConfiguration;
 import com.hubspot.singularity.data.RequestManager;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import org.slf4j.Logger;
@@ -59,7 +61,7 @@ public class SingularityGroupsScopesAuthorizer extends SingularityAuthorizer {
       return;
     }
     checkForbidden(user.isAuthenticated(), "Not Authenticated!");
-    checkReadScope(user);
+    checkScope(user, SingularityAuthorizationScope.READ);
   }
 
   @Override
@@ -79,7 +81,7 @@ public class SingularityGroupsScopesAuthorizer extends SingularityAuthorizer {
       "all",
       SingularityAuthorizationScope.READ
     );
-    checkReadScope(user);
+    checkScope(user, SingularityAuthorizationScope.READ);
   }
 
   @Override
@@ -94,24 +96,11 @@ public class SingularityGroupsScopesAuthorizer extends SingularityAuthorizer {
     checkForbidden(user.isAuthenticated(), "Not Authenticated!");
     switch (scope) {
       case READ:
-        Set<String> allowedReadGroups = getReadGroups(request);
-        checkForbiddenForGroups(user, allowedReadGroups, request.getId(), scope);
-        checkReadScope(user);
-        break;
-      case DEPLOY:
-        // same group constraints at write, with different scope if specified in config
-        Set<String> allowedDeployGroups = getWriteGroups(request);
-        checkForbiddenForGroups(user, allowedDeployGroups, request.getId(), scope);
-        if (!scopesConfiguration.getDeploy().isEmpty()) {
-          checkDeployScope(user);
-        } else {
-          checkWriteScope(user);
-        }
-        break;
       case WRITE:
-        Set<String> allowedWriteGroups = getWriteGroups(request);
-        checkForbiddenForGroups(user, allowedWriteGroups, request.getId(), scope);
-        checkWriteScope(user);
+      case DEPLOY:
+        Set<String> allowedReadGroups = getGroups(request, scope);
+        checkForbiddenForGroups(user, allowedReadGroups, request.getId(), scope);
+        checkScope(user, scope);
         break;
       case ADMIN:
       default:
@@ -131,77 +120,18 @@ public class SingularityGroupsScopesAuthorizer extends SingularityAuthorizer {
     if (!user.isAuthenticated()) {
       return false;
     }
-    if (isAdmin(user)) {
-      return true;
-    }
     switch (scope) {
       case READ:
-        if (!hasReadScope(user)) {
-          return false;
-        }
-        if (groupsIntersect(getReadGroups(request), user.getGroups())) {
-          return true;
-        }
-        if (isJita(user)) {
-          LOG.warn(
-            "JITA ACTION - User: {}, RequestId: {}, Scope Used: {}",
-            user.getId(),
-            request.getId(),
-            scope
-          );
-          return true;
-        }
-        return false;
-      case DEPLOY:
-        if (!scopesConfiguration.getDeploy().isEmpty()) {
-          if (!hasDeployScope(user)) {
-            return false;
-          }
-          if (groupsIntersect(getWriteGroups(request), user.getGroups())) {
-            return true;
-          }
-          if (isJita(user)) {
-            LOG.warn(
-              "JITA ACTION - User: {}, RequestId: {}, Scope Used: {}",
-              user.getId(),
-              request.getId(),
-              scope
-            );
-            return true;
-          }
-          return false;
-        } else {
-          if (!hasWriteScope(user)) {
-            return false;
-          }
-          if (groupsIntersect(getWriteGroups(request), user.getGroups())) {
-            return true;
-          }
-          if (isJita(user)) {
-            LOG.warn(
-              "JITA ACTION - User: {}, RequestId: {}, Scope Used: {}",
-              user.getId(),
-              request.getId(),
-              scope
-            );
-            return true;
-          }
-          return false;
-        }
       case WRITE:
-        if (!hasWriteScope(user)) {
+      case DEPLOY:
+        if (!hasScope(user, scope)) {
           return false;
         }
-        if (groupsIntersect(getWriteGroups(request), user.getGroups())) {
+        if (groupsIntersect(getGroups(request, scope), user.getGroups())) {
           return true;
         }
         if (isJita(user)) {
-          LOG.warn(
-            "JITA ACTION - User: {}, RequestId: {}, Scope Used: {}",
-            user.getId(),
-            request.getId(),
-            scope
-          );
+          warnJita(user, scope, request.getId());
           return true;
         }
         return false;
@@ -209,6 +139,19 @@ public class SingularityGroupsScopesAuthorizer extends SingularityAuthorizer {
       default:
         return hasAdminAuthorization(user);
     }
+  }
+
+  private void warnJita(
+    SingularityUser user,
+    SingularityAuthorizationScope scope,
+    String id
+  ) {
+    LOG.warn(
+      "JITA ACTION - User: {}, RequestId: {}, Scope Used: {}",
+      user.getId(),
+      id,
+      scope
+    );
   }
 
   @Override
@@ -239,50 +182,37 @@ public class SingularityGroupsScopesAuthorizer extends SingularityAuthorizer {
   }
 
   private boolean isAdmin(SingularityUser user) {
-    return groupsIntersect(scopesConfiguration.getAdmin(), user.getScopes());
+    return hasScope(user, SingularityAuthorizationScope.ADMIN);
   }
 
-  private boolean hasReadScope(SingularityUser user) {
-    return (
-      groupsIntersect(scopesConfiguration.getRead(), user.getScopes()) ||
-      groupsIntersect(scopesConfiguration.getWrite(), user.getScopes())
-    );
+  private Set<String> getScopes(SingularityAuthorizationScope scope) {
+    switch (scope) {
+      case READ:
+        return Sets.union(scopesConfiguration.getRead(), scopesConfiguration.getWrite());
+      case WRITE:
+        return scopesConfiguration.getWrite();
+      case DEPLOY:
+        return scopesConfiguration.getDeploy().isEmpty()
+          ? scopesConfiguration.getWrite()
+          : scopesConfiguration.getDeploy();
+      case ADMIN:
+      default:
+        return scopesConfiguration.getAdmin();
+    }
   }
 
-  private void checkReadScope(SingularityUser user) {
+  private boolean hasScope(SingularityUser user, SingularityAuthorizationScope scope) {
+    return groupsIntersect(user.getScopes(), getScopes(scope));
+  }
+
+  private void checkScope(SingularityUser user, SingularityAuthorizationScope scope) {
     checkForbidden(
-      hasReadScope(user),
-      "%s must have one or more scopes to READ: %s, %s",
+      hasScope(user, scope),
+      "%s must have one or more scopes to %s: %s",
       user.getId(),
-      scopesConfiguration.getRead(),
-      scopesConfiguration.getWrite()
+      scope.name(),
+      getScopes(scope)
     );
-  }
-
-  private boolean hasWriteScope(SingularityUser user) {
-    return groupsIntersect(scopesConfiguration.getWrite(), user.getScopes());
-  }
-
-  private void checkWriteScope(SingularityUser user) {
-    checkForbidden(
-      hasWriteScope(user),
-      "%s must have one or more scopes to WRITE: %s",
-      user.getId(),
-      scopesConfiguration.getWrite()
-    );
-  }
-
-  private void checkDeployScope(SingularityUser user) {
-    checkForbidden(
-      hasDeployScope(user),
-      "%s must have one or more scopes to DEPLOY: %s",
-      user.getId(),
-      scopesConfiguration.getDeploy()
-    );
-  }
-
-  private boolean hasDeployScope(SingularityUser user) {
-    return groupsIntersect(scopesConfiguration.getDeploy(), user.getScopes());
   }
 
   private void checkForbiddenForGroups(
@@ -300,12 +230,7 @@ public class SingularityGroupsScopesAuthorizer extends SingularityAuthorizer {
       user.getGroups()
     );
     if (inJitaGroups) {
-      LOG.warn(
-        "JITA ACTION - User: {}, RequestId: {}, Scope Used: {}",
-        user.getId(),
-        requestId,
-        scope
-      );
+      warnJita(user, scope, requestId);
     }
     checkForbidden(
       inJitaGroups,
@@ -313,6 +238,22 @@ public class SingularityGroupsScopesAuthorizer extends SingularityAuthorizer {
       user.getId(),
       allowedGroups
     );
+  }
+
+  private Set<String> getGroups(
+    SingularityRequest request,
+    SingularityAuthorizationScope scope
+  ) {
+    switch (scope) {
+      case READ:
+        return getReadGroups(request);
+      case WRITE:
+      case DEPLOY:
+        return getWriteGroups(request);
+      case ADMIN:
+      default:
+        return Collections.emptySet();
+    }
   }
 
   private Set<String> getReadGroups(SingularityRequest request) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityGroupsScopesAuthorizer.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityGroupsScopesAuthorizer.java
@@ -263,9 +263,9 @@ public class SingularityGroupsScopesAuthorizer extends SingularityAuthorizer {
     );
     allowedReadGroups.addAll(authConfiguration.getGlobalReadWriteGroups());
 
-    if (request.getGroupPermissionOverrides().isPresent()) {
+    if (request.getGroupScopeOverrides().isPresent()) {
       request
-        .getGroupPermissionOverrides()
+        .getGroupScopeOverrides()
         .get()
         .entrySet()
         .stream()
@@ -297,9 +297,9 @@ public class SingularityGroupsScopesAuthorizer extends SingularityAuthorizer {
       authConfiguration.getGlobalReadWriteGroups()
     );
 
-    if (request.getGroupPermissionOverrides().isPresent()) {
+    if (request.getGroupScopeOverrides().isPresent()) {
       request
-        .getGroupPermissionOverrides()
+        .getGroupScopeOverrides()
         .get()
         .entrySet()
         .stream()

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityGroupsScopesAuthorizer.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityGroupsScopesAuthorizer.java
@@ -14,7 +14,6 @@ import com.hubspot.singularity.config.ScopesConfiguration;
 import com.hubspot.singularity.data.RequestManager;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import org.slf4j.Logger;
@@ -291,26 +290,11 @@ public class SingularityGroupsScopesAuthorizer extends SingularityAuthorizer {
     );
     allowedReadGroups.addAll(authConfiguration.getGlobalReadWriteGroups());
 
-    if (request.getActionPermissions().isPresent()) {
-      request
-        .getActionPermissions()
-        .get()
-        .entrySet()
-        .stream()
-        .filter(
-          e ->
-            e.getValue().contains(SingularityAuthorizationScope.READ) ||
-            e.getValue().contains(SingularityAuthorizationScope.WRITE)
-        )
-        .map(Entry::getKey)
-        .forEach(allowedReadGroups::add);
-    } else {
-      if (!request.getReadOnlyGroups().isPresent()) {
-        allowedReadGroups.addAll(authConfiguration.getDefaultReadOnlyGroups());
-      }
-      request.getReadOnlyGroups().ifPresent(allowedReadGroups::addAll);
-      request.getReadWriteGroups().ifPresent(allowedReadGroups::addAll);
+    if (!request.getReadOnlyGroups().isPresent()) {
+      allowedReadGroups.addAll(authConfiguration.getDefaultReadOnlyGroups());
     }
+    request.getReadOnlyGroups().ifPresent(allowedReadGroups::addAll);
+    request.getReadWriteGroups().ifPresent(allowedReadGroups::addAll);
 
     request.getGroup().ifPresent(allowedReadGroups::add);
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityGroupsScopesAuthorizer.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityGroupsScopesAuthorizer.java
@@ -338,6 +338,10 @@ public class SingularityGroupsScopesAuthorizer extends SingularityAuthorizer {
     );
     request.getReadWriteGroups().ifPresent(allowedWriteGroups::addAll);
     request.getGroup().ifPresent(allowedWriteGroups::add);
+
+    // If one of the above is also set as a read-only group, assume the strictest
+    // possible meaning and disallow writing.
+    request.getReadOnlyGroups().ifPresent(allowedWriteGroups::removeAll);
     if (allowedWriteGroups.isEmpty()) {
       LOG.warn("No read/write-enabled groups set for {}", request.getId());
     }

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/ScopesConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/ScopesConfiguration.java
@@ -14,9 +14,6 @@ public class ScopesConfiguration {
   @NotEmpty
   private Set<String> read = Collections.singleton("SINGULARITY_READONLY");
 
-  @NotEmpty
-  private Set<String> exec = Collections.singleton("SINGULARITY_EXEC");
-
   // only enforced if not empty, otherwise will check for write
   private Set<String> deploy = Collections.emptySet();
 
@@ -50,13 +47,5 @@ public class ScopesConfiguration {
 
   public void setDeploy(Set<String> deploy) {
     this.deploy = deploy;
-  }
-
-  public Set<String> getExec() {
-    return exec;
-  }
-
-  public void setExec(Set<String> exec) {
-    this.exec = exec;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/ScopesConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/ScopesConfiguration.java
@@ -14,6 +14,9 @@ public class ScopesConfiguration {
   @NotEmpty
   private Set<String> read = Collections.singleton("SINGULARITY_READONLY");
 
+  @NotEmpty
+  private Set<String> exec = Collections.singleton("SINGULARITY_EXEC");
+
   // only enforced if not empty, otherwise will check for write
   private Set<String> deploy = Collections.emptySet();
 
@@ -47,5 +50,13 @@ public class ScopesConfiguration {
 
   public void setDeploy(Set<String> deploy) {
     this.deploy = deploy;
+  }
+
+  public Set<String> getExec() {
+    return exec;
+  }
+
+  public void setExec(Set<String> exec) {
+    this.exec = exec;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/DeployResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/DeployResource.java
@@ -157,7 +157,7 @@ public class DeployResource extends AbstractRequestResource {
     authorizationHelper.checkForAuthorization(
       requestWithState.getRequest(),
       user,
-      SingularityAuthorizationScope.DEPLOY
+      SingularityAuthorizationScope.WRITE
     );
 
     SingularityRequest request = requestWithState.getRequest();
@@ -337,7 +337,7 @@ public class DeployResource extends AbstractRequestResource {
     authorizationHelper.checkForAuthorization(
       requestWithState.getRequest(),
       user,
-      SingularityAuthorizationScope.DEPLOY
+      SingularityAuthorizationScope.WRITE
     );
     validator.checkActionEnabled(SingularityAction.CANCEL_DEPLOY);
 
@@ -403,7 +403,7 @@ public class DeployResource extends AbstractRequestResource {
     authorizationHelper.checkForAuthorization(
       requestWithState.getRequest(),
       user,
-      SingularityAuthorizationScope.DEPLOY
+      SingularityAuthorizationScope.WRITE
     );
 
     Optional<SingularityRequestDeployState> deployState = deployManager.getRequestDeployState(

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -575,7 +575,7 @@ public class RequestResource extends AbstractRequestResource {
     authorizationHelper.checkForAuthorization(
       requestWithState.getRequest(),
       user,
-      SingularityAuthorizationScope.EXEC
+      SingularityAuthorizationScope.WRITE
     );
     validator.checkActionEnabled(SingularityAction.BOUNCE_REQUEST);
 
@@ -798,7 +798,7 @@ public class RequestResource extends AbstractRequestResource {
     authorizationHelper.checkForAuthorization(
       requestWithState.getRequest(),
       user,
-      SingularityAuthorizationScope.EXEC
+      SingularityAuthorizationScope.WRITE
     );
 
     checkConflict(
@@ -945,7 +945,7 @@ public class RequestResource extends AbstractRequestResource {
     authorizationHelper.checkForAuthorization(
       requestWithState.getRequest(),
       user,
-      SingularityAuthorizationScope.EXEC
+      SingularityAuthorizationScope.WRITE
     );
 
     checkConflict(
@@ -1080,7 +1080,7 @@ public class RequestResource extends AbstractRequestResource {
     authorizationHelper.checkForAuthorization(
       requestWithState.getRequest(),
       user,
-      SingularityAuthorizationScope.EXEC
+      SingularityAuthorizationScope.WRITE
     );
 
     checkConflict(
@@ -1674,7 +1674,7 @@ public class RequestResource extends AbstractRequestResource {
     authorizationHelper.checkForAuthorization(
       oldRequest,
       user,
-      SingularityAuthorizationScope.EXEC
+      SingularityAuthorizationScope.WRITE
     );
     validator.checkActionEnabled(SingularityAction.SCALE_REQUEST);
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -39,6 +39,7 @@ import com.hubspot.singularity.SingularityTaskHealthcheckResult;
 import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.SingularityTransformHelpers;
 import com.hubspot.singularity.SingularityUser;
+import com.hubspot.singularity.SingularityUserFacingAction;
 import com.hubspot.singularity.TaskCleanupType;
 import com.hubspot.singularity.WebExceptions;
 import com.hubspot.singularity.api.SingularityBounceRequest;
@@ -575,7 +576,8 @@ public class RequestResource extends AbstractRequestResource {
     authorizationHelper.checkForAuthorization(
       requestWithState.getRequest(),
       user,
-      SingularityAuthorizationScope.WRITE
+      SingularityAuthorizationScope.WRITE,
+      SingularityUserFacingAction.BOUNCE_REQUEST
     );
     validator.checkActionEnabled(SingularityAction.BOUNCE_REQUEST);
 
@@ -798,7 +800,8 @@ public class RequestResource extends AbstractRequestResource {
     authorizationHelper.checkForAuthorization(
       requestWithState.getRequest(),
       user,
-      SingularityAuthorizationScope.WRITE
+      SingularityAuthorizationScope.WRITE,
+      SingularityUserFacingAction.RUN_REQUEST
     );
 
     checkConflict(
@@ -945,7 +948,8 @@ public class RequestResource extends AbstractRequestResource {
     authorizationHelper.checkForAuthorization(
       requestWithState.getRequest(),
       user,
-      SingularityAuthorizationScope.WRITE
+      SingularityAuthorizationScope.WRITE,
+      SingularityUserFacingAction.PAUSE_REQUEST
     );
 
     checkConflict(
@@ -1080,7 +1084,8 @@ public class RequestResource extends AbstractRequestResource {
     authorizationHelper.checkForAuthorization(
       requestWithState.getRequest(),
       user,
-      SingularityAuthorizationScope.WRITE
+      SingularityAuthorizationScope.WRITE,
+      SingularityUserFacingAction.PAUSE_REQUEST
     );
 
     checkConflict(
@@ -1674,7 +1679,8 @@ public class RequestResource extends AbstractRequestResource {
     authorizationHelper.checkForAuthorization(
       oldRequest,
       user,
-      SingularityAuthorizationScope.WRITE
+      SingularityAuthorizationScope.WRITE,
+      SingularityUserFacingAction.SCALE_REQUEST
     );
     validator.checkActionEnabled(SingularityAction.SCALE_REQUEST);
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -575,7 +575,7 @@ public class RequestResource extends AbstractRequestResource {
     authorizationHelper.checkForAuthorization(
       requestWithState.getRequest(),
       user,
-      SingularityAuthorizationScope.WRITE
+      SingularityAuthorizationScope.EXEC
     );
     validator.checkActionEnabled(SingularityAction.BOUNCE_REQUEST);
 
@@ -798,7 +798,7 @@ public class RequestResource extends AbstractRequestResource {
     authorizationHelper.checkForAuthorization(
       requestWithState.getRequest(),
       user,
-      SingularityAuthorizationScope.WRITE
+      SingularityAuthorizationScope.EXEC
     );
 
     checkConflict(
@@ -945,7 +945,7 @@ public class RequestResource extends AbstractRequestResource {
     authorizationHelper.checkForAuthorization(
       requestWithState.getRequest(),
       user,
-      SingularityAuthorizationScope.WRITE
+      SingularityAuthorizationScope.EXEC
     );
 
     checkConflict(
@@ -1080,7 +1080,7 @@ public class RequestResource extends AbstractRequestResource {
     authorizationHelper.checkForAuthorization(
       requestWithState.getRequest(),
       user,
-      SingularityAuthorizationScope.WRITE
+      SingularityAuthorizationScope.EXEC
     );
 
     checkConflict(
@@ -1674,7 +1674,7 @@ public class RequestResource extends AbstractRequestResource {
     authorizationHelper.checkForAuthorization(
       oldRequest,
       user,
-      SingularityAuthorizationScope.WRITE
+      SingularityAuthorizationScope.EXEC
     );
     validator.checkActionEnabled(SingularityAction.SCALE_REQUEST);
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -449,6 +449,7 @@ public class RequestResource extends AbstractRequestResource {
       .setGroup(updateGroupsRequest.getGroup())
       .setReadWriteGroups(Optional.of(updateGroupsRequest.getReadWriteGroups()))
       .setReadOnlyGroups(Optional.of(updateGroupsRequest.getReadOnlyGroups()))
+      .setActionPermissions(updateGroupsRequest.getActionPermissions())
       .build();
 
     submitRequest(
@@ -497,6 +498,7 @@ public class RequestResource extends AbstractRequestResource {
           .setGroup(updateGroupsRequest.getGroup())
           .setReadWriteGroups(Optional.of(updateGroupsRequest.getReadWriteGroups()))
           .setReadOnlyGroups(Optional.of(updateGroupsRequest.getReadOnlyGroups()))
+          .setActionPermissions(updateGroupsRequest.getActionPermissions())
           .build(),
         user,
         SingularityAuthorizationScope.WRITE
@@ -516,6 +518,7 @@ public class RequestResource extends AbstractRequestResource {
       .setGroup(updateGroupsRequest.getGroup())
       .setReadWriteGroups(Optional.of(updateGroupsRequest.getReadWriteGroups()))
       .setReadOnlyGroups(Optional.of(updateGroupsRequest.getReadOnlyGroups()))
+      .setActionPermissions(updateGroupsRequest.getActionPermissions())
       .build();
     authorizationHelper.checkForAuthorizedChanges(
       newRequest,
@@ -577,7 +580,7 @@ public class RequestResource extends AbstractRequestResource {
       requestWithState.getRequest(),
       user,
       SingularityAuthorizationScope.WRITE,
-      SingularityUserFacingAction.BOUNCE_REQUEST
+      SingularityUserFacingAction.BOUNCE
     );
     validator.checkActionEnabled(SingularityAction.BOUNCE_REQUEST);
 
@@ -801,7 +804,7 @@ public class RequestResource extends AbstractRequestResource {
       requestWithState.getRequest(),
       user,
       SingularityAuthorizationScope.WRITE,
-      SingularityUserFacingAction.RUN_REQUEST
+      SingularityUserFacingAction.EXEC
     );
 
     checkConflict(
@@ -949,7 +952,7 @@ public class RequestResource extends AbstractRequestResource {
       requestWithState.getRequest(),
       user,
       SingularityAuthorizationScope.WRITE,
-      SingularityUserFacingAction.PAUSE_REQUEST
+      SingularityUserFacingAction.PAUSE
     );
 
     checkConflict(
@@ -1085,7 +1088,7 @@ public class RequestResource extends AbstractRequestResource {
       requestWithState.getRequest(),
       user,
       SingularityAuthorizationScope.WRITE,
-      SingularityUserFacingAction.PAUSE_REQUEST
+      SingularityUserFacingAction.PAUSE
     );
 
     checkConflict(
@@ -1680,7 +1683,7 @@ public class RequestResource extends AbstractRequestResource {
       oldRequest,
       user,
       SingularityAuthorizationScope.WRITE,
-      SingularityUserFacingAction.SCALE_REQUEST
+      SingularityUserFacingAction.SCALE
     );
     validator.checkActionEnabled(SingularityAction.SCALE_REQUEST);
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
@@ -327,7 +327,7 @@ public class TaskResource extends AbstractLeaderAwareResource {
       authorizationHelper.checkForAuthorizationByRequestId(
         request.getId(),
         user,
-        SingularityAuthorizationScope.EXEC
+        SingularityAuthorizationScope.WRITE
       );
       checkBadRequest(
         request.getRequestType() == RequestType.ON_DEMAND,
@@ -836,7 +836,7 @@ public class TaskResource extends AbstractLeaderAwareResource {
   ) {
     final SingularityTask task = checkActiveTask(
       taskId,
-      SingularityAuthorizationScope.EXEC,
+      SingularityAuthorizationScope.WRITE,
       user
     );
 
@@ -1087,7 +1087,7 @@ public class TaskResource extends AbstractLeaderAwareResource {
     authorizationHelper.checkForAuthorizationByTaskId(
       taskId,
       user,
-      SingularityAuthorizationScope.EXEC
+      SingularityAuthorizationScope.WRITE
     );
     validator.checkActionEnabled(SingularityAction.RUN_SHELL_COMMAND);
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
@@ -327,7 +327,7 @@ public class TaskResource extends AbstractLeaderAwareResource {
       authorizationHelper.checkForAuthorizationByRequestId(
         request.getId(),
         user,
-        SingularityAuthorizationScope.WRITE
+        SingularityAuthorizationScope.EXEC
       );
       checkBadRequest(
         request.getRequestType() == RequestType.ON_DEMAND,
@@ -836,7 +836,7 @@ public class TaskResource extends AbstractLeaderAwareResource {
   ) {
     final SingularityTask task = checkActiveTask(
       taskId,
-      SingularityAuthorizationScope.WRITE,
+      SingularityAuthorizationScope.EXEC,
       user
     );
 
@@ -1087,7 +1087,7 @@ public class TaskResource extends AbstractLeaderAwareResource {
     authorizationHelper.checkForAuthorizationByTaskId(
       taskId,
       user,
-      SingularityAuthorizationScope.WRITE
+      SingularityAuthorizationScope.EXEC
     );
     validator.checkActionEnabled(SingularityAction.RUN_SHELL_COMMAND);
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/auth/SingularityGroupsScopesAuthorizerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/auth/SingularityGroupsScopesAuthorizerTest.java
@@ -212,8 +212,8 @@ public class SingularityGroupsScopesAuthorizerTest {
           Collections.singletonMap(
             "a",
             ImmutableSet.of(
-              SingularityUserFacingAction.BOUNCE_REQUEST,
-              SingularityUserFacingAction.SCALE_REQUEST
+              SingularityUserFacingAction.BOUNCE,
+              SingularityUserFacingAction.SCALE
             )
           )
         )
@@ -226,21 +226,21 @@ public class SingularityGroupsScopesAuthorizerTest {
       request,
       GROUP_A_READ_WRITE,
       SingularityAuthorizationScope.WRITE,
-      SingularityUserFacingAction.BOUNCE_REQUEST
+      SingularityUserFacingAction.BOUNCE
     );
     assertAuthorized(
       request,
       GROUP_A_READ_WRITE,
       SingularityAuthorizationScope.WRITE,
-      SingularityUserFacingAction.SCALE_REQUEST
+      SingularityUserFacingAction.SCALE
     );
 
-    // BOUNCE_TASK not explicitly allowed
+    // KILL_TASK not explicitly allowed
     assertNotAuthorized(
       request,
       GROUP_A_READ_WRITE,
       SingularityAuthorizationScope.WRITE,
-      SingularityUserFacingAction.BOUNCE_TASK
+      SingularityUserFacingAction.KILL_TASK
     );
 
     // Write scope missing
@@ -248,7 +248,7 @@ public class SingularityGroupsScopesAuthorizerTest {
       request,
       GROUP_A_READ_ONLY,
       SingularityAuthorizationScope.WRITE,
-      SingularityUserFacingAction.BOUNCE_REQUEST
+      SingularityUserFacingAction.BOUNCE
     );
 
     // Different group
@@ -256,7 +256,7 @@ public class SingularityGroupsScopesAuthorizerTest {
       request,
       GROUP_B_READ_WRITE,
       SingularityAuthorizationScope.WRITE,
-      SingularityUserFacingAction.BOUNCE_REQUEST
+      SingularityUserFacingAction.BOUNCE
     );
   }
 
@@ -268,7 +268,7 @@ public class SingularityGroupsScopesAuthorizerTest {
         Optional.of(
           Collections.singletonMap(
             "b",
-            Collections.singleton(SingularityUserFacingAction.BOUNCE_REQUEST)
+            Collections.singleton(SingularityUserFacingAction.BOUNCE)
           )
         )
       )
@@ -279,20 +279,20 @@ public class SingularityGroupsScopesAuthorizerTest {
       request,
       GROUP_A_READ_WRITE,
       SingularityAuthorizationScope.WRITE,
-      SingularityUserFacingAction.BOUNCE_REQUEST
+      SingularityUserFacingAction.BOUNCE
     );
 
     assertAuthorized(
       request.toBuilder().setReadWriteGroups(Optional.of(ImmutableSet.of("b"))).build(),
       GROUP_B_READ_WRITE,
       SingularityAuthorizationScope.WRITE,
-      SingularityUserFacingAction.BOUNCE_REQUEST
+      SingularityUserFacingAction.BOUNCE
     );
     assertNotAuthorized(
       request,
       GROUP_B_READ_WRITE,
       SingularityAuthorizationScope.WRITE,
-      SingularityUserFacingAction.BOUNCE_REQUEST
+      SingularityUserFacingAction.BOUNCE
     );
     assertNotAuthorized(request, GROUP_B_READ_WRITE, SingularityAuthorizationScope.WRITE);
   }

--- a/SingularityService/src/test/java/com/hubspot/singularity/auth/SingularityGroupsScopesAuthorizerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/auth/SingularityGroupsScopesAuthorizerTest.java
@@ -12,12 +12,9 @@ import com.hubspot.singularity.SingularityRequest;
 import com.hubspot.singularity.SingularityRequestBuilder;
 import com.hubspot.singularity.SingularityUser;
 import com.hubspot.singularity.config.AuthConfiguration;
-import com.hubspot.singularity.config.ScopesConfiguration;
 import com.hubspot.singularity.config.UserAuthMode;
 import com.squarespace.jersey2.guice.JerseyGuiceUtils;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import javax.ws.rs.WebApplicationException;
@@ -49,22 +46,10 @@ public class SingularityGroupsScopesAuthorizerTest {
     ImmutableSet.of("SINGULARITY_READONLY", "SINGULARITY_WRITE")
   );
 
-  private static final SingularityUser GROUP_A_READ_WRITE_EXEC = createSingularityUser(
-    "a",
-    Collections.singleton("a"),
-    ImmutableSet.of("SINGULARITY_READONLY", "SINGULARITY_WRITE", "SINGULARITY_EXEC")
-  );
-
   private static final SingularityUser GROUP_B_READ_WRITE = createSingularityUser(
     "b",
     Collections.singleton("b"),
     ImmutableSet.of("SINGULARITY_READONLY", "SINGULARITY_WRITE")
-  );
-
-  private static final SingularityUser GROUP_B_READ_WRITE_EXEC = createSingularityUser(
-    "b",
-    Collections.singleton("b"),
-    ImmutableSet.of("SINGULARITY_READONLY", "SINGULARITY_WRITE", "SINGULARITY_EXEC")
   );
 
   private static final SingularityUser GROUP_B_READ_ONLY = createSingularityUser(
@@ -95,12 +80,6 @@ public class SingularityGroupsScopesAuthorizerTest {
     "a",
     "jita",
     "SINGULARITY_READONLY"
-  );
-
-  private static final SingularityUser JITA_USER_EXEC = createSingularityUser(
-    "a",
-    ImmutableSet.of("jita"),
-    ImmutableSet.of("SINGULARITY_EXEC")
   );
 
   private static final SingularityRequest GROUP_A_REQUEST = new SingularityRequestBuilder(
@@ -180,14 +159,6 @@ public class SingularityGroupsScopesAuthorizerTest {
           SingularityAuthorizationScope.READ
         )
     );
-    assertDoesNotThrow(
-      () ->
-        authorizer.checkForAuthorization(
-          GROUP_A_REQUEST,
-          JITA_USER_EXEC,
-          SingularityAuthorizationScope.EXEC
-        )
-    );
     assertThrows(
       WebApplicationException.class,
       () ->
@@ -195,15 +166,6 @@ public class SingularityGroupsScopesAuthorizerTest {
           GROUP_A_REQUEST,
           JITA_USER_READ,
           SingularityAuthorizationScope.WRITE
-        )
-    );
-    assertThrows(
-      WebApplicationException.class,
-      () ->
-        authorizer.checkForAuthorization(
-          GROUP_A_REQUEST,
-          JITA_USER_READ,
-          SingularityAuthorizationScope.EXEC
         )
     );
   }
@@ -347,209 +309,6 @@ public class SingularityGroupsScopesAuthorizerTest {
           GROUP_B_READ_WRITE
         )
     );
-  }
-
-  @Test
-  public void itChecksDeployScopeIfConfigured() {
-    SingularityRequest request = GROUP_A_REQUEST
-      .toBuilder()
-      .setGroupScopeOverrides(
-        Optional.of(
-          Collections.singletonMap(
-            "a",
-            ImmutableSet.of(SingularityAuthorizationScope.WRITE)
-          )
-        )
-      )
-      .build();
-
-    assertAuthorized(request, GROUP_A_READ_WRITE, SingularityAuthorizationScope.READ);
-    assertAuthorized(request, GROUP_A_READ_WRITE, SingularityAuthorizationScope.WRITE);
-
-    // By default, no deploy scope is specified, so it falls back to check write scope, which is allowed.
-    assertAuthorized(request, GROUP_A_READ_WRITE, SingularityAuthorizationScope.DEPLOY);
-
-    // Build a configuration with a deploy scope specified.
-    AuthConfiguration authConfiguration = getAuthConfiguration();
-    ScopesConfiguration scopes = new ScopesConfiguration();
-    scopes.setDeploy(ImmutableSet.of("SINGULARITY_DEPLOY"));
-    authConfiguration.setScopes(scopes);
-    authorizer = new SingularityGroupsScopesAuthorizer(null, authConfiguration);
-
-    // Deploys no longer fall back to write access, and user a does not have deploy access.
-    assertNotAuthorized(
-      request,
-      GROUP_A_READ_WRITE,
-      SingularityAuthorizationScope.DEPLOY
-    );
-
-    // Give user a deploy privileges.
-    SingularityUser groupAWithDeployScope = createSingularityUser(
-      "a",
-      Collections.singleton("a"),
-      ImmutableSet.of("SINGULARITY_DEPLOY")
-    );
-    assertAuthorized(
-      request,
-      groupAWithDeployScope,
-      SingularityAuthorizationScope.DEPLOY
-    );
-  }
-
-  @Test
-  public void itChecksExecScope() {
-    assertAuthorized(
-      GROUP_A_REQUEST,
-      GROUP_A_READ_WRITE_EXEC,
-      SingularityAuthorizationScope.EXEC
-    );
-    assertNotAuthorized(
-      GROUP_A_REQUEST,
-      GROUP_A_READ_WRITE,
-      SingularityAuthorizationScope.EXEC
-    );
-    assertNotAuthorized(
-      GROUP_A_REQUEST
-        .toBuilder()
-        .setGroupScopeOverrides(
-          Optional.of(
-            Collections.singletonMap(
-              "a",
-              ImmutableSet.of(SingularityAuthorizationScope.WRITE)
-            )
-          )
-        )
-        .build(),
-      GROUP_A_READ_WRITE_EXEC,
-      SingularityAuthorizationScope.EXEC
-    );
-    assertNotAuthorized(
-      GROUP_A_REQUEST
-        .toBuilder()
-        .setReadOnlyGroups(Optional.of(ImmutableSet.of("a")))
-        .build(),
-      GROUP_A_READ_WRITE_EXEC,
-      SingularityAuthorizationScope.EXEC
-    );
-
-    assertNotAuthorized(
-      GROUP_A_REQUEST,
-      GROUP_B_READ_WRITE_EXEC,
-      SingularityAuthorizationScope.EXEC
-    );
-
-    assertAuthorized(
-      GROUP_A_REQUEST
-        .toBuilder()
-        .setGroupScopeOverrides(
-          Optional.of(
-            Collections.singletonMap(
-              "b",
-              ImmutableSet.of(SingularityAuthorizationScope.EXEC)
-            )
-          )
-        )
-        .build(),
-      GROUP_B_READ_WRITE_EXEC,
-      SingularityAuthorizationScope.EXEC
-    );
-  }
-
-  @Test
-  public void itRespectsGroupPermissions() {
-    Map<String, Set<SingularityAuthorizationScope>> groupPermissions = new HashMap<>();
-
-    groupPermissions.put("a", ImmutableSet.of(SingularityAuthorizationScope.READ));
-    groupPermissions.put("b", ImmutableSet.of(SingularityAuthorizationScope.WRITE));
-    groupPermissions.put(
-      "c",
-      ImmutableSet.of(
-        SingularityAuthorizationScope.READ,
-        SingularityAuthorizationScope.WRITE
-      )
-    );
-    groupPermissions.put(
-      "d",
-      ImmutableSet.of(
-        SingularityAuthorizationScope.WRITE,
-        SingularityAuthorizationScope.DEPLOY
-      )
-    );
-    groupPermissions.put(
-      "e",
-      ImmutableSet.of(
-        SingularityAuthorizationScope.READ,
-        SingularityAuthorizationScope.WRITE,
-        SingularityAuthorizationScope.DEPLOY
-      )
-    );
-
-    SingularityRequest request = GROUP_A_REQUEST
-      .toBuilder()
-      .setGroupScopeOverrides(Optional.of(groupPermissions))
-      .build();
-
-    assertAuthorized(request, GROUP_A_READ_ONLY, SingularityAuthorizationScope.READ);
-    assertAuthorized(request, GROUP_A_WRITE_ONLY, SingularityAuthorizationScope.READ);
-    assertNotAuthorized(request, GROUP_A_READ_ONLY, SingularityAuthorizationScope.WRITE);
-
-    assertAuthorized(request, GROUP_B_READ_WRITE, SingularityAuthorizationScope.READ);
-    assertAuthorized(request, GROUP_B_READ_WRITE, SingularityAuthorizationScope.WRITE);
-
-    // By default, no deploy scope is specified, so it falls back to check write scope, so this is allowed.
-    // Same for all following deploy checks below.
-    assertAuthorized(request, GROUP_B_READ_WRITE, SingularityAuthorizationScope.DEPLOY);
-    assertNotAuthorized(request, GROUP_B_READ_WRITE, SingularityAuthorizationScope.ADMIN);
-
-    SingularityUser groupC = createSingularityUser(
-      "c",
-      Collections.singleton("c"),
-      ImmutableSet.of("SINGULARITY_READONLY", "SINGULARITY_WRITE")
-    );
-    assertAuthorized(request, groupC, SingularityAuthorizationScope.READ);
-    assertAuthorized(request, groupC, SingularityAuthorizationScope.WRITE);
-    assertAuthorized(request, groupC, SingularityAuthorizationScope.DEPLOY);
-    assertNotAuthorized(request, groupC, SingularityAuthorizationScope.ADMIN);
-
-    SingularityUser groupD = createSingularityUser(
-      "d",
-      Collections.singleton("d"),
-      ImmutableSet.of("SINGULARITY_WRITE", "SINGULARITY_DEPLOY")
-    );
-    assertAuthorized(request, groupD, SingularityAuthorizationScope.READ);
-    assertAuthorized(request, groupD, SingularityAuthorizationScope.WRITE);
-    assertAuthorized(request, groupD, SingularityAuthorizationScope.DEPLOY);
-    assertNotAuthorized(request, groupD, SingularityAuthorizationScope.ADMIN);
-
-    SingularityUser groupE = createSingularityUser(
-      "e",
-      Collections.singleton("e"),
-      ImmutableSet.of("SINGULARITY_READONLY", "SINGULARITY_WRITE")
-    );
-    assertAuthorized(request, groupE, SingularityAuthorizationScope.READ);
-    assertAuthorized(request, groupE, SingularityAuthorizationScope.WRITE);
-    assertAuthorized(request, groupE, SingularityAuthorizationScope.DEPLOY);
-    assertNotAuthorized(request, groupE, SingularityAuthorizationScope.ADMIN);
-
-    SingularityUser groupF = createSingularityUser(
-      "f",
-      Collections.singleton("f"),
-      ImmutableSet.of("SINGULARITY_ADMIN")
-    );
-    assertAuthorized(request, groupF, SingularityAuthorizationScope.READ);
-    assertAuthorized(request, groupF, SingularityAuthorizationScope.WRITE);
-    assertAuthorized(request, groupF, SingularityAuthorizationScope.DEPLOY);
-    assertAuthorized(request, groupF, SingularityAuthorizationScope.ADMIN);
-
-    SingularityUser groupG = createSingularityUser(
-      "g",
-      Collections.singleton("g"),
-      ImmutableSet.of("SINGULARITY_READ")
-    );
-    assertNotAuthorized(request, groupG, SingularityAuthorizationScope.READ);
-    assertNotAuthorized(request, groupG, SingularityAuthorizationScope.WRITE);
-    assertNotAuthorized(request, groupG, SingularityAuthorizationScope.DEPLOY);
-    assertNotAuthorized(request, groupG, SingularityAuthorizationScope.ADMIN);
   }
 
   private static SingularityUser createSingularityUser(

--- a/SingularityService/src/test/java/com/hubspot/singularity/auth/SingularityGroupsScopesAuthorizerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/auth/SingularityGroupsScopesAuthorizerTest.java
@@ -16,6 +16,7 @@ import com.hubspot.singularity.config.UserAuthMode;
 import com.squarespace.jersey2.guice.JerseyGuiceUtils;
 import java.util.Collections;
 import java.util.Optional;
+import java.util.Set;
 import javax.ws.rs.WebApplicationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,85 +27,58 @@ public class SingularityGroupsScopesAuthorizerTest {
     JerseyGuiceUtils.install((s, serviceLocator) -> null);
   }
 
-  private static final SingularityUser ADMIN_USER = new SingularityUser(
+  private static final SingularityUser ADMIN_USER = createSingularityUser(
     "superman",
-    Optional.empty(),
-    Optional.empty(),
-    Collections.singleton("admin"),
-    ImmutableSet.of("SINGULARITY_ADMIN"),
-    true
+    "admin",
+    "SINGULARITY_ADMIN"
   );
 
-  private static final SingularityUser GROUP_AB_READ_WRITE = new SingularityUser(
+  private static final SingularityUser GROUP_AB_READ_WRITE = createSingularityUser(
     "a",
-    Optional.empty(),
-    Optional.empty(),
     ImmutableSet.of("a", "b"),
-    ImmutableSet.of("SINGULARITY_READONLY", "SINGULARITY_WRITE"),
-    true
+    ImmutableSet.of("SINGULARITY_READONLY", "SINGULARITY_WRITE")
   );
 
-  private static final SingularityUser GROUP_A_READ_WRITE = new SingularityUser(
+  private static final SingularityUser GROUP_A_READ_WRITE = createSingularityUser(
     "a",
-    Optional.empty(),
-    Optional.empty(),
     Collections.singleton("a"),
-    ImmutableSet.of("SINGULARITY_READONLY", "SINGULARITY_WRITE"),
-    true
+    ImmutableSet.of("SINGULARITY_READONLY", "SINGULARITY_WRITE")
   );
 
-  private static final SingularityUser GROUP_B_READ_WRITE = new SingularityUser(
+  private static final SingularityUser GROUP_B_READ_WRITE = createSingularityUser(
     "b",
-    Optional.empty(),
-    Optional.empty(),
     Collections.singleton("b"),
-    ImmutableSet.of("SINGULARITY_READONLY", "SINGULARITY_WRITE"),
-    true
+    ImmutableSet.of("SINGULARITY_READONLY", "SINGULARITY_WRITE")
   );
 
-  private static final SingularityUser GROUP_B_READ_ONLY = new SingularityUser(
+  private static final SingularityUser GROUP_B_READ_ONLY = createSingularityUser(
     "b",
-    Optional.empty(),
-    Optional.empty(),
-    Collections.singleton("b"),
-    ImmutableSet.of("SINGULARITY_READONLY"),
-    true
+    "b",
+    "SINGULARITY_READONLY"
   );
 
-  private static final SingularityUser GROUP_A_READ_ONLY = new SingularityUser(
+  private static final SingularityUser GROUP_A_READ_ONLY = createSingularityUser(
     "a",
-    Optional.empty(),
-    Optional.empty(),
-    Collections.singleton("a"),
-    ImmutableSet.of("SINGULARITY_READONLY"),
-    true
+    "a",
+    "SINGULARITY_READONLY"
   );
 
-  private static final SingularityUser GROUP_A_WRITE_ONLY = new SingularityUser(
+  private static final SingularityUser GROUP_A_WRITE_ONLY = createSingularityUser(
     "a",
-    Optional.empty(),
-    Optional.empty(),
-    Collections.singleton("a"),
-    ImmutableSet.of("SINGULARITY_WRITE"),
-    true
+    "a",
+    "SINGULARITY_WRITE"
   );
 
-  private static final SingularityUser DEFAULT_READ_GROUP = new SingularityUser(
+  private static final SingularityUser DEFAULT_READ_GROUP = createSingularityUser(
     "a",
-    Optional.empty(),
-    Optional.empty(),
-    Collections.singleton("default-read"),
-    ImmutableSet.of("SINGULARITY_READONLY"),
-    true
+    "default-read",
+    "SINGULARITY_READONLY"
   );
 
-  private static final SingularityUser JITA_USER_READ = new SingularityUser(
+  private static final SingularityUser JITA_USER_READ = createSingularityUser(
     "a",
-    Optional.empty(),
-    Optional.empty(),
-    Collections.singleton("jita"),
-    ImmutableSet.of("SINGULARITY_READONLY"),
-    true
+    "jita",
+    "SINGULARITY_READONLY"
   );
 
   private static final SingularityRequest GROUP_A_REQUEST = new SingularityRequestBuilder(
@@ -137,6 +111,12 @@ public class SingularityGroupsScopesAuthorizerTest {
     .setGroup(Optional.of("a"))
     .setReadWriteGroups(Optional.of(Collections.singleton("b")))
     .build();
+
+  private static final SingularityRequestBuilder GROUP_A_REQUEST_PERMISSIONS_BUILDER = new SingularityRequestBuilder(
+    "a",
+    RequestType.WORKER
+  )
+  .setGroup(Optional.of("a"));
 
   protected SingularityGroupsScopesAuthorizer authorizer;
 
@@ -321,6 +301,117 @@ public class SingularityGroupsScopesAuthorizerTest {
           GROUP_A_REQUEST,
           GROUP_B_READ_WRITE
         )
+    );
+  }
+
+  //  @Test
+  //  public void itRespectsGroupPermissions() {
+  //    Map<String, List<SingularityAuthorizationScope>> groupPermissions = new HashMap<>();
+  //
+  //    groupPermissions.put("a", Arrays.asList(SingularityAuthorizationScope.READ));
+  //    groupPermissions.put("b", Arrays.asList(SingularityAuthorizationScope.WRITE));
+  //    groupPermissions.put(
+  //      "c",
+  //      Arrays.asList(
+  //        SingularityAuthorizationScope.READ,
+  //        SingularityAuthorizationScope.WRITE
+  //      )
+  //    );
+  //    groupPermissions.put("d", Arrays.asList(SingularityAuthorizationScope.DEPLOY));
+  //    groupPermissions.put(
+  //      "e",
+  //      Arrays.asList(
+  //        SingularityAuthorizationScope.READ,
+  //        SingularityAuthorizationScope.DEPLOY
+  //      )
+  //    );
+  //
+  //    SingularityRequest request = GROUP_A_REQUEST
+  //      .toBuilder()
+  //      .setGroupPermissionOverrides(Optional.of(groupPermissions))
+  //      .build();
+  //
+  //    assertAuthorized(request, GROUP_A_READ_ONLY, SingularityAuthorizationScope.READ);
+  //    assertAuthorized(request, GROUP_A_WRITE_ONLY, SingularityAuthorizationScope.READ); // Write inherently grants read
+  //    assertNotAuthorized(request, GROUP_A_READ_ONLY, SingularityAuthorizationScope.WRITE);
+  //
+  //    assertAuthorized(request, GROUP_B_READ_WRITE, SingularityAuthorizationScope.READ);
+  //    assertAuthorized(request, GROUP_B_READ_WRITE, SingularityAuthorizationScope.WRITE);
+  //    assertNotAuthorized(
+  //      request,
+  //      GROUP_B_READ_WRITE,
+  //      SingularityAuthorizationScope.DEPLOY
+  //    );
+  //    assertNotAuthorized(request, GROUP_B_READ_WRITE, SingularityAuthorizationScope.ADMIN);
+  //
+  //    SingularityUser groupC = createSingularityUser(
+  //      "c",
+  //      Collections.singleton("c"),
+  //      ImmutableSet.of("SINGULARITY_READONLY", "SINGULARITY_WRITE")
+  //    );
+  //    assertAuthorized(request, groupC, SingularityAuthorizationScope.READ);
+  //    assertAuthorized(request, groupC, SingularityAuthorizationScope.WRITE);
+  //    assertNotAuthorized(request, groupC, SingularityAuthorizationScope.DEPLOY);
+  //    assertNotAuthorized(request, groupC, SingularityAuthorizationScope.ADMIN);
+  //
+  //    SingularityUser groupD = createSingularityUser(
+  //      "d",
+  //      Collections.singleton("d"),
+  //      ImmutableSet.of("SINGULARITY_READONLY", "SINGULARITY_WRITE")
+  //    );
+  //    assertAuthorized(request, groupD, SingularityAuthorizationScope.DEPLOY);
+  //    assertNotAuthorized(request, groupD, SingularityAuthorizationScope.READ);
+  //    assertNotAuthorized(request, groupD, SingularityAuthorizationScope.WRITE);
+  //    assertNotAuthorized(request, groupD, SingularityAuthorizationScope.ADMIN);
+  //
+  //    SingularityUser groupE = createSingularityUser(
+  //      "e",
+  //      Collections.singleton("e"),
+  //      ImmutableSet.of("SINGULARITY_READONLY", "SINGULARITY_WRITE")
+  //    );
+  //    assertAuthorized(request, groupE, SingularityAuthorizationScope.READ);
+  //    assertAuthorized(request, groupE, SingularityAuthorizationScope.DEPLOY);
+  //    assertNotAuthorized(request, groupE, SingularityAuthorizationScope.WRITE);
+  //    assertNotAuthorized(request, groupE, SingularityAuthorizationScope.ADMIN);
+  //
+  //    SingularityUser groupF = createSingularityUser(
+  //      "f",
+  //      Collections.singleton("f"),
+  //      ImmutableSet.of("SINGULARITY_ADMIN")
+  //    );
+  //    assertAuthorized(request, groupF, SingularityAuthorizationScope.READ);
+  //    assertAuthorized(request, groupF, SingularityAuthorizationScope.WRITE);
+  //    assertAuthorized(request, groupF, SingularityAuthorizationScope.DEPLOY);
+  //    assertAuthorized(request, groupF, SingularityAuthorizationScope.ADMIN);
+  //  }
+
+  private static SingularityUser createSingularityUser(
+    String id,
+    String groups,
+    String scope
+  ) {
+    return new SingularityUser(
+      id,
+      Optional.empty(),
+      Optional.empty(),
+      Collections.singleton(groups),
+      ImmutableSet.of(scope),
+      true
+    );
+  }
+
+  private static SingularityUser createSingularityUser(
+    String id,
+    Set<String> groups,
+    Set<String> scopes
+  ) {
+    return new SingularityUser(
+      id,
+      Optional.empty(),
+      Optional.empty(),
+      groups,
+      scopes,
+      true
     );
   }
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/auth/SingularityGroupsScopesAuthorizerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/auth/SingularityGroupsScopesAuthorizerTest.java
@@ -19,7 +19,6 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 import javax.ws.rs.WebApplicationException;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -128,7 +127,6 @@ public class SingularityGroupsScopesAuthorizerTest {
     authorizer = new SingularityGroupsScopesAuthorizer(null, authConfiguration);
   }
 
-  @NotNull
   private AuthConfiguration getAuthConfiguration() {
     AuthConfiguration authConfiguration = new AuthConfiguration();
     authConfiguration.setEnabled(true);

--- a/SingularityService/src/test/java/com/hubspot/singularity/auth/SingularityGroupsScopesAuthorizerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/auth/SingularityGroupsScopesAuthorizerTest.java
@@ -82,6 +82,12 @@ public class SingularityGroupsScopesAuthorizerTest {
     "SINGULARITY_READONLY"
   );
 
+  private static final SingularityUser JITA_USER_READ_WRITE = createSingularityUser(
+    "a",
+    Collections.singleton("jita"),
+    ImmutableSet.of("SINGULARITY_READONLY", "SINGULARITY_WRITE")
+  );
+
   private static final SingularityRequest GROUP_A_REQUEST = new SingularityRequestBuilder(
     "a",
     RequestType.WORKER
@@ -112,12 +118,6 @@ public class SingularityGroupsScopesAuthorizerTest {
     .setGroup(Optional.of("a"))
     .setReadWriteGroups(Optional.of(Collections.singleton("b")))
     .build();
-
-  private static final SingularityRequestBuilder GROUP_A_REQUEST_PERMISSIONS_BUILDER = new SingularityRequestBuilder(
-    "a",
-    RequestType.WORKER
-  )
-  .setGroup(Optional.of("a"));
 
   protected SingularityGroupsScopesAuthorizer authorizer;
 
@@ -204,6 +204,22 @@ public class SingularityGroupsScopesAuthorizerTest {
   }
 
   @Test
+  public void itChecksActionPermissionsForJitaUsers() {
+    assertNotAuthorized(
+      GROUP_A_REQUEST,
+      JITA_USER_READ,
+      SingularityAuthorizationScope.WRITE,
+      SingularityUserFacingAction.BOUNCE
+    );
+    assertAuthorized(
+      GROUP_A_REQUEST,
+      JITA_USER_READ_WRITE,
+      SingularityAuthorizationScope.WRITE,
+      SingularityUserFacingAction.BOUNCE
+    );
+  }
+
+  @Test
   public void itChecksActionPermissionsForOwningGroup() {
     SingularityRequest request = GROUP_A_REQUEST
       .toBuilder()
@@ -257,6 +273,20 @@ public class SingularityGroupsScopesAuthorizerTest {
       GROUP_B_READ_WRITE,
       SingularityAuthorizationScope.WRITE,
       SingularityUserFacingAction.BOUNCE
+    );
+
+    // Check admin
+    assertAuthorized(
+      request,
+      ADMIN_USER,
+      SingularityAuthorizationScope.WRITE,
+      SingularityUserFacingAction.BOUNCE
+    );
+    assertAuthorized(
+      request,
+      ADMIN_USER,
+      SingularityAuthorizationScope.WRITE,
+      SingularityUserFacingAction.PAUSE
     );
   }
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/auth/SingularityGroupsScopesAuthorizerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/auth/SingularityGroupsScopesAuthorizerTest.java
@@ -12,12 +12,16 @@ import com.hubspot.singularity.SingularityRequest;
 import com.hubspot.singularity.SingularityRequestBuilder;
 import com.hubspot.singularity.SingularityUser;
 import com.hubspot.singularity.config.AuthConfiguration;
+import com.hubspot.singularity.config.ScopesConfiguration;
 import com.hubspot.singularity.config.UserAuthMode;
 import com.squarespace.jersey2.guice.JerseyGuiceUtils;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import javax.ws.rs.WebApplicationException;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -122,12 +126,18 @@ public class SingularityGroupsScopesAuthorizerTest {
 
   @BeforeEach
   public void setup() {
+    AuthConfiguration authConfiguration = getAuthConfiguration();
+    authorizer = new SingularityGroupsScopesAuthorizer(null, authConfiguration);
+  }
+
+  @NotNull
+  private AuthConfiguration getAuthConfiguration() {
     AuthConfiguration authConfiguration = new AuthConfiguration();
     authConfiguration.setEnabled(true);
     authConfiguration.setAuthMode(UserAuthMode.GROUPS_SCOPES);
     authConfiguration.setJitaGroups(Collections.singleton("jita"));
     authConfiguration.setDefaultReadOnlyGroups(Collections.singleton("default-read"));
-    authorizer = new SingularityGroupsScopesAuthorizer(null, authConfiguration);
+    return authConfiguration;
   }
 
   @Test
@@ -304,86 +314,149 @@ public class SingularityGroupsScopesAuthorizerTest {
     );
   }
 
-  //  @Test
-  //  public void itRespectsGroupPermissions() {
-  //    Map<String, List<SingularityAuthorizationScope>> groupPermissions = new HashMap<>();
-  //
-  //    groupPermissions.put("a", Arrays.asList(SingularityAuthorizationScope.READ));
-  //    groupPermissions.put("b", Arrays.asList(SingularityAuthorizationScope.WRITE));
-  //    groupPermissions.put(
-  //      "c",
-  //      Arrays.asList(
-  //        SingularityAuthorizationScope.READ,
-  //        SingularityAuthorizationScope.WRITE
-  //      )
-  //    );
-  //    groupPermissions.put("d", Arrays.asList(SingularityAuthorizationScope.DEPLOY));
-  //    groupPermissions.put(
-  //      "e",
-  //      Arrays.asList(
-  //        SingularityAuthorizationScope.READ,
-  //        SingularityAuthorizationScope.DEPLOY
-  //      )
-  //    );
-  //
-  //    SingularityRequest request = GROUP_A_REQUEST
-  //      .toBuilder()
-  //      .setGroupPermissionOverrides(Optional.of(groupPermissions))
-  //      .build();
-  //
-  //    assertAuthorized(request, GROUP_A_READ_ONLY, SingularityAuthorizationScope.READ);
-  //    assertAuthorized(request, GROUP_A_WRITE_ONLY, SingularityAuthorizationScope.READ); // Write inherently grants read
-  //    assertNotAuthorized(request, GROUP_A_READ_ONLY, SingularityAuthorizationScope.WRITE);
-  //
-  //    assertAuthorized(request, GROUP_B_READ_WRITE, SingularityAuthorizationScope.READ);
-  //    assertAuthorized(request, GROUP_B_READ_WRITE, SingularityAuthorizationScope.WRITE);
-  //    assertNotAuthorized(
-  //      request,
-  //      GROUP_B_READ_WRITE,
-  //      SingularityAuthorizationScope.DEPLOY
-  //    );
-  //    assertNotAuthorized(request, GROUP_B_READ_WRITE, SingularityAuthorizationScope.ADMIN);
-  //
-  //    SingularityUser groupC = createSingularityUser(
-  //      "c",
-  //      Collections.singleton("c"),
-  //      ImmutableSet.of("SINGULARITY_READONLY", "SINGULARITY_WRITE")
-  //    );
-  //    assertAuthorized(request, groupC, SingularityAuthorizationScope.READ);
-  //    assertAuthorized(request, groupC, SingularityAuthorizationScope.WRITE);
-  //    assertNotAuthorized(request, groupC, SingularityAuthorizationScope.DEPLOY);
-  //    assertNotAuthorized(request, groupC, SingularityAuthorizationScope.ADMIN);
-  //
-  //    SingularityUser groupD = createSingularityUser(
-  //      "d",
-  //      Collections.singleton("d"),
-  //      ImmutableSet.of("SINGULARITY_READONLY", "SINGULARITY_WRITE")
-  //    );
-  //    assertAuthorized(request, groupD, SingularityAuthorizationScope.DEPLOY);
-  //    assertNotAuthorized(request, groupD, SingularityAuthorizationScope.READ);
-  //    assertNotAuthorized(request, groupD, SingularityAuthorizationScope.WRITE);
-  //    assertNotAuthorized(request, groupD, SingularityAuthorizationScope.ADMIN);
-  //
-  //    SingularityUser groupE = createSingularityUser(
-  //      "e",
-  //      Collections.singleton("e"),
-  //      ImmutableSet.of("SINGULARITY_READONLY", "SINGULARITY_WRITE")
-  //    );
-  //    assertAuthorized(request, groupE, SingularityAuthorizationScope.READ);
-  //    assertAuthorized(request, groupE, SingularityAuthorizationScope.DEPLOY);
-  //    assertNotAuthorized(request, groupE, SingularityAuthorizationScope.WRITE);
-  //    assertNotAuthorized(request, groupE, SingularityAuthorizationScope.ADMIN);
-  //
-  //    SingularityUser groupF = createSingularityUser(
-  //      "f",
-  //      Collections.singleton("f"),
-  //      ImmutableSet.of("SINGULARITY_ADMIN")
-  //    );
-  //    assertAuthorized(request, groupF, SingularityAuthorizationScope.READ);
-  //    assertAuthorized(request, groupF, SingularityAuthorizationScope.WRITE);
-  //    assertAuthorized(request, groupF, SingularityAuthorizationScope.DEPLOY);
-  //    assertAuthorized(request, groupF, SingularityAuthorizationScope.ADMIN);
-  //  }
+  @Test
+  public void itChecksDeployScopeIfConfigured() {
+    SingularityRequest request = GROUP_A_REQUEST
+      .toBuilder()
+      .setGroupPermissionOverrides(
+        Optional.of(
+          Collections.singletonMap(
+            "a",
+            ImmutableSet.of(SingularityAuthorizationScope.WRITE)
+          )
+        )
+      )
+      .build();
+
+    assertAuthorized(request, GROUP_A_READ_WRITE, SingularityAuthorizationScope.READ);
+    assertAuthorized(request, GROUP_A_READ_WRITE, SingularityAuthorizationScope.WRITE);
+
+    // By default, no deploy scope is specified, so it falls back to check write scope, which is allowed.
+    assertAuthorized(request, GROUP_A_READ_WRITE, SingularityAuthorizationScope.DEPLOY);
+
+    // Build a configuration with a deploy scope specified.
+    AuthConfiguration authConfiguration = getAuthConfiguration();
+    ScopesConfiguration scopes = new ScopesConfiguration();
+    scopes.setDeploy(ImmutableSet.of("SINGULARITY_DEPLOY"));
+    authConfiguration.setScopes(scopes);
+    authorizer = new SingularityGroupsScopesAuthorizer(null, authConfiguration);
+
+    // Deploys no longer fall back to write access, and user a does not have deploy access.
+    assertNotAuthorized(
+      request,
+      GROUP_A_READ_WRITE,
+      SingularityAuthorizationScope.DEPLOY
+    );
+
+    // Give user a deploy privileges.
+    SingularityUser groupAWithDeployScope = createSingularityUser(
+      "a",
+      Collections.singleton("a"),
+      ImmutableSet.of("SINGULARITY_DEPLOY")
+    );
+    assertAuthorized(
+      request,
+      groupAWithDeployScope,
+      SingularityAuthorizationScope.DEPLOY
+    );
+  }
+
+  @Test
+  public void itRespectsGroupPermissions() {
+    Map<String, Set<SingularityAuthorizationScope>> groupPermissions = new HashMap<>();
+
+    groupPermissions.put("a", ImmutableSet.of(SingularityAuthorizationScope.READ));
+    groupPermissions.put("b", ImmutableSet.of(SingularityAuthorizationScope.WRITE));
+    groupPermissions.put(
+      "c",
+      ImmutableSet.of(
+        SingularityAuthorizationScope.READ,
+        SingularityAuthorizationScope.WRITE
+      )
+    );
+    groupPermissions.put(
+      "d",
+      ImmutableSet.of(
+        SingularityAuthorizationScope.WRITE,
+        SingularityAuthorizationScope.DEPLOY
+      )
+    );
+    groupPermissions.put(
+      "e",
+      ImmutableSet.of(
+        SingularityAuthorizationScope.READ,
+        SingularityAuthorizationScope.WRITE,
+        SingularityAuthorizationScope.DEPLOY
+      )
+    );
+
+    SingularityRequest request = GROUP_A_REQUEST
+      .toBuilder()
+      .setGroupPermissionOverrides(Optional.of(groupPermissions))
+      .build();
+
+    assertAuthorized(request, GROUP_A_READ_ONLY, SingularityAuthorizationScope.READ);
+    assertAuthorized(request, GROUP_A_WRITE_ONLY, SingularityAuthorizationScope.READ);
+    assertNotAuthorized(request, GROUP_A_READ_ONLY, SingularityAuthorizationScope.WRITE);
+
+    assertAuthorized(request, GROUP_B_READ_WRITE, SingularityAuthorizationScope.READ);
+    assertAuthorized(request, GROUP_B_READ_WRITE, SingularityAuthorizationScope.WRITE);
+
+    // By default, no deploy scope is specified, so it falls back to check write scope, so this is allowed.
+    // Same for all following deploy checks below.
+    assertAuthorized(request, GROUP_B_READ_WRITE, SingularityAuthorizationScope.DEPLOY);
+    assertNotAuthorized(request, GROUP_B_READ_WRITE, SingularityAuthorizationScope.ADMIN);
+
+    SingularityUser groupC = createSingularityUser(
+      "c",
+      Collections.singleton("c"),
+      ImmutableSet.of("SINGULARITY_READONLY", "SINGULARITY_WRITE")
+    );
+    assertAuthorized(request, groupC, SingularityAuthorizationScope.READ);
+    assertAuthorized(request, groupC, SingularityAuthorizationScope.WRITE);
+    assertAuthorized(request, groupC, SingularityAuthorizationScope.DEPLOY);
+    assertNotAuthorized(request, groupC, SingularityAuthorizationScope.ADMIN);
+
+    SingularityUser groupD = createSingularityUser(
+      "d",
+      Collections.singleton("d"),
+      ImmutableSet.of("SINGULARITY_WRITE", "SINGULARITY_DEPLOY")
+    );
+    assertAuthorized(request, groupD, SingularityAuthorizationScope.READ);
+    assertAuthorized(request, groupD, SingularityAuthorizationScope.WRITE);
+    assertAuthorized(request, groupD, SingularityAuthorizationScope.DEPLOY);
+    assertNotAuthorized(request, groupD, SingularityAuthorizationScope.ADMIN);
+
+    SingularityUser groupE = createSingularityUser(
+      "e",
+      Collections.singleton("e"),
+      ImmutableSet.of("SINGULARITY_READONLY", "SINGULARITY_WRITE")
+    );
+    assertAuthorized(request, groupE, SingularityAuthorizationScope.READ);
+    assertAuthorized(request, groupE, SingularityAuthorizationScope.WRITE);
+    assertAuthorized(request, groupE, SingularityAuthorizationScope.DEPLOY);
+    assertNotAuthorized(request, groupE, SingularityAuthorizationScope.ADMIN);
+
+    SingularityUser groupF = createSingularityUser(
+      "f",
+      Collections.singleton("f"),
+      ImmutableSet.of("SINGULARITY_ADMIN")
+    );
+    assertAuthorized(request, groupF, SingularityAuthorizationScope.READ);
+    assertAuthorized(request, groupF, SingularityAuthorizationScope.WRITE);
+    assertAuthorized(request, groupF, SingularityAuthorizationScope.DEPLOY);
+    assertAuthorized(request, groupF, SingularityAuthorizationScope.ADMIN);
+
+    SingularityUser groupG = createSingularityUser(
+      "g",
+      Collections.singleton("g"),
+      ImmutableSet.of("SINGULARITY_READ")
+    );
+    assertNotAuthorized(request, groupG, SingularityAuthorizationScope.READ);
+    assertNotAuthorized(request, groupG, SingularityAuthorizationScope.WRITE);
+    assertNotAuthorized(request, groupG, SingularityAuthorizationScope.DEPLOY);
+    assertNotAuthorized(request, groupG, SingularityAuthorizationScope.ADMIN);
+  }
 
   private static SingularityUser createSingularityUser(
     String id,

--- a/SingularityService/src/test/java/com/hubspot/singularity/auth/SingularityGroupsScopesAuthorizerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/auth/SingularityGroupsScopesAuthorizerTest.java
@@ -404,6 +404,11 @@ public class SingularityGroupsScopesAuthorizerTest {
       SingularityAuthorizationScope.EXEC
     );
     assertNotAuthorized(
+      GROUP_A_REQUEST,
+      GROUP_A_READ_WRITE,
+      SingularityAuthorizationScope.EXEC
+    );
+    assertNotAuthorized(
       GROUP_A_REQUEST
         .toBuilder()
         .setGroupScopeOverrides(

--- a/SingularityService/src/test/java/com/hubspot/singularity/auth/SingularityGroupsScopesAuthorizerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/auth/SingularityGroupsScopesAuthorizerTest.java
@@ -318,7 +318,7 @@ public class SingularityGroupsScopesAuthorizerTest {
   public void itChecksDeployScopeIfConfigured() {
     SingularityRequest request = GROUP_A_REQUEST
       .toBuilder()
-      .setGroupPermissionOverrides(
+      .setGroupScopeOverrides(
         Optional.of(
           Collections.singletonMap(
             "a",
@@ -392,7 +392,7 @@ public class SingularityGroupsScopesAuthorizerTest {
 
     SingularityRequest request = GROUP_A_REQUEST
       .toBuilder()
-      .setGroupPermissionOverrides(Optional.of(groupPermissions))
+      .setGroupScopeOverrides(Optional.of(groupPermissions))
       .build();
 
     assertAuthorized(request, GROUP_A_READ_ONLY, SingularityAuthorizationScope.READ);


### PR DESCRIPTION
Some requests need to be runnable ONLY by someone other than the group owner for compliance purposes. For example, Team A would write and deploy a sensitive request, and only Team B could run it (or bounce, scale, kill tasks, or pause).

This provides a more generic solution in the form of an action permissions override map. 