### PR TITLE
Add extension to agent decom

### DIFF
--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
@@ -136,6 +136,8 @@ public class SingularityClient {
   private static final String AGENT_DETAIL_FORMAT = AGENTS_FORMAT + "/agent/%s/details";
   private static final String AGENTS_DECOMISSION_FORMAT =
     AGENTS_FORMAT + "/agent/%s/decommission";
+  private static final String EXTEND_AGENTS_DECOMISSION_FORMAT =
+    AGENTS_FORMAT + "/agent/%s/decommission/extend";
   private static final String AGENTS_FREEZE_FORMAT = AGENTS_FORMAT + "/agent/%s/freeze";
   private static final String AGENTS_ACTIVATE_FORMAT =
     AGENTS_FORMAT + "/agent/%s/activate";
@@ -1166,12 +1168,12 @@ public class SingularityClient {
       String.format(DELETE_DEPLOY_FORMAT, getApiBase(host), deployId, requestId);
 
     SingularityRequestParent singularityRequestParent = delete(
-        requestUri,
-        "pending deploy",
-        new SingularityDeployKey(requestId, deployId).getId(),
-        Optional.empty(),
-        Optional.of(SingularityRequestParent.class)
-      )
+      requestUri,
+      "pending deploy",
+      new SingularityDeployKey(requestId, deployId).getId(),
+      Optional.empty(),
+      Optional.of(SingularityRequestParent.class)
+    )
       .get();
 
     return getAndLogRequestAndDeployStatus(singularityRequestParent);
@@ -1412,12 +1414,12 @@ public class SingularityClient {
       String.format(TASKS_GET_ACTIVE_STATES_FORMAT, getApiBase(host));
 
     return getSingleWithParams(
-        requestUri,
-        "active tasks ids",
-        "all",
-        Optional.empty(),
-        new TypeReference<Map<SingularityTaskId, List<SingularityTaskHistoryUpdate>>>() {}
-      )
+      requestUri,
+      "active tasks ids",
+      "all",
+      Optional.empty(),
+      new TypeReference<Map<SingularityTaskId, List<SingularityTaskHistoryUpdate>>>() {}
+    )
       .orElse(Collections.emptyMap());
   }
 
@@ -1523,11 +1525,11 @@ public class SingularityClient {
       String.format(SHELL_COMMAND_FORMAT, getApiBase(host), taskId);
 
     return post(
-        requestUri,
-        "start shell command",
-        Optional.of(shellCommand),
-        Optional.of(SingularityTaskShellCommandRequest.class)
-      )
+      requestUri,
+      "start shell command",
+      Optional.of(shellCommand),
+      Optional.of(SingularityTaskShellCommandRequest.class)
+    )
       .orElse(null);
   }
 
@@ -1714,6 +1716,20 @@ public class SingularityClient {
     post(
       requestUri,
       String.format("decommission agent %s", agentId),
+      Optional.of(machineChangeRequest.orElse(SingularityMachineChangeRequest.empty()))
+    );
+  }
+
+  public void extendDecommissionedAgent(
+    String agentId,
+    Optional<SingularityMachineChangeRequest> machineChangeRequest
+  ) {
+    final Function<String, String> requestUri = host ->
+      String.format(EXTEND_AGENTS_DECOMISSION_FORMAT, getApiBase(host), agentId);
+
+    post(
+      requestUri,
+      String.format("extend decommission agent %s", agentId),
       Optional.of(machineChangeRequest.orElse(SingularityMachineChangeRequest.empty()))
     );
   }

--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
@@ -1168,12 +1168,12 @@ public class SingularityClient {
       String.format(DELETE_DEPLOY_FORMAT, getApiBase(host), deployId, requestId);
 
     SingularityRequestParent singularityRequestParent = delete(
-      requestUri,
-      "pending deploy",
-      new SingularityDeployKey(requestId, deployId).getId(),
-      Optional.empty(),
-      Optional.of(SingularityRequestParent.class)
-    )
+        requestUri,
+        "pending deploy",
+        new SingularityDeployKey(requestId, deployId).getId(),
+        Optional.empty(),
+        Optional.of(SingularityRequestParent.class)
+      )
       .get();
 
     return getAndLogRequestAndDeployStatus(singularityRequestParent);
@@ -1414,12 +1414,12 @@ public class SingularityClient {
       String.format(TASKS_GET_ACTIVE_STATES_FORMAT, getApiBase(host));
 
     return getSingleWithParams(
-      requestUri,
-      "active tasks ids",
-      "all",
-      Optional.empty(),
-      new TypeReference<Map<SingularityTaskId, List<SingularityTaskHistoryUpdate>>>() {}
-    )
+        requestUri,
+        "active tasks ids",
+        "all",
+        Optional.empty(),
+        new TypeReference<Map<SingularityTaskId, List<SingularityTaskHistoryUpdate>>>() {}
+      )
       .orElse(Collections.emptyMap());
   }
 
@@ -1525,11 +1525,11 @@ public class SingularityClient {
       String.format(SHELL_COMMAND_FORMAT, getApiBase(host), taskId);
 
     return post(
-      requestUri,
-      "start shell command",
-      Optional.of(shellCommand),
-      Optional.of(SingularityTaskShellCommandRequest.class)
-    )
+        requestUri,
+        "start shell command",
+        Optional.of(shellCommand),
+        Optional.of(SingularityTaskShellCommandRequest.class)
+      )
       .orElse(null);
   }
 

--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
@@ -136,8 +136,8 @@ public class SingularityClient {
   private static final String AGENT_DETAIL_FORMAT = AGENTS_FORMAT + "/agent/%s/details";
   private static final String AGENTS_DECOMISSION_FORMAT =
     AGENTS_FORMAT + "/agent/%s/decommission";
-  private static final String EXTEND_AGENTS_DECOMISSION_FORMAT =
-    AGENTS_FORMAT + "/agent/%s/decommission/extend";
+  private static final String UPDATE_AGENTS_DECOMISSION_FORMAT =
+    AGENTS_FORMAT + "/agent/%s/decommission/update";
   private static final String AGENTS_FREEZE_FORMAT = AGENTS_FORMAT + "/agent/%s/freeze";
   private static final String AGENTS_ACTIVATE_FORMAT =
     AGENTS_FORMAT + "/agent/%s/activate";
@@ -1720,16 +1720,16 @@ public class SingularityClient {
     );
   }
 
-  public void extendDecommissionedAgent(
+  public void updateDecommissionedAgent(
     String agentId,
     Optional<SingularityMachineChangeRequest> machineChangeRequest
   ) {
     final Function<String, String> requestUri = host ->
-      String.format(EXTEND_AGENTS_DECOMISSION_FORMAT, getApiBase(host), agentId);
+      String.format(UPDATE_AGENTS_DECOMISSION_FORMAT, getApiBase(host), agentId);
 
     post(
       requestUri,
-      String.format("extend decommission agent %s", agentId),
+      String.format("update decommission agent %s", agentId),
       Optional.of(machineChangeRequest.orElse(SingularityMachineChangeRequest.empty()))
     );
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractMachineResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractMachineResource.java
@@ -132,6 +132,24 @@ public abstract class AbstractMachineResource<T extends SingularityMachineAbstra
     saveExpiring(decommissionRequest, user, objectId);
   }
 
+  public void updateDecommissionAgent(
+    SingularityUser user,
+    String agentId,
+    SingularityMachineChangeRequest changeRequest
+  ) {
+    authorizationHelper.checkAdminAuthorization(user);
+    final Optional<SingularityMachineChangeRequest> maybeChangeRequest = Optional.ofNullable(
+      changeRequest
+    );
+    validator.checkActionEnabled(SingularityAction.ACTIVATE_AGENT);
+    validator.checkActionEnabled(SingularityAction.DECOMMISSION_AGENT);
+
+    if (manager.getExpiringObject(agentId).isPresent()) {
+      manager.deleteExpiringObject(agentId);
+      saveExpiring(maybeChangeRequest, user, agentId);
+    }
+  }
+
   protected void freeze(
     String objectId,
     Optional<SingularityMachineChangeRequest> freezeRequest,
@@ -166,7 +184,7 @@ public abstract class AbstractMachineResource<T extends SingularityMachineAbstra
     saveExpiring(activateRequest, user, objectId);
   }
 
-  protected void saveExpiring(
+  private void saveExpiring(
     Optional<SingularityMachineChangeRequest> changeRequest,
     SingularityUser user,
     String objectId

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractMachineResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/AbstractMachineResource.java
@@ -166,7 +166,7 @@ public abstract class AbstractMachineResource<T extends SingularityMachineAbstra
     saveExpiring(activateRequest, user, objectId);
   }
 
-  private void saveExpiring(
+  protected void saveExpiring(
     Optional<SingularityMachineChangeRequest> changeRequest,
     SingularityUser user,
     String objectId

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/AgentResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/AgentResource.java
@@ -207,7 +207,10 @@ public class AgentResource extends AbstractMachineResource<SingularityAgent> {
       changeRequest
     );
 
-    super.saveExpiring(maybeChangeRequest, user, agentId);
+    if (manager.getExpiringObject(agentId).isPresent()) {
+      manager.deleteExpiringObject(agentId);
+      super.saveExpiring(maybeChangeRequest, user, agentId);
+    }
   }
 
   @POST

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/AgentResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/AgentResource.java
@@ -174,10 +174,10 @@ public class AgentResource extends AbstractMachineResource<SingularityAgent> {
   }
 
   @POST
-  @Path("/agent/{agentId}/decommission/extend")
-  @Operation(summary = "Extend decommission time of a specific active agent")
+  @Path("/agent/{agentId}/decommission/update")
+  @Operation(summary = "Update decommission of a specific active agent")
   @Consumes({ MediaType.APPLICATION_JSON })
-  public Response extendDecommissionAgent(
+  public Response updateDecommissionAgent(
     @Context HttpServletRequest requestContext,
     @Parameter(hidden = true) @Auth SingularityUser user,
     @Parameter(required = true, description = "Active agentId") @PathParam(
@@ -192,26 +192,10 @@ public class AgentResource extends AbstractMachineResource<SingularityAgent> {
       Response.class,
       changeRequest,
       () -> {
-        extendDecommissionAgent(user, agentId, changeRequest);
+        super.updateDecommissionAgent(user, agentId, changeRequest);
         return Response.ok().build();
       }
     );
-  }
-
-  public void extendDecommissionAgent(
-    SingularityUser user,
-    String agentId,
-    SingularityMachineChangeRequest changeRequest
-  ) {
-    authorizationHelper.checkAdminAuthorization(user);
-    final Optional<SingularityMachineChangeRequest> maybeChangeRequest = Optional.ofNullable(
-      changeRequest
-    );
-
-    if (manager.getExpiringObject(agentId).isPresent()) {
-      manager.deleteExpiringObject(agentId);
-      super.saveExpiring(maybeChangeRequest, user, agentId);
-    }
   }
 
   @POST

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/AgentResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/AgentResource.java
@@ -174,6 +174,43 @@ public class AgentResource extends AbstractMachineResource<SingularityAgent> {
   }
 
   @POST
+  @Path("/agent/{agentId}/decommission/extend")
+  @Operation(summary = "Extend decommission time of a specific active agent")
+  @Consumes({ MediaType.APPLICATION_JSON })
+  public Response extendDecommissionAgent(
+    @Context HttpServletRequest requestContext,
+    @Parameter(hidden = true) @Auth SingularityUser user,
+    @Parameter(required = true, description = "Active agentId") @PathParam(
+      "agentId"
+    ) String agentId,
+    @RequestBody(
+      description = "Settings related to changing the state of a agent"
+    ) SingularityMachineChangeRequest changeRequest
+  ) {
+    return maybeProxyToLeader(
+      requestContext,
+      Response.class,
+      changeRequest,
+      () -> {
+        extendDecommissionAgent(user, agentId, changeRequest);
+        return Response.ok().build();
+      }
+    );
+  }
+
+  public void extendDecommissionAgent(
+    SingularityUser user,
+    String agentId,
+    SingularityMachineChangeRequest changeRequest
+  ) {
+    final Optional<SingularityMachineChangeRequest> maybeChangeRequest = Optional.ofNullable(
+      changeRequest
+    );
+
+    super.saveExpiring(maybeChangeRequest, user, agentId);
+  }
+
+  @POST
   @Path("/agent/{agentId}/freeze")
   @Operation(summary = "Freeze tasks on a specific agent")
   @Consumes({ MediaType.APPLICATION_JSON })

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/AgentResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/AgentResource.java
@@ -203,6 +203,7 @@ public class AgentResource extends AbstractMachineResource<SingularityAgent> {
     String agentId,
     SingularityMachineChangeRequest changeRequest
   ) {
+    authorizationHelper.checkAdminAuthorization(user);
     final Optional<SingularityMachineChangeRequest> maybeChangeRequest = Optional.ofNullable(
       changeRequest
     );


### PR DESCRIPTION
We have been experiencing decommissioned agents coming back online too early. This endpoint will allow us to extend the decommission time if the agent isn't ready.