### PR TITLE
Better handling of errors in scheduler poller

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -359,7 +359,7 @@ public class SingularityScheduler {
             () ->
               lock.runWithRequestLock(
                 () ->
-                  handlePendingRequestsForDeployKey(
+                  handlePendingRequestsForDeployKeySafe(
                     obsoleteRequests,
                     heldForScheduledActiveTask,
                     totalNewScheduledTasks,
@@ -382,6 +382,26 @@ public class SingularityScheduler {
       heldForScheduledActiveTask.get(),
       JavaUtils.duration(start)
     );
+  }
+
+  private void handlePendingRequestsForDeployKeySafe(
+    AtomicInteger obsoleteRequests,
+    AtomicInteger heldForScheduledActiveTask,
+    AtomicInteger totalNewScheduledTasks,
+    SingularityDeployKey deployKey,
+    List<SingularityPendingRequest> pendingRequestsForDeploy
+  ) {
+    try {
+      handlePendingRequestsForDeployKey(
+        obsoleteRequests,
+        heldForScheduledActiveTask,
+        totalNewScheduledTasks,
+        deployKey,
+        pendingRequestsForDeploy
+      );
+    } catch (Exception e) {
+      LOG.error("Error handling pending requests for {}, skipping", deployKey, e);
+    }
   }
 
   private void handlePendingRequestsForDeployKey(

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularitySchedulerPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularitySchedulerPoller.java
@@ -72,4 +72,9 @@ public class SingularitySchedulerPoller extends SingularityLeaderOnlyPoller {
       "SingularitySchedulerPoller"
     );
   }
+
+  @Override
+  protected boolean abortsOnError() {
+    return false;
+  }
 }

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -96,6 +96,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
+import org.quartz.CronExpression;
 
 public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
   @Inject
@@ -3839,6 +3840,12 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
       newScheduleQuartz,
       requestManager.getRequest(requestId).get().getRequest().getQuartzScheduleSafe()
     );
+  }
+
+  @Test
+  public void testBrokenQuartzCron() throws Exception {
+    String quartz = "0 0/60 * * * ?";
+    new CronExpression(quartz);
   }
 
   @Test


### PR DESCRIPTION
Currently if the scheduler poller encounters an unexpected error it causes Singularity as a whole to abort. This PR changes the scheduler poller to try again in the event of unexpected errors, as well as modifying the scheduled task poll action to log errors for specific failed tasks instead of failing the entire batch.

This approach may swallow too much, but there are metrics that should still inform us if something is wrong with the scheduler as a whole.

cc - @pschoenfelder 