### PR TITLE
Add fire alarm

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/FireAlarm.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/FireAlarm.java
@@ -1,0 +1,72 @@
+package com.hubspot.singularity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Objects;
+import java.util.Optional;
+
+@Schema(description = "Warning to users users about potential destructive actions")
+public class FireAlarm {
+  private final String title;
+  private final String message;
+  private final Optional<String> url;
+
+  @JsonCreator
+  public FireAlarm(
+    @JsonProperty("title") String title,
+    @JsonProperty("message") String message,
+    @JsonProperty("url") Optional<String> url
+  ) {
+    this.title = title;
+    this.message = message;
+    this.url = url;
+  }
+
+  @Schema(required = true, description = "Fire alarm title")
+  public String getTitle() {
+    return title;
+  }
+
+  @Schema(required = true, description = "Fire alarm message")
+  public String getMessage() {
+    return message;
+  }
+
+  @Schema(required = true, description = "Fire alarm url to link to for more information")
+  public Optional<String> getUrl() {
+    return url;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    FireAlarm that = (FireAlarm) o;
+    return (
+      Objects.equals(title, that.title) &&
+      Objects.equals(message, that.message) &&
+      Objects.equals(url, that.url)
+    );
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(title, message, url);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects
+      .toStringHelper(this)
+      .add("title", title)
+      .add("message", message)
+      .add("url", url)
+      .toString();
+  }
+}

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityFireAlarm.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityFireAlarm.java
@@ -8,13 +8,13 @@ import java.util.Objects;
 import java.util.Optional;
 
 @Schema(description = "Warning to users users about potential destructive actions")
-public class FireAlarm {
+public class SingularityFireAlarm {
   private final String title;
   private final String message;
   private final Optional<String> url;
 
   @JsonCreator
-  public FireAlarm(
+  public SingularityFireAlarm(
     @JsonProperty("title") String title,
     @JsonProperty("message") String message,
     @JsonProperty("url") Optional<String> url
@@ -47,7 +47,7 @@ public class FireAlarm {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    FireAlarm that = (FireAlarm) o;
+    SingularityFireAlarm that = (SingularityFireAlarm) o;
     return (
       Objects.equals(title, that.title) &&
       Objects.equals(message, that.message) &&

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityState.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityState.java
@@ -64,6 +64,7 @@ public class SingularityState {
 
   private final long avgStatusUpdateDelayMs;
   private final long lastHeartbeatAt;
+  private final Optional<FireAlarm> fireAlarm;
 
   @SuppressFBWarnings("NP_NULL_PARAM_DEREF_NONVIRTUAL")
   public SingularityState(
@@ -106,7 +107,8 @@ public class SingularityState {
     Optional<Boolean> authDatastoreHealthy,
     Optional<Double> minimumPriorityLevel,
     long avgStatusUpdateDelayMs,
-    long lastHeartbeatAt
+    long lastHeartbeatAt,
+    Optional<FireAlarm> fireAlarm
   ) {
     this(
       activeTasks,
@@ -152,7 +154,8 @@ public class SingularityState {
       activeAgents,
       deadAgents,
       decommissioningAgents,
-      unknownAgents
+      unknownAgents,
+      fireAlarm
     );
   }
 
@@ -203,7 +206,8 @@ public class SingularityState {
     @JsonProperty("activeAgents") Integer activeAgents,
     @JsonProperty("deadAgents") Integer deadAgents,
     @JsonProperty("decommissioningAgents") Integer decommissioningAgents,
-    @JsonProperty("unknownAgents") Integer unknownAgents
+    @JsonProperty("unknownAgents") Integer unknownAgents,
+    @JsonProperty("fireAlarm") Optional<FireAlarm> fireAlarm
   ) {
     this.activeTasks = activeTasks;
     this.launchingTasks = launchingTasks;
@@ -247,6 +251,7 @@ public class SingularityState {
     this.minimumPriorityLevel = minimumPriorityLevel;
     this.avgStatusUpdateDelayMs = avgStatusUpdateDelayMs;
     this.lastHeartbeatAt = lastHeartbeatAt;
+    this.fireAlarm = fireAlarm;
   }
 
   @Schema(description = "Count of requests in finished state")
@@ -522,6 +527,11 @@ public class SingularityState {
     return lastHeartbeatAt;
   }
 
+  @Schema(description = "Fire alarm status")
+  public Optional<FireAlarm> getFireAlarm() {
+    return fireAlarm;
+  }
+
   @Override
   public String toString() {
     return (
@@ -606,6 +616,8 @@ public class SingularityState {
       avgStatusUpdateDelayMs +
       ", lastHeartbeatAt=" +
       lastHeartbeatAt +
+      ", fireAlarm=" +
+      fireAlarm +
       '}'
     );
   }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityState.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityState.java
@@ -64,7 +64,7 @@ public class SingularityState {
 
   private final long avgStatusUpdateDelayMs;
   private final long lastHeartbeatAt;
-  private final Optional<FireAlarm> fireAlarm;
+  private final Optional<SingularityFireAlarm> fireAlarm;
 
   @SuppressFBWarnings("NP_NULL_PARAM_DEREF_NONVIRTUAL")
   public SingularityState(
@@ -108,7 +108,7 @@ public class SingularityState {
     Optional<Double> minimumPriorityLevel,
     long avgStatusUpdateDelayMs,
     long lastHeartbeatAt,
-    Optional<FireAlarm> fireAlarm
+    Optional<SingularityFireAlarm> fireAlarm
   ) {
     this(
       activeTasks,
@@ -207,7 +207,7 @@ public class SingularityState {
     @JsonProperty("deadAgents") Integer deadAgents,
     @JsonProperty("decommissioningAgents") Integer decommissioningAgents,
     @JsonProperty("unknownAgents") Integer unknownAgents,
-    @JsonProperty("fireAlarm") Optional<FireAlarm> fireAlarm
+    @JsonProperty("fireAlarm") Optional<SingularityFireAlarm> fireAlarm
   ) {
     this.activeTasks = activeTasks;
     this.launchingTasks = launchingTasks;
@@ -528,7 +528,7 @@ public class SingularityState {
   }
 
   @Schema(description = "Fire alarm status")
-  public Optional<FireAlarm> getFireAlarm() {
+  public Optional<SingularityFireAlarm> getFireAlarm() {
     return fireAlarm;
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/DisasterManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/DisasterManager.java
@@ -2,6 +2,7 @@ package com.hubspot.singularity.data;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.inject.Inject;
+import com.hubspot.singularity.FireAlarm;
 import com.hubspot.singularity.SingularityAction;
 import com.hubspot.singularity.SingularityCreateResult;
 import com.hubspot.singularity.SingularityDeleteResult;
@@ -32,11 +33,14 @@ public class DisasterManager extends CuratorAsyncManager {
   private static final String DISASTER_STATS_PATH = DISASTERS_ROOT + "/statistics";
   private static final String DISABLE_AUTOMATED_PATH = DISASTERS_ROOT + "/disabled";
 
+  private static final String FIRE_ALARM_PATH = "/firealarm";
+
   private static final String MESSAGE_FORMAT = "Cannot perform action %s: %s";
   private static final String DEFAULT_MESSAGE = "Action is currently disabled";
 
   private final Transcoder<SingularityDisabledAction> disabledActionTranscoder;
   private final Transcoder<SingularityDisasterDataPoints> disasterStatsTranscoder;
+  private final Transcoder<FireAlarm> fireAlarmTranscoder;
 
   @Inject
   public DisasterManager(
@@ -44,11 +48,13 @@ public class DisasterManager extends CuratorAsyncManager {
     SingularityConfiguration configuration,
     MetricRegistry metricRegistry,
     Transcoder<SingularityDisabledAction> disabledActionTranscoder,
-    Transcoder<SingularityDisasterDataPoints> disasterStatsTranscoder
+    Transcoder<SingularityDisasterDataPoints> disasterStatsTranscoder,
+    Transcoder<FireAlarm> fireAlarmTranscoder
   ) {
     super(curator, configuration, metricRegistry);
     this.disabledActionTranscoder = disabledActionTranscoder;
     this.disasterStatsTranscoder = disasterStatsTranscoder;
+    this.fireAlarmTranscoder = fireAlarmTranscoder;
   }
 
   private String getActionPath(SingularityAction action) {
@@ -260,5 +266,13 @@ public class DisasterManager extends CuratorAsyncManager {
 
   public boolean isAutomatedDisabledActionsDisabled() {
     return exists(DISABLE_AUTOMATED_PATH);
+  }
+
+  public void setFireAlarm(FireAlarm fireAlarm) {
+    save(FIRE_ALARM_PATH, fireAlarm, fireAlarmTranscoder);
+  }
+
+  public void deleteFireAlarm() {
+    delete(FIRE_ALARM_PATH);
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/DisasterManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/DisasterManager.java
@@ -2,7 +2,6 @@ package com.hubspot.singularity.data;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.inject.Inject;
-import com.hubspot.singularity.FireAlarm;
 import com.hubspot.singularity.SingularityAction;
 import com.hubspot.singularity.SingularityCreateResult;
 import com.hubspot.singularity.SingularityDeleteResult;
@@ -11,6 +10,7 @@ import com.hubspot.singularity.SingularityDisaster;
 import com.hubspot.singularity.SingularityDisasterDataPoints;
 import com.hubspot.singularity.SingularityDisasterType;
 import com.hubspot.singularity.SingularityDisastersData;
+import com.hubspot.singularity.SingularityFireAlarm;
 import com.hubspot.singularity.SingularityUser;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.transcoders.Transcoder;
@@ -40,7 +40,7 @@ public class DisasterManager extends CuratorAsyncManager {
 
   private final Transcoder<SingularityDisabledAction> disabledActionTranscoder;
   private final Transcoder<SingularityDisasterDataPoints> disasterStatsTranscoder;
-  private final Transcoder<FireAlarm> fireAlarmTranscoder;
+  private final Transcoder<SingularityFireAlarm> fireAlarmTranscoder;
 
   @Inject
   public DisasterManager(
@@ -49,7 +49,7 @@ public class DisasterManager extends CuratorAsyncManager {
     MetricRegistry metricRegistry,
     Transcoder<SingularityDisabledAction> disabledActionTranscoder,
     Transcoder<SingularityDisasterDataPoints> disasterStatsTranscoder,
-    Transcoder<FireAlarm> fireAlarmTranscoder
+    Transcoder<SingularityFireAlarm> fireAlarmTranscoder
   ) {
     super(curator, configuration, metricRegistry);
     this.disabledActionTranscoder = disabledActionTranscoder;
@@ -268,11 +268,11 @@ public class DisasterManager extends CuratorAsyncManager {
     return exists(DISABLE_AUTOMATED_PATH);
   }
 
-  public void setFireAlarm(FireAlarm fireAlarm) {
+  public void setFireAlarm(SingularityFireAlarm fireAlarm) {
     save(FIRE_ALARM_PATH, fireAlarm, fireAlarmTranscoder);
   }
 
-  public Optional<FireAlarm> getFireAlarm() {
+  public Optional<SingularityFireAlarm> getFireAlarm() {
     return getData(FIRE_ALARM_PATH, fireAlarmTranscoder);
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/DisasterManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/DisasterManager.java
@@ -272,6 +272,10 @@ public class DisasterManager extends CuratorAsyncManager {
     save(FIRE_ALARM_PATH, fireAlarm, fireAlarmTranscoder);
   }
 
+  public Optional<FireAlarm> getFireAlarm() {
+    return getData(FIRE_ALARM_PATH, fireAlarmTranscoder);
+  }
+
   public void deleteFireAlarm() {
     delete(FIRE_ALARM_PATH);
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/StateManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/StateManager.java
@@ -52,6 +52,7 @@ public class StateManager extends CuratorManager {
   private final DeployManager deployManager;
   private final AgentManager agentManager;
   private final RackManager rackManager;
+  private final DisasterManager disasterManager;
   private final Transcoder<SingularityState> stateTranscoder;
   private final Transcoder<SingularityHostState> hostStateTranscoder;
   private final SingularityConfiguration singularityConfiguration;
@@ -71,6 +72,7 @@ public class StateManager extends CuratorManager {
     DeployManager deployManager,
     AgentManager agentManager,
     RackManager rackManager,
+    DisasterManager disasterManager,
     Transcoder<SingularityState> stateTranscoder,
     Transcoder<SingularityHostState> hostStateTranscoder,
     SingularityConfiguration singularityConfiguration,
@@ -89,6 +91,7 @@ public class StateManager extends CuratorManager {
     this.hostStateTranscoder = hostStateTranscoder;
     this.agentManager = agentManager;
     this.rackManager = rackManager;
+    this.disasterManager = disasterManager;
     this.deployManager = deployManager;
     this.singularityConfiguration = singularityConfiguration;
     this.authDatastore = authDatastore;
@@ -330,7 +333,8 @@ public class StateManager extends CuratorManager {
       authDatastoreHealthy,
       minimumPriorityLevel,
       (long) statusUpdateDeltas.getSnapshot().getMean(),
-      lastHeartbeatTime.get()
+      lastHeartbeatTime.get(),
+      disasterManager.getFireAlarm()
     );
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/transcoders/SingularityTranscoderModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/transcoders/SingularityTranscoderModule.java
@@ -19,6 +19,7 @@ import com.hubspot.singularity.SingularityDeployStatistics;
 import com.hubspot.singularity.SingularityDeployUpdate;
 import com.hubspot.singularity.SingularityDisabledAction;
 import com.hubspot.singularity.SingularityDisasterDataPoints;
+import com.hubspot.singularity.SingularityFireAlarm;
 import com.hubspot.singularity.SingularityHostState;
 import com.hubspot.singularity.SingularityKilledTaskIdRecord;
 import com.hubspot.singularity.SingularityLoadBalancerUpdate;
@@ -71,6 +72,7 @@ public class SingularityTranscoderModule implements Module {
     bindTranscoder(binder).asJson(SingularityDeployMarker.class);
     bindTranscoder(binder).asJson(SingularityDeployResult.class);
     bindTranscoder(binder).asJson(SingularityDeployStatistics.class);
+    bindTranscoder(binder).asJson(SingularityFireAlarm.class);
     bindTranscoder(binder).asJson(SingularityKilledTaskIdRecord.class);
     bindTranscoder(binder).asJson(SingularityLoadBalancerUpdate.class);
     bindTranscoder(binder).asJson(SingularityPendingDeploy.class);

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/DisastersResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/DisastersResource.java
@@ -224,8 +224,7 @@ public class DisastersResource extends AbstractLeaderAwareResource {
   @Path("/firealarm")
   @Operation(summary = "Get a firealarm warning in singularity")
   public Optional<FireAlarm> getFireAlarm(
-    @Parameter(hidden = true) @Auth SingularityUser user,
-    FireAlarm fireAlarm
+    @Parameter(hidden = true) @Auth SingularityUser user
   ) {
     return disasterManager.getFireAlarm();
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/DisastersResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/DisastersResource.java
@@ -2,7 +2,6 @@ package com.hubspot.singularity.resources;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
-import com.hubspot.singularity.FireAlarm;
 import com.hubspot.singularity.Singularity;
 import com.hubspot.singularity.SingularityAbort;
 import com.hubspot.singularity.SingularityAbort.AbortReason;
@@ -10,6 +9,7 @@ import com.hubspot.singularity.SingularityAction;
 import com.hubspot.singularity.SingularityDisabledAction;
 import com.hubspot.singularity.SingularityDisasterType;
 import com.hubspot.singularity.SingularityDisastersData;
+import com.hubspot.singularity.SingularityFireAlarm;
 import com.hubspot.singularity.SingularityUser;
 import com.hubspot.singularity.api.SingularityDisabledActionRequest;
 import com.hubspot.singularity.auth.SingularityAuthorizer;
@@ -223,7 +223,7 @@ public class DisastersResource extends AbstractLeaderAwareResource {
   @GET
   @Path("/firealarm")
   @Operation(summary = "Get a firealarm warning in singularity")
-  public Optional<FireAlarm> getFireAlarm(
+  public Optional<SingularityFireAlarm> getFireAlarm(
     @Parameter(hidden = true) @Auth SingularityUser user
   ) {
     return disasterManager.getFireAlarm();
@@ -234,7 +234,7 @@ public class DisastersResource extends AbstractLeaderAwareResource {
   @Operation(summary = "Set a firealarm warning in singularity")
   public void enableFireAlarm(
     @Parameter(hidden = true) @Auth SingularityUser user,
-    FireAlarm fireAlarm
+    SingularityFireAlarm fireAlarm
   ) {
     authorizationHelper.checkAdminAuthorization(user);
     disasterManager.setFireAlarm(fireAlarm);

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/DisastersResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/DisastersResource.java
@@ -220,6 +220,16 @@ public class DisastersResource extends AbstractLeaderAwareResource {
     return Response.ok().build();
   }
 
+  @GET
+  @Path("/firealarm")
+  @Operation(summary = "Set a firealarm warning in singularity")
+  public Optional<FireAlarm> getFireAlarm(
+    @Parameter(hidden = true) @Auth SingularityUser user,
+    FireAlarm fireAlarm
+  ) {
+    return disasterManager.getFireAlarm();
+  }
+
   @POST
   @Path("/firealarm")
   @Operation(summary = "Set a firealarm warning in singularity")

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/DisastersResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/DisastersResource.java
@@ -222,7 +222,7 @@ public class DisastersResource extends AbstractLeaderAwareResource {
 
   @GET
   @Path("/firealarm")
-  @Operation(summary = "Set a firealarm warning in singularity")
+  @Operation(summary = "Get a firealarm warning in singularity")
   public Optional<FireAlarm> getFireAlarm(
     @Parameter(hidden = true) @Auth SingularityUser user,
     FireAlarm fireAlarm

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/DisastersResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/DisastersResource.java
@@ -2,6 +2,7 @@ package com.hubspot.singularity.resources;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
+import com.hubspot.singularity.FireAlarm;
 import com.hubspot.singularity.Singularity;
 import com.hubspot.singularity.SingularityAbort;
 import com.hubspot.singularity.SingularityAbort.AbortReason;
@@ -217,5 +218,24 @@ public class DisastersResource extends AbstractLeaderAwareResource {
       Executors.newSingleThreadExecutor()
     );
     return Response.ok().build();
+  }
+
+  @POST
+  @Path("/firealarm")
+  @Operation(summary = "Set a firealarm warning in singularity")
+  public void enableFireAlarm(
+    @Parameter(hidden = true) @Auth SingularityUser user,
+    FireAlarm fireAlarm
+  ) {
+    authorizationHelper.checkAdminAuthorization(user);
+    disasterManager.setFireAlarm(fireAlarm);
+  }
+
+  @DELETE
+  @Path("/firealarm")
+  @Operation(summary = "Deleting ongoing fire alarm")
+  public void disableFireAlarm(@Parameter(hidden = true) @Auth SingularityUser user) {
+    authorizationHelper.checkAdminAuthorization(user);
+    disasterManager.deleteFireAlarm();
   }
 }

--- a/SingularityUI/app/components/common/Application.jsx
+++ b/SingularityUI/app/components/common/Application.jsx
@@ -5,6 +5,7 @@ import Navigation from './Navigation';
 import GlobalSearch from '../globalSearch/GlobalSearch';
 import Title from './Title';
 import Utils from '../../utils';
+import FireAlarm from './FireAlarm';
 
 const DISMISS_TASK_LAG_NOFICATION_DURATION_IN_MS = 1000 * 60 * 60;
 const MAX_LATE_REQUESTS = 100;
@@ -58,6 +59,7 @@ class Application extends Component {
         <Title routes={this.props.routes} params={this.props.params} />
         <Navigation location={this.props.location} history={this.props.history} />
         <GlobalSearch />
+        <FireAlarm />
         {this.props.children}
       </div>
     );

--- a/SingularityUI/app/components/common/FireAlarm.jsx
+++ b/SingularityUI/app/components/common/FireAlarm.jsx
@@ -1,0 +1,39 @@
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { Alert } from 'react-bootstrap';
+
+class FireAlarm extends Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    const { fireAlarm } = this.props;
+
+    if (fireAlarm) {
+      return (
+        <Alert bsStyle="warning">
+          <div className="fireAlarm">
+            <span className="h4 fireAlarmTitle">{fireAlarm.title}</span>
+            <span className="fireAlarmMessage">{fireAlarm.message}</span>
+            <a className="fireAlarmUrl">{fireAlarm.url}</a>
+          </div>
+        </Alert>
+      );
+    }
+
+    return null;
+  }
+}
+
+FireAlarm.propTypes = {
+  fireAlarm: PropTypes.object,
+};
+
+const mapStateToProps = (state) => {
+  return {
+    fireAlarm: state.api.status.data.fireAlarm,
+  };
+};
+
+export default connect(mapStateToProps)(FireAlarm);

--- a/SingularityUI/app/styles/stylus/fireAlarm.styl
+++ b/SingularityUI/app/styles/stylus/fireAlarm.styl
@@ -1,0 +1,19 @@
+.fireAlarm
+  display: flex
+  align-items: baseline
+  margin-left: auto;
+  margin-right: auto
+
+.fireAlarmTitle
+  margin: 0
+  margin-right: 1rem
+  display: inline
+
+.fireAlarmMessage
+  margin: 0
+  margin-right: 1rem
+  display: inline
+
+.fireAlarmUrl
+  margin: 0
+  display: inline


### PR DESCRIPTION
Fairly basic fire alarm capability for Singularity. 

The idea is that in an emergency, when users taking certain actions could be destructive (e.g. bouncing while agent capacity is low due to an outage) but we don't want to outright disallow then, a banner can be displayed warning users about the potential consequences of certain actions. 

This allows setting, updating, and deleting a firealarm. Can easily make it more sophisticated if necessary. 

This does not include UI updates. When it's time to implement that, the banner should probably also check the disasters resource to check what actions are currently explicitly disallowed.