### PR TITLE
Mutate request instances based on existing request

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -2136,7 +2136,7 @@ public class SingularityConfiguration extends Configuration {
     return allowEmptyRequestInstances;
   }
 
-  public void setallowEmptyRequestInstances(boolean allowEmptyRequestInstances) {
+  public void setAllowEmptyRequestInstances(boolean allowEmptyRequestInstances) {
     this.allowEmptyRequestInstances = allowEmptyRequestInstances;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -453,6 +453,8 @@ public class SingularityConfiguration extends Configuration {
 
   private boolean skipPersistingTooLongTaskIds = false;
 
+  private boolean allowSettingRequestInstances = false;
+
   public long getAskDriverToKillTasksAgainAfterMillis() {
     return askDriverToKillTasksAgainAfterMillis;
   }
@@ -2118,5 +2120,13 @@ public class SingularityConfiguration extends Configuration {
 
   public void setSkipPersistingTooLongTaskIds(boolean skipPersistingTooLongTaskIds) {
     this.skipPersistingTooLongTaskIds = skipPersistingTooLongTaskIds;
+  }
+
+  public boolean allowSettingRequestInstances() {
+    return allowSettingRequestInstances;
+  }
+
+  public void setAllowSettingRequestInstances(boolean allowSettingRequestInstances) {
+    this.allowSettingRequestInstances = allowSettingRequestInstances;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -453,7 +453,7 @@ public class SingularityConfiguration extends Configuration {
 
   private boolean skipPersistingTooLongTaskIds = false;
 
-  private boolean allowSettingRequestInstances = false;
+  private boolean allowEmptyRequestInstances = false;
 
   public long getAskDriverToKillTasksAgainAfterMillis() {
     return askDriverToKillTasksAgainAfterMillis;
@@ -2122,11 +2122,11 @@ public class SingularityConfiguration extends Configuration {
     this.skipPersistingTooLongTaskIds = skipPersistingTooLongTaskIds;
   }
 
-  public boolean allowSettingRequestInstances() {
-    return allowSettingRequestInstances;
+  public boolean allowEmptyRequestInstances() {
+    return allowEmptyRequestInstances;
   }
 
-  public void setAllowSettingRequestInstances(boolean allowSettingRequestInstances) {
-    this.allowSettingRequestInstances = allowSettingRequestInstances;
+  public void setallowEmptyRequestInstances(boolean allowEmptyRequestInstances) {
+    this.allowEmptyRequestInstances = allowEmptyRequestInstances;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
@@ -230,10 +230,30 @@ public class SingularityValidator {
       request.getId().length(),
       request.getId()
     );
-    checkBadRequest(
-      !request.getInstances().isPresent() || request.getInstances().get() > 0,
-      "Instances must be greater than 0"
-    );
+
+    if (singularityConfiguration.allowSettingRequestInstances()) {
+      checkBadRequest(
+        (
+          !existingRequest.flatMap(SingularityRequest::getInstances).isPresent() &&
+          !request.getInstances().isPresent()
+        ) ||
+        request.getInstances().get() > 0,
+        "Instances must be greater than 0"
+      );
+
+      if (
+        existingRequest.flatMap(SingularityRequest::getInstances).isPresent() &&
+        !request.getInstances().isPresent()
+      ) {
+        request =
+          request.toBuilder().setInstances(existingRequest.get().getInstances()).build();
+      }
+    } else {
+      checkBadRequest(
+        !request.getInstances().isPresent() || request.getInstances().get() > 0,
+        "Instances must be greater than 0"
+      );
+    }
 
     checkBadRequest(
       request.getInstancesSafe() <= maxInstancesPerRequest,

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
@@ -231,16 +231,12 @@ public class SingularityValidator {
       request.getId()
     );
 
-    if (singularityConfiguration.allowEmptyRequestInstances()) {
-      checkBadRequest(
-        (
-          !existingRequest.flatMap(SingularityRequest::getInstances).isPresent() &&
-          !request.getInstances().isPresent()
-        ) ||
-        request.getInstances().get() > 0,
-        "Instances must be greater than 0"
-      );
+    checkBadRequest(
+      !request.getInstances().isPresent() || request.getInstances().get() > 0,
+      "Instances must be greater than 0"
+    );
 
+    if (singularityConfiguration.allowEmptyRequestInstances()) {
       if (
         (
           request.getRequestType().equals(RequestType.SERVICE) ||
@@ -252,11 +248,6 @@ public class SingularityValidator {
         request =
           request.toBuilder().setInstances(existingRequest.get().getInstances()).build();
       }
-    } else {
-      checkBadRequest(
-        !request.getInstances().isPresent() || request.getInstances().get() > 0,
-        "Instances must be greater than 0"
-      );
     }
 
     checkBadRequest(

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java
@@ -231,7 +231,7 @@ public class SingularityValidator {
       request.getId()
     );
 
-    if (singularityConfiguration.allowSettingRequestInstances()) {
+    if (singularityConfiguration.allowEmptyRequestInstances()) {
       checkBadRequest(
         (
           !existingRequest.flatMap(SingularityRequest::getInstances).isPresent() &&
@@ -242,6 +242,10 @@ public class SingularityValidator {
       );
 
       if (
+        (
+          request.getRequestType().equals(RequestType.SERVICE) ||
+          request.getRequestType().equals(RequestType.WORKER)
+        ) &&
         existingRequest.flatMap(SingularityRequest::getInstances).isPresent() &&
         !request.getInstances().isPresent()
       ) {

--- a/SingularityService/src/test/java/com/hubspot/singularity/data/ValidatorTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/data/ValidatorTest.java
@@ -562,4 +562,30 @@ public class ValidatorTest extends SingularitySchedulerTestBase {
         )
     );
   }
+
+  @Test
+  public void itKeepPreviousInstancesCountWhenEmpty() {
+    singularityConfiguration.setAllowEmptyRequestInstances(true);
+    SingularityRequest request = new SingularityRequestBuilder("test", RequestType.WORKER)
+      .setInstances(Optional.of(5))
+      .build();
+    SingularityRequest newRequest = new SingularityRequestBuilder(
+      "test",
+      RequestType.WORKER
+    )
+    .build();
+
+    SingularityRequest returnedRequest = validator.checkSingularityRequest(
+      newRequest,
+      Optional.of(request),
+      Optional.empty(),
+      Optional.empty()
+    );
+
+    Assertions.assertTrue(returnedRequest.getInstances().isPresent());
+    Assertions.assertSame(
+      returnedRequest.getInstances().get(),
+      request.getInstances().get()
+    );
+  }
 }


### PR DESCRIPTION
We want to start allowing deploys with Singularity Requests that have an empty `instances` field and instead of failing to deploy, those requests will take on the instance count of the existing Singularity Request. 

The new code path behind the config value  `allowSettingRequestInstances` will check checkBadRequest for both the new request has empty instances and the existing request being empty/empty instances. If the existing request isn't empty && doesn't have an empty `instances` field and the current request has empty `instances`, then the current request is updated to have the existing request's instance count.