### PR TITLE
Add status queue size accessor for status update handler

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosStatusUpdateHandler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosStatusUpdateHandler.java
@@ -649,6 +649,10 @@ public class SingularityMesosStatusUpdateHandler {
     );
   }
 
+  public int getQueueSize() {
+    return statusUpdatesExecutor.getQueue().size();
+  }
+
   public double getQueueFullness() {
     LOG.info(
       "Queue size: {}, queue limit: {}, queue fullness: {}",


### PR DESCRIPTION
Added an accessor to get the status queue size from the `statusUpdatesExecutor` to gather metrics.