### PR TITLE
Fix possible port collisions across tasks

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
@@ -597,10 +597,7 @@ public class SingularityMesosOfferScheduler {
                               scorePerOffer.get(bestOffer.getAgentId()),
                               bestOffer.getSanitizedHost()
                             );
-                            acceptTask(
-                              bestOffer,
-                              taskRequestHolder
-                            );
+                            acceptTask(bestOffer, taskRequestHolder);
                             tasksScheduled.getAndIncrement();
                             updateAgentUsageScores(
                               taskRequestHolder,

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
@@ -597,12 +597,11 @@ public class SingularityMesosOfferScheduler {
                               scorePerOffer.get(bestOffer.getAgentId()),
                               bestOffer.getSanitizedHost()
                             );
-                            SingularityMesosTaskHolder taskHolder = acceptTask(
+                            acceptTask(
                               bestOffer,
                               taskRequestHolder
                             );
                             tasksScheduled.getAndIncrement();
-                            bestOffer.addMatchedTask(taskHolder);
                             updateAgentUsageScores(
                               taskRequestHolder,
                               currentUsagesById,
@@ -999,7 +998,11 @@ public class SingularityMesosOfferScheduler {
     return score;
   }
 
-  private SingularityMesosTaskHolder acceptTask(
+  // This method is synchronized to avoid resource reuse within a single offer.
+  // Decisions about resources to use, specifically ports are made during the buildTask call, however
+  // these resources aren't subtracted from the offer until the addMatchedTask call, making this method
+  // not thread safe
+  private synchronized void acceptTask(
     SingularityOfferHolder offerHolder,
     SingularityTaskRequestHolder taskRequestHolder
   ) {
@@ -1023,7 +1026,7 @@ public class SingularityMesosOfferScheduler {
     );
 
     taskManager.createTaskAndDeletePendingTask(zkTask);
-    return taskHolder;
+    offerHolder.addMatchedTask(taskHolder);
   }
 
   private boolean isTooManyInstancesForRequest(


### PR DESCRIPTION
There was a subtle race condition here since we thread out across TaskHolder objects, not across OfferHolder objects when constructing tasks to submit to the master. This makes it possible that two `buildTask` calls are running at once, before either of them calls addMatchedTask on the offer holder. The former of those grabs ports to assign to a task, while the latter subtracts the assigned ports from the offer resources so they aren't used a second time. Obviously not safe to run in parallel :doh:. Moved that all into the acceptTask method and marked as synchronized