### PR TITLE
Counters for last persister successes

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityDeployHistoryPersister.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityDeployHistoryPersister.java
@@ -147,9 +147,10 @@ public class SingularityDeployHistoryPersister
       );
     } finally {
       if (persisterSuccess.get()) {
+        lastPersisterSuccess.set(System.currentTimeMillis());
         LOG.info(
-          "Deploy Persister: successful move to history ({} so far)",
-          lastPersisterSuccess.incrementAndGet()
+          "Finished run on deploy history persist at {}",
+          lastPersisterSuccess.get()
         );
       }
       persisterLock.unlock();

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityDeployHistoryPersister.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityDeployHistoryPersister.java
@@ -149,7 +149,7 @@ public class SingularityDeployHistoryPersister
       if (persisterSuccess.get()) {
         lastPersisterSuccess.set(System.currentTimeMillis());
         LOG.info(
-          "Finished run on deploy history persist at {}",
+          "Finished run on deploy history persister at {}",
           lastPersisterSuccess.get()
         );
       }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityDeployHistoryPersister.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityDeployHistoryPersister.java
@@ -147,7 +147,7 @@ public class SingularityDeployHistoryPersister
       );
     } finally {
       if (persisterSuccess.get()) {
-        LOG.trace(
+        LOG.info(
           "Deploy Persister: successful move to history ({} so far)",
           lastPersisterSuccess.incrementAndGet()
         );

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityDeployHistoryPersister.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityDeployHistoryPersister.java
@@ -142,6 +142,13 @@ public class SingularityDeployHistoryPersister
         JavaUtils.duration(start)
       );
     } finally {
+      if (persisterSuccess) {
+        LOG.trace(
+          "Deploy Persister: successful move to history ({} so far)",
+          lastPersisterSuccess.incrementAndGet()
+        );
+        persisterSuccess = false;
+      }
       persisterLock.unlock();
     }
   }
@@ -193,16 +200,14 @@ public class SingularityDeployHistoryPersister
   protected boolean moveToHistory(SingularityDeployHistory deployHistory) {
     try {
       historyManager.saveDeployHistory(deployHistory);
-      LOG.trace(
-        "Deploy Persister: successful move to history ({} so far)",
-        lastPersisterSuccess.incrementAndGet()
-      );
+      persisterSuccess = true;
     } catch (Throwable t) {
       LOG.warn(
         "Failed to persist deploy {}",
         SingularityDeployKey.fromDeployMarker(deployHistory.getDeployMarker()),
         t
       );
+      persisterSuccess = false;
       return false;
     }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityHistoryModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityHistoryModule.java
@@ -9,12 +9,20 @@ import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Named;
 import com.hubspot.singularity.data.history.SingularityMappers.SingularityIdMapper;
 import com.hubspot.singularity.data.history.SingularityMappers.SingularityJsonStringMapper;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.mapper.RowMapper;
 
 public class SingularityHistoryModule extends AbstractModule {
   public static final String PERSISTER_LOCK = "history.persister.lock";
+
+  public static final String LAST_TASK_PERSISTER_SUCCESS =
+    "last-task-history-persister-success";
+  public static final String LAST_REQUEST_PERSISTER_SUCCESS =
+    "last-request-history-persister-success";
+  public static final String LAST_DEPLOY_PERSISTER_SUCCESS =
+    "last-deploy-history-persister-success";
 
   public SingularityHistoryModule() {}
 
@@ -82,5 +90,26 @@ public class SingularityHistoryModule extends AbstractModule {
   @Named(PERSISTER_LOCK)
   public ReentrantLock providePersisterLock() {
     return new ReentrantLock();
+  }
+
+  @Provides
+  @Singleton
+  @Named(LAST_TASK_PERSISTER_SUCCESS)
+  public AtomicLong lastTaskPersisterSuccess() {
+    return new AtomicLong();
+  }
+
+  @Provides
+  @Singleton
+  @Named(LAST_REQUEST_PERSISTER_SUCCESS)
+  public AtomicLong lastRequestPersisterSuccess() {
+    return new AtomicLong();
+  }
+
+  @Provides
+  @Singleton
+  @Named(LAST_DEPLOY_PERSISTER_SUCCESS)
+  public AtomicLong lastDeployPersisterSuccess() {
+    return new AtomicLong();
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityHistoryPersister.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityHistoryPersister.java
@@ -7,6 +7,7 @@ import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.scheduler.SingularityLeaderOnlyPoller;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,13 +21,17 @@ public abstract class SingularityHistoryPersister<T extends SingularityHistoryIt
   protected final SingularityConfiguration configuration;
   protected final ReentrantLock persisterLock;
 
+  protected final AtomicLong lastPersisterSuccess;
+
   public SingularityHistoryPersister(
     SingularityConfiguration configuration,
-    ReentrantLock persisterLock
+    ReentrantLock persisterLock,
+    AtomicLong lastPersisterSuccess
   ) {
     super(configuration.getPersistHistoryEverySeconds(), TimeUnit.SECONDS);
     this.configuration = configuration;
     this.persisterLock = persisterLock;
+    this.lastPersisterSuccess = lastPersisterSuccess;
   }
 
   @Override

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityHistoryPersister.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityHistoryPersister.java
@@ -22,7 +22,6 @@ public abstract class SingularityHistoryPersister<T extends SingularityHistoryIt
   protected final ReentrantLock persisterLock;
 
   protected final AtomicLong lastPersisterSuccess;
-  protected boolean persisterSuccess;
 
   public SingularityHistoryPersister(
     SingularityConfiguration configuration,
@@ -33,7 +32,6 @@ public abstract class SingularityHistoryPersister<T extends SingularityHistoryIt
     this.configuration = configuration;
     this.persisterLock = persisterLock;
     this.lastPersisterSuccess = lastPersisterSuccess;
-    persisterSuccess = false;
   }
 
   @Override

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityHistoryPersister.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityHistoryPersister.java
@@ -22,6 +22,7 @@ public abstract class SingularityHistoryPersister<T extends SingularityHistoryIt
   protected final ReentrantLock persisterLock;
 
   protected final AtomicLong lastPersisterSuccess;
+  protected boolean persisterSuccess;
 
   public SingularityHistoryPersister(
     SingularityConfiguration configuration,
@@ -32,6 +33,7 @@ public abstract class SingularityHistoryPersister<T extends SingularityHistoryIt
     this.configuration = configuration;
     this.persisterLock = persisterLock;
     this.lastPersisterSuccess = lastPersisterSuccess;
+    persisterSuccess = false;
   }
 
   @Override

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityRequestHistoryPersister.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityRequestHistoryPersister.java
@@ -181,7 +181,7 @@ public class SingularityRequestHistoryPersister
       if (persisterSuccess.get()) {
         lastPersisterSuccess.set(System.currentTimeMillis());
         LOG.info(
-          "Finished run on request history persist at {}",
+          "Finished run on request history persister at {}",
           lastPersisterSuccess.get()
         );
       }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityRequestHistoryPersister.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityRequestHistoryPersister.java
@@ -174,6 +174,14 @@ public class SingularityRequestHistoryPersister
         JavaUtils.duration(start)
       );
     } finally {
+      if (persisterSuccess) {
+        LOG.trace(
+          "Request Persister: successful move to history ({} so far)",
+          lastPersisterSuccess.incrementAndGet()
+        );
+        persisterSuccess = false;
+      }
+
       persisterLock.unlock();
     }
   }
@@ -195,12 +203,10 @@ public class SingularityRequestHistoryPersister
     for (SingularityRequestHistory requestHistory : object.history) {
       try {
         historyManager.saveRequestHistoryUpdate(requestHistory);
-        LOG.trace(
-          "Request Persister: successful move to history ({} so far)",
-          lastPersisterSuccess.incrementAndGet()
-        );
+        persisterSuccess = true;
       } catch (Throwable t) {
         LOG.warn("Failed to persist {} into History", requestHistory, t);
+        persisterSuccess = false;
         return false;
       }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityRequestHistoryPersister.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityRequestHistoryPersister.java
@@ -179,7 +179,7 @@ public class SingularityRequestHistoryPersister
       );
     } finally {
       if (persisterSuccess.get()) {
-        LOG.trace(
+        LOG.info(
           "Request Persister: successful move to history ({} so far)",
           lastPersisterSuccess.incrementAndGet()
         );

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityRequestHistoryPersister.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityRequestHistoryPersister.java
@@ -179,9 +179,10 @@ public class SingularityRequestHistoryPersister
       );
     } finally {
       if (persisterSuccess.get()) {
+        lastPersisterSuccess.set(System.currentTimeMillis());
         LOG.info(
-          "Request Persister: successful move to history ({} so far)",
-          lastPersisterSuccess.incrementAndGet()
+          "Finished run on request history persist at {}",
+          lastPersisterSuccess.get()
         );
       }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityTaskHistoryPersister.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityTaskHistoryPersister.java
@@ -109,7 +109,7 @@ public class SingularityTaskHistoryPersister
       }
     } finally {
       if (persisterSuccess) {
-        LOG.trace(
+        LOG.info(
           "Task Persister: successful move to history ({} so far)",
           lastPersisterSuccess.incrementAndGet()
         );

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityTaskHistoryPersister.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityTaskHistoryPersister.java
@@ -105,6 +105,14 @@ public class SingularityTaskHistoryPersister
         }
       }
     } finally {
+      if (persisterSuccess) {
+        LOG.trace(
+          "Task Persister: successful move to history ({} so far)",
+          lastPersisterSuccess.incrementAndGet()
+        );
+        persisterSuccess = false;
+      }
+
       persisterLock.unlock();
     }
   }
@@ -188,12 +196,10 @@ public class SingularityTaskHistoryPersister
       LOG.debug("Moving {} to history", object);
       try {
         historyManager.saveTaskHistory(taskHistory.get());
-        LOG.trace(
-          "Task Persister: successful move to history ({} so far)",
-          lastPersisterSuccess.incrementAndGet()
-        );
+        persisterSuccess = true;
       } catch (Throwable t) {
         LOG.warn("Failed to persist task into History for task {}", object, t);
+        persisterSuccess = false;
         return false;
       }
     } else {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityTaskHistoryPersister.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityTaskHistoryPersister.java
@@ -111,7 +111,7 @@ public class SingularityTaskHistoryPersister
       if (persisterSuccess) {
         lastPersisterSuccess.set(System.currentTimeMillis());
         LOG.info(
-          "Finished run on task history persist at {}",
+          "Finished run on task history persister at {}",
           lastPersisterSuccess.get()
         );
       }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityTaskHistoryPersister.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityTaskHistoryPersister.java
@@ -109,9 +109,10 @@ public class SingularityTaskHistoryPersister
       }
     } finally {
       if (persisterSuccess) {
+        lastPersisterSuccess.set(System.currentTimeMillis());
         LOG.info(
-          "Task Persister: successful move to history ({} so far)",
-          lastPersisterSuccess.incrementAndGet()
+          "Finished run on task history persist at {}",
+          lastPersisterSuccess.get()
         );
       }
 


### PR DESCRIPTION
Counter to ensure that zk -> mysql is happening. Every time one of the persisters move their data to history, the counter is logged and increased.