### PR TITLE
Create thread pool that blocks when full

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityManagedThreadPoolFactory.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityManagedThreadPoolFactory.java
@@ -110,7 +110,7 @@ public class SingularityManagedThreadPoolFactory {
     }
   }
 
-  public final class ThreadPoolQueue extends LinkedBlockingQueue<Runnable> {
+  public static final class ThreadPoolQueue extends LinkedBlockingQueue<Runnable> {
 
     public ThreadPoolQueue(int capacity) {
       super(capacity);

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosStatusUpdateHandler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosStatusUpdateHandler.java
@@ -139,7 +139,8 @@ public class SingularityMesosStatusUpdateHandler {
       threadPoolFactory.get(
         "status-updates",
         configuration.getMesosConfiguration().getStatusUpdateConcurrencyLimit(),
-        configuration.getMesosConfiguration().getMaxStatusUpdateQueueSize()
+        configuration.getMesosConfiguration().getMaxStatusUpdateQueueSize(),
+        true
       );
   }
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/helpers/SingularityBlockingThreadPoolTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/helpers/SingularityBlockingThreadPoolTest.java
@@ -1,0 +1,63 @@
+package com.hubspot.singularity.helpers;
+
+import com.hubspot.singularity.SingularityManagedThreadPoolFactory;
+import com.hubspot.singularity.async.ExecutorAndQueue;
+import com.hubspot.singularity.config.SingularityConfiguration;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class SingularityBlockingThreadPoolTest {
+
+  @Test
+  public void testBoundedQueueBlocksWhenFull() {
+    SingularityManagedThreadPoolFactory threadPoolFactory = new SingularityManagedThreadPoolFactory(
+      new SingularityConfiguration()
+    );
+    Assertions.assertThrows(
+      RejectedExecutionException.class,
+      () -> {
+        ExecutorAndQueue executorAndQueue = threadPoolFactory.get("test", 2, 5, false);
+        IntStream
+          .range(0, 10)
+          .forEach(
+            i ->
+              executorAndQueue
+                .getExecutorService()
+                .submit(
+                  () -> {
+                    try {
+                      Thread.sleep(2000);
+                    } catch (InterruptedException ie) {
+                      // didn't see that...
+                    }
+                  }
+                )
+          );
+      }
+    );
+
+    Assertions.assertDoesNotThrow(
+      () -> {
+        ExecutorAndQueue executorAndQueue = threadPoolFactory.get("test", 2, 5, true);
+        IntStream
+          .range(0, 10)
+          .forEach(
+            i ->
+              executorAndQueue
+                .getExecutorService()
+                .submit(
+                  () -> {
+                    try {
+                      Thread.sleep(2000);
+                    } catch (InterruptedException ie) {
+                      // didn't see that...
+                    }
+                  }
+                )
+          );
+      }
+    );
+  }
+}


### PR DESCRIPTION
So, the theory here, is that it will be much better to just block the producing thread (main rxjava thread carrying mesos events) when the status update queue is full than to throw a RejectedExecutionException and abort/restart/bai//etc. If we are falling behind on status updates it's nearly always the case that those have to catch up first before we can do anything else.

Java-y bits added here are a custom ThreadPoolQueue which, because it delegates to put, will block on the put to the underlying queue when full instead of throwing the reject exception