### PR TITLE
Add ability to re-add recovered tasks to the load balancer

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -1137,6 +1137,13 @@ public class TaskManager extends CuratorAsyncManager {
     lbHistory.ifPresent(loadBalancerUpdates::add);
   }
 
+  public void clearLoadBalancerHistory(SingularityTaskId taskId) {
+    delete(getLoadBalancerStatePath(taskId, LoadBalancerRequestType.REMOVE));
+    delete(getLoadBalancerStatePath(taskId, LoadBalancerRequestType.ADD));
+    delete(getLoadBalancerStatePath(taskId, LoadBalancerRequestType.DEPLOY));
+    delete(getLoadBalancerStatePath(taskId, LoadBalancerRequestType.DELETE));
+  }
+
   public boolean hasNotifiedOverdue(SingularityTaskId taskId) {
     return checkExists(getNotifiedOverduePath(taskId)).isPresent();
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosStatusUpdateHandler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosStatusUpdateHandler.java
@@ -381,6 +381,10 @@ public class SingularityMesosStatusUpdateHandler {
           }
           if (
             canRecoverLbState &&
+            deployManager
+              .getActiveDeployId(taskIdObj.getRequestId())
+              .map(d -> d.equals(taskIdObj.getDeployId()))
+              .orElse(false) &&
             taskManager.reactivateTask(
               taskIdObj,
               taskState,
@@ -455,13 +459,18 @@ public class SingularityMesosStatusUpdateHandler {
       }
 
       // Check tasks with no lb component or not yet removed from LB
-      boolean reactivated = taskManager.reactivateTask(
-        taskIdObj,
-        taskState,
-        newTaskStatusHolder,
-        Optional.ofNullable(status.getMessage()),
-        status.hasReason() ? Optional.of(status.getReason().name()) : Optional.empty()
-      );
+      boolean reactivated =
+        deployManager
+          .getActiveDeployId(taskIdObj.getRequestId())
+          .map(d -> d.equals(taskIdObj.getDeployId()))
+          .orElse(false) &&
+        taskManager.reactivateTask(
+          taskIdObj,
+          taskState,
+          newTaskStatusHolder,
+          Optional.ofNullable(status.getMessage()),
+          status.hasReason() ? Optional.of(status.getReason().name()) : Optional.empty()
+        );
       requestManager.addToPendingQueue(
         new SingularityPendingRequest(
           taskIdObj.getRequestId(),

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityNewTaskChecker.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityNewTaskChecker.java
@@ -32,7 +32,6 @@ import com.hubspot.singularity.data.TaskManager;
 import com.hubspot.singularity.hooks.LoadBalancerClient;
 import com.hubspot.singularity.scheduler.SingularityDeployHealthHelper.DeployHealth;
 import com.hubspot.singularity.sentry.SingularityExceptionNotifier;
-import com.hubspot.singularity.smtp.SingularityMailer;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -334,7 +333,7 @@ public class SingularityNewTaskChecker {
     );
   }
 
-  private void enqueueCheckWithDelay(
+  public void enqueueCheckWithDelay(
     final SingularityTask task,
     long delaySeconds,
     SingularityHealthchecker healthchecker

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -4400,7 +4400,9 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
         f -> {
           try {
             f.get(5, TimeUnit.SECONDS);
-          } catch (InterruptedException | ExecutionException | TimeoutException e) {
+          } catch (TimeoutException te) {
+            // Didn't see that....
+          } catch (InterruptedException | ExecutionException e) {
             throw new RuntimeException(e);
           }
         }

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -81,6 +81,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import javax.ws.rs.WebApplicationException;
 import org.apache.mesos.v1.Protos.AgentID;
@@ -4398,8 +4399,8 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
       .forEach(
         f -> {
           try {
-            f.get();
-          } catch (InterruptedException | ExecutionException e) {
+            f.get(5, TimeUnit.SECONDS);
+          } catch (InterruptedException | ExecutionException | TimeoutException e) {
             throw new RuntimeException(e);
           }
         }


### PR DESCRIPTION
Previously our handling of this was to just clean up everything if it was already removed from the load balancer. This PR adds a few things to the reregistration flow:

- Always enqueue a pending request to reevaluate state/scale so that we don't end up with a multiple instance 1s kind of state and get stuck there
- If the task is recoverable in zk (not persisted yet) but has already been removed from the lb. Instead of cleaning it up, treat it as if it were a new healthy task that just finished passing healthchecks. This way we can recover running tasks, especially in cases of large network partitions where relaunching that many new things could take some large amount of time

Updated the unit test for this to make sure the lb pending add is present, but would appreciate extra 👀 on it

cc @pschoenfelder @ajammala @rosalind210 