### PR TITLE
Add request-level maximum scale option 

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequest.java
@@ -14,13 +14,14 @@ import java.util.Optional;
 import java.util.Set;
 
 @Schema(
-  description = "Settings that apply to all tasks and deploys assocaited with this request"
+  description = "Settings that apply to all tasks and deploys associated with this request"
 )
 public class SingularityRequest {
   private final String id;
   private final RequestType requestType;
   private final Optional<List<String>> owners;
   private final Optional<Integer> numRetriesOnFailure;
+  private final Optional<Integer> maxScale;
   private final Optional<String> schedule;
   private final Optional<String> quartzSchedule;
   private final Optional<ScheduleType> scheduleType;
@@ -61,6 +62,7 @@ public class SingularityRequest {
     @JsonProperty("requestType") RequestType requestType,
     @JsonProperty("owners") Optional<List<String>> owners,
     @JsonProperty("numRetriesOnFailure") Optional<Integer> numRetriesOnFailure,
+    @JsonProperty("maxScale") Optional<Integer> maxScale,
     @JsonProperty("schedule") Optional<String> schedule,
     @JsonProperty("instances") Optional<Integer> instances,
     @JsonProperty("rackSensitive") Optional<Boolean> rackSensitive,
@@ -129,6 +131,7 @@ public class SingularityRequest {
     this.id = checkNotNull(id, "id cannot be null");
     this.owners = owners;
     this.numRetriesOnFailure = numRetriesOnFailure;
+    this.maxScale = maxScale;
     this.schedule = schedule;
     this.rackSensitive = rackSensitive;
     this.instances = instances;
@@ -183,6 +186,7 @@ public class SingularityRequest {
       .setLoadBalanced(loadBalanced)
       .setInstances(instances)
       .setNumRetriesOnFailure(numRetriesOnFailure)
+      .setMaxScale(maxScale)
       .setOwners(copyOfList(owners))
       .setRackSensitive(rackSensitive)
       .setSchedule(schedule)
@@ -241,6 +245,10 @@ public class SingularityRequest {
   )
   public Optional<Integer> getNumRetriesOnFailure() {
     return numRetriesOnFailure;
+  }
+
+  public Optional<Integer> getMaxScale() {
+    return maxScale;
   }
 
   @Schema(nullable = true, description = "A schedule in cron, RFC5545, or quartz format")
@@ -586,6 +594,7 @@ public class SingularityRequest {
       requestType == that.requestType &&
       Objects.equals(owners, that.owners) &&
       Objects.equals(numRetriesOnFailure, that.numRetriesOnFailure) &&
+      Objects.equals(maxScale, that.maxScale) &&
       Objects.equals(schedule, that.schedule) &&
       Objects.equals(quartzSchedule, that.quartzSchedule) &&
       Objects.equals(scheduleType, that.scheduleType) &&
@@ -639,6 +648,7 @@ public class SingularityRequest {
       requestType,
       owners,
       numRetriesOnFailure,
+      maxScale,
       schedule,
       quartzSchedule,
       scheduleType,
@@ -686,6 +696,8 @@ public class SingularityRequest {
       owners +
       ", numRetriesOnFailure=" +
       numRetriesOnFailure +
+      ", maxScale=" +
+      maxScale +
       ", schedule=" +
       schedule +
       ", quartzSchedule=" +

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestBuilder.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityRequestBuilder.java
@@ -14,6 +14,7 @@ public class SingularityRequestBuilder {
 
   private Optional<List<String>> owners;
   private Optional<Integer> numRetriesOnFailure;
+  private Optional<Integer> maxScale;
 
   private Optional<String> schedule;
   private Optional<String> quartzSchedule;
@@ -60,6 +61,7 @@ public class SingularityRequestBuilder {
     this.requestType = checkNotNull(requestType, "requestType cannot be null");
     this.owners = Optional.empty();
     this.numRetriesOnFailure = Optional.empty();
+    this.maxScale = Optional.empty();
     this.schedule = Optional.empty();
     this.scheduleType = Optional.empty();
     this.killOldNonLongRunningTasksAfterMillis = Optional.empty();
@@ -99,6 +101,7 @@ public class SingularityRequestBuilder {
       requestType,
       owners,
       numRetriesOnFailure,
+      maxScale,
       schedule,
       instances,
       rackSensitive,
@@ -184,6 +187,15 @@ public class SingularityRequestBuilder {
     Optional<Integer> numRetriesOnFailure
   ) {
     this.numRetriesOnFailure = numRetriesOnFailure;
+    return this;
+  }
+
+  public Optional<Integer> getMaxScale() {
+    return maxScale;
+  }
+
+  public SingularityRequestBuilder setMaxScale(Optional<Integer> maxScale) {
+    this.maxScale = maxScale;
     return this;
   }
 
@@ -535,6 +547,7 @@ public class SingularityRequestBuilder {
       requestType == that.requestType &&
       Objects.equals(owners, that.owners) &&
       Objects.equals(numRetriesOnFailure, that.numRetriesOnFailure) &&
+      Objects.equals(maxScale, that.maxScale) &&
       Objects.equals(schedule, that.schedule) &&
       Objects.equals(quartzSchedule, that.quartzSchedule) &&
       Objects.equals(scheduleTimeZone, that.scheduleTimeZone) &&
@@ -588,6 +601,7 @@ public class SingularityRequestBuilder {
       requestType,
       owners,
       numRetriesOnFailure,
+      maxScale,
       schedule,
       quartzSchedule,
       scheduleTimeZone,
@@ -635,6 +649,8 @@ public class SingularityRequestBuilder {
       owners +
       ", numRetriesOnFailure=" +
       numRetriesOnFailure +
+      ", maxScale=" +
+      maxScale +
       ", schedule=" +
       schedule +
       ", quartzSchedule=" +

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
@@ -231,31 +231,7 @@ public class SingularityValidator {
       "Instances must be greater than 0"
     );
 
-    // requested instances cannot exceed request-level max scale (if present) or global max scale
-    if (request.getMaxScale().isPresent()) {
-      if (request.getMaxScale().get() < maxInstancesPerRequest) {
-        checkBadRequest(
-          request.getInstancesSafe() <= request.getMaxScale().get(),
-          "Instances (%s) cannot be greater than %s (maxScale in request)",
-          request.getInstancesSafe(),
-          request.getMaxScale()
-        );
-      } else {
-        checkBadRequest(
-          request.getInstancesSafe() <= maxInstancesPerRequest,
-          "Instances (%s) cannot be greater than %s (maxInstancesPerRequest in mesos configuration)",
-          request.getInstancesSafe(),
-          maxInstancesPerRequest
-        );
-      }
-    } else {
-      checkBadRequest(
-        request.getInstancesSafe() <= maxInstancesPerRequest,
-        "Instances (%s) cannot be greater than %s (maxInstancesPerRequest in mesos configuration)",
-        request.getInstancesSafe(),
-        maxInstancesPerRequest
-      );
-    }
+    validateScale(request);
 
     if (request.getTaskPriorityLevel().isPresent()) {
       checkBadRequest(
@@ -395,6 +371,34 @@ public class SingularityValidator {
       .toBuilder()
       .setQuartzSchedule(Optional.ofNullable(quartzSchedule))
       .build();
+  }
+
+  public void validateScale(SingularityRequest request) {
+    // requested instances cannot exceed request-level max scale (if present) or global max scale
+    if (request.getMaxScale().isPresent()) {
+      if (request.getMaxScale().get() < maxInstancesPerRequest) {
+        checkBadRequest(
+          request.getInstancesSafe() <= request.getMaxScale().get(),
+          "Instances (%s) cannot be greater than %s (maxScale in request)",
+          request.getInstancesSafe(),
+          request.getMaxScale()
+        );
+      } else {
+        checkBadRequest(
+          request.getInstancesSafe() <= maxInstancesPerRequest,
+          "Instances (%s) cannot be greater than %s (maxInstancesPerRequest in mesos configuration)",
+          request.getInstancesSafe(),
+          maxInstancesPerRequest
+        );
+      }
+    } else {
+      checkBadRequest(
+        request.getInstancesSafe() <= maxInstancesPerRequest,
+        "Instances (%s) cannot be greater than %s (maxInstancesPerRequest in mesos configuration)",
+        request.getInstancesSafe(),
+        maxInstancesPerRequest
+      );
+    }
   }
 
   public SingularityWebhook checkSingularityWebhook(SingularityWebhook webhook) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
@@ -245,7 +245,9 @@ public class SingularityValidator {
     if (request.getRequestType().isLongRunning() && request.getMaxScale().isPresent()) {
       checkBadRequest(
         request.getInstancesSafe() <= request.getMaxScale().get(),
-        "Instances (%s) cannot be greater than %s (maxScale in request)"
+        "Instances (%s) cannot be greater than %s (maxScale in request)",
+        request.getInstancesSafe(),
+        request.getMaxScale()
       );
     }
 
@@ -1216,7 +1218,9 @@ public class SingularityValidator {
       if (request.getRequestType().isLongRunning() && request.getMaxScale().isPresent()) {
         checkBadRequest(
           request.getInstancesSafe() <= request.getMaxScale().get(),
-          "Instances (%s) cannot be greater than %s (maxScale in request)"
+          "Instances (%s) cannot be greater than %s (maxScale in request)",
+          request.getInstancesSafe(),
+          request.getMaxScale()
         );
       }
     }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
@@ -231,7 +231,7 @@ public class SingularityValidator {
       "Instances must be greater than 0"
     );
 
-    validateScale(request);
+    validateAgainstMaxScale(request);
 
     if (request.getTaskPriorityLevel().isPresent()) {
       checkBadRequest(
@@ -373,7 +373,7 @@ public class SingularityValidator {
       .build();
   }
 
-  public void validateScale(SingularityRequest request) {
+  public void validateAgainstMaxScale(SingularityRequest request) {
     // requested instances cannot exceed request-level max scale (if present) or global max scale
     if (request.getMaxScale().isPresent()) {
       if (request.getMaxScale().get() < maxInstancesPerRequest) {
@@ -1224,6 +1224,8 @@ public class SingularityValidator {
         requiredAgentCount,
         currentActiveAgentCount
       );
+
+      validateAgainstMaxScale(request);
     }
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
@@ -230,12 +230,22 @@ public class SingularityValidator {
       !request.getInstances().isPresent() || request.getInstances().get() > 0,
       "Instances must be greater than 0"
     );
-    checkBadRequest(
-      request.getInstancesSafe() <= maxInstancesPerRequest,
-      "Instances (%s) be greater than %s (maxInstancesPerRequest in mesos configuration)",
-      request.getInstancesSafe(),
-      maxInstancesPerRequest
-    );
+
+    if (request.getMaxScale().isPresent()) { // check if number of instances exceeds request-level max scale first
+      checkBadRequest(
+        request.getInstancesSafe() <= request.getMaxScale().get(),
+        "Instances (%s) cannot be greater than %s (maxScale in request)",
+        request.getInstancesSafe(),
+        request.getMaxScale()
+      );
+    } else { // check if exceeds global config max scale
+      checkBadRequest(
+        request.getInstancesSafe() <= maxInstancesPerRequest,
+        "Instances (%s) cannot be greater than %s (maxInstancesPerRequest in mesos configuration)",
+        request.getInstancesSafe(),
+        maxInstancesPerRequest
+      );
+    }
 
     if (request.getTaskPriorityLevel().isPresent()) {
       checkBadRequest(

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
@@ -231,21 +231,17 @@ public class SingularityValidator {
       "Instances must be greater than 0"
     );
 
-    if (request.getMaxScale().isPresent()) { // check if number of instances exceeds request-level max scale first
-      checkBadRequest(
-        request.getInstancesSafe() <= request.getMaxScale().get(),
-        "Instances (%s) cannot be greater than %s (maxScale in request)",
-        request.getInstancesSafe(),
-        request.getMaxScale()
-      );
-    } else { // check if exceeds global config max scale
-      checkBadRequest(
-        request.getInstancesSafe() <= maxInstancesPerRequest,
-        "Instances (%s) cannot be greater than %s (maxInstancesPerRequest in mesos configuration)",
-        request.getInstancesSafe(),
-        maxInstancesPerRequest
-      );
-    }
+    // check if requested number of instances exceeds max scale
+    int maxInstances = request.getMaxScale().isPresent()
+      ? request.getMaxScale().get()
+      : maxInstancesPerRequest;
+
+    checkBadRequest(
+      request.getInstancesSafe() <= maxInstances,
+      "Instances (%s) cannot be greater than %s",
+      request.getInstancesSafe(),
+      maxInstances
+    );
 
     if (request.getTaskPriorityLevel().isPresent()) {
       checkBadRequest(

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
@@ -231,7 +231,7 @@ public class SingularityValidator {
       "Instances must be greater than 0"
     );
 
-    validateAgainstMaxScale(request);
+    checkRequestAgainstMaxScale(request);
 
     if (request.getTaskPriorityLevel().isPresent()) {
       checkBadRequest(
@@ -373,7 +373,7 @@ public class SingularityValidator {
       .build();
   }
 
-  public void validateAgainstMaxScale(SingularityRequest request) {
+  private void checkRequestAgainstMaxScale(SingularityRequest request) {
     // requested instances cannot exceed request-level max scale (if present) or global max scale
     if (request.getMaxScale().isPresent()) {
       if (request.getMaxScale().get() < maxInstancesPerRequest) {
@@ -1225,7 +1225,7 @@ public class SingularityValidator {
         currentActiveAgentCount
       );
 
-      validateAgainstMaxScale(request);
+      checkRequestAgainstMaxScale(request);
     }
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
@@ -247,7 +247,7 @@ public class SingularityValidator {
         request.getInstancesSafe() <= request.getMaxScale().get(),
         "Instances (%s) cannot be greater than %s (maxScale in request)",
         request.getInstancesSafe(),
-        request.getMaxScale()
+        request.getMaxScale().get()
       );
     }
 
@@ -1220,7 +1220,7 @@ public class SingularityValidator {
           request.getInstancesSafe() <= request.getMaxScale().get(),
           "Instances (%s) cannot be greater than %s (maxScale in request)",
           request.getInstancesSafe(),
-          request.getMaxScale()
+          request.getMaxScale().get()
         );
       }
     }

--- a/SingularityService/src/test/java/com/hubspot/singularity/data/ValidatorTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/data/ValidatorTest.java
@@ -169,7 +169,7 @@ public class ValidatorTest extends SingularitySchedulerTestBase {
     int requestMaxScale = globalMaxScale - 5;
     SingularityRequest request = new SingularityRequestBuilder(
       "requestId",
-      RequestType.RUN_ONCE
+      RequestType.SERVICE
     )
       .setMaxScale(Optional.of(requestMaxScale)) // request level max scale < global max scale
       .setInstances(Optional.of(requestMaxScale + 1)) // instances > request level max scale
@@ -195,7 +195,7 @@ public class ValidatorTest extends SingularitySchedulerTestBase {
     int requestMaxScale = globalMaxScale + 5;
     SingularityRequest request = new SingularityRequestBuilder(
       "requestId",
-      RequestType.RUN_ONCE
+      RequestType.SERVICE
     )
       .setMaxScale(Optional.of(requestMaxScale)) // global max scale < request level max scale
       .setInstances(Optional.of(globalMaxScale + 1)) // instances > global max scale (mesos config)

--- a/SingularityService/src/test/java/com/hubspot/singularity/data/ValidatorTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/data/ValidatorTest.java
@@ -213,9 +213,8 @@ public class ValidatorTest extends SingularitySchedulerTestBase {
     int globalMaxScale = configuration
       .getMesosConfiguration()
       .getMaxNumInstancesPerRequest();
-
-    SingularityRequest request = new SingularityRequestBuilder(
-      "requestId",
+    SingularityRequest request1 = new SingularityRequestBuilder(
+      "requestId1",
       RequestType.RUN_ONCE
     )
       .setInstances(Optional.of(globalMaxScale + 1)) // instances > global max scale (mesos config)
@@ -225,7 +224,7 @@ public class ValidatorTest extends SingularitySchedulerTestBase {
     Assertions.assertDoesNotThrow(
       () ->
         validator.checkSingularityRequest(
-          request,
+          request1,
           Optional.empty(),
           Optional.empty(),
           Optional.empty()


### PR DESCRIPTION
This adds a maximum scale option at the request level for users to specify the maximum number of instances allowed for a particular request. Previously, there only existed a global limit in `MesosConfiguration` to prevent overscales that applied to all requests.

https://git.hubteam.com/HubSpot/PaaS-Run/issues/1546