### PR TITLE
Add endpoint and client call to retrieve scheduled tasks info

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityScheduledTasksInfo.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityScheduledTasksInfo.java
@@ -1,5 +1,7 @@
 package com.hubspot.singularity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 public class SingularityScheduledTasksInfo {
@@ -9,12 +11,13 @@ public class SingularityScheduledTasksInfo {
   private final List<SingularityPendingTaskId> lateTasks;
   private final List<SingularityPendingTaskId> onDemandLateTasks;
 
+  @JsonCreator
   public SingularityScheduledTasksInfo(
-    List<SingularityPendingTaskId> lateTasks,
-    List<SingularityPendingTaskId> onDemandLateTasks,
-    int numFutureTasks,
-    long maxTaskLag,
-    long timestamp
+    @JsonProperty("lateTasks") List<SingularityPendingTaskId> lateTasks,
+    @JsonProperty("onDemandLateTasks") List<SingularityPendingTaskId> onDemandLateTasks,
+    @JsonProperty("numFutureTasks") int numFutureTasks,
+    @JsonProperty("maxTaskLag") long maxTaskLag,
+    @JsonProperty("timestamp") long timestamp
   ) {
     this.lateTasks = lateTasks;
     this.onDemandLateTasks = onDemandLateTasks;

--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
@@ -53,6 +53,7 @@ import com.hubspot.singularity.SingularityRequestParent;
 import com.hubspot.singularity.SingularityRequestWithState;
 import com.hubspot.singularity.SingularityS3Log;
 import com.hubspot.singularity.SingularitySandbox;
+import com.hubspot.singularity.SingularityScheduledTasksInfo;
 import com.hubspot.singularity.SingularityShellCommand;
 import com.hubspot.singularity.SingularitySlave;
 import com.hubspot.singularity.SingularityState;
@@ -118,8 +119,7 @@ public class SingularityClient {
     AUTH_FORMAT + "/groups/auth-check";
 
   private static final String STATE_FORMAT = "%s/state";
-  private static final String LATE_TASKS_FORMAT = "%s/state/late-tasks";
-  private static final String TASK_LAG_FORMAT = "%s/state/task-lag";
+  private static final String SCHEDULED_TASKS_INFO_FORMAT = "%s/scheduled-tasks-info";
   private static final String TASK_RECONCILIATION_FORMAT =
     STATE_FORMAT + "/task-reconciliation";
 
@@ -831,11 +831,11 @@ public class SingularityClient {
   // GLOBAL
   //
 
-  public int getNumLateTasks() {
+  public SingularityScheduledTasksInfo getScheduledTasksInfo() {
     final Function<String, String> uri = host ->
-      String.format(LATE_TASKS_FORMAT, getApiBase(host));
+      String.format(SCHEDULED_TASKS_INFO_FORMAT, getApiBase(host));
 
-    LOG.info("Fetching number of late tasks from {}", uri);
+    LOG.info("Fetching scheduled tasks info from {}", uri);
 
     final long start = System.currentTimeMillis();
 
@@ -848,35 +848,11 @@ public class SingularityClient {
       queryParams
     );
 
-    checkResponse("number of late tasks", response);
+    checkResponse("singularity scheduled tasks info", response);
 
-    LOG.info("Got number of late tasks in {}ms", System.currentTimeMillis() - start);
+    LOG.info("Got scheduled tasks info {}ms", System.currentTimeMillis() - start);
 
-    return response.getAs(Integer.class);
-  }
-
-  public long getMaxTaskLag() {
-    final Function<String, String> uri = host ->
-      String.format(TASK_LAG_FORMAT, getApiBase(host));
-
-    LOG.info("Fetching maximum task lag from {}", uri);
-
-    final long start = System.currentTimeMillis();
-
-    Map<String, Boolean> queryParams = new HashMap<>();
-
-    HttpResponse response = executeRequest(
-      uri,
-      Method.GET,
-      Optional.empty(),
-      queryParams
-    );
-
-    checkResponse("max task lag", response);
-
-    LOG.info("Got maximum task lag in {}ms", System.currentTimeMillis() - start);
-
-    return response.getAs(Long.class);
+    return response.getAs(SingularityScheduledTasksInfo.class);
   }
 
   public SingularityState getState(

--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
@@ -839,13 +839,11 @@ public class SingularityClient {
 
     final long start = System.currentTimeMillis();
 
-    Map<String, Boolean> queryParams = new HashMap<>();
-
     HttpResponse response = executeRequest(
       uri,
       Method.GET,
       Optional.empty(),
-      queryParams
+      Collections.emptyMap()
     );
 
     checkResponse("singularity scheduled tasks info", response);

--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
@@ -118,6 +118,8 @@ public class SingularityClient {
     AUTH_FORMAT + "/groups/auth-check";
 
   private static final String STATE_FORMAT = "%s/state";
+  private static final String LATE_TASKS_FORMAT = "%s/state/late-tasks";
+  private static final String TASK_LAG_FORMAT = "%s/state/task-lag";
   private static final String TASK_RECONCILIATION_FORMAT =
     STATE_FORMAT + "/task-reconciliation";
 
@@ -828,6 +830,54 @@ public class SingularityClient {
   //
   // GLOBAL
   //
+
+  public int getNumLateTasks() {
+    final Function<String, String> uri = host ->
+      String.format(LATE_TASKS_FORMAT, getApiBase(host));
+
+    LOG.info("Fetching number of late tasks from {}", uri);
+
+    final long start = System.currentTimeMillis();
+
+    Map<String, Boolean> queryParams = new HashMap<>();
+
+    HttpResponse response = executeRequest(
+      uri,
+      Method.GET,
+      Optional.empty(),
+      queryParams
+    );
+
+    checkResponse("number of late tasks", response);
+
+    LOG.info("Got number of late tasks in {}ms", System.currentTimeMillis() - start);
+
+    return response.getAs(Integer.class);
+  }
+
+  public long getMaxTaskLag() {
+    final Function<String, String> uri = host ->
+      String.format(TASK_LAG_FORMAT, getApiBase(host));
+
+    LOG.info("Fetching maximum task lag from {}", uri);
+
+    final long start = System.currentTimeMillis();
+
+    Map<String, Boolean> queryParams = new HashMap<>();
+
+    HttpResponse response = executeRequest(
+      uri,
+      Method.GET,
+      Optional.empty(),
+      queryParams
+    );
+
+    checkResponse("max task lag", response);
+
+    LOG.info("Got maximum task lag in {}ms", System.currentTimeMillis() - start);
+
+    return response.getAs(Long.class);
+  }
 
   public SingularityState getState(
     Optional<Boolean> skipCache,

--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
@@ -850,7 +850,7 @@ public class SingularityClient {
 
     checkResponse("singularity scheduled tasks info", response);
 
-    LOG.info("Got scheduled tasks info {}ms", System.currentTimeMillis() - start);
+    LOG.info("Got scheduled tasks info in {}ms", System.currentTimeMillis() - start);
 
     return response.getAs(SingularityScheduledTasksInfo.class);
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/StateManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/StateManager.java
@@ -139,14 +139,6 @@ public class StateManager extends CuratorManager {
     }
   }
 
-  public int getNumLateTasks() {
-    return getScheduledTasksInfo().getLateTasks().size();
-  }
-
-  public long getMaxTaskLag() {
-    return getScheduledTasksInfo().getMaxTaskLag();
-  }
-
   public SingularityState getState(boolean skipCache, boolean includeRequestIds) {
     if (!skipCache) {
       return getData(STATE_PATH, stateTranscoder).orElse(null);
@@ -346,7 +338,7 @@ public class StateManager extends CuratorManager {
     );
   }
 
-  private SingularityScheduledTasksInfo getScheduledTasksInfo() {
+  public SingularityScheduledTasksInfo getScheduledTasksInfo() {
     long now = System.currentTimeMillis();
     List<SingularityPendingTaskId> allPendingTaskIds = taskManager.getPendingTaskIds();
     List<SingularityPendingTaskId> lateTasks = allPendingTaskIds

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/StateManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/StateManager.java
@@ -139,6 +139,14 @@ public class StateManager extends CuratorManager {
     }
   }
 
+  public int getNumLateTasks() {
+    return getScheduledTasksInfo().getLateTasks().size();
+  }
+
+  public long getMaxTaskLag() {
+    return getScheduledTasksInfo().getMaxTaskLag();
+  }
+
   public SingularityState getState(boolean skipCache, boolean includeRequestIds) {
     if (!skipCache) {
       return getData(STATE_PATH, stateTranscoder).orElse(null);

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/StateResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/StateResource.java
@@ -1,6 +1,7 @@
 package com.hubspot.singularity.resources;
 
 import com.google.inject.Inject;
+import com.hubspot.singularity.SingularityScheduledTasksInfo;
 import com.hubspot.singularity.SingularityState;
 import com.hubspot.singularity.SingularityTaskReconciliationStatistics;
 import com.hubspot.singularity.config.ApiPaths;
@@ -33,17 +34,10 @@ public class StateResource {
   }
 
   @GET
-  @Path("/late-tasks")
-  @Operation(summary = "Retrieve the number of late tasks.")
-  public int getLateTasks() {
-    return stateManager.getNumLateTasks();
-  }
-
-  @GET
-  @Path("/task-lag")
-  @Operation(summary = "Retrieve the maximum task lag.")
-  public long getTaskLag() {
-    return stateManager.getMaxTaskLag();
+  @Path("/scheduled-tasks-info")
+  @Operation(summary = "Retrieve the scheduled tasks info.")
+  public SingularityScheduledTasksInfo getScheduledTasksInfo() {
+    return stateManager.getScheduledTasksInfo();
   }
 
   @GET

--- a/SingularityService/src/main/java/com/hubspot/singularity/resources/StateResource.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/resources/StateResource.java
@@ -12,12 +12,14 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 import java.util.List;
 import java.util.Optional;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
+@Consumes(MediaType.APPLICATION_JSON)
 @Path(ApiPaths.STATE_RESOURCE_PATH)
 @Produces({ MediaType.APPLICATION_JSON })
 @Schema(title = "Provides information about the current state of Singularity")
@@ -28,6 +30,20 @@ public class StateResource {
   @Inject
   public StateResource(StateManager stateManager) {
     this.stateManager = stateManager;
+  }
+
+  @GET
+  @Path("/late-tasks")
+  @Operation(summary = "Retrieve the number of late tasks.")
+  public int getLateTasks() {
+    return stateManager.getNumLateTasks();
+  }
+
+  @GET
+  @Path("/task-lag")
+  @Operation(summary = "Retrieve the maximum task lag.")
+  public long getTaskLag() {
+    return stateManager.getMaxTaskLag();
   }
 
   @GET

--- a/SingularityServiceIntegrationTests/src/test/java/com/hubspot/singularity/SingularityStateIT.java
+++ b/SingularityServiceIntegrationTests/src/test/java/com/hubspot/singularity/SingularityStateIT.java
@@ -24,14 +24,8 @@ public class SingularityStateIT {
   }
 
   @Test
-  public void testLateTasksEndpoint(SingularityClient singularityClient) {
-    final int lateTasks = singularityClient.getNumLateTasks();
-    // TODO: assertion
-  }
-
-  @Test
-  public void testTaskLagEndpoint(SingularityClient singularityClient) {
-    final long taskLag = singularityClient.getMaxTaskLag();
+  public void testScheduledTasksInfoEndpoint(SingularityClient singularityClient) {
+    final SingularityScheduledTasksInfo scheduledTasksInfo = singularityClient.getScheduledTasksInfo();
     // TODO: assertion
   }
 }

--- a/SingularityServiceIntegrationTests/src/test/java/com/hubspot/singularity/SingularityStateIT.java
+++ b/SingularityServiceIntegrationTests/src/test/java/com/hubspot/singularity/SingularityStateIT.java
@@ -22,10 +22,4 @@ public class SingularityStateIT {
 
     assertEquals(3, state.getActiveAgents());
   }
-
-  @Test
-  public void testScheduledTasksInfoEndpoint(SingularityClient singularityClient) {
-    final SingularityScheduledTasksInfo scheduledTasksInfo = singularityClient.getScheduledTasksInfo();
-    // TODO: assertion
-  }
 }

--- a/SingularityServiceIntegrationTests/src/test/java/com/hubspot/singularity/SingularityStateIT.java
+++ b/SingularityServiceIntegrationTests/src/test/java/com/hubspot/singularity/SingularityStateIT.java
@@ -22,4 +22,16 @@ public class SingularityStateIT {
 
     assertEquals(3, state.getActiveAgents());
   }
+
+  @Test
+  public void testLateTasksEndpoint(SingularityClient singularityClient) {
+    final int lateTasks = singularityClient.getNumLateTasks();
+    // TODO: assertion
+  }
+
+  @Test
+  public void testTaskLagEndpoint(SingularityClient singularityClient) {
+    final long taskLag = singularityClient.getMaxTaskLag();
+    // TODO: assertion
+  }
 }


### PR DESCRIPTION
This PR adds an endpoint to `StateResource` and client call to `SingularityClient` that enable retrieval of the current `SingularityScheduledTasksInfo`. `SingularityScheduledTasksInfo` contains the number of late task and maximum task lag, both of which will be checked in Serenity before decommissioning agents in order to implement a slow drain and prevent decommissioning too quickly.

issue: https://git.hubteam.com/HubSpot/PaaS-Run/issues/1588
context: https://hubspot.slack.com/archives/CD13L0XCY/p1642617864005200
