### PR TITLE
Wire up the ability for SingularityExecutor to compress arbitrary sandbox files

### DIFF
--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorCompressAdditionalFile.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorCompressAdditionalFile.java
@@ -1,0 +1,35 @@
+package com.hubspot.singularity.executor.config;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.hubspot.singularity.runner.base.shared.CompressionType;
+import java.util.Optional;
+
+public class SingularityExecutorCompressAdditionalFile {
+  private final Optional<String> directory;
+  private final String filenameGlob;
+  private final CompressionType compressionType;
+
+  @JsonCreator
+  public SingularityExecutorCompressAdditionalFile(
+    @JsonProperty("directory") String directory,
+    @JsonProperty("filenameGlob") String filenameGlob,
+    @JsonProperty("compressionType") CompressionType compressionType
+  ) {
+    this.directory = Optional.ofNullable(directory);
+    this.filenameGlob = filenameGlob;
+    this.compressionType = compressionType;
+  }
+
+  public Optional<String> getDirectory() {
+    return directory;
+  }
+
+  public String getFilenameGlob() {
+    return filenameGlob;
+  }
+
+  public CompressionType getCompressionType() {
+    return compressionType;
+  }
+}

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/config/SingularityExecutorConfiguration.java
@@ -136,6 +136,10 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
   @JsonProperty
   private List<SingularityExecutorLogrotateAdditionalFile> logrotateAdditionalFiles = Collections.emptyList();
 
+  @NotNull
+  @JsonProperty
+  private List<SingularityExecutorCompressAdditionalFile> compressAdditionalFiles = Collections.emptyList();
+
   @Min(1)
   @JsonProperty
   private int tailLogLinesToSave = 2500;
@@ -291,6 +295,16 @@ public class SingularityExecutorConfiguration extends BaseRunnerConfiguration {
     List<SingularityExecutorLogrotateAdditionalFile> logrotateAdditionalFiles
   ) {
     this.logrotateAdditionalFiles = logrotateAdditionalFiles;
+  }
+
+  public List<SingularityExecutorCompressAdditionalFile> getCompressAdditionalFiles() {
+    return compressAdditionalFiles;
+  }
+
+  public void setCompressAdditionalFiles(
+    List<SingularityExecutorCompressAdditionalFile> compressAdditionalFiles
+  ) {
+    this.compressAdditionalFiles = compressAdditionalFiles;
   }
 
   public String getExecutorJavaLog() {

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskLogManager.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskLogManager.java
@@ -256,7 +256,7 @@ public class SingularityExecutorTaskLogManager {
             return;
           }
 
-          if (pathMatcher.matches(path)) {
+          if (pathMatcher.matches(path.getFileName())) {
             toCompress.add(new SimpleEntry<>(path, file.getCompressionType()));
           }
         }

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskLogManager.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskLogManager.java
@@ -250,7 +250,7 @@ public class SingularityExecutorTaskLogManager {
             Stream
               .of(CompressionType.values())
               .map(CompressionType::getExtention)
-              .anyMatch(path::endsWith)
+              .anyMatch(ext -> path.toString().endsWith(ext))
           ) {
             // already compressed
             return;

--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskLogManager.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/task/SingularityExecutorTaskLogManager.java
@@ -246,6 +246,16 @@ public class SingularityExecutorTaskLogManager {
             return;
           }
 
+          if (
+            Stream
+              .of(CompressionType.values())
+              .map(CompressionType::getExtention)
+              .anyMatch(path::endsWith)
+          ) {
+            // already compressed
+            return;
+          }
+
           if (pathMatcher.matches(path)) {
             toCompress.add(new SimpleEntry<>(path, file.getCompressionType()));
           }


### PR DESCRIPTION
An example SingularityExecutor config that leverages this feature might look like:
```
executor:
  compressAdditionalFiles:
  - directory: logs
    filenameGlob: some.rotated.log.*
    compressionType: GZIP
```