### PR TITLE
Add taskId to loadbalancer upstream

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/LoadBalancerUpstream.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/LoadBalancerUpstream.java
@@ -11,23 +11,27 @@ public class LoadBalancerUpstream {
   private final String upstream;
   private final String group;
   private final Optional<String> rackId;
+  private final Optional<String> taskId;
 
   @JsonCreator
   public LoadBalancerUpstream(
     @JsonProperty("upstream") String upstream,
     @JsonProperty("group") String group,
-    @JsonProperty("rackId") Optional<String> rackId
+    @JsonProperty("rackId") Optional<String> rackId,
+    @JsonProperty("taskId") Optional<String> taskId
   ) {
     this.upstream = upstream;
     this.group = group;
     this.rackId = rackId;
+    this.taskId = taskId;
   }
 
   public static LoadBalancerUpstream fromBaragonUpstream(UpstreamInfo upstreamInfo) {
     return new LoadBalancerUpstream(
       upstreamInfo.getUpstream(),
       upstreamInfo.getGroup(),
-      upstreamInfo.getRackId().toJavaUtil()
+      upstreamInfo.getRackId().toJavaUtil(),
+      Optional.empty()
     );
   }
 
@@ -41,6 +45,10 @@ public class LoadBalancerUpstream {
 
   public Optional<String> getRackId() {
     return rackId;
+  }
+
+  public Optional<String> getTaskId() {
+    return taskId;
   }
 
   @Override

--- a/SingularityService/src/main/java/com/hubspot/singularity/hooks/LoadBalancerClient.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/hooks/LoadBalancerClient.java
@@ -123,7 +123,12 @@ public abstract class LoadBalancerClient {
         }
 
         upstreams.add(
-          new LoadBalancerUpstream(upstream, group.orElse("default"), task.getRackId())
+          new LoadBalancerUpstream(
+            upstream,
+            group.orElse("default"),
+            task.getRackId(),
+            Optional.of(task.getTaskId().getId())
+          )
         );
       } else {
         LOG.warn(


### PR DESCRIPTION
Allows partitioning loadbalancer upstreams per deploy.

@pschoenfelder 