### PR TITLE
Clean up lifecycle ordering on shutdown

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityAbort.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityAbort.java
@@ -10,6 +10,7 @@ import com.hubspot.mesos.JavaUtils;
 import com.hubspot.singularity.config.SMTPConfiguration;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.managed.SingularityLifecycleManaged;
+import com.hubspot.singularity.managed.SingularityPreJettyLifecycle;
 import com.hubspot.singularity.sentry.SingularityExceptionNotifier;
 import com.hubspot.singularity.smtp.SingularitySmtpSender;
 import java.io.PrintWriter;
@@ -72,7 +73,11 @@ public class SingularityAbort {
         SingularityLifecycleManaged lifecycle = injector.getInstance(
           SingularityLifecycleManaged.class
         );
+        SingularityPreJettyLifecycle preJettyLifecycle = injector.getInstance(
+          SingularityPreJettyLifecycle.class
+        );
         try {
+          preJettyLifecycle.stop();
           lifecycle.stop();
         } catch (Throwable t) {
           LOG.error("While shutting down", t);

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityMainModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityMainModule.java
@@ -46,6 +46,7 @@ import com.hubspot.singularity.hooks.SnsWebhookManager;
 import com.hubspot.singularity.hooks.SnsWebhookRetryer;
 import com.hubspot.singularity.hooks.WebhookQueueType;
 import com.hubspot.singularity.managed.SingularityLifecycleManaged;
+import com.hubspot.singularity.managed.SingularityPreJettyLifecycle;
 import com.hubspot.singularity.mesos.OfferCache;
 import com.hubspot.singularity.mesos.SingularityMesosStatusUpdateHandler;
 import com.hubspot.singularity.mesos.SingularityNoOfferCache;
@@ -209,6 +210,7 @@ public class SingularityMainModule implements Module {
     binder.bind(SingularityMesosStatusUpdateHandler.class).in(Scopes.SINGLETON);
 
     binder.bind(SingularityLifecycleManaged.class).asEagerSingleton();
+    binder.bind(SingularityPreJettyLifecycle.class).asEagerSingleton();
 
     if (configuration.isCacheOffers()) {
       binder.bind(OfferCache.class).to(SingularityOfferCache.class).in(Scopes.SINGLETON);

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityManagedScheduledExecutorServiceFactory.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityManagedScheduledExecutorServiceFactory.java
@@ -12,9 +12,15 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Singleton
 public class SingularityManagedScheduledExecutorServiceFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(
+    SingularityManagedScheduledExecutorServiceFactory.class
+  );
+
   private final AtomicBoolean stopped = new AtomicBoolean();
   private final List<ScheduledExecutorService> executorPools = new ArrayList<>();
 
@@ -68,7 +74,9 @@ public class SingularityManagedScheduledExecutorServiceFactory {
         final long start = System.currentTimeMillis();
 
         if (!service.awaitTermination(timeoutLeftInMillis, TimeUnit.MILLISECONDS)) {
-          return;
+          LOG.warn("Scheduled executor service task did not exit cleanly");
+          service.shutdownNow();
+          continue;
         }
 
         timeoutLeftInMillis -= (System.currentTimeMillis() - start);

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityManagedThreadPoolFactory.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityManagedThreadPoolFactory.java
@@ -93,7 +93,7 @@ public class SingularityManagedThreadPoolFactory {
           final long start = System.currentTimeMillis();
 
           if (!service.awaitTermination(timeoutLeftInMillis, TimeUnit.MILLISECONDS)) {
-            LOG.warn("Eeecutor service tasks did not exit in time");
+            LOG.warn("Executor service tasks did not exit in time");
             continue;
           }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityManagedThreadPoolFactory.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityManagedThreadPoolFactory.java
@@ -12,13 +12,18 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Singleton
 public class SingularityManagedThreadPoolFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(
+    SingularityManagedThreadPoolFactory.class
+  );
+
   private final AtomicBoolean stopped = new AtomicBoolean();
   private final List<ExecutorService> executorPools = new ArrayList<>();
 
@@ -88,7 +93,8 @@ public class SingularityManagedThreadPoolFactory {
           final long start = System.currentTimeMillis();
 
           if (!service.awaitTermination(timeoutLeftInMillis, TimeUnit.MILLISECONDS)) {
-            return;
+            LOG.warn("Eeecutor service tasks did not exit in time");
+            continue;
           }
 
           timeoutLeftInMillis -= (System.currentTimeMillis() - start);

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -308,7 +308,7 @@ public class SingularityConfiguration extends Configuration {
 
   private int coreThreadpoolSize = 8;
 
-  private long threadpoolShutdownDelayInSeconds = 10;
+  private long threadpoolShutdownDelayInSeconds = 20;
 
   @Valid
   @JsonProperty("customExecutor")

--- a/SingularityService/src/main/java/com/hubspot/singularity/managed/SingularityLifecycleManaged.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/managed/SingularityLifecycleManaged.java
@@ -184,13 +184,17 @@ public class SingularityLifecycleManaged implements Managed {
 
   private void stopLeaderLatch() {
     try {
+      String thisId = leaderLatch.getId();
       if (!readOnly) {
         LOG.info("Stopping leader latch");
         leaderLatch.close();
       }
       // Wait until leader change has actually propagated
       long start = System.currentTimeMillis();
-      while (leaderLatch.hasLeadership() && System.currentTimeMillis() - start < 15000) {
+      while (
+        thisId.equals(leaderLatch.getLeader().getId()) &&
+        System.currentTimeMillis() - start < 15000
+      ) {
         LOG.warn("Instance still has leadership, waiting and checking again");
         Thread.sleep(1000);
       }

--- a/SingularityService/src/main/java/com/hubspot/singularity/managed/SingularityPreJettyLifecycle.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/managed/SingularityPreJettyLifecycle.java
@@ -1,0 +1,57 @@
+package com.hubspot.singularity.managed;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import io.dropwizard.lifecycle.Managed;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.eclipse.jetty.util.MultiException;
+import org.eclipse.jetty.util.component.AbstractLifeCycle;
+import org.eclipse.jetty.util.thread.ShutdownThread;
+
+/**
+ * This class runs shutdown hooks before the default Jetty server shutdown hook / lifecycle management.
+ * Actions will be run serially - any exceptions will be swallowed until after all have run.
+ *
+ * This class does not need to be created after the Jetty server.
+ */
+@Singleton
+public class SingularityPreJettyLifecycle extends AbstractLifeCycle implements Managed {
+  private final List<Runnable> hooks;
+  private final AtomicBoolean hasRun;
+
+  @Inject
+  public SingularityPreJettyLifecycle() {
+    this.hooks = new CopyOnWriteArrayList<>();
+    this.hasRun = new AtomicBoolean();
+  }
+
+  @Override
+  protected void doStart() throws Exception {
+    // Registering at index 0 ensures this hook is run first during shutdown.
+    ShutdownThread.register(0, this);
+  }
+
+  @Override
+  protected synchronized void doStop() throws Exception {
+    if (hasRun.get()) {
+      return;
+    }
+
+    MultiException exceptions = new MultiException();
+    for (Runnable hook : hooks) {
+      try {
+        hook.run();
+      } catch (Exception e) {
+        exceptions.add(e);
+      }
+    }
+    hasRun.set(true);
+    exceptions.ifExceptionThrow();
+  }
+
+  public boolean registerShutdownHook(Runnable runnable) {
+    return hooks.add(runnable);
+  }
+}

--- a/SingularityService/src/test/java/com/hubspot/singularity/managed/SingularityLifecycleManagedTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/managed/SingularityLifecycleManagedTest.java
@@ -28,7 +28,8 @@ public class SingularityLifecycleManagedTest extends SingularityLifecycleManaged
     SingularityGraphiteReporter graphiteReporter,
     ExecutorIdGenerator executorIdGenerator,
     Set<SingularityLeaderOnlyPoller> leaderOnlyPollers,
-    SingularityConfiguration configuration
+    SingularityConfiguration configuration,
+    SingularityPreJettyLifecycle preJettyLifecycle
   ) {
     super(
       cachedThreadPoolFactory,
@@ -41,7 +42,8 @@ public class SingularityLifecycleManagedTest extends SingularityLifecycleManaged
       graphiteReporter,
       executorIdGenerator,
       leaderOnlyPollers,
-      configuration
+      configuration,
+      preJettyLifecycle
     );
   }
 


### PR DESCRIPTION
Realized there were a few cases in here where we could possibly still have blips of multiple leaders or no leaders at a time. In particular the following set of events:

- Old leader gets a TERM signal
- Old leader fails to properly wait for all scheduled pollers to exit
- Old leader relinquishes leadership
- New leader gains leadership and starts loading leader cache
- Old leader pollers finish their run, possibly flush more state to zk
- state flushed by old leader is now not in leader cache on new leader

Need to test this a bit, but this adds:
- A specific pre-jetty-shutdown hook so that the leader cleanly moves from the leading instance to a read-only/standby before actually fully shutting down (so that we don't have weird blips in serving writes when leader changes). All pollers should stop in this step
- poll for leadership change to make sure it has propagated
- better/longer wait on running pollers
- log when pollers aren't shut down cleanly