### PR TITLE
Task Persister skips too long task Ids

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -2116,7 +2116,7 @@ public class SingularityConfiguration extends Configuration {
     return skipPersistingTooLongTaskIds;
   }
 
-  public void skipPersistingTooLongTaskIds(boolean validateTaskIdLengthOnDeploy) {
-    this.skipPersistingTooLongTaskIds = validateTaskIdLengthOnDeploy;
+  public void skipPersistingTooLongTaskIds(boolean skipPersistingTooLongTaskIds) {
+    this.skipPersistingTooLongTaskIds = skipPersistingTooLongTaskIds;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -451,6 +451,8 @@ public class SingularityConfiguration extends Configuration {
   private int deployCacheTtlInSeconds = 5;
   private int requestCacheTtlInSeconds = 5;
 
+  private boolean skipPersistingTooLongTaskIds = false;
+
   public long getAskDriverToKillTasksAgainAfterMillis() {
     return askDriverToKillTasksAgainAfterMillis;
   }
@@ -2108,5 +2110,13 @@ public class SingularityConfiguration extends Configuration {
 
   public void setRequestCacheTtl(int requestCacheTtlInSeconds) {
     this.requestCacheTtlInSeconds = requestCacheTtlInSeconds;
+  }
+
+  public boolean skipPersistingTooLongTaskIds() {
+    return skipPersistingTooLongTaskIds;
+  }
+
+  public void skipPersistingTooLongTaskIds(boolean validateTaskIdLengthOnDeploy) {
+    this.skipPersistingTooLongTaskIds = validateTaskIdLengthOnDeploy;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -2116,7 +2116,7 @@ public class SingularityConfiguration extends Configuration {
     return skipPersistingTooLongTaskIds;
   }
 
-  public void skipPersistingTooLongTaskIds(boolean skipPersistingTooLongTaskIds) {
+  public void setSkipPersistingTooLongTaskIds(boolean skipPersistingTooLongTaskIds) {
     this.skipPersistingTooLongTaskIds = skipPersistingTooLongTaskIds;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityDeployHistoryPersister.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityDeployHistoryPersister.java
@@ -130,6 +130,7 @@ public class SingularityDeployHistoryPersister
               if (moveToHistoryOrCheckForPurge(deployHistory, i++)) {
                 numTransferred.increment();
               } else {
+                LOG.error("Deploy History Persister failed on {}", deployHistory);
                 persisterSuccess.getAndSet(false);
               }
             }
@@ -206,7 +207,7 @@ public class SingularityDeployHistoryPersister
     try {
       historyManager.saveDeployHistory(deployHistory);
     } catch (Throwable t) {
-      LOG.warn(
+      LOG.error(
         "Failed to persist deploy {}",
         SingularityDeployKey.fromDeployMarker(deployHistory.getDeployMarker()),
         t

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityRequestHistoryPersister.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityRequestHistoryPersister.java
@@ -20,7 +20,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantLock;
 import javax.inject.Singleton;
 import org.slf4j.Logger;
@@ -164,6 +163,7 @@ public class SingularityRequestHistoryPersister
             if (moveToHistoryOrCheckForPurge(requestHistoryParent, i.getAndIncrement())) {
               numHistoryTransferred.getAndAdd(requestHistoryParent.history.size());
             } else {
+              LOG.error("Request History Persister failed on {}", requestHistoryParent);
               persisterSuccess.getAndSet(false);
             }
           },
@@ -210,7 +210,7 @@ public class SingularityRequestHistoryPersister
       try {
         historyManager.saveRequestHistoryUpdate(requestHistory);
       } catch (Throwable t) {
-        LOG.warn("Failed to persist {} into History", requestHistory, t);
+        LOG.error("Failed to persist {} into History", requestHistory, t);
         return false;
       }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityTaskHistoryPersister.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityTaskHistoryPersister.java
@@ -88,21 +88,40 @@ public class SingularityTaskHistoryPersister
           int forRequest = 0;
           int transferred = 0;
           for (SingularityTaskId taskId : taskIds) {
-            if (moveToHistoryOrCheckForPurge(taskId, forRequest)) {
-              LOG.debug("Transferred task {}", taskId);
-              transferred++;
+            if (
+              configuration.skipPersistingTooLongTaskIds() &&
+              taskId.getId().length() > 200
+            ) {
+              if (
+                System.currentTimeMillis() -
+                taskId.getCreateTimestampForCalculatingHistoryAge() >
+                TimeUnit.DAYS.toMillis(7)
+              ) {
+                LOG.warn(
+                  "Deleting {} from ZK, could not persist in DB because of task ID length",
+                  taskId.getId()
+                );
+                purgeFromZk(taskId);
+              }
+              LOG.error("Task ID {} too long to pesist to DB, skipping", taskId.getId());
             } else {
-              persisterSuccess = false;
-            }
+              if (moveToHistoryOrCheckForPurge(taskId, forRequest)) {
+                LOG.debug("Transferred task {}", taskId);
+                transferred++;
+              } else {
+                LOG.error("Task History Persister failed on {}", taskId);
+                persisterSuccess = false;
+              }
 
-            forRequest++;
+              forRequest++;
+            }
+            LOG.debug(
+              "Transferred {} out of {} inactive task ids in {}",
+              transferred,
+              taskIds.size(),
+              JavaUtils.duration(start)
+            );
           }
-          LOG.debug(
-            "Transferred {} out of {} inactive task ids in {}",
-            transferred,
-            taskIds.size(),
-            JavaUtils.duration(start)
-          );
         } catch (Exception e) {
           LOG.error("Could not persist", e);
         }
@@ -200,7 +219,7 @@ public class SingularityTaskHistoryPersister
       try {
         historyManager.saveTaskHistory(taskHistory.get());
       } catch (Throwable t) {
-        LOG.warn("Failed to persist task into History for task {}", object, t);
+        LOG.error("Failed to persist task into History for task {}", object, t);
         return false;
       }
     } else {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityTaskHistoryPersister.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityTaskHistoryPersister.java
@@ -102,8 +102,12 @@ public class SingularityTaskHistoryPersister
                   taskId.getId()
                 );
                 purgeFromZk(taskId);
+              } else {
+                LOG.error(
+                  "Task ID {} too long to persist to DB, skipping",
+                  taskId.getId()
+                );
               }
-              LOG.error("Task ID {} too long to pesist to DB, skipping", taskId.getId());
             } else {
               if (moveToHistoryOrCheckForPurge(taskId, forRequest)) {
                 LOG.debug("Transferred task {}", taskId);


### PR DESCRIPTION
We won't be able to save tasks whose task Ids are greater than the DB column setting, so we should skip them and delete them from ZK after some time (set to 1 week in PR).

Once we have a longterm solution for these task IDs, we shouldn't need to skip anymore. 