### PR TITLE
Initialize last persister AtomicLongs to current time

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityHistoryModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityHistoryModule.java
@@ -96,20 +96,20 @@ public class SingularityHistoryModule extends AbstractModule {
   @Singleton
   @Named(LAST_TASK_PERSISTER_SUCCESS)
   public AtomicLong lastTaskPersisterSuccess() {
-    return new AtomicLong();
+    return new AtomicLong(System.currentTimeMillis());
   }
 
   @Provides
   @Singleton
   @Named(LAST_REQUEST_PERSISTER_SUCCESS)
   public AtomicLong lastRequestPersisterSuccess() {
-    return new AtomicLong();
+    return new AtomicLong(System.currentTimeMillis());
   }
 
   @Provides
   @Singleton
   @Named(LAST_DEPLOY_PERSISTER_SUCCESS)
   public AtomicLong lastDeployPersisterSuccess() {
-    return new AtomicLong();
+    return new AtomicLong(System.currentTimeMillis());
   }
 }


### PR DESCRIPTION
Initializing each last persister success AtomicLongs to current time so we don't get alerts. When the metric is first grabbed and initialized to zero, the metric is read as last success in 1970, which triggers an alert.