### PR TITLE
Fix accidental crash loop dedupe

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/CrashLoopInfo.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/CrashLoopInfo.java
@@ -1,6 +1,7 @@
 package com.hubspot.singularity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Optional;
 
@@ -55,21 +56,29 @@ public class CrashLoopInfo {
       return false;
     }
 
-    CrashLoopInfo that = (CrashLoopInfo) o;
+    CrashLoopInfo info = (CrashLoopInfo) o;
 
-    if (requestId != null ? !requestId.equals(that.requestId) : that.requestId != null) {
+    if (start != info.start) {
       return false;
     }
-    if (deployId != null ? !deployId.equals(that.deployId) : that.deployId != null) {
+    if (requestId != null ? !requestId.equals(info.requestId) : info.requestId != null) {
       return false;
     }
-    return type == that.type;
+    if (deployId != null ? !deployId.equals(info.deployId) : info.deployId != null) {
+      return false;
+    }
+    if (end != null ? !end.equals(info.end) : info.end != null) {
+      return false;
+    }
+    return type == info.type;
   }
 
   @Override
   public int hashCode() {
     int result = requestId != null ? requestId.hashCode() : 0;
     result = 31 * result + (deployId != null ? deployId.hashCode() : 0);
+    result = 31 * result + (int) (start ^ (start >>> 32));
+    result = 31 * result + (end != null ? end.hashCode() : 0);
     result = 31 * result + (type != null ? type.hashCode() : 0);
     return result;
   }
@@ -91,6 +100,16 @@ public class CrashLoopInfo {
       ", type=" +
       type +
       '}'
+    );
+  }
+
+  @JsonIgnore
+  public boolean matches(CrashLoopInfo other) {
+    return (
+      requestId.equals(other.requestId) &&
+      deployId.equals(other.deployId) &&
+      type == other.type &&
+      end.isPresent() == other.end.isPresent()
     );
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCrashLoopChecker.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCrashLoopChecker.java
@@ -18,7 +18,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -141,14 +140,14 @@ public class SingularityCrashLoopChecker {
         continue;
       }
 
-      Set<CrashLoopInfo> active = crashLoops.getActiveCrashLoops(
+      List<CrashLoopInfo> active = crashLoops.getActiveCrashLoops(
         maybeDeployStatistics.get()
       );
 
       if (!active.isEmpty()) {
         active.forEach(
           l -> {
-            if (!previouslyActive.contains(l)) {
+            if (previouslyActive.stream().noneMatch(l::matches)) {
               LOG.info("New crash loop for {}: {}", request.getRequest().getId(), l);
               requestManager.saveCrashLoop(l);
             }
@@ -159,7 +158,7 @@ public class SingularityCrashLoopChecker {
       if (!previouslyActive.isEmpty()) {
         previouslyActive.forEach(
           l -> {
-            if (!active.contains(l)) {
+            if (active.stream().noneMatch(l::matches)) {
               LOG.info("Crash loop resolved for {}: {}", request.getRequest().getId(), l);
               requestManager.saveCrashLoop(
                 new CrashLoopInfo(

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCrashLoops.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCrashLoops.java
@@ -18,11 +18,9 @@ import com.hubspot.singularity.data.RequestManager;
 import com.hubspot.singularity.data.TaskManager;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -102,8 +100,8 @@ public class SingularityCrashLoops {
     return !shouldBeInCooldown(deployStatistics, recentFailureTimestamp);
   }
 
-  Set<CrashLoopInfo> getActiveCrashLoops(SingularityDeployStatistics deployStatistics) {
-    Set<CrashLoopInfo> active = new HashSet<>();
+  List<CrashLoopInfo> getActiveCrashLoops(SingularityDeployStatistics deployStatistics) {
+    List<CrashLoopInfo> active = new ArrayList<>();
 
     if (deployStatistics.getTaskFailureEvents().isEmpty()) {
       return active;

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityCrashLoopTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityCrashLoopTest.java
@@ -50,6 +50,20 @@ public class SingularityCrashLoopTest extends SingularitySchedulerTestBase {
   }
 
   @Test
+  public void itSavesSubsequentLoopsOfSameType() {
+    requestManager.saveCrashLoop(
+      new CrashLoopInfo(
+        requestId,
+        firstDeployId,
+        System.currentTimeMillis() - 60000,
+        Optional.of(System.currentTimeMillis() - 30000),
+        CrashLoopType.FAST_FAILURE_LOOP
+      )
+    );
+    itDetectsFastFailureLoopsForNonLongRunning();
+  }
+
+  @Test
   public void itDetectsSlowConsistentFailureLoops() {
     initRequestWithType(RequestType.WORKER, false);
     initFirstDeploy();

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityCrashLoopTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityCrashLoopTest.java
@@ -11,8 +11,8 @@ import com.hubspot.singularity.SingularityTaskCleanup;
 import com.hubspot.singularity.TaskCleanupType;
 import com.hubspot.singularity.TaskFailureType;
 import com.hubspot.singularity.helpers.MesosProtosUtils;
+import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.apache.mesos.v1.Protos.TaskState;
 import org.apache.mesos.v1.Protos.TaskStatus;
@@ -41,7 +41,7 @@ public class SingularityCrashLoopTest extends SingularitySchedulerTestBase {
     SingularityDeployStatistics deployStatistics = deployManager
       .getDeployStatistics(requestId, firstDeployId)
       .get();
-    Set<CrashLoopInfo> active = crashLoops.getActiveCrashLoops(deployStatistics);
+    List<CrashLoopInfo> active = crashLoops.getActiveCrashLoops(deployStatistics);
     Assertions.assertEquals(1, active.size());
     Assertions.assertEquals(
       CrashLoopType.FAST_FAILURE_LOOP,
@@ -119,7 +119,7 @@ public class SingularityCrashLoopTest extends SingularitySchedulerTestBase {
     SingularityDeployStatistics deployStatistics = deployManager
       .getDeployStatistics(requestId, firstDeployId)
       .get();
-    Set<CrashLoopInfo> active = crashLoops.getActiveCrashLoops(deployStatistics);
+    List<CrashLoopInfo> active = crashLoops.getActiveCrashLoops(deployStatistics);
     Assertions.assertEquals(1, active.size());
     Assertions.assertEquals(
       CrashLoopType.SLOW_FAILURES,
@@ -142,7 +142,7 @@ public class SingularityCrashLoopTest extends SingularitySchedulerTestBase {
     SingularityDeployStatistics deployStatistics = deployManager
       .getDeployStatistics(requestId, firstDeployId)
       .get();
-    Set<CrashLoopInfo> active = crashLoops.getActiveCrashLoops(deployStatistics);
+    List<CrashLoopInfo> active = crashLoops.getActiveCrashLoops(deployStatistics);
     Assertions.assertEquals(0, active.size());
   }
 
@@ -171,7 +171,7 @@ public class SingularityCrashLoopTest extends SingularitySchedulerTestBase {
     SingularityDeployStatistics deployStatistics = deployManager
       .getDeployStatistics(requestId, firstDeployId)
       .get();
-    Set<CrashLoopInfo> active = crashLoops.getActiveCrashLoops(deployStatistics);
+    List<CrashLoopInfo> active = crashLoops.getActiveCrashLoops(deployStatistics);
     Assertions.assertEquals(1, active.size());
     Assertions.assertEquals(
       CrashLoopType.STARTUP_FAILURE_LOOP,
@@ -192,7 +192,7 @@ public class SingularityCrashLoopTest extends SingularitySchedulerTestBase {
     SingularityDeployStatistics deployStatistics = deployManager
       .getDeployStatistics(requestId, firstDeployId)
       .get();
-    Set<CrashLoopInfo> active = crashLoops.getActiveCrashLoops(deployStatistics);
+    List<CrashLoopInfo> active = crashLoops.getActiveCrashLoops(deployStatistics);
     Assertions.assertTrue(active.size() > 1);
     Assertions.assertTrue(
       active.stream().map(CrashLoopInfo::getType).anyMatch(l -> l == CrashLoopType.OOM)
@@ -224,7 +224,7 @@ public class SingularityCrashLoopTest extends SingularitySchedulerTestBase {
     SingularityDeployStatistics deployStatistics = deployManager
       .getDeployStatistics(requestId, firstDeployId)
       .get();
-    Set<CrashLoopInfo> active = crashLoops.getActiveCrashLoops(deployStatistics);
+    List<CrashLoopInfo> active = crashLoops.getActiveCrashLoops(deployStatistics);
 
     Assertions.assertTrue(active.isEmpty());
   }
@@ -255,7 +255,7 @@ public class SingularityCrashLoopTest extends SingularitySchedulerTestBase {
     SingularityDeployStatistics deployStatistics = deployManager
       .getDeployStatistics(requestId, firstDeployId)
       .get();
-    Set<CrashLoopInfo> active = crashLoops.getActiveCrashLoops(deployStatistics);
+    List<CrashLoopInfo> active = crashLoops.getActiveCrashLoops(deployStatistics);
     Assertions.assertEquals(1, active.size());
     Assertions.assertEquals(
       CrashLoopType.SINGLE_INSTANCE_FAILURE_LOOP,
@@ -299,7 +299,7 @@ public class SingularityCrashLoopTest extends SingularitySchedulerTestBase {
     SingularityDeployStatistics deployStatistics = deployManager
       .getDeployStatistics(requestId, firstDeployId)
       .get();
-    Set<CrashLoopInfo> active = crashLoops.getActiveCrashLoops(deployStatistics);
+    List<CrashLoopInfo> active = crashLoops.getActiveCrashLoops(deployStatistics);
     Assertions.assertEquals(1, active.size());
     Assertions.assertEquals(
       CrashLoopType.MULTI_INSTANCE_FAILURE,


### PR DESCRIPTION
This fixes an issue where, if a crash loop of the same type had just resolved, a new crash loop of that type could be missed. The previouslyActive.contains check was eating these due to the implementation of equals/hashCode on the CrashLoopInfo object. Changed that and the check to determine which are no longer active as well as adding start/end time to the equals and hash methods