### PR TITLE
Guice bindings for custom authorizer implementations

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/SingularityService.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/SingularityService.java
@@ -100,7 +100,7 @@ public class SingularityService<T extends SingularityConfiguration>
 
     GuiceBundle.Builder<SingularityConfiguration> guiceBundleBuilder = GuiceBundle
       .defaultBuilder(SingularityConfiguration.class)
-      .modules(getServiceModule(), getObjectMapperModule(), new SingularityAuthModule())
+      .modules(getServiceModule(), getObjectMapperModule(), getAuthModule())
       .modules(additionalModules)
       .enableGuiceEnforcer(false)
       .stage(getGuiceStage());
@@ -169,6 +169,10 @@ public class SingularityService<T extends SingularityConfiguration>
         .bind(ObjectMapper.class)
         .toProvider(DropwizardObjectMapperProvider.class)
         .in(Scopes.SINGLETON);
+  }
+
+  public Module getAuthModule() {
+    return new SingularityAuthModule();
   }
 
   /**

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAuthorizer.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAuthorizer.java
@@ -10,6 +10,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.hubspot.singularity.InvalidSingularityTaskIdException;
 import com.hubspot.singularity.SingularityAuthorizationScope;
+import com.hubspot.singularity.SingularityDeploy;
 import com.hubspot.singularity.SingularityRequest;
 import com.hubspot.singularity.SingularityRequestWithState;
 import com.hubspot.singularity.SingularityTaskId;
@@ -66,6 +67,13 @@ public abstract class SingularityAuthorizer {
     SingularityAuthorizationScope scope,
     Optional<SingularityUserFacingAction> action
   );
+
+  public void checkForAuthorization(
+    SingularityRequest request,
+    SingularityDeploy deploy,
+    SingularityUser user,
+    SingularityAuthorizationScope scope
+  ) {}
 
   public boolean isAuthorizedForRequest(
     SingularityRequest request,

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAuthorizer.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAuthorizer.java
@@ -45,6 +45,15 @@ public abstract class SingularityAuthorizer {
   public abstract void checkReadAuthorization(SingularityUser user);
 
   public void checkForAuthorization(
+    SingularityRequest oldRequest,
+    SingularityRequest newRequest,
+    SingularityUser user,
+    SingularityAuthorizationScope scope
+  ) {
+    checkForAuthorization(oldRequest, user, scope, Optional.empty());
+  }
+
+  public void checkForAuthorization(
     SingularityRequest request,
     SingularityUser user,
     SingularityAuthorizationScope scope

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAuthorizer.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAuthorizer.java
@@ -45,15 +45,6 @@ public abstract class SingularityAuthorizer {
   public abstract void checkReadAuthorization(SingularityUser user);
 
   public void checkForAuthorization(
-    SingularityRequest oldRequest,
-    SingularityRequest newRequest,
-    SingularityUser user,
-    SingularityAuthorizationScope scope
-  ) {
-    checkForAuthorization(oldRequest, user, scope, Optional.empty());
-  }
-
-  public void checkForAuthorization(
     SingularityRequest request,
     SingularityUser user,
     SingularityAuthorizationScope scope
@@ -107,6 +98,16 @@ public abstract class SingularityAuthorizer {
     SingularityAuthorizationScope scope,
     Optional<SingularityUserFacingAction> action
   );
+
+  public void checkForAuthorizedChanges(
+    SingularityRequest newRequest,
+    Optional<SingularityRequest> oldRequest,
+    SingularityUser user
+  ) {
+    if (oldRequest.isPresent()) {
+      checkForAuthorizedChanges(newRequest, oldRequest.get(), user);
+    } else {}
+  }
 
   public abstract void checkForAuthorizedChanges(
     SingularityRequest request,

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAuthorizer.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAuthorizer.java
@@ -32,7 +32,7 @@ public abstract class SingularityAuthorizer {
     this.authEnabled = authEnabled;
   }
 
-  static boolean groupsIntersect(Set<String> a, Set<String> b) {
+  public static boolean groupsIntersect(Set<String> a, Set<String> b) {
     return !Sets.intersection(a, b).isEmpty();
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAuthorizer.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityAuthorizer.java
@@ -106,7 +106,7 @@ public abstract class SingularityAuthorizer {
   ) {
     if (oldRequest.isPresent()) {
       checkForAuthorizedChanges(newRequest, oldRequest.get(), user);
-    } else {}
+    }
   }
 
   public abstract void checkForAuthorizedChanges(

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityGroupsScopesAuthorizer.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityGroupsScopesAuthorizer.java
@@ -290,7 +290,7 @@ public class SingularityGroupsScopesAuthorizer extends SingularityAuthorizer {
     );
   }
 
-  private Set<String> getGroups(
+  protected Set<String> getGroups(
     SingularityRequest request,
     SingularityAuthorizationScope scope
   ) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityGroupsScopesAuthorizer.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/auth/SingularityGroupsScopesAuthorizer.java
@@ -27,7 +27,7 @@ public class SingularityGroupsScopesAuthorizer extends SingularityAuthorizer {
     SingularityGroupsScopesAuthorizer.class
   );
 
-  private final AuthConfiguration authConfiguration;
+  protected final AuthConfiguration authConfiguration;
   private final ScopesConfiguration scopesConfiguration;
   private final SingularityEventListener singularityEventListener;
 
@@ -227,7 +227,7 @@ public class SingularityGroupsScopesAuthorizer extends SingularityAuthorizer {
     return groupsIntersect(authConfiguration.getJitaGroups(), user.getGroups());
   }
 
-  private boolean isAdmin(SingularityUser user) {
+  protected boolean isAdmin(SingularityUser user) {
     return hasScope(user, SingularityAuthorizationScope.ADMIN);
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/DeployResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/DeployResource.java
@@ -164,6 +164,13 @@ public class DeployResource extends AbstractRequestResource {
     );
 
     SingularityRequest request = requestWithState.getRequest();
+    authorizationHelper.checkForAuthorization(
+      request,
+      deploy,
+      user,
+      SingularityAuthorizationScope.WRITE
+    );
+
     final Optional<SingularityRequest> updatedValidatedRequest;
     if (deployRequest.getUpdatedRequest().isPresent()) {
       authorizationHelper.checkForAuthorizedChanges(

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -196,6 +196,7 @@ public class RequestResource extends AbstractRequestResource {
     if (oldRequest.isPresent()) {
       authorizationHelper.checkForAuthorization(
         oldRequest.get(),
+        request,
         user,
         SingularityAuthorizationScope.WRITE
       );

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/RequestResource.java
@@ -193,14 +193,14 @@ public class RequestResource extends AbstractRequestResource {
       ? Optional.of(oldRequestWithState.get().getRequest())
       : Optional.<SingularityRequest>empty();
 
+    authorizationHelper.checkForAuthorizedChanges(request, oldRequest, user);
+
     if (oldRequest.isPresent()) {
       authorizationHelper.checkForAuthorization(
         oldRequest.get(),
-        request,
         user,
         SingularityAuthorizationScope.WRITE
       );
-      authorizationHelper.checkForAuthorizedChanges(request, oldRequest.get(), user);
       validator.checkActionEnabled(SingularityAction.UPDATE_REQUEST);
     } else {
       validator.checkActionEnabled(SingularityAction.CREATE_REQUEST);


### PR DESCRIPTION
Allows overriding `getAuthModule` to inject custom implementations of `SingularityAuthorizer`