### PR TITLE
Fix possible port collisions across tasks again

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
@@ -1042,10 +1042,11 @@ public class SingularityMesosOfferScheduler {
 
     LOG.trace("Accepted and built task {}", zkTask);
     LOG.info(
-      "Launching task {} slot on agent {} ({})",
+      "Launching task {} slot on agent {} ({}) with resources: {}",
       taskHolder.getTask().getTaskId(),
       offerHolder.getAgentId(),
-      offerHolder.getHostname()
+      offerHolder.getHostname(),
+      taskHolder.getMesosTask().getResourcesList()
     );
 
     taskManager.createTaskAndDeletePendingTask(zkTask);

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
@@ -1042,11 +1042,16 @@ public class SingularityMesosOfferScheduler {
 
     LOG.trace("Accepted and built task {}", zkTask);
     LOG.info(
-      "Launching task {} slot on agent {} ({}) with resources: {}",
+      "Launching task {} slot on agent {} ({})",
       taskHolder.getTask().getTaskId(),
       offerHolder.getAgentId(),
-      offerHolder.getHostname(),
-      taskHolder.getMesosTask().getResourcesList()
+      offerHolder.getHostname()
+    );
+    LOG.info(
+      "Task {} offer resource usage: {} / {}",
+      taskHolder.getTask().getTaskId(),
+      taskHolder.getMesosTask().getResourcesList(),
+      offerHolder.getCurrentResources()
     );
 
     taskManager.createTaskAndDeletePendingTask(zkTask);

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerClient.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerClient.java
@@ -2,6 +2,7 @@ package com.hubspot.singularity.mesos;
 
 import com.google.common.base.Throwables;
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import com.google.protobuf.ByteString;
 import com.hubspot.mesos.rx.java.AwaitableSubscription;
@@ -61,6 +62,7 @@ import rx.subjects.SerializedSubject;
  * <p>
  * http://mesos.apache.org/documentation/latest/scheduler-http-api/
  */
+@Singleton
 public class SingularityMesosSchedulerClient {
   private static final Logger LOG = LoggerFactory.getLogger(
     SingularityMesosSchedulerClient.class

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/MesosUtilsTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/MesosUtilsTest.java
@@ -183,12 +183,47 @@ public class MesosUtilsTest {
       )
     );
 
-    // TODO - mesos utils expects but does not validate that subtraction of resources produces valid results
+    // TODO - mesos utils expects but does not validate that subtraction arguments produce positive/valid results
     Assertions.assertNotEquals(
       createResources(3, 60, "23:23", "100:100", "103:1000"),
       MesosUtils.subtractResources(
         createResources(5, 100, "23:23", "100:1000"),
         createResources(2, 40, "24:24", "101:102")
+      )
+    );
+  }
+
+  @Test
+  public void testSubtractDuplicatePorts() {
+    // TODO - if an offer were to have duplicate port ranges, subtraction will not dedup
+    Assertions.assertEquals(
+      createResources(3, 60, "23:23", "100:100", "103:1000", "100:100", "103:1000"),
+      MesosUtils.subtractResources(
+        createResources(5, 100, "23:23", "23:23", "100:1000", "100:1000"),
+        createResources(2, 40, "23:23", "101:102")
+      )
+    );
+  }
+
+  @Test
+  public void testCombineDuplicatePorts() {
+    Assertions.assertEquals(
+      createResources(7, 140, "23:23", "100:1000"),
+      MesosUtils.combineResources(
+        Arrays.asList(
+          createResources(5, 100, "23:23", "100:1000"),
+          createResources(2, 40, "23:23", "100:420")
+        )
+      )
+    );
+
+    Assertions.assertEquals(
+      createResources(7, 140, "23:23", "24:24", "25:32", "100:1000"),
+      MesosUtils.combineResources(
+        Arrays.asList(
+          createResources(5, 100, "23:23", "25:30", "100:1000"),
+          createResources(2, 40, "23:23", "24:24", "27:32", "100:420")
+        )
       )
     );
   }

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/MesosUtilsTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/MesosUtilsTest.java
@@ -163,30 +163,55 @@ public class MesosUtilsTest {
     );
   }
 
+  @Test
+  public void testSubtractMissingResources() {
+    // cpu
+    Assertions.assertEquals(
+      createResources(-3, 60, "100:1000"),
+      MesosUtils.subtractResources(
+        createResources(2, 100, "23:23", "100:1000"),
+        createResources(5, 40, "23:23")
+      )
+    );
+
+    // memory
+    Assertions.assertEquals(
+      createResources(3, -60, "100:1000"),
+      MesosUtils.subtractResources(
+        createResources(5, 40, "23:23", "100:1000"),
+        createResources(2, 100, "23:23")
+      )
+    );
+
+    // TODO - mesos utils expects but does not validate that subtraction of resources produces valid results
+    Assertions.assertNotEquals(
+      createResources(3, 60, "23:23", "100:100", "103:1000"),
+      MesosUtils.subtractResources(
+        createResources(5, 100, "23:23", "100:1000"),
+        createResources(2, 40, "24:24", "101:102")
+      )
+    );
+  }
+
   private List<Resource> createResources(int cpus, int memory, String... ranges) {
     List<Resource> resources = Lists.newArrayList();
 
-    if (cpus > 0) {
-      resources.add(
-        Resource
-          .newBuilder()
-          .setType(Type.SCALAR)
-          .setName(MesosUtils.CPUS)
-          .setScalar(Scalar.newBuilder().setValue(cpus).build())
-          .build()
-      );
-    }
-
-    if (memory > 0) {
-      resources.add(
-        Resource
-          .newBuilder()
-          .setType(Type.SCALAR)
-          .setName(MesosUtils.MEMORY)
-          .setScalar(Scalar.newBuilder().setValue(memory).build())
-          .build()
-      );
-    }
+    resources.add(
+      Resource
+        .newBuilder()
+        .setType(Type.SCALAR)
+        .setName(MesosUtils.CPUS)
+        .setScalar(Scalar.newBuilder().setValue(cpus).build())
+        .build()
+    );
+    resources.add(
+      Resource
+        .newBuilder()
+        .setType(Type.SCALAR)
+        .setName(MesosUtils.MEMORY)
+        .setScalar(Scalar.newBuilder().setValue(memory).build())
+        .build()
+    );
 
     if (ranges.length > 0) {
       resources.add(buildPortRanges(ranges));

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTestBase.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTestBase.java
@@ -811,6 +811,24 @@ public class SingularitySchedulerTestBase extends SingularityCuratorTestBase {
     return deploy;
   }
 
+  protected SingularityDeploy deployRequest(
+    SingularityRequest request,
+    String deployId,
+    Resources resources
+  ) {
+    SingularityDeploy deploy = new SingularityDeployBuilder(request.getId(), deployId)
+      .setCommand(Optional.of("sleep 1"))
+      .setResources(Optional.of(resources))
+      .build();
+
+    deployResource.deploy(
+      new SingularityDeployRequest(deploy, Optional.empty(), Optional.empty()),
+      singularityUser
+    );
+
+    return deploy;
+  }
+
   protected void initRequestWithType(RequestType requestType, boolean isLoadBalanced) {
     SingularityRequestBuilder bldr = new SingularityRequestBuilder(
       requestId,


### PR DESCRIPTION
Attempts to address the same issue as https://github.com/HubSpot/Singularity/pull/2215.

Current logging hasn't uncovered a smoking gun, but there appears to a potential source of duplicated ports when offers are combined in SingularityOfferHolder. The most likely alternative cause would be stale offers in the cache, which would require a much heavier fix. For now, going to put this out there with additional logging around resource offers to help determine whether the cache or resource duplication is the root cause.
