### PR TITLE
Curator framework improvements

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/data/curator/SingularityCuratorFramework.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/curator/SingularityCuratorFramework.java
@@ -50,7 +50,7 @@ public class SingularityCuratorFramework implements CuratorFramework {
 
   @Override
   public CuratorFrameworkState getState() {
-    return null;
+    return distributor.getCuratorFramework().getState();
   }
 
   @Override
@@ -60,127 +60,133 @@ public class SingularityCuratorFramework implements CuratorFramework {
 
   @Override
   public CreateBuilder create() {
-    return null;
+    return distributor.getCuratorFramework().create();
   }
 
   @Override
   public DeleteBuilder delete() {
-    return null;
+    return distributor.getCuratorFramework().delete();
   }
 
   @Override
   public ExistsBuilder checkExists() {
-    return null;
+    return distributor.getCuratorFramework().checkExists();
   }
 
   @Override
   public GetDataBuilder getData() {
-    return null;
+    return distributor.getCuratorFramework().getData();
   }
 
   @Override
   public SetDataBuilder setData() {
-    return null;
+    return distributor.getCuratorFramework().setData();
   }
 
   @Override
   public GetChildrenBuilder getChildren() {
-    return null;
+    return distributor.getCuratorFramework().getChildren();
   }
 
   @Override
   public GetACLBuilder getACL() {
-    return null;
+    return distributor.getCuratorFramework().getACL();
   }
 
   @Override
   public SetACLBuilder setACL() {
-    return null;
+    return distributor.getCuratorFramework().setACL();
   }
 
   @Override
   public ReconfigBuilder reconfig() {
-    return null;
+    return distributor.getCuratorFramework().reconfig();
   }
 
   @Override
   public GetConfigBuilder getConfig() {
-    return null;
+    return distributor.getCuratorFramework().getConfig();
   }
 
   @Override
   public CuratorTransaction inTransaction() {
-    return null;
+    return distributor.getCuratorFramework().inTransaction();
   }
 
   @Override
   public CuratorMultiTransaction transaction() {
-    return null;
+    return distributor.getCuratorFramework().transaction();
   }
 
   @Override
   public TransactionOp transactionOp() {
-    return null;
+    return distributor.getCuratorFramework().transactionOp();
   }
 
   @Override
-  public void sync(String path, Object backgroundContextObject) {}
+  public void sync(String path, Object backgroundContextObject) {
+    distributor.getCuratorFramework().sync(path, backgroundContextObject);
+  }
 
   @Override
-  public void createContainers(String path) throws Exception {}
+  public void createContainers(String path) throws Exception {
+    distributor.getCuratorFramework().createContainers(path);
+  }
 
   @Override
   public SyncBuilder sync() {
-    return null;
+    return distributor.getCuratorFramework().sync();
   }
 
   @Override
   public RemoveWatchesBuilder watches() {
-    return null;
+    return distributor.getCuratorFramework().watches();
   }
 
   @Override
   public Listenable<ConnectionStateListener> getConnectionStateListenable() {
-    return null;
+    return distributor.getCuratorFramework().getConnectionStateListenable();
   }
 
   @Override
   public Listenable<CuratorListener> getCuratorListenable() {
-    return null;
+    return distributor.getCuratorFramework().getCuratorListenable();
   }
 
   @Override
   public Listenable<UnhandledErrorListener> getUnhandledErrorListenable() {
-    return null;
+    return distributor.getCuratorFramework().getUnhandledErrorListenable();
   }
 
   @Override
   public CuratorFramework nonNamespaceView() {
-    return null;
+    return distributor.getCuratorFramework().nonNamespaceView();
   }
 
   @Override
   public CuratorFramework usingNamespace(String newNamespace) {
-    return null;
+    return distributor.getCuratorFramework().usingNamespace(newNamespace);
   }
 
   @Override
   public String getNamespace() {
-    return null;
+    return distributor.getCuratorFramework().getNamespace();
   }
 
   @Override
   public CuratorZookeeperClient getZookeeperClient() {
-    return null;
+    return distributor.getCuratorFramework().getZookeeperClient();
   }
 
   @Override
   public EnsurePath newNamespaceAwareEnsurePath(String path) {
-    return null;
+    return distributor.getCuratorFramework().newNamespaceAwareEnsurePath(path);
   }
 
   @Override
-  public void clearWatcherReferences(Watcher watcher) {}
+  public void clearWatcherReferences(Watcher watcher) {
+    distributor.getCuratorFramework().clearWatcherReferences(watcher);
+  }
 
   @Override
   public boolean blockUntilConnected(int maxWaitTime, TimeUnit units)
@@ -193,31 +199,31 @@ public class SingularityCuratorFramework implements CuratorFramework {
 
   @Override
   public WatcherRemoveCuratorFramework newWatcherRemoveCuratorFramework() {
-    return null;
+    return distributor.getCuratorFramework().newWatcherRemoveCuratorFramework();
   }
 
   @Override
   public ConnectionStateErrorPolicy getConnectionStateErrorPolicy() {
-    return null;
+    return distributor.getCuratorFramework().getConnectionStateErrorPolicy();
   }
 
   @Override
   public QuorumVerifier getCurrentConfig() {
-    return null;
+    return distributor.getCuratorFramework().getCurrentConfig();
   }
 
   @Override
   public SchemaSet getSchemaSet() {
-    return null;
+    return distributor.getCuratorFramework().getSchemaSet();
   }
 
   @Override
   public boolean isZk34CompatibilityMode() {
-    return false;
+    return distributor.getCuratorFramework().isZk34CompatibilityMode();
   }
 
   @Override
   public CompletableFuture<Void> runSafe(Runnable runnable) {
-    return null;
+    return distributor.getCuratorFramework().runSafe(runnable);
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/curator/SingularityCuratorFramework.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/curator/SingularityCuratorFramework.java
@@ -1,0 +1,223 @@
+package com.hubspot.singularity.data.curator;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.apache.curator.CuratorZookeeperClient;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.WatcherRemoveCuratorFramework;
+import org.apache.curator.framework.api.CreateBuilder;
+import org.apache.curator.framework.api.CuratorListener;
+import org.apache.curator.framework.api.DeleteBuilder;
+import org.apache.curator.framework.api.ExistsBuilder;
+import org.apache.curator.framework.api.GetACLBuilder;
+import org.apache.curator.framework.api.GetChildrenBuilder;
+import org.apache.curator.framework.api.GetConfigBuilder;
+import org.apache.curator.framework.api.GetDataBuilder;
+import org.apache.curator.framework.api.ReconfigBuilder;
+import org.apache.curator.framework.api.RemoveWatchesBuilder;
+import org.apache.curator.framework.api.SetACLBuilder;
+import org.apache.curator.framework.api.SetDataBuilder;
+import org.apache.curator.framework.api.SyncBuilder;
+import org.apache.curator.framework.api.UnhandledErrorListener;
+import org.apache.curator.framework.api.transaction.CuratorMultiTransaction;
+import org.apache.curator.framework.api.transaction.CuratorTransaction;
+import org.apache.curator.framework.api.transaction.TransactionOp;
+import org.apache.curator.framework.imps.CuratorFrameworkState;
+import org.apache.curator.framework.listen.Listenable;
+import org.apache.curator.framework.schema.SchemaSet;
+import org.apache.curator.framework.state.ConnectionStateErrorPolicy;
+import org.apache.curator.framework.state.ConnectionStateListener;
+import org.apache.curator.utils.EnsurePath;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.server.quorum.flexible.QuorumVerifier;
+
+public class SingularityCuratorFramework implements CuratorFramework {
+  private final ZkClientsLoadDistributor distributor;
+
+  public SingularityCuratorFramework(ZkClientsLoadDistributor distributor) {
+    this.distributor = distributor;
+  }
+
+  @Override
+  public void start() {
+    distributor.start();
+  }
+
+  @Override
+  public void close() {
+    distributor.close();
+  }
+
+  @Override
+  public CuratorFrameworkState getState() {
+    return null;
+  }
+
+  @Override
+  public boolean isStarted() {
+    return false;
+  }
+
+  @Override
+  public CreateBuilder create() {
+    return null;
+  }
+
+  @Override
+  public DeleteBuilder delete() {
+    return null;
+  }
+
+  @Override
+  public ExistsBuilder checkExists() {
+    return null;
+  }
+
+  @Override
+  public GetDataBuilder getData() {
+    return null;
+  }
+
+  @Override
+  public SetDataBuilder setData() {
+    return null;
+  }
+
+  @Override
+  public GetChildrenBuilder getChildren() {
+    return null;
+  }
+
+  @Override
+  public GetACLBuilder getACL() {
+    return null;
+  }
+
+  @Override
+  public SetACLBuilder setACL() {
+    return null;
+  }
+
+  @Override
+  public ReconfigBuilder reconfig() {
+    return null;
+  }
+
+  @Override
+  public GetConfigBuilder getConfig() {
+    return null;
+  }
+
+  @Override
+  public CuratorTransaction inTransaction() {
+    return null;
+  }
+
+  @Override
+  public CuratorMultiTransaction transaction() {
+    return null;
+  }
+
+  @Override
+  public TransactionOp transactionOp() {
+    return null;
+  }
+
+  @Override
+  public void sync(String path, Object backgroundContextObject) {}
+
+  @Override
+  public void createContainers(String path) throws Exception {}
+
+  @Override
+  public SyncBuilder sync() {
+    return null;
+  }
+
+  @Override
+  public RemoveWatchesBuilder watches() {
+    return null;
+  }
+
+  @Override
+  public Listenable<ConnectionStateListener> getConnectionStateListenable() {
+    return null;
+  }
+
+  @Override
+  public Listenable<CuratorListener> getCuratorListenable() {
+    return null;
+  }
+
+  @Override
+  public Listenable<UnhandledErrorListener> getUnhandledErrorListenable() {
+    return null;
+  }
+
+  @Override
+  public CuratorFramework nonNamespaceView() {
+    return null;
+  }
+
+  @Override
+  public CuratorFramework usingNamespace(String newNamespace) {
+    return null;
+  }
+
+  @Override
+  public String getNamespace() {
+    return null;
+  }
+
+  @Override
+  public CuratorZookeeperClient getZookeeperClient() {
+    return null;
+  }
+
+  @Override
+  public EnsurePath newNamespaceAwareEnsurePath(String path) {
+    return null;
+  }
+
+  @Override
+  public void clearWatcherReferences(Watcher watcher) {}
+
+  @Override
+  public boolean blockUntilConnected(int maxWaitTime, TimeUnit units)
+    throws InterruptedException {
+    return false;
+  }
+
+  @Override
+  public void blockUntilConnected() throws InterruptedException {}
+
+  @Override
+  public WatcherRemoveCuratorFramework newWatcherRemoveCuratorFramework() {
+    return null;
+  }
+
+  @Override
+  public ConnectionStateErrorPolicy getConnectionStateErrorPolicy() {
+    return null;
+  }
+
+  @Override
+  public QuorumVerifier getCurrentConfig() {
+    return null;
+  }
+
+  @Override
+  public SchemaSet getSchemaSet() {
+    return null;
+  }
+
+  @Override
+  public boolean isZk34CompatibilityMode() {
+    return false;
+  }
+
+  @Override
+  public CompletableFuture<Void> runSafe(Runnable runnable) {
+    return null;
+  }
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/curator/ZkClientsLoadDistributor.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/curator/ZkClientsLoadDistributor.java
@@ -1,0 +1,16 @@
+package com.hubspot.singularity.data.curator;
+
+import java.util.List;
+import org.apache.curator.framework.CuratorFramework;
+
+public class ZkClientsLoadDistributor {
+  private final List<CuratorFramework> curatorFrameworks;
+
+  public ZkClientsLoadDistributor(List<CuratorFramework> curatorFrameworks) {
+    this.curatorFrameworks = curatorFrameworks;
+  }
+
+  public void start() {}
+
+  public void close() {}
+}

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/curator/ZkClientsLoadDistributor.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/curator/ZkClientsLoadDistributor.java
@@ -29,4 +29,8 @@ public class ZkClientsLoadDistributor {
   public CuratorFramework getCuratorFramework() {
     return iterator.next();
   }
+
+  public List<CuratorFramework> getAll() {
+    return this.curatorFrameworks;
+  }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/curator/ZkClientsLoadDistributor.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/curator/ZkClientsLoadDistributor.java
@@ -1,16 +1,32 @@
 package com.hubspot.singularity.data.curator;
 
+import com.google.common.collect.Iterators;
+import java.util.Iterator;
 import java.util.List;
 import org.apache.curator.framework.CuratorFramework;
 
 public class ZkClientsLoadDistributor {
   private final List<CuratorFramework> curatorFrameworks;
+  private final Iterator<CuratorFramework> iterator;
 
   public ZkClientsLoadDistributor(List<CuratorFramework> curatorFrameworks) {
     this.curatorFrameworks = curatorFrameworks;
+    this.iterator = Iterators.cycle(curatorFrameworks);
   }
 
-  public void start() {}
+  public void start() {
+    for (CuratorFramework framework : curatorFrameworks) {
+      framework.start();
+    }
+  }
 
-  public void close() {}
+  public void close() {
+    for (CuratorFramework framework : curatorFrameworks) {
+      framework.close();
+    }
+  }
+
+  public CuratorFramework getCuratorFramework() {
+    return iterator.next();
+  }
 }


### PR DESCRIPTION
Currently we use a single instance of CuratorFramework for the entire service. This PR adds a way to create multiple instances of CuratorFramework and wrap them behind a load distributor (using round robin scheduling). 