### PR TITLE
Fix npe for tasks with null hostnames from decommissioned host resources

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityAgentAndRackManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityAgentAndRackManager.java
@@ -800,18 +800,7 @@ public class SingularityAgentAndRackManager {
 
     for (MesosMasterAgentObject agentJsonObject : state.getAgents()) {
       String agentId = agentJsonObject.getId();
-      if (agentsById.containsKey(agentId)) {
-        SingularityAgent agent = agentsById.get(agentId);
-        if (agent != null) {
-          LOG.info(
-            "Found resources ({}) for decommissioned agent {}",
-            agentJsonObject.getResources(),
-            agent
-          );
-          agentManager.saveObject(agent.withResources(agentJsonObject.getResources()));
-        }
-        agentsById.remove(agentId);
-      }
+      agentsById.remove(agentId);
     }
 
     for (SingularityAgent leftOverAgent : agentsById.values()) {

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityStartup.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityStartup.java
@@ -108,8 +108,8 @@ class SingularityStartup {
 
     MesosMasterStateObject state = mesosClient.getMasterState(uri);
 
-    agentAndRackManager.loadAgentsAndRacksFromMaster(state, true);
     agentAndRackManager.checkDecommissionedAgentsFromMaster(state, true);
+    agentAndRackManager.loadAgentsAndRacksFromMaster(state, true);
 
     ExecutorService startupExecutor = Executors.newFixedThreadPool(
       configuration.getSchedulerStartupConcurrency(),


### PR DESCRIPTION
#2253 likely caused null hostnames / updates for tasks on decommissioned hosts, because agent resource fields could get overwritten with nulls from mesos master on startup. This PR preserves the cleanup logic, while removing the unneeded agent resource updates.

cc - @ssalinas 