### PR TITLE
Cleanup old decommissioned agents

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityAgentReconciliationPoller.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityAgentReconciliationPoller.java
@@ -96,9 +96,15 @@ public class SingularityAgentReconciliationPoller extends SingularityLeaderOnlyP
 
     LOG.debug("Found {} agents missing on startup", missingOnStartupAgents.size());
 
+    List<SingularityAgent> decommissionedAgents = agentManager.getObjectsFiltered(
+      MachineState.DECOMMISSIONED
+    );
+    LOG.debug("Found {} agents decommissioned", decommissionedAgents.size());
+
     List<SingularityAgent> inactiveAgents = new ArrayList<>();
     inactiveAgents.addAll(deadAgents);
     inactiveAgents.addAll(missingOnStartupAgents);
+    inactiveAgents.addAll(decommissionedAgents);
 
     if (inactiveAgents.isEmpty()) {
       LOG.trace("No inactive agents");


### PR DESCRIPTION
Assuming that if an agent is decommissioned (not stuck decommissioning) for a long time, it should be safe to clean it up the same way as dead/missing agents.

cc - @ssalinas 