### PR TITLE
Also check if a task is a killed task in rack placements

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityAgentAndRackManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityAgentAndRackManager.java
@@ -190,10 +190,9 @@ public class SingularityAgentAndRackManager {
     Collection<SingularityTaskId> cleaningTasks = leaderCache.getCleanupTaskIds();
 
     for (SingularityTaskId taskId : activeTaskIdsForRequest) {
-      // TODO consider using executorIds
-
       if (
         !cleaningTasks.contains(taskId) &&
+        !taskManager.isKilledTask(taskId) &&
         taskRequest.getDeploy().getId().equals(taskId.getDeployId())
       ) {
         countPerRack.add(taskId.getSanitizedRackId());


### PR DESCRIPTION
We would previously wait until tasks that were cleaned -> killed -> still shutting down exited before actually scheduling a new pending task due to rack placement issues. This also removes tasks that are already killed from the counts fo rack placement as well as those in cleaning state