### PR TITLE
Thread and stream clean up

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityManagedThreadPoolFactory.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityManagedThreadPoolFactory.java
@@ -48,8 +48,12 @@ public class SingularityManagedThreadPoolFactory {
 
   public synchronized ExecutorService get(String name, int maxSize) {
     checkState(!stopped.get(), "already stopped");
-    ExecutorService service = Executors.newFixedThreadPool(
+    ExecutorService service = new ThreadPoolExecutor(
+      1,
       maxSize,
+      60L,
+      TimeUnit.SECONDS,
+      new LinkedBlockingQueue<>(),
       new ThreadFactoryBuilder().setNameFormat(name + "-%d").build()
     );
     executorPools.add(service);

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/TaskResource.java
@@ -1395,6 +1395,10 @@ public class TaskResource extends AbstractLeaderAwareResource {
           requestBuilder.execute(this).get();
         } catch (ExecutionException | InterruptedException e) {
           LOG.error("Failed or interrupted while proxying a download from Mesos", e);
+        } finally {
+          if (wrappedOutputStream != null) {
+            wrappedOutputStream.close();
+          }
         }
       }
     }


### PR DESCRIPTION
- Don't start all the threads at once on sized pools (non-scheduler instances were sitting with hundreds of them open and unused)
- Clean up open streams on failed download calls. It looked like we possibly had a leak previously, keeping these open. Unclear if that was the case or not and need to test