### PR TITLE
Throw exception to resubscribe to mesos

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerClient.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerClient.java
@@ -196,7 +196,8 @@ public class SingularityMesosSchedulerClient {
     URI mesosMasterURI,
     FrameworkInfo frameworkInfo,
     SingularityMesosScheduler scheduler
-  ) throws URISyntaxException {
+  )
+    throws URISyntaxException {
     MesosClientBuilder<Call, Event> clientBuilder = ProtobufMesosClientBuilder
       .schedulerUsingProtos()
       .mesosUri(mesosMasterURI)

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerClient.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerClient.java
@@ -7,6 +7,7 @@ import com.google.protobuf.ByteString;
 import com.hubspot.mesos.rx.java.AwaitableSubscription;
 import com.hubspot.mesos.rx.java.MesosClient;
 import com.hubspot.mesos.rx.java.MesosClientBuilder;
+import com.hubspot.mesos.rx.java.MesosException;
 import com.hubspot.mesos.rx.java.SinkOperation;
 import com.hubspot.mesos.rx.java.SinkOperations;
 import com.hubspot.mesos.rx.java.protobuf.ProtobufMesosClientBuilder;
@@ -195,8 +196,7 @@ public class SingularityMesosSchedulerClient {
     URI mesosMasterURI,
     FrameworkInfo frameworkInfo,
     SingularityMesosScheduler scheduler
-  )
-    throws URISyntaxException {
+  ) throws URISyntaxException {
     MesosClientBuilder<Call, Event> clientBuilder = ProtobufMesosClientBuilder
       .schedulerUsingProtos()
       .mesosUri(mesosMasterURI)
@@ -383,12 +383,7 @@ public class SingularityMesosSchedulerClient {
 
     String message = t.getMessage();
 
-    if (
-      message != null &&
-      message.equals(
-        "Error while trying to send request. Status: 403 Message: \'Framework is not subscribed\'"
-      )
-    ) {
+    if (t instanceof MesosException && message.contains("403")) {
       return CompletableFuture.runAsync(
         () -> scheduler.onUncaughtException(new PrematureChannelClosureException()),
         executorService

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerClient.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerClient.java
@@ -5,9 +5,9 @@ import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.google.protobuf.ByteString;
 import com.hubspot.mesos.rx.java.AwaitableSubscription;
+import com.hubspot.mesos.rx.java.Mesos4xxException;
 import com.hubspot.mesos.rx.java.MesosClient;
 import com.hubspot.mesos.rx.java.MesosClientBuilder;
-import com.hubspot.mesos.rx.java.MesosException;
 import com.hubspot.mesos.rx.java.SinkOperation;
 import com.hubspot.mesos.rx.java.SinkOperations;
 import com.hubspot.mesos.rx.java.protobuf.ProtobufMesosClientBuilder;
@@ -383,7 +383,7 @@ public class SingularityMesosSchedulerClient {
 
     String message = t.getMessage();
 
-    if (t instanceof MesosException && message.contains("403")) {
+    if (t instanceof Mesos4xxException && message.contains("403")) {
       return CompletableFuture.runAsync(
         () -> scheduler.onUncaughtException(new PrematureChannelClosureException()),
         executorService

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerClientTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerClientTest.java
@@ -1,0 +1,81 @@
+package com.hubspot.singularity.mesos;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import com.hubspot.singularity.SingularityManagedThreadPoolFactory;
+import com.hubspot.singularity.config.SingularityConfiguration;
+import java.lang.reflect.Field;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+
+public class SingularityMesosSchedulerClientTest {
+  private SingularityMesosSchedulerClient client;
+  private ExecutorService executorService;
+  private Exception exception;
+  private SingularityMesosScheduler scheduler;
+
+  @BeforeEach
+  public void setup() {
+    executorService = Mockito.mock(ExecutorService.class);
+    SingularityManagedThreadPoolFactory executorServiceFactory = Mockito.mock(
+      SingularityManagedThreadPoolFactory.class
+    );
+    Mockito
+      .when(executorServiceFactory.get("singularity-mesos-scheduler-client", 1))
+      .thenReturn(executorService);
+
+    client =
+      new SingularityMesosSchedulerClient(
+        Mockito.mock(SingularityConfiguration.class),
+        "test",
+        Mockito.mock(AtomicLong.class),
+        executorServiceFactory
+      );
+
+    scheduler = Mockito.mock(SingularityMesosScheduler.class);
+    exception = Mockito.mock(Exception.class);
+
+    try {
+      Field schedulerField =
+        SingularityMesosSchedulerClient.class.getDeclaredField("scheduler");
+      schedulerField.setAccessible(true);
+      schedulerField.set(client, scheduler);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  public void itCheckAndReconnectThrowsException() {
+    doAnswer(
+        (InvocationOnMock invocation) -> {
+          ((Runnable) invocation.getArguments()[0]).run();
+          return null;
+        }
+      )
+      .when(executorService)
+      .execute(any(Runnable.class));
+
+    Mockito
+      .when(exception.getMessage())
+      .thenReturn(
+        "Error while trying to send request. Status: 403 Message: \'Framework is not subscribed\'"
+      );
+    client.checkAndReconnect(exception).join();
+
+    verify(scheduler, times(1)).onUncaughtException(any());
+  }
+
+  @Test
+  public void itCheckAndReconnectDoesNotThrowsException() {
+    Mockito.when(exception.getMessage()).thenReturn(null);
+    client.checkAndReconnect(exception).join();
+
+    verify(scheduler, never()).onUncaughtException(any());
+  }
+}

--- a/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerClientTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerClientTest.java
@@ -3,6 +3,7 @@ package com.hubspot.singularity.mesos;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import com.hubspot.mesos.rx.java.MesosException;
 import com.hubspot.singularity.SingularityManagedThreadPoolFactory;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import java.lang.reflect.Field;
@@ -16,7 +17,6 @@ import org.mockito.invocation.InvocationOnMock;
 public class SingularityMesosSchedulerClientTest {
   private SingularityMesosSchedulerClient client;
   private ExecutorService executorService;
-  private Exception exception;
   private SingularityMesosScheduler scheduler;
 
   @BeforeEach
@@ -38,7 +38,6 @@ public class SingularityMesosSchedulerClientTest {
       );
 
     scheduler = Mockito.mock(SingularityMesosScheduler.class);
-    exception = Mockito.mock(Exception.class);
 
     try {
       Field schedulerField =
@@ -52,6 +51,8 @@ public class SingularityMesosSchedulerClientTest {
 
   @Test
   public void itCheckAndReconnectThrowsException() {
+    MesosException exception = Mockito.mock(MesosException.class);
+
     doAnswer(
         (InvocationOnMock invocation) -> {
           ((Runnable) invocation.getArguments()[0]).run();
@@ -73,6 +74,8 @@ public class SingularityMesosSchedulerClientTest {
 
   @Test
   public void itCheckAndReconnectDoesNotThrowsException() {
+    RuntimeException exception = Mockito.mock(RuntimeException.class);
+
     Mockito.when(exception.getMessage()).thenReturn(null);
     client.checkAndReconnect(exception).join();
 


### PR DESCRIPTION
Sometimes there's an issue connecting to Mesos master and the alert that went off was a Mesos4xxException, stating that the framework is no longer subscribed to master. When that happens, we want to throw an exception to be picked up by the `SingularityMesosSchedulerImpl` to pause and reconnect. This is done on a separate thread so as to not disrupt the current one.

Unit tests check that the new function checkAndReconnect only attempts a reconnect when the exception is the correct exception.