### PR TITLE
Fix condition for evaluating crash loops

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCrashLoops.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCrashLoops.java
@@ -217,7 +217,7 @@ public class SingularityCrashLoops {
      * Startup failure loop
      * b) multiple instances failing healthchecks too many times in X minutes
      */
-    if (!hasStartupFailure) {
+    if (hasStartupFailure) {
       long startupFailThreshold =
         now -
         TimeUnit.MINUTES.toMillis(configuration.getEvaluateStartupLoopOverMinutes());


### PR DESCRIPTION
Looking into some cases where this triggered too slow for something that should have caught the startup failure loop. Trying to remember why this was a ! ...