### PR TITLE
Don't include history in leader cache query + more efficient task persister

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -652,7 +652,7 @@ public class TaskManager extends CuratorAsyncManager {
   }
 
   public Map<SingularityTaskId, List<SingularityTaskHistoryUpdate>> getAllTaskHistoryUpdates() {
-    return getTaskHistoryUpdates(getAllTaskIds());
+    return getTaskHistoryUpdates(getActiveTaskIds());
   }
 
   public int getNumNonstartupHealthchecks(SingularityTaskId taskId) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -445,6 +445,10 @@ public class TaskManager extends CuratorAsyncManager {
     return save(pendingPath, task, pendingTaskTranscoder);
   }
 
+  public List<String> getRequestIdsInTaskHistory() {
+    return getChildren(HISTORY_PATH_ROOT);
+  }
+
   public List<SingularityTaskId> getAllTaskIds() {
     final List<String> requestIds = getChildren(HISTORY_PATH_ROOT);
     final List<String> paths = Lists.newArrayListWithCapacity(requestIds.size());

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/TestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/TestResource.java
@@ -9,7 +9,9 @@ import com.hubspot.singularity.SingularityLeaderController;
 import com.hubspot.singularity.config.ApiPaths;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.history.HistoryManager;
+import com.hubspot.singularity.data.history.SingularityDeployHistoryPersister;
 import com.hubspot.singularity.data.history.SingularityHistoryPurger;
+import com.hubspot.singularity.data.history.SingularityRequestHistoryPersister;
 import com.hubspot.singularity.data.history.SingularityTaskHistoryPersister;
 import com.hubspot.singularity.mesos.SingularityMesosScheduler;
 import com.hubspot.singularity.scheduler.SingularityTaskReconciliation;
@@ -42,6 +44,8 @@ public class TestResource {
   private final SingularityHistoryPurger historyPurger;
   private final HistoryManager historyManager;
   private final SingularityTaskHistoryPersister taskHistoryPersister;
+  private final SingularityDeployHistoryPersister deployHistoryPersister;
+  private final SingularityRequestHistoryPersister requestHistoryPersister;
 
   @Inject
   public TestResource(
@@ -52,7 +56,9 @@ public class TestResource {
     SingularityTaskReconciliation taskReconciliation,
     SingularityHistoryPurger historyPurger,
     HistoryManager historyManager,
-    SingularityTaskHistoryPersister taskHistoryPersister
+    SingularityTaskHistoryPersister taskHistoryPersister,
+    SingularityDeployHistoryPersister deployHistoryPersister,
+    SingularityRequestHistoryPersister requestHistoryPersister
   ) {
     this.configuration = configuration;
     this.managed = managed;
@@ -62,6 +68,8 @@ public class TestResource {
     this.historyPurger = historyPurger;
     this.historyManager = historyManager;
     this.taskHistoryPersister = taskHistoryPersister;
+    this.deployHistoryPersister = deployHistoryPersister;
+    this.requestHistoryPersister = requestHistoryPersister;
   }
 
   @POST
@@ -329,5 +337,43 @@ public class TestResource {
       "Test resource calls are disabled (set isAllowTestResourceCalls to true in configuration)"
     );
     CompletableFuture.runAsync(taskHistoryPersister::runActionOnPoll);
+  }
+
+  @POST
+  @Path("/persist-deploy-history")
+  @Operation(
+    summary = "Trigger a deploy history persister run",
+    responses = {
+      @ApiResponse(
+        responseCode = "403",
+        description = "Test resource calls are currently not enabled, set `allowTestResourceCalls` to `true` in config yaml to enable"
+      )
+    }
+  )
+  public void persistDeployHistory() {
+    checkForbidden(
+      configuration.isAllowTestResourceCalls(),
+      "Test resource calls are disabled (set isAllowTestResourceCalls to true in configuration)"
+    );
+    CompletableFuture.runAsync(deployHistoryPersister::runActionOnPoll);
+  }
+
+  @POST
+  @Path("/persist-request-history")
+  @Operation(
+    summary = "Trigger a request history persister run",
+    responses = {
+      @ApiResponse(
+        responseCode = "403",
+        description = "Test resource calls are currently not enabled, set `allowTestResourceCalls` to `true` in config yaml to enable"
+      )
+    }
+  )
+  public void persistRequestHistory() {
+    checkForbidden(
+      configuration.isAllowTestResourceCalls(),
+      "Test resource calls are disabled (set isAllowTestResourceCalls to true in configuration)"
+    );
+    CompletableFuture.runAsync(requestHistoryPersister::runActionOnPoll);
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/TestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/TestResource.java
@@ -20,6 +20,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -327,6 +328,6 @@ public class TestResource {
       configuration.isAllowTestResourceCalls(),
       "Test resource calls are disabled (set isAllowTestResourceCalls to true in configuration)"
     );
-    taskHistoryPersister.runActionOnPoll();
+    CompletableFuture.runAsync(taskHistoryPersister::runActionOnPoll);
   }
 }


### PR DESCRIPTION
Think this is slowing us down when sql purge has not run in a while. We don't need the full history, only active