### PR TITLE
S3Uploader aws client usage efficiency

### DIFF
--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/S3ClientProvider.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/S3ClientProvider.java
@@ -1,0 +1,56 @@
+package com.hubspot.singularity.s3uploader;
+
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Singleton
+public class S3ClientProvider {
+  private static final Logger LOG = LoggerFactory.getLogger(S3ClientProvider.class);
+
+  private final Map<String, AmazonS3> clientByKey;
+  private final Map<String, AtomicInteger> clientHolds;
+
+  @Inject
+  public S3ClientProvider() {
+    this.clientByKey = new HashMap<>();
+    this.clientHolds = new HashMap<>();
+  }
+
+  public synchronized AmazonS3 getClient(BasicAWSCredentials credentials) {
+    String key = credsToKey(credentials);
+    AmazonS3 s3 = clientByKey.computeIfAbsent(key, k -> new AmazonS3Client(credentials));
+    clientHolds.computeIfAbsent(key, k -> new AtomicInteger(0)).incrementAndGet();
+    return s3;
+  }
+
+  public synchronized void returnClient(BasicAWSCredentials credentials) {
+    String key = credsToKey(credentials);
+    AtomicInteger holds = clientHolds.get(key);
+    if (holds == null) {
+      LOG.error("Client returned before being checked out!");
+    } else {
+      int remaining = holds.decrementAndGet();
+      if (remaining == 0) {
+        clientHolds.remove(key);
+        clientByKey.remove(key);
+      }
+    }
+  }
+
+  public static String credsToKey(BasicAWSCredentials credentials) {
+    // BasicAWSCredentials doesn't implement any sort of hash code, use this
+    return String.format(
+      "%s%s",
+      credentials.getAWSAccessKeyId(),
+      credentials.getAWSSecretKey()
+    );
+  }
+}

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3UploaderDriver.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityS3UploaderDriver.java
@@ -74,6 +74,7 @@ public class SingularityS3UploaderDriver
   private final Set<SingularityUploader> expiring;
   private final SingularityS3UploaderMetrics metrics;
   private final JsonObjectFileHelper jsonObjectFileHelper;
+  private final S3ClientProvider s3ClientProvider;
   private final ProcessUtils processUtils;
   private final String hostname;
   private final SingularityRunnerExceptionNotifier exceptionNotifier;
@@ -91,6 +92,7 @@ public class SingularityS3UploaderDriver
     SingularityS3Configuration s3Configuration,
     SingularityS3UploaderMetrics metrics,
     JsonObjectFileHelper jsonObjectFileHelper,
+    S3ClientProvider s3ClientProvider,
     @Named(SingularityRunnerBaseModule.HOST_NAME_PROPERTY) String hostname,
     SingularityRunnerExceptionNotifier exceptionNotifier
   ) {
@@ -110,6 +112,7 @@ public class SingularityS3UploaderDriver
     this.fileSystem = FileSystems.getDefault();
 
     this.jsonObjectFileHelper = jsonObjectFileHelper;
+    this.s3ClientProvider = s3ClientProvider;
     this.configuration = configuration;
 
     this.metadataToUploader = Maps.newHashMap();
@@ -679,6 +682,7 @@ public class SingularityS3UploaderDriver
         uploader =
           new SingularityS3Uploader(
             bucketCreds.orElse(defaultCredentials),
+            s3ClientProvider,
             metadata,
             fileSystem,
             metrics,

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityUploader.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/SingularityUploader.java
@@ -28,6 +28,7 @@ import java.nio.file.Paths;
 import java.nio.file.attribute.UserDefinedFileAttributeView;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -76,7 +77,7 @@ public abstract class SingularityUploader {
           fileSystem.getPathMatcher("glob:" + uploadMetadata.getOnFinishGlob().get())
         );
     } else {
-      finishedPathMatcher = Optional.<PathMatcher>empty();
+      finishedPathMatcher = Optional.empty();
     }
 
     this.hostname = hostname;
@@ -371,40 +372,22 @@ public abstract class SingularityUploader {
 
     SingularityS3Uploader that = (SingularityS3Uploader) o;
 
-    if (
-      uploadMetadata != null
-        ? !uploadMetadata.equals(that.uploadMetadata)
-        : that.uploadMetadata != null
-    ) {
+    if (!Objects.equals(uploadMetadata, that.uploadMetadata)) {
       return false;
     }
-    if (
-      fileDirectory != null
-        ? !fileDirectory.equals(that.fileDirectory)
-        : that.fileDirectory != null
-    ) {
+    if (!Objects.equals(fileDirectory, that.fileDirectory)) {
       return false;
     }
-    if (
-      bucketName != null ? !bucketName.equals(that.bucketName) : that.bucketName != null
-    ) {
+    if (!Objects.equals(bucketName, that.bucketName)) {
       return false;
     }
-    if (
-      metadataPath != null
-        ? !metadataPath.equals(that.metadataPath)
-        : that.metadataPath != null
-    ) {
+    if (!Objects.equals(metadataPath, that.metadataPath)) {
       return false;
     }
-    if (
-      logIdentifier != null
-        ? !logIdentifier.equals(that.logIdentifier)
-        : that.logIdentifier != null
-    ) {
+    if (!Objects.equals(logIdentifier, that.logIdentifier)) {
       return false;
     }
-    return hostname != null ? hostname.equals(that.hostname) : that.hostname == null;
+    return Objects.equals(hostname, that.hostname);
   }
 
   @Override

--- a/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/config/SingularityS3UploaderModule.java
+++ b/SingularityS3Uploader/src/main/java/com/hubspot/singularity/s3uploader/config/SingularityS3UploaderModule.java
@@ -1,8 +1,10 @@
 package com.hubspot.singularity.s3uploader.config;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.Scopes;
 import com.hubspot.singularity.runner.base.shared.SingularityDriver;
 import com.hubspot.singularity.s3.base.SingularityS3BaseModule;
+import com.hubspot.singularity.s3uploader.S3ClientProvider;
 import com.hubspot.singularity.s3uploader.SingularityS3UploaderDriver;
 
 public class SingularityS3UploaderModule extends AbstractModule {
@@ -11,5 +13,6 @@ public class SingularityS3UploaderModule extends AbstractModule {
   protected void configure() {
     install(new SingularityS3BaseModule());
     bind(SingularityDriver.class).to(SingularityS3UploaderDriver.class);
+    bind(S3ClientProvider.class).in(Scopes.SINGLETON);
   }
 }


### PR DESCRIPTION
Previously we spun up one client per S3Uploader object, since they often have separate creds. However, many are shared, and duplicates become a problem when we start hitting thousands of uploader objects.

Open questions:
- Should there be some sort of cool down period before I junk a client so we aren't recreating too often?
- Keying on the string concat of creds feels dirty, but BasicAwsCredentials doesn't implement hashCode, thoughts? It's not logged anywhere, and the BasicAwsCreds are already in memory like that elsewhere obviously, just felt weird to write 🤷 


cc @baconmania 