### PR TITLE
More efficient active tasks for request listing

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -999,18 +999,12 @@ public class TaskManager extends CuratorAsyncManager {
     String requestId,
     TaskFilter taskFilter
   ) {
-    if (taskFilter == TaskFilter.ACTIVE) {
-      if (leaderCache.active()) {
-        return leaderCache.getActiveTaskIdsForRequest(requestId);
-      } else {
-        return getActiveTaskIds()
-          .stream()
-          .filter(t -> t.getRequestId().equals(requestId))
-          .collect(Collectors.toList());
-      }
-    }
     final List<SingularityTaskId> requestTaskIds = getTaskIdsForRequest(requestId);
     final List<SingularityTaskId> activeTaskIds = filterActiveTaskIds(requestTaskIds);
+
+    if (taskFilter == TaskFilter.ACTIVE) {
+      return activeTaskIds;
+    }
     Iterables.removeAll(requestTaskIds, activeTaskIds);
 
     return requestTaskIds;

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -999,12 +999,14 @@ public class TaskManager extends CuratorAsyncManager {
     String requestId,
     TaskFilter taskFilter
   ) {
-    final List<SingularityTaskId> requestTaskIds = getTaskIdsForRequest(requestId);
-    final List<SingularityTaskId> activeTaskIds = filterActiveTaskIds(requestTaskIds);
-
+    final List<SingularityTaskId> activeTaskIds = getChildrenAsIds(
+      getLastActiveTaskParent(requestId),
+      taskIdTranscoder
+    );
     if (taskFilter == TaskFilter.ACTIVE) {
       return activeTaskIds;
     }
+    final List<SingularityTaskId> requestTaskIds = getTaskIdsForRequest(requestId);
     Iterables.removeAll(requestTaskIds, activeTaskIds);
 
     return requestTaskIds;


### PR DESCRIPTION
Untangled a bit of code from when the active task parent used to be consolidated instead of split by request id. The very I thought would be more stable actually scaled zk call count with number of requests instead of number of tasks for the request being queried. Since the active tasks are split unlike the old setup a year+ ago, this can actually be always a single zk call for active tasks for a request