### PR TITLE
Fix env var inheritance in docker

### DIFF
--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/models/DockerEnvironmentContext.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/models/DockerEnvironmentContext.java
@@ -1,5 +1,6 @@
 package com.hubspot.singularity.executor.models;
 
+import com.google.common.base.Joiner;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -20,16 +21,12 @@ public class DockerEnvironmentContext extends EnvironmentContext {
     List<Variable> variables = new ArrayList<>();
     Set<String> keys = new HashSet<>();
 
-    inheritVariables.forEach(
-      v -> {
-        if (!keys.contains(v)) {
-          String val = System.getenv(v);
-          if (val != null) {
-            variables.add(Variable.newBuilder().setName(v).setValue(val).build());
-            keys.add(v);
-          }
-        }
-      }
+    variables.add(
+      Variable
+        .newBuilder()
+        .setName("INHERIT_ENV_VARS")
+        .setValue(Joiner.on(" ").join(inheritVariables))
+        .build()
     );
 
     taskInfo

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/models/DockerEnvironmentContext.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/models/DockerEnvironmentContext.java
@@ -1,6 +1,5 @@
 package com.hubspot.singularity.executor.models;
 
-import com.google.common.base.Joiner;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -21,14 +20,6 @@ public class DockerEnvironmentContext extends EnvironmentContext {
     List<Variable> variables = new ArrayList<>();
     Set<String> keys = new HashSet<>();
 
-    variables.add(
-      Variable
-        .newBuilder()
-        .setName("INHERIT_ENV_VARS")
-        .setValue(Joiner.on(" ").join(inheritVariables))
-        .build()
-    );
-
     taskInfo
       .getExecutor()
       .getCommand()
@@ -43,5 +34,9 @@ public class DockerEnvironmentContext extends EnvironmentContext {
         }
       );
     return variables;
+  }
+
+  public List<String> getInheritedVariables() {
+    return inheritVariables;
   }
 }

--- a/SingularityExecutor/src/main/resources/docker.sh.hbs
+++ b/SingularityExecutor/src/main/resources/docker.sh.hbs
@@ -82,6 +82,16 @@ DOCKER_IMAGE={{{ envContext.dockerInfo.image }}}
 
 # load env vars
 touch docker.env
+
+INHERIT_ENV_VARS=({{envContext.env["INHERIT_ENV_VARS"]}})
+for name in "${INHERIT_ENV_VARS[@]}"; do
+   value=$(printenv "$name")
+   if [ ! -z "$value" ]; then
+    quoted_value=$(printf %q "$value")
+    echo "${name}=${quoted_value}" >> docker.env
+  fi
+done
+
 {{#each envContext.env}}
 {{#ifHasNewLinesOrBackticks value}}
 {{{name}}}={{{shellQuote value}}}

--- a/SingularityExecutor/src/main/resources/docker.sh.hbs
+++ b/SingularityExecutor/src/main/resources/docker.sh.hbs
@@ -83,14 +83,15 @@ DOCKER_IMAGE={{{ envContext.dockerInfo.image }}}
 # load env vars
 touch docker.env
 
-INHERIT_ENV_VARS=({{envContext.env["INHERIT_ENV_VARS"]}})
-for name in "${INHERIT_ENV_VARS[@]}"; do
-   value=$(printenv "$name")
-   if [ ! -z "$value" ]; then
-    quoted_value=$(printf %q "$value")
-    echo "${name}=${quoted_value}" >> docker.env
-  fi
-done
+{{#each envContext.inheritedVariables}}
+value=$(printenv {{{this}}})
+{{#ifHasNewLinesOrBackticks value}}
+{{{this}}}={{{shellQuote value}}}
+{{else}}
+{{{this}}}={{{bashEscaped value}}}
+echo "{{{this}}}=${{{this}}}" >> docker.env
+{{/ifHasNewLinesOrBackticks}}
+{{/each}}
 
 {{#each envContext.env}}
 {{#ifHasNewLinesOrBackticks value}}


### PR DESCRIPTION
Env vars need to be gotten while running the `docker.sh` (templated out as `runner.sh`), because they may not be available from the executor process.