### PR TITLE
Stability improvements for sql/zk usage

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -431,6 +431,9 @@ public class SingularityConfiguration extends Configuration {
   // Stops persisters + purgers from running when the DB is enabled. Forces binding of zk-based usage manager
   private boolean sqlReadOnlyMode = false;
 
+  // Instructs this instance to not contend for leadership. It will only serve api calls
+  private boolean readOnlyInstance = false;
+
   public long getAskDriverToKillTasksAgainAfterMillis() {
     return askDriverToKillTasksAgainAfterMillis;
   }
@@ -2024,5 +2027,13 @@ public class SingularityConfiguration extends Configuration {
 
   public void setSqlReadOnlyMode(boolean sqlReadOnlyMode) {
     this.sqlReadOnlyMode = sqlReadOnlyMode;
+  }
+
+  public boolean isReadOnlyInstance() {
+    return readOnlyInstance;
+  }
+
+  public void setReadOnlyInstance(boolean readOnlyInstance) {
+    this.readOnlyInstance = readOnlyInstance;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/CuratorManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/CuratorManager.java
@@ -155,10 +155,6 @@ public abstract class CuratorManager {
     return checkExists(path).isPresent();
   }
 
-  protected int countChildren(String path) {
-    return checkExists(path).map(Stat::getNumChildren).orElse(0);
-  }
-
   protected List<String> getChildren(String root) {
     LOG.trace("Preparing to call getChildren() on {}", root);
     final long start = System.currentTimeMillis();

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/CuratorManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/CuratorManager.java
@@ -155,6 +155,10 @@ public abstract class CuratorManager {
     return checkExists(path).isPresent();
   }
 
+  protected int countChildren(String path) {
+    return checkExists(path).map(Stat::getNumChildren).orElse(0);
+  }
+
   protected List<String> getChildren(String root) {
     LOG.trace("Preparing to call getChildren() on {}", root);
     final long start = System.currentTimeMillis();

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -449,6 +449,10 @@ public class TaskManager extends CuratorAsyncManager {
     return getChildren(HISTORY_PATH_ROOT);
   }
 
+  public int getTaskCountForRequest(String requestId) {
+    return countChildren(getRequestPath(requestId));
+  }
+
   public List<SingularityTaskId> getAllTaskIds() {
     final List<String> requestIds = getChildren(HISTORY_PATH_ROOT);
     final List<String> paths = Lists.newArrayListWithCapacity(requestIds.size());

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -450,7 +450,7 @@ public class TaskManager extends CuratorAsyncManager {
   }
 
   public int getTaskCountForRequest(String requestId) {
-    return countChildren(getRequestPath(requestId));
+    return getNumChildren(getRequestPath(requestId));
   }
 
   public List<SingularityTaskId> getAllTaskIds() {
@@ -999,13 +999,18 @@ public class TaskManager extends CuratorAsyncManager {
     String requestId,
     TaskFilter taskFilter
   ) {
+    if (taskFilter == TaskFilter.ACTIVE) {
+      if (leaderCache.active()) {
+        return leaderCache.getActiveTaskIdsForRequest(requestId);
+      } else {
+        return getActiveTaskIds()
+          .stream()
+          .filter(t -> t.getRequestId().equals(requestId))
+          .collect(Collectors.toList());
+      }
+    }
     final List<SingularityTaskId> requestTaskIds = getTaskIdsForRequest(requestId);
     final List<SingularityTaskId> activeTaskIds = filterActiveTaskIds(requestTaskIds);
-
-    if (taskFilter == TaskFilter.ACTIVE) {
-      return activeTaskIds;
-    }
-
     Iterables.removeAll(requestTaskIds, activeTaskIds);
 
     return requestTaskIds;

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityTaskHistoryPersister.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityTaskHistoryPersister.java
@@ -12,6 +12,7 @@ import com.hubspot.singularity.SingularityTaskId;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.DeployManager;
 import com.hubspot.singularity.data.TaskManager;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -58,7 +59,11 @@ public class SingularityTaskHistoryPersister
       LOG.info("Checking inactive task ids for task history persistence");
 
       final long start = System.currentTimeMillis();
-      for (String requestId : taskManager.getRequestIdsInTaskHistory()) {
+      List<String> requestIds = taskManager.getRequestIdsInTaskHistory();
+      requestIds.sort(
+        Comparator.comparingLong(taskManager::getTaskCountForRequest).reversed()
+      );
+      for (String requestId : requestIds) {
         try {
           LOG.info("Checking request {}", requestId);
           List<SingularityTaskId> taskIds = taskManager.getTaskIdsForRequest(requestId);

--- a/SingularityService/src/main/java/com/hubspot/singularity/managed/SingularityLifecycleManaged.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/managed/SingularityLifecycleManaged.java
@@ -81,6 +81,8 @@ public class SingularityLifecycleManaged implements Managed {
       startCurator();
       if (!readOnly) {
         leaderLatch.start();
+      } else {
+        LOG.info("Registered as read only, will not attempt to become the leader");
       }
       leaderController.start(); // start the state poller
       graphiteReporter.start();

--- a/SingularityService/src/test/java/com/hubspot/singularity/managed/SingularityLifecycleManagedTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/managed/SingularityLifecycleManagedTest.java
@@ -4,6 +4,7 @@ import com.google.inject.Inject;
 import com.hubspot.singularity.SingularityLeaderController;
 import com.hubspot.singularity.SingularityManagedScheduledExecutorServiceFactory;
 import com.hubspot.singularity.SingularityManagedThreadPoolFactory;
+import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.ExecutorIdGenerator;
 import com.hubspot.singularity.mesos.SingularityMesosExecutorInfoSupport;
 import com.hubspot.singularity.metrics.SingularityGraphiteReporter;
@@ -26,7 +27,8 @@ public class SingularityLifecycleManagedTest extends SingularityLifecycleManaged
     SingularityMesosExecutorInfoSupport executorInfoSupport,
     SingularityGraphiteReporter graphiteReporter,
     ExecutorIdGenerator executorIdGenerator,
-    Set<SingularityLeaderOnlyPoller> leaderOnlyPollers
+    Set<SingularityLeaderOnlyPoller> leaderOnlyPollers,
+    SingularityConfiguration configuration
   ) {
     super(
       cachedThreadPoolFactory,
@@ -38,7 +40,8 @@ public class SingularityLifecycleManagedTest extends SingularityLifecycleManaged
       executorInfoSupport,
       graphiteReporter,
       executorIdGenerator,
-      leaderOnlyPollers
+      leaderOnlyPollers,
+      configuration
     );
   }
 

--- a/SingularityUI/app/thirdPartyConfigurations.es6
+++ b/SingularityUI/app/thirdPartyConfigurations.es6
@@ -31,7 +31,7 @@ export const loadThirdParty = () => {
 
   // Messenger options
   window.Messenger.options = {
-    extraClasses: 'messenger-on-bottom  messenger-on-right',
+    extraClasses: 'messenger-fixed messenger-on-bottom  messenger-on-right',
     theme: 'air',
     hideOnNavigate: true,
     maxMessages: 1,

--- a/SingularityUI/app/thirdPartyConfigurations.es6
+++ b/SingularityUI/app/thirdPartyConfigurations.es6
@@ -31,7 +31,7 @@ export const loadThirdParty = () => {
 
   // Messenger options
   window.Messenger.options = {
-    extraClasses: 'messenger-fixed messenger-on-top',
+    extraClasses: 'messenger-on-bottom  messenger-on-right',
     theme: 'air',
     hideOnNavigate: true,
     maxMessages: 1,


### PR DESCRIPTION
Few things here after we experienced some hiccups with persisting:
- Sort the task persisting by child node count, to take care of more expensive/troublesome parent nodes first
- Enable spinning up a separate instance that only serves api calls (i.e. a deployment pattern to isolate the scheduler)
- Optimize the active tasks for request id check
- make a cheaper HEAD request method to check if a request exists without having to fetch full request + active task data for the request parent object