### PR TITLE
Task lag sensitive request lock

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityManagedThreadPoolFactory.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityManagedThreadPoolFactory.java
@@ -46,21 +46,7 @@ public class SingularityManagedThreadPoolFactory {
     return service;
   }
 
-  public synchronized ExecutorService get(String name, int maxSize) {
-    checkState(!stopped.get(), "already stopped");
-    ExecutorService service = new ThreadPoolExecutor(
-      1,
-      maxSize,
-      60L,
-      TimeUnit.SECONDS,
-      new LinkedBlockingQueue<>(),
-      new ThreadFactoryBuilder().setNameFormat(name + "-%d").build()
-    );
-    executorPools.add(service);
-    return service;
-  }
-
-  public synchronized ExecutorService fixed(String name, int size) {
+  public synchronized ExecutorService get(String name, int size) {
     checkState(!stopped.get(), "already stopped");
     ExecutorService service = new ThreadPoolExecutor(
       size,

--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityManagedThreadPoolFactory.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityManagedThreadPoolFactory.java
@@ -60,6 +60,20 @@ public class SingularityManagedThreadPoolFactory {
     return service;
   }
 
+  public synchronized ExecutorService fixed(String name, int size) {
+    checkState(!stopped.get(), "already stopped");
+    ExecutorService service = new ThreadPoolExecutor(
+      size,
+      size,
+      60L,
+      TimeUnit.SECONDS,
+      new LinkedBlockingQueue<>(),
+      new ThreadFactoryBuilder().setNameFormat(name + "-%d").build()
+    );
+    executorPools.add(service);
+    return service;
+  }
+
   public synchronized ExecutorAndQueue get(
     String name,
     int maxSize,

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/CuratorAsyncManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/CuratorAsyncManager.java
@@ -122,6 +122,8 @@ public abstract class CuratorAsyncManager extends CuratorManager {
           if (cache.isPresent()) {
             cache.get().set(event.getPath(), object);
           }
+        } catch (Exception e) {
+          LOG.error("Exception processing curator result", e);
         } finally {
           latch.countDown();
         }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/DeployManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/DeployManager.java
@@ -276,12 +276,12 @@ public class DeployManager extends CuratorAsyncManager {
     return deployKeyToDeploy;
   }
 
-  public SingularityCreateResult saveDeploy(
+  public SingularityCreateResult createDeployIfNotExists(
     SingularityRequest request,
     SingularityDeployMarker deployMarker,
     SingularityDeploy deploy
   ) {
-    final SingularityCreateResult deploySaveResult = create(
+    SingularityCreateResult deploySaveResult = create(
       getDeployDataPath(deploy.getRequestId(), deploy.getId()),
       deploy,
       deployTranscoder
@@ -294,7 +294,15 @@ public class DeployManager extends CuratorAsyncManager {
         deployMarker
       );
     }
+    return deploySaveResult;
+  }
 
+  public SingularityCreateResult saveDeploy(
+    SingularityRequest request,
+    SingularityDeployMarker deployMarker,
+    SingularityDeploy deploy
+  ) {
+    createDeployIfNotExists(request, deployMarker, deploy);
     LOG.info("Creating deploy {}", deployMarker);
 
     singularityEventListener.deployHistoryEvent(

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/StateManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/StateManager.java
@@ -334,10 +334,10 @@ public class StateManager extends CuratorManager {
     );
   }
 
-  private SingularityScheduledTasksInfo getScheduledTasksInfo() {
+  public List<SingularityPendingTaskId> getLateTasks() {
     long now = System.currentTimeMillis();
     List<SingularityPendingTaskId> allPendingTaskIds = taskManager.getPendingTaskIds();
-    List<SingularityPendingTaskId> lateTasks = allPendingTaskIds
+    return allPendingTaskIds
       .stream()
       .filter(
         p ->
@@ -346,6 +346,11 @@ public class StateManager extends CuratorManager {
           singularityConfiguration.getDeltaAfterWhichTasksAreLateMillis()
       )
       .collect(Collectors.toList());
+  }
+
+  private SingularityScheduledTasksInfo getScheduledTasksInfo() {
+    long now = System.currentTimeMillis();
+    List<SingularityPendingTaskId> lateTasks = getLateTasks();
 
     Map<Boolean, List<SingularityPendingTaskId>> lateTasksPartitionedByOnDemand = lateTasks
       .stream()

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
@@ -156,7 +156,7 @@ public class SingularityMesosOfferScheduler {
       this.normalizedDiskWeight = diskWeight;
     }
     this.offerScoringExecutor =
-      threadPoolFactory.fixed("offer-scoring", configuration.getCoreThreadpoolSize());
+      threadPoolFactory.get("offer-scoring", configuration.getCoreThreadpoolSize());
   }
 
   public void resourceOffers(List<Offer> uncached) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosOfferScheduler.java
@@ -156,7 +156,7 @@ public class SingularityMesosOfferScheduler {
       this.normalizedDiskWeight = diskWeight;
     }
     this.offerScoringExecutor =
-      threadPoolFactory.get("offer-scoring", configuration.getCoreThreadpoolSize());
+      threadPoolFactory.fixed("offer-scoring", configuration.getCoreThreadpoolSize());
   }
 
   public void resourceOffers(List<Offer> uncached) {
@@ -526,7 +526,7 @@ public class SingularityMesosOfferScheduler {
 
     // We spend much of the offer check loop for request level locks. Wait for the locks in parallel, but ensure that actual offer checks
     // are done in serial to not over commit a single offer
-    ReentrantLock offerCheckTempLock = new ReentrantLock(true);
+    ReentrantLock offerCheckTempLock = new ReentrantLock(false);
     CompletableFutures
       .allOf(
         sortedTaskRequestHolders
@@ -538,7 +538,7 @@ public class SingularityMesosOfferScheduler {
             entry ->
               runAsync(
                 () -> {
-                  lock.runWithRequestLock(
+                  lock.tryRunWithRequestLock(
                     () -> {
                       offerCheckTempLock.lock();
                       try {
@@ -640,7 +640,9 @@ public class SingularityMesosOfferScheduler {
                       }
                     },
                     entry.getKey(),
-                    String.format("%s#%s", getClass().getSimpleName(), "checkOffers")
+                    String.format("%s#%s", getClass().getSimpleName(), "checkOffers"),
+                    mesosConfiguration.getOfferLoopRequestTimeoutMillis(),
+                    TimeUnit.MILLISECONDS
                   );
                 }
               )

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySchedulerLock.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySchedulerLock.java
@@ -77,6 +77,7 @@ public class SingularitySchedulerLock {
         requestId,
         JavaUtils.duration(start)
       );
+      Thread.currentThread().interrupt();
       return -1;
     }
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySchedulerLock.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySchedulerLock.java
@@ -43,6 +43,38 @@ public class SingularitySchedulerLock {
     return System.currentTimeMillis();
   }
 
+  /** Returns start time of lock if successful, -1 otherwise. */
+  private long tryLock(String requestId, String name, long timeout, TimeUnit timeunit) {
+    try {
+      final long start = System.currentTimeMillis();
+      LOG.trace("{} - Trying Locking {}", name, requestId);
+      ReentrantLock lock = requestLocks.computeIfAbsent(
+        requestId,
+        r -> new ReentrantLock()
+      );
+      boolean locked = lock.tryLock(timeout, timeunit);
+      if (locked) {
+        LOG.trace(
+          "{} - Acquired lock on {} ({})",
+          name,
+          requestId,
+          JavaUtils.duration(start)
+        );
+        return start;
+      } else {
+        LOG.trace(
+          "{} - Failed to acquire lock on {} ({})",
+          name,
+          requestId,
+          JavaUtils.duration(start)
+        );
+        return -1;
+      }
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   private void unlock(String requestId, String name, long start) {
     long duration = System.currentTimeMillis() - start;
     if (duration > 1000) {
@@ -63,6 +95,23 @@ public class SingularitySchedulerLock {
       function.run();
     } finally {
       unlock(requestId, name, start);
+    }
+  }
+
+  public void tryRunWithRequestLock(
+    Runnable function,
+    String requestId,
+    String name,
+    long timeout,
+    TimeUnit timeunit
+  ) {
+    long start = tryLock(requestId, name, timeout, timeunit);
+    if (start > 0) {
+      try {
+        function.run();
+      } finally {
+        unlock(requestId, name, start);
+      }
     }
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySchedulerLock.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySchedulerLock.java
@@ -45,9 +45,9 @@ public class SingularitySchedulerLock {
 
   /** Returns start time of lock if successful, -1 otherwise. */
   private long tryLock(String requestId, String name, long timeout, TimeUnit timeunit) {
+    final long start = System.currentTimeMillis();
     try {
-      final long start = System.currentTimeMillis();
-      LOG.trace("{} - Trying Locking {}", name, requestId);
+      LOG.trace("{} - TryLocking {}", name, requestId);
       ReentrantLock lock = requestLocks.computeIfAbsent(
         requestId,
         r -> new ReentrantLock()
@@ -71,7 +71,13 @@ public class SingularitySchedulerLock {
         return -1;
       }
     } catch (InterruptedException e) {
-      throw new RuntimeException(e);
+      LOG.info(
+        "{} - Interrupted trying to acquire lock on {} ({})",
+        name,
+        requestId,
+        JavaUtils.duration(start)
+      );
+      return -1;
     }
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySchedulerLock.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySchedulerLock.java
@@ -62,7 +62,7 @@ public class SingularitySchedulerLock {
         );
         return start;
       } else {
-        LOG.trace(
+        LOG.info(
           "{} - Failed to acquire lock on {} ({})",
           name,
           requestId,

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/DeployResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/DeployResource.java
@@ -264,6 +264,11 @@ public class DeployResource extends AbstractRequestResource {
       // This can cause a conflict if run outside the lock, causing the pending deploy to be checked before deploy data is saved
       schedulerLock.runWithRequestLock(
         () -> {
+          deployManager.createDeployIfNotExists(
+            updatedRequest,
+            deployMarker,
+            validatedDeploy
+          );
           deployAlreadyInProgress.set(
             deployManager.createPendingDeploy(pendingDeployObj) ==
             SingularityCreateResult.EXISTED

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -491,12 +491,25 @@ public class SingularityScheduler {
         pendingRequest,
         maybePendingDeploy
       );
-      if (
-        missingInstances == 0 &&
-        !matchingTaskIds.isEmpty() &&
-        updatedRequest.isScheduled() &&
-        pendingRequest.getPendingType() == PendingType.NEW_DEPLOY
-      ) {
+      boolean scheduledRequestWithActiveTask =
+        (
+          missingInstances == 0 &&
+          !matchingTaskIds.isEmpty() &&
+          updatedRequest.isScheduled() &&
+          pendingRequest.getPendingType() == PendingType.NEW_DEPLOY
+        );
+      boolean scheduledRequestWithOutdatedActiveTask =
+        (
+          missingInstances == 0 &&
+          matchingTaskIds.isEmpty() &&
+          updatedRequest.isScheduled() &&
+          (
+            pendingRequest.getPendingType() == PendingType.NEW_DEPLOY ||
+            pendingRequest.getPendingType() == PendingType.STARTUP
+          )
+        );
+
+      if (scheduledRequestWithActiveTask || scheduledRequestWithOutdatedActiveTask) {
         LOG.trace(
           "Holding pending request {} because it is scheduled and has an active task",
           pendingRequest


### PR DESCRIPTION
Sketched out a way to prevent request locks from being acquired by lower priority components (everything besides deploys and offer loop?). Concerned about this change introducing difficult bugs, because previously lock acquisition would wait for the lock forever instead of short circuiting.

cc - @ssalinas  