### PR TITLE
Fix SingularityScheduledTasksInfo retrieval in client

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityScheduledTasksInfo.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityScheduledTasksInfo.java
@@ -52,4 +52,22 @@ public class SingularityScheduledTasksInfo {
   public long getTimestamp() {
     return timestamp;
   }
+
+  @Override
+  public String toString() {
+    return (
+      "SingularityScheduledTasksInfo{" +
+      "lateTasks=" +
+      lateTasks +
+      ", onDemandLateTasks=" +
+      onDemandLateTasks +
+      ", numFutureTasks" +
+      numFutureTasks +
+      ", maxTaskLag" +
+      maxTaskLag +
+      ", timestamp" +
+      timestamp +
+      "}"
+    );
+  }
 }

--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityScheduledTasksInfo.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityScheduledTasksInfo.java
@@ -67,7 +67,7 @@ public class SingularityScheduledTasksInfo {
       maxTaskLag +
       ", timestamp" +
       timestamp +
-      "}"
+      '}'
     );
   }
 }

--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
@@ -849,6 +849,7 @@ public class SingularityClient {
     checkResponse("singularity scheduled tasks info", response);
 
     LOG.info("Got scheduled tasks info in {}ms", System.currentTimeMillis() - start);
+    LOG.info("Scheduled tasks info response: {}", response);
 
     return response.getAs(SingularityScheduledTasksInfo.class);
   }

--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
@@ -119,7 +119,8 @@ public class SingularityClient {
     AUTH_FORMAT + "/groups/auth-check";
 
   private static final String STATE_FORMAT = "%s/state";
-  private static final String SCHEDULED_TASKS_INFO_FORMAT = "%s/scheduled-tasks-info";
+  private static final String SCHEDULED_TASKS_INFO_FORMAT =
+    STATE_FORMAT + "/scheduled-tasks-info";
   private static final String TASK_RECONCILIATION_FORMAT =
     STATE_FORMAT + "/task-reconciliation";
 
@@ -849,7 +850,6 @@ public class SingularityClient {
     checkResponse("singularity scheduled tasks info", response);
 
     LOG.info("Got scheduled tasks info in {}ms", System.currentTimeMillis() - start);
-    LOG.info("Scheduled tasks info response: {}", response);
 
     return response.getAs(SingularityScheduledTasksInfo.class);
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/transcoders/SingularityTranscoderModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/transcoders/SingularityTranscoderModule.java
@@ -114,7 +114,7 @@ public class SingularityTranscoderModule implements Module {
     bindTranscoder(binder).asJson(RequestUtilization.class);
     bindTranscoder(binder).asJson(CrashLoopInfo.class);
     bindTranscoder(binder).asJson(ElevatedAccessEvent.class);
-    //    bindTranscoder(binder).asJson(SingularityScheduledTasksInfo.class);
+    bindTranscoder(binder).asJson(SingularityScheduledTasksInfo.class);
 
     bindTranscoder(binder).asCompressedJson(SingularityDeployHistory.class);
     bindTranscoder(binder).asCompressedJson(SingularityDeploy.class);
@@ -126,7 +126,6 @@ public class SingularityTranscoderModule implements Module {
     bindTranscoder(binder).asCompressedJson(SingularityTaskStatusHolder.class);
     bindTranscoder(binder).asCompressedJson(SingularityTask.class);
     bindTranscoder(binder).asCompressedJson(SingularityTaskMetadata.class);
-    bindTranscoder(binder).asCompressedJson(SingularityScheduledTasksInfo.class);
 
     bindTranscoder(binder).asJson(SingularityPriorityFreezeParent.class);
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/transcoders/SingularityTranscoderModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/transcoders/SingularityTranscoderModule.java
@@ -37,6 +37,7 @@ import com.hubspot.singularity.SingularityRequestGroup;
 import com.hubspot.singularity.SingularityRequestHistory;
 import com.hubspot.singularity.SingularityRequestLbCleanup;
 import com.hubspot.singularity.SingularityRequestWithState;
+import com.hubspot.singularity.SingularityScheduledTasksInfo;
 import com.hubspot.singularity.SingularityState;
 import com.hubspot.singularity.SingularityTask;
 import com.hubspot.singularity.SingularityTaskCleanup;
@@ -113,6 +114,7 @@ public class SingularityTranscoderModule implements Module {
     bindTranscoder(binder).asJson(RequestUtilization.class);
     bindTranscoder(binder).asJson(CrashLoopInfo.class);
     bindTranscoder(binder).asJson(ElevatedAccessEvent.class);
+    bindTranscoder(binder).asJson(SingularityScheduledTasksInfo.class);
 
     bindTranscoder(binder).asCompressedJson(SingularityDeployHistory.class);
     bindTranscoder(binder).asCompressedJson(SingularityDeploy.class);

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/transcoders/SingularityTranscoderModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/transcoders/SingularityTranscoderModule.java
@@ -114,7 +114,7 @@ public class SingularityTranscoderModule implements Module {
     bindTranscoder(binder).asJson(RequestUtilization.class);
     bindTranscoder(binder).asJson(CrashLoopInfo.class);
     bindTranscoder(binder).asJson(ElevatedAccessEvent.class);
-    bindTranscoder(binder).asJson(SingularityScheduledTasksInfo.class);
+    //    bindTranscoder(binder).asJson(SingularityScheduledTasksInfo.class);
 
     bindTranscoder(binder).asCompressedJson(SingularityDeployHistory.class);
     bindTranscoder(binder).asCompressedJson(SingularityDeploy.class);
@@ -126,6 +126,7 @@ public class SingularityTranscoderModule implements Module {
     bindTranscoder(binder).asCompressedJson(SingularityTaskStatusHolder.class);
     bindTranscoder(binder).asCompressedJson(SingularityTask.class);
     bindTranscoder(binder).asCompressedJson(SingularityTaskMetadata.class);
+    bindTranscoder(binder).asCompressedJson(SingularityScheduledTasksInfo.class);
 
     bindTranscoder(binder).asJson(SingularityPriorityFreezeParent.class);
   }


### PR DESCRIPTION
This corrects the API call path in `SingularityClient` for getting `SingularityScheduledTasksInfo` objects, and adds `SingularityScheduledTasksInfo` to `SingularityTranscoderModule` for JSON parsing.

https://git.hubteam.com/HubSpot/PaaS-Run/issues/1588