### PR TITLE
Fix junit jupiter setup

### DIFF
--- a/SingularityClient/pom.xml
+++ b/SingularityClient/pom.xml
@@ -99,18 +99,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/SingularityExecutor/pom.xml
+++ b/SingularityExecutor/pom.xml
@@ -150,18 +150,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/SingularityS3Base/pom.xml
+++ b/SingularityS3Base/pom.xml
@@ -103,18 +103,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/SingularityService/pom.xml
+++ b/SingularityService/pom.xml
@@ -493,18 +493,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/SingularityServiceIntegrationTests/pom.xml
+++ b/SingularityServiceIntegrationTests/pom.xml
@@ -53,18 +53,6 @@
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <dep.jersey2.version>2.25.1</dep.jersey2.version>
     <dep.jetty.version>9.4.18.v20190429</dep.jetty.version>
     <dep.joda.version>2.10.1</dep.joda.version>
-    <dep.junit.jupiter.version>5.5.0</dep.junit.jupiter.version>
+    <dep.junit-jupiter.version>5.5.0</dep.junit-jupiter.version>
     <dep.junit.platform.version>1.5.0</dep.junit.platform.version>
     <dep.liquibase.version>3.6.3</dep.liquibase.version>
     <dep.logback.version>1.2.3</dep.logback.version>
@@ -63,7 +63,7 @@
     <dep.mysql-connector-java.version>8.0.23</dep.mysql-connector-java.version>
     <dep.netty.version>4.1.27.Final</dep.netty.version>
     <dep.netty3.version>3.10.6.Final</dep.netty3.version>
-    <dep.plugin.surefire.version>2.22.1</dep.plugin.surefire.version>
+    <dep.plugin.surefire.version>3.0.0-M5</dep.plugin.surefire.version>
     <dep.protobuf-java.version>3.11.4</dep.protobuf-java.version>
     <dep.reflections.version>0.9.11</dep.reflections.version>
     <dep.rxJava.version>1.3.8</dep.rxJava.version>
@@ -737,24 +737,11 @@
       </dependency>
 
       <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-api</artifactId>
-        <version>${dep.junit.jupiter.version}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
-        <version>${dep.junit.jupiter.version}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.junit.platform</groupId>
-        <artifactId>junit-platform-runner</artifactId>
-        <version>${dep.junit.platform.version}</version>
-        <scope>test</scope>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${dep.junit-jupiter.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
     </dependencies>


### PR DESCRIPTION
Having `junit-platform-runner` on the classpath can prevent maven from running junit 5 tests though it curiously it seems as though the tests were still running in this case, unlike in https://github.com/HubSpot/Baragon/pull/374. In any case, this gets the junit deps into a good state.

@ssalinas @pschoenfelder @WH77 @baconmania @snommit-mit @Xcelled @kmclarnon 