### PR TITLE
Lifecycle tweaks for Singularity

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityManagedScheduledExecutorServiceFactory.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityManagedScheduledExecutorServiceFactory.java
@@ -74,22 +74,12 @@ public class SingularityManagedScheduledExecutorServiceFactory {
         closeExecutor(entry.getValue(), timeoutLeftInMillis, entry.getKey());
         timeoutLeftInMillis -= (System.currentTimeMillis() - start);
       }
-      for (Map.Entry<String, ScheduledExecutorService> entry : executorPools.entrySet()) {
-        final long start = System.currentTimeMillis();
-        closeExecutor(entry.getValue(), timeoutLeftInMillis, entry.getKey());
-        timeoutLeftInMillis -= (System.currentTimeMillis() - start);
-      }
     }
   }
 
   public void stopOtherPollers() throws Exception {
     if (!stopped.getAndSet(true)) {
       long timeoutLeftInMillis = timeoutInMillis;
-      for (Map.Entry<String, ScheduledExecutorService> entry : leaderPollerPools.entrySet()) {
-        final long start = System.currentTimeMillis();
-        closeExecutor(entry.getValue(), timeoutLeftInMillis, entry.getKey());
-        timeoutLeftInMillis -= (System.currentTimeMillis() - start);
-      }
       for (Map.Entry<String, ScheduledExecutorService> entry : executorPools.entrySet()) {
         final long start = System.currentTimeMillis();
         closeExecutor(entry.getValue(), timeoutLeftInMillis, entry.getKey());

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -440,7 +440,9 @@ public class TaskManager extends CuratorAsyncManager {
   public SingularityCreateResult savePendingTask(SingularityPendingTask task) {
     final String pendingPath = getPendingPath(task.getPendingTaskId());
 
-    leaderCache.savePendingTask(task);
+    if (leaderCache.active()) {
+      leaderCache.savePendingTask(task);
+    }
 
     return save(pendingPath, task, pendingTaskTranscoder);
   }
@@ -1384,6 +1386,7 @@ public class TaskManager extends CuratorAsyncManager {
         .and()
         .commit();
 
+      // Not checking isActive here, already called within offer check flow
       leaderCache.putActiveTask(task.getTaskId());
       taskCache.set(path, task);
     } catch (KeeperException.NodeExistsException nee) {
@@ -1451,7 +1454,9 @@ public class TaskManager extends CuratorAsyncManager {
 
   @Timed
   public SingularityDeleteResult deleteLastActiveTaskStatus(SingularityTaskId taskId) {
-    leaderCache.deleteActiveTaskId(taskId);
+    if (leaderCache.active()) {
+      leaderCache.deleteActiveTaskId(taskId);
+    }
     return delete(getLastActiveTaskStatusPath(taskId));
   }
 
@@ -1547,7 +1552,9 @@ public class TaskManager extends CuratorAsyncManager {
 
   public SingularityCreateResult saveTaskCleanup(SingularityTaskCleanup cleanup) {
     saveTaskHistoryUpdate(cleanup);
-    leaderCache.saveTaskCleanup(cleanup);
+    if (leaderCache.active()) {
+      leaderCache.saveTaskCleanup(cleanup);
+    }
     return save(
       getCleanupPath(cleanup.getTaskId().getId()),
       cleanup,
@@ -1581,7 +1588,9 @@ public class TaskManager extends CuratorAsyncManager {
   }
 
   public SingularityCreateResult createTaskCleanup(SingularityTaskCleanup cleanup) {
-    leaderCache.createTaskCleanupIfNotExists(cleanup);
+    if (leaderCache.active()) {
+      leaderCache.createTaskCleanupIfNotExists(cleanup);
+    }
     final SingularityCreateResult result = create(
       getCleanupPath(cleanup.getTaskId().getId()),
       cleanup,
@@ -1596,13 +1605,17 @@ public class TaskManager extends CuratorAsyncManager {
   }
 
   public void deletePendingTask(SingularityPendingTaskId pendingTaskId) {
-    leaderCache.deletePendingTask(pendingTaskId);
+    if (leaderCache.active()) {
+      leaderCache.deletePendingTask(pendingTaskId);
+    }
     delete(getPendingPath(pendingTaskId));
     delete(getPendingTasksToDeletePath(pendingTaskId));
   }
 
   public void markPendingTaskForDeletion(SingularityPendingTaskId pendingTaskId) {
-    leaderCache.markPendingTaskForDeletion(pendingTaskId);
+    if (leaderCache.active()) {
+      leaderCache.markPendingTaskForDeletion(pendingTaskId);
+    }
     create(getPendingTasksToDeletePath(pendingTaskId));
   }
 
@@ -1615,7 +1628,9 @@ public class TaskManager extends CuratorAsyncManager {
   }
 
   public void deleteCleanupTask(String taskId) {
-    leaderCache.deleteTaskCleanup(SingularityTaskId.valueOf(taskId));
+    if (leaderCache.active()) {
+      leaderCache.deleteTaskCleanup(SingularityTaskId.valueOf(taskId));
+    }
     delete(getCleanupPath(taskId));
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/managed/SingularityLifecycleManaged.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/managed/SingularityLifecycleManaged.java
@@ -119,7 +119,7 @@ public class SingularityLifecycleManaged implements Managed {
   @Override
   public void stop() throws Exception {
     if (!stopped.getAndSet(true)) {
-      scheduledExecutorServiceFactory.stopLeaderPollers();
+      stopOtherExecutors();
       stopCurator(); // disconnect from zk
       stopGraphiteReporter();
     } else {

--- a/SingularityService/src/main/java/com/hubspot/singularity/managed/SingularityLifecycleManaged.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/managed/SingularityLifecycleManaged.java
@@ -119,6 +119,7 @@ public class SingularityLifecycleManaged implements Managed {
   @Override
   public void stop() throws Exception {
     if (!stopped.getAndSet(true)) {
+      scheduledExecutorServiceFactory.stopLeaderPollers();
       stopCurator(); // disconnect from zk
       stopGraphiteReporter();
     } else {
@@ -156,9 +157,19 @@ public class SingularityLifecycleManaged implements Managed {
 
   private void stopExecutors() {
     try {
-      LOG.info("Stopping pollers and executors");
+      LOG.info("Stopping leader pollers and executors");
       cachedThreadPoolFactory.stop();
-      scheduledExecutorServiceFactory.stop();
+      scheduledExecutorServiceFactory.stopLeaderPollers();
+    } catch (Throwable t) {
+      LOG.warn("Could not stop scheduled executors ({})}", t.getMessage());
+    }
+  }
+
+  // Post jetty stop, these can be hit on request paths still
+  private void stopOtherExecutors() {
+    try {
+      LOG.info("Stopping pollers and executors");
+      scheduledExecutorServiceFactory.stopOtherPollers();
     } catch (Throwable t) {
       LOG.warn("Could not stop scheduled executors ({})}", t.getMessage());
     }

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
@@ -527,14 +527,13 @@ public class SingularityCleaner {
               CompletableFuture.runAsync(
                 () ->
                   lock.runWithRequestLock(
-                    () -> {
+                    () ->
                       processRequestCleanup(
                         start,
                         numTasksKilled,
                         numScheduledTasksRemoved,
                         requestCleanup
-                      );
-                    },
+                      ),
                     requestCleanup.getRequestId(),
                     String.format(
                       "%s#%s",

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCache.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCache.java
@@ -67,7 +67,7 @@ public class SingularityLeaderCache {
     active = true;
     bootstrapping = false;
     synchronized (syncObject) {
-      syncObject.notify();
+      syncObject.notifyAll();
     }
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCacheCoordinator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderCacheCoordinator.java
@@ -56,6 +56,7 @@ public class SingularityLeaderCacheCoordinator {
       6,
       new ThreadFactoryBuilder().setNameFormat("leader-cache-%d").build()
     );
+    leaderCache.startBootstrap();
     CompletableFutures
       .allOf(
         ImmutableList.of(

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderOnlyPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityLeaderOnlyPoller.java
@@ -47,7 +47,7 @@ public abstract class SingularityLeaderOnlyPoller {
     SingularityAbort abort,
     SingularityMesosScheduler mesosScheduler
   ) {
-    this.executorService = executorServiceFactory.get(getClass().getSimpleName());
+    this.executorService = executorServiceFactory.get(getClass().getSimpleName(), true);
     this.leaderLatch = checkNotNull(leaderLatch, "leaderLatch is null");
     this.exceptionNotifier = checkNotNull(exceptionNotifier, "exceptionNotifier is null");
     this.abort = checkNotNull(abort, "abort is null");

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityTaskReconciliationPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityTaskReconciliationPoller.java
@@ -42,4 +42,10 @@ public class SingularityTaskReconciliationPoller extends SingularityLeaderOnlyPo
       taskReconciliation.startReconciliation();
     }
   }
+
+  @Override
+  public void stop() {
+    taskReconciliation.cancelReconciliation();
+    super.stop();
+  }
 }

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityLeaderCacheTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityLeaderCacheTest.java
@@ -1,0 +1,35 @@
+package com.hubspot.singularity.scheduler;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class SingularityLeaderCacheTest {
+
+  @Test
+  public void testBlockWhileBootstrapping() throws Exception {
+    SingularityLeaderCache leaderCache = new SingularityLeaderCache();
+    AtomicBoolean reachedTheEnd = new AtomicBoolean(false);
+    ExecutorService executorService = Executors.newSingleThreadExecutor();
+    Runnable testRun = () -> {
+      if (leaderCache.active()) {
+        reachedTheEnd.set(true);
+      }
+    };
+
+    // Should now block anything calling leaderCache.active() until bootstrap done
+    leaderCache.startBootstrap();
+    CompletableFuture.runAsync(testRun, executorService);
+    Assertions.assertFalse(reachedTheEnd.get());
+    Thread.sleep(200); // just in case
+    Assertions.assertFalse(reachedTheEnd.get());
+
+    // should notify any waiting and unblock
+    leaderCache.activate();
+    Thread.sleep(200);
+    Assertions.assertTrue(reachedTheEnd.get());
+  }
+}


### PR DESCRIPTION
Small one:
- Make sure to cancel in progress task reconciliation on shutdown

Bigger one:
Currently when a new leader takes over we can hit an order of events like the following:
- Gains leadership
- Other api instances see this and start sending writes to new leader
- leader cache bootstrapping starts
- leader cache bootstrapping loads type X (e.g. requests, deploys, etc) but is not yet activated
- Writes make it through to zk, but not to leader cache because active() is false
- leader cache finishes bootstrapping

We now have a case of a write for type X that made it to ZK, but not to the leader cache. This can result in missing deploy data, missing requests, requests that are present but actually were deleted, etc.

The new PR here adds an additional check within active() that should serve to block the calling thread when bootstrapping of the leader cache is still in progress. So, we will delay all incoming writes and wait for this to finish, rather than trying to reconcile state afterwards.

Would like feedback on the java-y bits here for sure:
- Is this performant enough during regular operation? In staring it down it should just be one additional if statement on a volatile boolean
- Any race conditions where the calling thread could get stuck permanently? I think I covered this with the while loop and synchronized objects, but want to be sure