### PR TITLE
Retry failed tasks with new deploys

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -428,7 +428,7 @@ public class SingularityScheduler {
     );
 
     if (!isRequestActive(maybeRequest)) {
-      LOG.debug(
+      LOG.info(
         "Pending request {} was obsolete (request {})",
         requestId,
         SingularityRequestWithState.getRequestState(maybeRequest)
@@ -475,7 +475,7 @@ public class SingularityScheduler {
           maybeRequestDeployState
         )
       ) {
-        LOG.debug(
+        LOG.info(
           "Pending request {} was obsolete (request {})",
           pendingRequest,
           SingularityRequestWithState.getRequestState(maybeRequest)

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -1016,7 +1016,7 @@ public class SingularityScheduler {
     if (!isDeployInUse(requestDeployState, taskId.getDeployId(), true)) {
       // failed tasks with remaining retries cannot short circuit here
       if (
-        state.equals(ExtendedTaskState.TASK_FAILED) &&
+        !state.equals(ExtendedTaskState.TASK_FINISHED) &&
         (
           deployStatistics.getNumSequentialRetries() <
           request.getNumRetriesOnFailure().orElse(0)

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -1014,12 +1014,27 @@ public class SingularityScheduler {
     );
 
     if (!isDeployInUse(requestDeployState, taskId.getDeployId(), true)) {
-      LOG.debug(
-        "Task {} completed, but it didn't match active deploy state {} - ignoring",
-        taskId.getId(),
-        requestDeployState
-      );
-      return Optional.empty();
+      // failed tasks with remaining retries cannot short circuit here
+      if (
+        state.equals(ExtendedTaskState.TASK_FAILED) &&
+        (
+          deployStatistics.getNumSequentialRetries() <
+          request.getNumRetriesOnFailure().orElse(0)
+        )
+      ) {
+        LOG.info(
+          "Task {} failed, but it didn't match active deploy state {} - may retry with current deploy state",
+          taskId.getId(),
+          requestDeployState
+        );
+      } else {
+        LOG.info(
+          "Task {} completed, but it didn't match active deploy state {} - ignoring",
+          taskId.getId(),
+          requestDeployState
+        );
+        return Optional.empty();
+      }
     }
 
     if (

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityScheduler.java
@@ -1015,8 +1015,9 @@ public class SingularityScheduler {
 
     if (!isDeployInUse(requestDeployState, taskId.getDeployId(), true)) {
       // failed tasks with remaining retries cannot short circuit here
+      // isFailed is false for lost and other weird task states
       if (
-        !state.equals(ExtendedTaskState.TASK_FINISHED) &&
+        !state.isSuccess() &&
         (
           deployStatistics.getNumSequentialRetries() <
           request.getNumRetriesOnFailure().orElse(0)

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -1255,6 +1255,94 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     Assertions.assertTrue(taskManager.getActiveTaskIds().isEmpty());
   }
 
+  @Test
+  public void testRetriesWithNewDeploys() {
+    SingularityRequestBuilder bldr = new SingularityRequestBuilder(
+      requestId,
+      RequestType.RUN_ONCE
+    );
+    request = bldr.setNumRetriesOnFailure(Optional.of(2)).build();
+    saveRequest(request);
+
+    deployResource.deploy(
+      new SingularityDeployRequest(
+        new SingularityDeployBuilder(requestId, "d1")
+          .setCommand(Optional.of("cmd"))
+          .build(),
+        Optional.empty(),
+        Optional.empty()
+      ),
+      singularityUser
+    );
+
+    scheduler.drainPendingQueue();
+    deployChecker.checkDeploys();
+    resourceOffers();
+
+    Assertions.assertEquals(1, taskManager.getActiveTaskIds().size());
+
+    deployResource.deploy(
+      new SingularityDeployRequest(
+        new SingularityDeployBuilder(requestId, "d2")
+          .setCommand(Optional.of("cmd"))
+          .build(),
+        Optional.empty(),
+        Optional.empty()
+      ),
+      singularityUser
+    );
+
+    statusUpdate(taskManager.getActiveTasks().get(0), TaskState.TASK_LOST);
+
+    scheduler.drainPendingQueue();
+    deployChecker.checkDeploys();
+    resourceOffers();
+
+    Assertions.assertEquals(1, taskManager.getActiveTaskIds().size());
+    Assertions.assertEquals("d2", taskManager.getActiveTaskIds().get(0).getDeployId());
+
+    deployResource.deploy(
+      new SingularityDeployRequest(
+        new SingularityDeployBuilder(requestId, "d3")
+          .setCommand(Optional.of("cmd"))
+          .build(),
+        Optional.empty(),
+        Optional.empty()
+      ),
+      singularityUser
+    );
+
+    statusUpdate(taskManager.getActiveTasks().get(0), TaskState.TASK_LOST);
+
+    scheduler.drainPendingQueue();
+    deployChecker.checkDeploys();
+    resourceOffers();
+
+    Assertions.assertEquals(1, taskManager.getActiveTaskIds().size());
+    Assertions.assertEquals("d3", taskManager.getActiveTaskIds().get(0).getDeployId());
+
+    deployResource.deploy(
+      new SingularityDeployRequest(
+        new SingularityDeployBuilder(requestId, "d4")
+          .setCommand(Optional.of("cmd"))
+          .build(),
+        Optional.empty(),
+        Optional.empty()
+      ),
+      singularityUser
+    );
+
+    statusUpdate(taskManager.getActiveTasks().get(0), TaskState.TASK_LOST);
+
+    scheduler.drainPendingQueue();
+    deployChecker.checkDeploys();
+    resourceOffers();
+
+    // TODO - new deploys have new deploy statistics, so we lose track of the # of retries
+    Assertions.assertEquals(1, taskManager.getActiveTaskIds().size());
+    Assertions.assertEquals("d4", taskManager.getActiveTaskIds().get(0).getDeployId());
+  }
+
   /* @Test
   public void testCooldownAfterSequentialFailures() {
     initRequest();

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -1277,6 +1277,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
 
     scheduler.drainPendingQueue();
     deployChecker.checkDeploys();
+    scheduler.drainPendingQueue();
     resourceOffers();
 
     Assertions.assertEquals(1, taskManager.getActiveTaskIds().size());
@@ -1296,6 +1297,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
 
     scheduler.drainPendingQueue();
     deployChecker.checkDeploys();
+    scheduler.drainPendingQueue();
     resourceOffers();
 
     Assertions.assertEquals(1, taskManager.getActiveTaskIds().size());
@@ -1316,6 +1318,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
 
     scheduler.drainPendingQueue();
     deployChecker.checkDeploys();
+    scheduler.drainPendingQueue();
     resourceOffers();
 
     Assertions.assertEquals(1, taskManager.getActiveTaskIds().size());
@@ -1336,6 +1339,7 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
 
     scheduler.drainPendingQueue();
     deployChecker.checkDeploys();
+    scheduler.drainPendingQueue();
     resourceOffers();
 
     // TODO - new deploys have new deploy statistics, so we lose track of the # of retries


### PR DESCRIPTION
This PR should fix failed tasks not being retried due to newer deploys while the tasks were running.

The branch that skips the newer deploy short circuit should generally get to the current retry logic, but all the other checks / cooldowns still apply.

The log level changes are in case I was mistaken and that the real cause of these tasks not getting retried was obsolete requests all along.

cc - @ssalinas , @pschoenfelder 