### PR TITLE
Count all lost tasks as inactive

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityDeployCheckHelper.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityDeployCheckHelper.java
@@ -444,25 +444,6 @@ public class SingularityDeployCheckHelper {
       pendingDeploy.getDeployProgress().getFailedDeployTasks()
     );
 
-    return newInactiveDeployTasks
-      .stream()
-      .filter(
-        t -> {
-          // All TASK_LOSTs that are not resource limit related should be able to be retried
-          for (SingularityTaskHistoryUpdate historyUpdate : taskManager.getTaskHistoryUpdates(
-            t
-          )) {
-            String historyUpdateReason = historyUpdate.getStatusReason().orElse("");
-            if (
-              historyUpdate.getTaskState() == ExtendedTaskState.TASK_LOST &&
-              !historyUpdateReason.startsWith("REASON_CONTAINER_LIM")
-            ) {
-              return false;
-            }
-          }
-          return true;
-        }
-      )
-      .collect(Collectors.toSet());
+    return newInactiveDeployTasks;
   }
 }


### PR DESCRIPTION
In a previous PR, we updated our evaluation of `TASK_LOST` during a deploy to allow for certain lost tasks, specifically tasks lost because of the container resource limit bug, to retry. This had the unintended effect of getting other deploys with tasks lost stuck in a loop of waiting, because that task wasn't being relaunched and wasn't being counted as failed. Since the source of the container resource limit bug has been found, we are just removing this logic and going to count all lost tasks as failed.