### PR TITLE
Caffeine cache for request api

### DIFF
--- a/SingularityService/pom.xml
+++ b/SingularityService/pom.xml
@@ -510,6 +510,11 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityServiceModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityServiceModule.java
@@ -35,7 +35,8 @@ import java.util.concurrent.TimeUnit;
 
 public class SingularityServiceModule
   extends DropwizardAwareModule<SingularityConfiguration> {
-  public static final String REQUESTS_CAFFEINE_CACHE = "requests_caffeine_cache";
+  public static final String REQUESTS_CAFFEINE_CACHE =
+    "singularity.service.resources.request";
   private final Function<SingularityConfiguration, Module> dbModuleProvider;
   private Optional<Class<? extends LoadBalancerClient>> lbClientClass = Optional.empty();
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityServiceModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityServiceModule.java
@@ -4,7 +4,6 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.base.Function;
 import com.google.inject.Binder;
-import com.google.inject.Inject;
 import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
@@ -138,11 +137,10 @@ public class SingularityServiceModule
 
   @Provides
   @Singleton
-  @Inject
   @Named(REQUESTS_CAFFEINE_CACHE)
-  public Cache<String, List<SingularityRequestParent>> getRequestsCaffeineCache(
-    SingularityConfiguration configuration
-  ) {
+  public Cache<String, List<SingularityRequestParent>> getRequestsCaffeineCache() {
+    SingularityConfiguration configuration = getConfiguration();
+
     return Caffeine
       .newBuilder()
       .expireAfterWrite(configuration.getCaffeineCacheTtl(), TimeUnit.SECONDS)

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -2076,7 +2076,7 @@ public class SingularityConfiguration extends Configuration {
     this.statusQueueNearlyFull = statusQueueNearlyFull;
   }
 
-  public boolean isUseCaffeineCache() {
+  public boolean useCaffeineCache() {
     return useCaffeineCache;
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -443,6 +443,12 @@ public class SingularityConfiguration extends Configuration {
   // For blocking queue reconciliation if the queue is too full
   private double statusQueueNearlyFull = 0.8;
 
+  // Enable caffeine cache on heavily requested endpoint
+  private boolean useCaffeineCache = false;
+
+  // Caffeine cache ttl
+  private int caffeineCacheTtl = 1;
+
   public long getAskDriverToKillTasksAgainAfterMillis() {
     return askDriverToKillTasksAgainAfterMillis;
   }
@@ -2068,5 +2074,21 @@ public class SingularityConfiguration extends Configuration {
 
   public void setStatusQueueNearlyFull(double statusQueueNearlyFull) {
     this.statusQueueNearlyFull = statusQueueNearlyFull;
+  }
+
+  public boolean isUseCaffeineCache() {
+    return useCaffeineCache;
+  }
+
+  public void setUseCaffeineCache(boolean useCaffeineCache) {
+    this.useCaffeineCache = useCaffeineCache;
+  }
+
+  public int getCaffeineCacheTtl() {
+    return caffeineCacheTtl;
+  }
+
+  public void setCaffeineCacheTtl(int caffeineCacheTtl) {
+    this.caffeineCacheTtl = caffeineCacheTtl;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -1484,6 +1484,8 @@ public class RequestResource extends AbstractRequestResource {
       List<SingularityRequestParent> cachedRequests = requestsCache.getIfPresent(key);
 
       if (cachedRequests != null) {
+        LOG.info("Grabbed getRequests value for {} from cache", key);
+
         return cachedRequests;
       }
     }
@@ -1503,6 +1505,8 @@ public class RequestResource extends AbstractRequestResource {
 
     if (useCaffeineCache(useWebCache)) {
       requestsCache.put(key, requests);
+
+      LOG.info("Setting getRequests value for {} in cache", key);
     }
 
     return requests;

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -1480,7 +1480,7 @@ public class RequestResource extends AbstractRequestResource {
       limit,
       requestTypes
     );
-    if (!useWebCache(useWebCache)) {
+    if (useCaffeineCache(useWebCache)) {
       List<SingularityRequestParent> cachedRequests = requestsCache.getIfPresent(key);
 
       if (cachedRequests != null) {
@@ -1501,9 +1501,15 @@ public class RequestResource extends AbstractRequestResource {
       requestTypes
     );
 
-    requestsCache.put(key, requests);
+    if (useCaffeineCache(useWebCache)) {
+      requestsCache.put(key, requests);
+    }
 
     return requests;
+  }
+
+  private boolean useCaffeineCache(boolean useWebCache) {
+    return !useWebCache(useWebCache) && configuration.useCaffeineCache();
   }
 
   private String getRequestCacheKey(

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -1480,7 +1480,7 @@ public class RequestResource extends AbstractRequestResource {
       limit,
       requestTypes
     );
-    if (useCaffeineCache(useWebCache)) {
+    if (!useWebCache(useWebCache) && configuration.useCaffeineCache()) {
       List<SingularityRequestParent> cachedRequests = requestsCache.getIfPresent(key);
 
       if (cachedRequests != null) {
@@ -1503,17 +1503,13 @@ public class RequestResource extends AbstractRequestResource {
       requestTypes
     );
 
-    if (useCaffeineCache(useWebCache)) {
+    if (!useWebCache(useWebCache) && configuration.useCaffeineCache()) {
       requestsCache.put(key, requests);
 
       LOG.info("Setting getRequests value for {} in cache", key);
     }
 
     return requests;
-  }
-
-  private boolean useCaffeineCache(boolean useWebCache) {
-    return !useWebCache(useWebCache) && configuration.useCaffeineCache();
   }
 
   private String getRequestCacheKey(

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -6,7 +6,6 @@ import static com.hubspot.singularity.WebExceptions.checkNotNullBadRequest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -5,6 +5,8 @@ import static com.hubspot.singularity.WebExceptions.checkConflict;
 import static com.hubspot.singularity.WebExceptions.checkNotNullBadRequest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
@@ -86,6 +88,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
@@ -120,6 +123,7 @@ public class RequestResource extends AbstractRequestResource {
   private final SingularityConfiguration configuration;
   private final SingularityExceptionNotifier exceptionNotifier;
   private final SingularityAgentAndRackManager agentAndRackManager;
+  private final Cache<String, List<SingularityRequestParent>> requestsCache;
 
   @Inject
   public RequestResource(
@@ -157,6 +161,12 @@ public class RequestResource extends AbstractRequestResource {
     this.configuration = configuration;
     this.exceptionNotifier = exceptionNotifier;
     this.agentAndRackManager = agentAndRackManager;
+
+    this.requestsCache =
+      Caffeine
+        .newBuilder()
+        .expireAfterWrite(configuration.getCaffeineCacheTtl(), TimeUnit.SECONDS)
+        .build();
   }
 
   private void submitRequest(
@@ -1463,7 +1473,22 @@ public class RequestResource extends AbstractRequestResource {
       "requestType"
     ) List<RequestType> requestTypes
   ) {
-    return requestHelper.fillDataForRequestsAndFilter(
+    String key = getRequestCacheKey(
+      user.getId(),
+      filterRelevantForUser,
+      includeFullRequestData,
+      limit,
+      requestTypes
+    );
+    if (!useWebCache(useWebCache)) {
+      List<SingularityRequestParent> cachedRequests = requestsCache.getIfPresent(key);
+
+      if (cachedRequests != null) {
+        return cachedRequests;
+      }
+    }
+
+    List<SingularityRequestParent> requests = requestHelper.fillDataForRequestsAndFilter(
       filterAutorized(
         requestManager.getRequests(useWebCache(useWebCache)),
         SingularityAuthorizationScope.READ,
@@ -1475,6 +1500,37 @@ public class RequestResource extends AbstractRequestResource {
       Optional.ofNullable(limit),
       requestTypes
     );
+
+    requestsCache.put(key, requests);
+
+    return requests;
+  }
+
+  private String getRequestCacheKey(
+    String id,
+    Boolean filterRelevantForUser,
+    Boolean includeFullRequestData,
+    Integer limit,
+    List<RequestType> requestTypes
+  ) {
+    StringBuilder key = new StringBuilder(id);
+
+    if (filterRelevantForUser != null) {
+      key.append("_").append(filterRelevantForUser);
+    }
+    if (includeFullRequestData != null) {
+      key.append("_").append(includeFullRequestData);
+    }
+    if (limit != null) {
+      key.append("_").append(limit);
+    }
+    if (!requestTypes.isEmpty()) {
+      for (RequestType type : requestTypes) {
+        key.append("_").append(type.name());
+      }
+    }
+
+    return key.toString();
   }
 
   private boolean valueOrFalse(Boolean input) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -1483,7 +1483,7 @@ public class RequestResource extends AbstractRequestResource {
       List<SingularityRequestParent> cachedRequests = requestsCache.getIfPresent(key);
 
       if (cachedRequests != null) {
-        LOG.info("Grabbed getRequests value for {} from cache", key);
+        LOG.trace("Grabbed getRequests value for {} from cache", key);
 
         return cachedRequests;
       }
@@ -1505,7 +1505,7 @@ public class RequestResource extends AbstractRequestResource {
     if (!useWebCache(useWebCache) && configuration.useCaffeineCache()) {
       requestsCache.put(key, requests);
 
-      LOG.info("Setting getRequests value for {} in cache", key);
+      LOG.trace("Setting getRequests value for {} in cache", key);
     }
 
     return requests;

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -1521,15 +1521,16 @@ public class RequestResource extends AbstractRequestResource {
     StringBuilder key = new StringBuilder(id);
 
     if (filterRelevantForUser != null) {
-      key.append("_").append(filterRelevantForUser);
+      key.append("_filter_").append(filterRelevantForUser);
     }
     if (includeFullRequestData != null) {
-      key.append("_").append(includeFullRequestData);
+      key.append("_fullRequestData_").append(includeFullRequestData);
     }
     if (limit != null) {
-      key.append("_").append(limit);
+      key.append("_limit_").append(limit);
     }
     if (!requestTypes.isEmpty()) {
+      key.append("_types_");
       for (RequestType type : requestTypes) {
         key.append("_").append(type.name());
       }

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityTestModule.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityTestModule.java
@@ -9,6 +9,8 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.net.HostAndPort;
@@ -18,10 +20,13 @@ import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.OutOfScopeException;
 import com.google.inject.Provider;
+import com.google.inject.Provides;
 import com.google.inject.Scopes;
+import com.google.inject.Singleton;
 import com.google.inject.Stage;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.Multibinder;
+import com.google.inject.name.Named;
 import com.google.inject.util.Modules;
 import com.hubspot.dropwizard.guicier.DropwizardModule;
 import com.hubspot.dropwizard.guicier.GuiceBundle;
@@ -30,6 +35,8 @@ import com.hubspot.mesos.client.MesosClient;
 import com.hubspot.singularity.SingularityAbort;
 import com.hubspot.singularity.SingularityLeaderController;
 import com.hubspot.singularity.SingularityMainModule;
+import com.hubspot.singularity.SingularityRequestParent;
+import com.hubspot.singularity.SingularityServiceModule;
 import com.hubspot.singularity.SingularityTestAuthenticator;
 import com.hubspot.singularity.auth.SingularityAuthorizer;
 import com.hubspot.singularity.auth.SingularityGroupsAuthorizer;
@@ -68,8 +75,10 @@ import com.hubspot.singularity.sentry.SingularityExceptionNotifier;
 import com.hubspot.singularity.smtp.SingularityMailer;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.setup.Environment;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import javax.servlet.http.HttpServletRequest;
 import net.kencochrane.raven.Raven;
@@ -202,7 +211,6 @@ public class SingularityTestModule implements Module {
 
               binder.bind(ObjectMapper.class).toInstance(om);
               binder.bind(Environment.class).toInstance(environment);
-
               binder
                 .bind(HostAndPort.class)
                 .annotatedWith(named(HTTP_HOST_AND_PORT))
@@ -333,5 +341,12 @@ public class SingularityTestModule implements Module {
     config.setConsiderTaskHealthyAfterRunningForSeconds(0);
 
     return config;
+  }
+
+  @Provides
+  @Singleton
+  @Named(SingularityServiceModule.REQUESTS_CAFFEINE_CACHE)
+  public Cache<String, List<SingularityRequestParent>> getRequestsCaffeineCache() {
+    return Caffeine.newBuilder().expireAfterWrite(1, TimeUnit.SECONDS).build();
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -757,6 +757,12 @@
         <scope>test</scope>
       </dependency>
 
+      <dependency>
+        <groupId>com.github.ben-manes.caffeine</groupId>
+        <artifactId>caffeine</artifactId>
+        <version>3.0.2</version>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -760,7 +760,7 @@
       <dependency>
         <groupId>com.github.ben-manes.caffeine</groupId>
         <artifactId>caffeine</artifactId>
-        <version>3.0.2</version>
+        <version>2.6.0</version>
       </dependency>
 
     </dependencies>


### PR DESCRIPTION
In response to Singularity experiencing slowness due to one endpoint getting hammered, we want the ability to cache a request value for at least a second to have some de-bouncing. To do this, we are using CaffeineCache with an expireAfterWrite of one second that can be re-configured to another value if necessary.

Open question: should the cache be in the resource file or somewhere nested in the `RequestManager` and `RequestHelper`?