### PR TITLE
Cleanup hosts marked as missing on startup

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/data/InactiveAgentManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/InactiveAgentManager.java
@@ -51,7 +51,6 @@ public class InactiveAgentManager extends CuratorManager {
    * @param host agent hostname
    */
   public void cleanInactiveAgent(String host) {
-    LOG.debug("Attempting to clean inactive host {}", host);
     Optional<Stat> stat = checkExists(pathOf(host));
     if (stat.isPresent()) {
       delete(pathOf(host));
@@ -61,7 +60,6 @@ public class InactiveAgentManager extends CuratorManager {
 
   public void cleanInactiveAgentsList(long thresholdTime) {
     for (String host : getInactiveAgents()) {
-      LOG.debug("Attempting to clean inactive host {}", host);
       Optional<Stat> stat = checkExists(pathOf(host));
       if (stat.isPresent() && stat.get().getMtime() < thresholdTime) {
         delete(pathOf(host));

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/InactiveAgentManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/InactiveAgentManager.java
@@ -9,10 +9,13 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Singleton
 public class InactiveAgentManager extends CuratorManager {
   private static final String ROOT_PATH = "/inactiveSlaves";
+  private static final Logger LOG = LoggerFactory.getLogger(InactiveAgentManager.class);
 
   @Inject
   public InactiveAgentManager(
@@ -52,6 +55,7 @@ public class InactiveAgentManager extends CuratorManager {
     Optional<Stat> stat = checkExists(pathOf(host));
     if (stat.isPresent()) {
       delete(pathOf(host));
+      LOG.debug("Deleted inactive host {}", host);
     }
   }
 
@@ -61,6 +65,7 @@ public class InactiveAgentManager extends CuratorManager {
       Optional<Stat> stat = checkExists(pathOf(host));
       if (stat.isPresent() && stat.get().getMtime() < thresholdTime) {
         delete(pathOf(host));
+        LOG.debug("Deleted inactive host {}", host);
       }
     }
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/InactiveAgentManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/InactiveAgentManager.java
@@ -51,6 +51,7 @@ public class InactiveAgentManager extends CuratorManager {
    * @param host agent hostname
    */
   public void cleanInactiveAgent(String host) {
+    LOG.debug("Attempting to clean inactive host {}", host);
     Optional<Stat> stat = checkExists(pathOf(host));
     if (stat.isPresent()) {
       delete(pathOf(host));
@@ -60,6 +61,7 @@ public class InactiveAgentManager extends CuratorManager {
 
   public void cleanInactiveAgentsList(long thresholdTime) {
     for (String host : getInactiveAgents()) {
+      LOG.debug("Attempting to clean inactive host {}", host);
       Optional<Stat> stat = checkExists(pathOf(host));
       if (stat.isPresent() && stat.get().getMtime() < thresholdTime) {
         delete(pathOf(host));

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/InactiveAgentManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/InactiveAgentManager.java
@@ -9,13 +9,10 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.zookeeper.data.Stat;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Singleton
 public class InactiveAgentManager extends CuratorManager {
   private static final String ROOT_PATH = "/inactiveSlaves";
-  private static final Logger LOG = LoggerFactory.getLogger(InactiveAgentManager.class);
 
   @Inject
   public InactiveAgentManager(
@@ -55,7 +52,6 @@ public class InactiveAgentManager extends CuratorManager {
     Optional<Stat> stat = checkExists(pathOf(host));
     if (stat.isPresent()) {
       delete(pathOf(host));
-      LOG.debug("Deleted inactive host {}", host);
     }
   }
 
@@ -65,7 +61,6 @@ public class InactiveAgentManager extends CuratorManager {
       Optional<Stat> stat = checkExists(pathOf(host));
       if (stat.isPresent() && stat.get().getMtime() < thresholdTime) {
         delete(pathOf(host));
-        LOG.debug("Deleted inactive host {}", host);
       }
     }
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/InactiveAgentManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/InactiveAgentManager.java
@@ -43,6 +43,17 @@ public class InactiveAgentManager extends CuratorManager {
     return String.format("%s/%s", ROOT_PATH, host);
   }
 
+  /**
+   * Delete single agent from inactive agent list.
+   * @param host agent hostname
+   */
+  public void cleanInactiveAgent(String host) {
+    Optional<Stat> stat = checkExists(pathOf(host));
+    if (stat.isPresent()) {
+      delete(pathOf(host));
+    }
+  }
+
   public void cleanInactiveAgentsList(long thresholdTime) {
     for (String host : getInactiveAgents()) {
       Optional<Stat> stat = checkExists(pathOf(host));

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/InactiveAgentManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/InactiveAgentManager.java
@@ -9,10 +9,13 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Singleton
 public class InactiveAgentManager extends CuratorManager {
   private static final String ROOT_PATH = "/inactiveSlaves";
+  private static final Logger LOG = LoggerFactory.getLogger(InactiveAgentManager.class);
 
   @Inject
   public InactiveAgentManager(
@@ -51,6 +54,7 @@ public class InactiveAgentManager extends CuratorManager {
     Optional<Stat> stat = checkExists(pathOf(host));
     if (stat.isPresent()) {
       delete(pathOf(host));
+      LOG.debug("Deleted inactive host {}", host);
     }
   }
 
@@ -59,6 +63,7 @@ public class InactiveAgentManager extends CuratorManager {
       Optional<Stat> stat = checkExists(pathOf(host));
       if (stat.isPresent() && stat.get().getMtime() < thresholdTime) {
         delete(pathOf(host));
+        LOG.debug("Deleted inactive host {}", host);
       }
     }
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityStartup.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityStartup.java
@@ -108,7 +108,7 @@ class SingularityStartup {
 
     MesosMasterStateObject state = mesosClient.getMasterState(uri);
 
-    agentAndRackManager.loadAgentsAndRacksFromMaster(state, true);
+    agentAndRackManager.loadAgentsAndRacksFromMaster(state, true); // TODO: is this correctly doing host reconciliation?
 
     ExecutorService startupExecutor = Executors.newFixedThreadPool(
       configuration.getSchedulerStartupConcurrency(),

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityStartup.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityStartup.java
@@ -108,7 +108,7 @@ class SingularityStartup {
 
     MesosMasterStateObject state = mesosClient.getMasterState(uri);
 
-    agentAndRackManager.loadAgentsAndRacksFromMaster(state, true); // TODO: is this correctly doing host reconciliation?
+    agentAndRackManager.loadAgentsAndRacksFromMaster(state, true);
 
     ExecutorService startupExecutor = Executors.newFixedThreadPool(
       configuration.getSchedulerStartupConcurrency(),

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityAgentReconciliationPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityAgentReconciliationPoller.java
@@ -82,6 +82,7 @@ public class SingularityAgentReconciliationPoller extends SingularityLeaderOnlyP
   private void checkInactiveAgents() {
     final long start = System.currentTimeMillis();
 
+    // filter dead and missing on startup agents for cleanup
     final List<SingularityAgent> inactiveAgents = agentManager.getObjectsFiltered(
       MachineState.DEAD
     );
@@ -106,6 +107,7 @@ public class SingularityAgentReconciliationPoller extends SingularityLeaderOnlyP
 
       if (duration > maxDuration) {
         SingularityDeleteResult result = agentManager.deleteObject(inactiveAgent.getId());
+        inactiveAgentManager.cleanInactiveAgent(inactiveAgent.getHost()); // delete agent from inactive list too
 
         deleted++;
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityAgentReconciliationPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityAgentReconciliationPoller.java
@@ -13,6 +13,7 @@ import com.hubspot.singularity.data.InactiveAgentManager;
 import com.hubspot.singularity.helpers.MesosUtils;
 import com.hubspot.singularity.mesos.SingularityAgentAndRackManager;
 import com.hubspot.singularity.mesos.SingularityMesosScheduler;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -83,13 +84,21 @@ public class SingularityAgentReconciliationPoller extends SingularityLeaderOnlyP
     final long start = System.currentTimeMillis();
 
     // filter dead and missing on startup agents for cleanup
-    final List<SingularityAgent> inactiveAgents = agentManager.getObjectsFiltered(
+    List<SingularityAgent> deadAgents = agentManager.getObjectsFiltered(
       MachineState.DEAD
     );
 
-    inactiveAgents.addAll(
-      agentManager.getObjectsFiltered(MachineState.MISSING_ON_STARTUP)
+    LOG.debug("Found {} dead agents", deadAgents.size());
+
+    List<SingularityAgent> missingOnStartupAgents = agentManager.getObjectsFiltered(
+      MachineState.MISSING_ON_STARTUP
     );
+
+    LOG.debug("Found {} agents missing on startup", missingOnStartupAgents.size());
+
+    List<SingularityAgent> inactiveAgents = new ArrayList<>();
+    inactiveAgents.addAll(deadAgents);
+    inactiveAgents.addAll(missingOnStartupAgents);
 
     if (inactiveAgents.isEmpty()) {
       LOG.trace("No inactive agents");

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityAgentReconciliationPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityAgentReconciliationPoller.java
@@ -13,7 +13,6 @@ import com.hubspot.singularity.data.InactiveAgentManager;
 import com.hubspot.singularity.helpers.MesosUtils;
 import com.hubspot.singularity.mesos.SingularityAgentAndRackManager;
 import com.hubspot.singularity.mesos.SingularityMesosScheduler;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -84,21 +83,13 @@ public class SingularityAgentReconciliationPoller extends SingularityLeaderOnlyP
     final long start = System.currentTimeMillis();
 
     // filter dead and missing on startup agents for cleanup
-    List<SingularityAgent> deadAgents = agentManager.getObjectsFiltered(
+    final List<SingularityAgent> inactiveAgents = agentManager.getObjectsFiltered(
       MachineState.DEAD
     );
 
-    LOG.debug("Found {} dead agents", deadAgents.size());
-
-    List<SingularityAgent> missingOnStartupAgents = agentManager.getObjectsFiltered(
-      MachineState.MISSING_ON_STARTUP
+    inactiveAgents.addAll(
+      agentManager.getObjectsFiltered(MachineState.MISSING_ON_STARTUP)
     );
-
-    LOG.debug("Found {} agents missing on startup", missingOnStartupAgents.size());
-
-    List<SingularityAgent> inactiveAgents = new ArrayList<>();
-    inactiveAgents.addAll(deadAgents);
-    inactiveAgents.addAll(missingOnStartupAgents);
 
     if (inactiveAgents.isEmpty()) {
       LOG.trace("No inactive agents");

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityMachinesTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityMachinesTest.java
@@ -57,7 +57,7 @@ public class SingularityMachinesTest extends SingularitySchedulerTestBase {
 
   @Test
   public void testDeadAgentsArePurged() {
-    long deleteDeadAgentsAfterHours = configuration.getDeleteDeadAgentsAfterHours();
+    long previousDeleteDeadAgentsAfterHours = configuration.getDeleteDeadAgentsAfterHours();
     SingularityAgent liveAgent = new SingularityAgent(
       "1",
       "h1",
@@ -108,7 +108,7 @@ public class SingularityMachinesTest extends SingularitySchedulerTestBase {
 
     configuration.setDeleteDeadAgentsAfterHours(1);
 
-    agentReconciliationPoller.runActionOnPoll();
+    agentReconciliationPoller.runActionOnPoll(); // dead agent should be deleted
 
     Assertions.assertEquals(
       1,
@@ -116,13 +116,13 @@ public class SingularityMachinesTest extends SingularitySchedulerTestBase {
     );
     Assertions.assertEquals(0, agentManager.getObjectsFiltered(MachineState.DEAD).size());
 
-    // reset to previous value
-    configuration.setDeleteDeadAgentsAfterHours(deleteDeadAgentsAfterHours);
+    // reset config to previous value for subsequent tests
+    configuration.setDeleteDeadAgentsAfterHours(previousDeleteDeadAgentsAfterHours);
   }
 
   @Test
   public void testMissingAgentsArePurged() {
-    long deleteDeadAgentsAfterHours = configuration.getDeleteDeadAgentsAfterHours();
+    long previousDeleteDeadAgentsAfterHours = configuration.getDeleteDeadAgentsAfterHours();
     SingularityAgent liveAgent = new SingularityAgent(
       "3",
       "h1",
@@ -163,7 +163,6 @@ public class SingularityMachinesTest extends SingularitySchedulerTestBase {
 
     agentManager.saveObject(liveAgent);
     agentManager.saveObject(missingAgent);
-
     agentReconciliationPoller.runActionOnPoll();
 
     Assertions.assertEquals(
@@ -177,7 +176,7 @@ public class SingularityMachinesTest extends SingularitySchedulerTestBase {
 
     configuration.setDeleteDeadAgentsAfterHours(1);
 
-    agentReconciliationPoller.runActionOnPoll();
+    agentReconciliationPoller.runActionOnPoll(); // missing agent should be deleted
 
     Assertions.assertEquals(
       1,
@@ -188,8 +187,8 @@ public class SingularityMachinesTest extends SingularitySchedulerTestBase {
       agentManager.getObjectsFiltered(MachineState.MISSING_ON_STARTUP).size()
     );
 
-    // reset to previous value
-    configuration.setDeleteDeadAgentsAfterHours(deleteDeadAgentsAfterHours);
+    // reset config to previous value for subsequent tests
+    configuration.setDeleteDeadAgentsAfterHours(previousDeleteDeadAgentsAfterHours);
   }
 
   @Test

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityMachinesTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityMachinesTest.java
@@ -119,17 +119,17 @@ public class SingularityMachinesTest extends SingularitySchedulerTestBase {
   @Test
   public void testMissingSlavesArePurged() {
     SingularityAgent liveSlave = new SingularityAgent(
-      "1",
+      "3",
       "h1",
       "r1",
-      ImmutableMap.of("uniqueAttribute", "1"),
+      ImmutableMap.of("uniqueAttribute", "3"),
       Optional.empty()
     );
     SingularityAgent missingSlave = new SingularityAgent(
-      "2",
+      "4",
       "h1",
       "r1",
-      ImmutableMap.of("uniqueAttribute", "2"),
+      ImmutableMap.of("uniqueAttribute", "4"),
       Optional.empty()
     );
 
@@ -138,7 +138,7 @@ public class SingularityMachinesTest extends SingularitySchedulerTestBase {
     liveSlave =
       liveSlave.changeState(
         new SingularityMachineStateHistoryUpdate(
-          "1",
+          "3",
           MachineState.ACTIVE,
           100,
           Optional.empty(),
@@ -148,7 +148,7 @@ public class SingularityMachinesTest extends SingularitySchedulerTestBase {
     missingSlave =
       missingSlave.changeState(
         new SingularityMachineStateHistoryUpdate(
-          "2",
+          "4",
           MachineState.MISSING_ON_STARTUP,
           now - TimeUnit.HOURS.toMillis(10),
           Optional.empty(),

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityMachinesTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityMachinesTest.java
@@ -56,15 +56,15 @@ public class SingularityMachinesTest extends SingularitySchedulerTestBase {
   }
 
   @Test
-  public void testDeadSlavesArePurged() {
-    SingularityAgent liveSlave = new SingularityAgent(
+  public void testDeadAgentsArePurged() {
+    SingularityAgent liveAgent = new SingularityAgent(
       "1",
       "h1",
       "r1",
       ImmutableMap.of("uniqueAttribute", "1"),
       Optional.empty()
     );
-    SingularityAgent deadSlave = new SingularityAgent(
+    SingularityAgent deadAgent = new SingularityAgent(
       "2",
       "h1",
       "r1",
@@ -74,8 +74,8 @@ public class SingularityMachinesTest extends SingularitySchedulerTestBase {
 
     final long now = System.currentTimeMillis();
 
-    liveSlave =
-      liveSlave.changeState(
+    liveAgent =
+      liveAgent.changeState(
         new SingularityMachineStateHistoryUpdate(
           "1",
           MachineState.ACTIVE,
@@ -84,8 +84,8 @@ public class SingularityMachinesTest extends SingularitySchedulerTestBase {
           Optional.empty()
         )
       );
-    deadSlave =
-      deadSlave.changeState(
+    deadAgent =
+      deadAgent.changeState(
         new SingularityMachineStateHistoryUpdate(
           "2",
           MachineState.DEAD,
@@ -95,8 +95,8 @@ public class SingularityMachinesTest extends SingularitySchedulerTestBase {
         )
       );
 
-    agentManager.saveObject(liveSlave);
-    agentManager.saveObject(deadSlave);
+    agentManager.saveObject(liveAgent);
+    agentManager.saveObject(deadAgent);
     agentReconciliationPoller.runActionOnPoll();
 
     Assertions.assertEquals(
@@ -117,15 +117,15 @@ public class SingularityMachinesTest extends SingularitySchedulerTestBase {
   }
 
   @Test
-  public void testMissingSlavesArePurged() {
-    SingularityAgent liveSlave = new SingularityAgent(
+  public void testMissingAgentsArePurged() {
+    SingularityAgent liveAgent = new SingularityAgent(
       "3",
       "h1",
       "r1",
       ImmutableMap.of("uniqueAttribute", "3"),
       Optional.empty()
     );
-    SingularityAgent missingSlave = new SingularityAgent(
+    SingularityAgent missingAgent = new SingularityAgent(
       "4",
       "h1",
       "r1",
@@ -135,8 +135,8 @@ public class SingularityMachinesTest extends SingularitySchedulerTestBase {
 
     final long now = System.currentTimeMillis();
 
-    liveSlave =
-      liveSlave.changeState(
+    liveAgent =
+      liveAgent.changeState(
         new SingularityMachineStateHistoryUpdate(
           "3",
           MachineState.ACTIVE,
@@ -145,8 +145,8 @@ public class SingularityMachinesTest extends SingularitySchedulerTestBase {
           Optional.empty()
         )
       );
-    missingSlave =
-      missingSlave.changeState(
+    missingAgent =
+      missingAgent.changeState(
         new SingularityMachineStateHistoryUpdate(
           "4",
           MachineState.MISSING_ON_STARTUP,
@@ -156,8 +156,8 @@ public class SingularityMachinesTest extends SingularitySchedulerTestBase {
         )
       );
 
-    agentManager.saveObject(liveSlave);
-    agentManager.saveObject(missingSlave);
+    agentManager.saveObject(liveAgent);
+    agentManager.saveObject(missingAgent);
 
     agentReconciliationPoller.runActionOnPoll();
 

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityMachinesTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularityMachinesTest.java
@@ -57,6 +57,7 @@ public class SingularityMachinesTest extends SingularitySchedulerTestBase {
 
   @Test
   public void testDeadAgentsArePurged() {
+    long deleteDeadAgentsAfterHours = configuration.getDeleteDeadAgentsAfterHours();
     SingularityAgent liveAgent = new SingularityAgent(
       "1",
       "h1",
@@ -114,10 +115,14 @@ public class SingularityMachinesTest extends SingularitySchedulerTestBase {
       agentManager.getObjectsFiltered(MachineState.ACTIVE).size()
     );
     Assertions.assertEquals(0, agentManager.getObjectsFiltered(MachineState.DEAD).size());
+
+    // reset to previous value
+    configuration.setDeleteDeadAgentsAfterHours(deleteDeadAgentsAfterHours);
   }
 
   @Test
   public void testMissingAgentsArePurged() {
+    long deleteDeadAgentsAfterHours = configuration.getDeleteDeadAgentsAfterHours();
     SingularityAgent liveAgent = new SingularityAgent(
       "3",
       "h1",
@@ -182,6 +187,9 @@ public class SingularityMachinesTest extends SingularitySchedulerTestBase {
       0,
       agentManager.getObjectsFiltered(MachineState.MISSING_ON_STARTUP).size()
     );
+
+    // reset to previous value
+    configuration.setDeleteDeadAgentsAfterHours(deleteDeadAgentsAfterHours);
   }
 
   @Test


### PR DESCRIPTION
This PR modifies the `SingularityAgentReconciliationPoller` to delete hosts that are marked as missing on startup. Previously, only hosts marked as dead were deleted by the poller, causing inactive hosts marked as missing on startup to still appear in Singularity.

Hosts that are dead or missing on startup are deleted from both the `AgentManager` and `InactiveAgentManager` lists to cleanup inactive hosts in the Singularity UI.

https://git.hubteam.com/HubSpot/PaaS-Run/issues/1525