### PR TITLE
Run persisters in parallel

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -261,6 +261,8 @@ public class SingularityConfiguration extends Configuration {
 
   private long persistHistoryEverySeconds = TimeUnit.MINUTES.toSeconds(2);
 
+  private int historyPollerConcurrency = 5;
+
   private int maxPendingImmediatePersists = 200;
 
   private long reconcileAgentsEveryMinutes = TimeUnit.HOURS.toMinutes(1);
@@ -2108,5 +2110,13 @@ public class SingularityConfiguration extends Configuration {
 
   public void setRequestCacheTtl(int requestCacheTtlInSeconds) {
     this.requestCacheTtlInSeconds = requestCacheTtlInSeconds;
+  }
+
+  public int getHistoryPollerConcurrency() {
+    return historyPollerConcurrency;
+  }
+
+  public void setHistoryPollerConcurrency(int historyPollerConcurrency) {
+    this.historyPollerConcurrency = historyPollerConcurrency;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityRequestHistoryPersister.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityRequestHistoryPersister.java
@@ -6,7 +6,9 @@ import com.google.inject.name.Named;
 import com.hubspot.mesos.JavaUtils;
 import com.hubspot.singularity.SingularityDeleteResult;
 import com.hubspot.singularity.SingularityHistoryItem;
+import com.hubspot.singularity.SingularityManagedThreadPoolFactory;
 import com.hubspot.singularity.SingularityRequestHistory;
+import com.hubspot.singularity.async.CompletableFutures;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.RequestManager;
 import com.hubspot.singularity.data.history.SingularityRequestHistoryPersister.SingularityRequestHistoryParent;
@@ -16,6 +18,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -43,12 +46,13 @@ public class SingularityRequestHistoryPersister
     RequestManager requestManager,
     HistoryManager historyManager,
     SingularitySchedulerLock lock,
+    SingularityManagedThreadPoolFactory managedThreadPoolFactory,
     @Named(SingularityHistoryModule.PERSISTER_LOCK) ReentrantLock persisterLock,
     @Named(
       SingularityHistoryModule.LAST_REQUEST_PERSISTER_SUCCESS
     ) AtomicLong lastPersisterSuccess
   ) {
-    super(configuration, persisterLock, lastPersisterSuccess);
+    super(configuration, persisterLock, lastPersisterSuccess, managedThreadPoolFactory);
     this.requestManager = requestManager;
     this.historyManager = historyManager;
     this.lock = lock;
@@ -158,21 +162,34 @@ public class SingularityRequestHistoryPersister
       Collections.sort(requestHistoryParents, Collections.reverseOrder()); // createdAt descending
 
       AtomicInteger i = new AtomicInteger();
+      List<CompletableFuture<Void>> futures = new ArrayList<>();
       for (SingularityRequestHistoryParent requestHistoryParent : requestHistoryParents) {
-        lock.runWithRequestLock(
-          () -> {
-            if (moveToHistoryOrCheckForPurge(requestHistoryParent, i.getAndIncrement())) {
-              numHistoryTransferred.getAndAdd(requestHistoryParent.history.size());
-            } else {
-              persisterSuccess.getAndSet(false);
-            }
-          },
-          requestHistoryParent.requestId,
-          "request history purger",
-          SingularitySchedulerLock.Priority.LOW
+        futures.add(
+          CompletableFuture.runAsync(
+            () ->
+              lock.runWithRequestLock(
+                () -> {
+                  if (
+                    moveToHistoryOrCheckForPurge(
+                      requestHistoryParent,
+                      i.getAndIncrement()
+                    )
+                  ) {
+                    numHistoryTransferred.getAndAdd(requestHistoryParent.history.size());
+                  } else {
+                    persisterSuccess.getAndSet(false);
+                  }
+                },
+                requestHistoryParent.requestId,
+                "request history purger",
+                SingularitySchedulerLock.Priority.LOW
+              ),
+            persisterExecutor
+          )
         );
       }
 
+      CompletableFutures.allOf(futures).join();
       LOG.info(
         "Transferred {} history updates for {} requests in {}",
         numHistoryTransferred,

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityTaskHistoryPersister.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/history/SingularityTaskHistoryPersister.java
@@ -5,17 +5,22 @@ import com.google.inject.name.Named;
 import com.hubspot.mesos.JavaUtils;
 import com.hubspot.singularity.ExtendedTaskState;
 import com.hubspot.singularity.SingularityDeleteResult;
+import com.hubspot.singularity.SingularityManagedThreadPoolFactory;
 import com.hubspot.singularity.SingularityPendingDeploy;
 import com.hubspot.singularity.SingularityTaskHistory;
 import com.hubspot.singularity.SingularityTaskHistoryUpdate;
 import com.hubspot.singularity.SingularityTaskId;
+import com.hubspot.singularity.async.CompletableFutures;
 import com.hubspot.singularity.config.SingularityConfiguration;
 import com.hubspot.singularity.data.DeployManager;
 import com.hubspot.singularity.data.TaskManager;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
@@ -42,12 +47,13 @@ public class SingularityTaskHistoryPersister
     TaskManager taskManager,
     DeployManager deployManager,
     HistoryManager historyManager,
+    SingularityManagedThreadPoolFactory managedThreadPoolFactory,
     @Named(SingularityHistoryModule.PERSISTER_LOCK) ReentrantLock persisterLock,
     @Named(
       SingularityHistoryModule.LAST_TASK_PERSISTER_SUCCESS
     ) AtomicLong lastPersisterSuccess
   ) {
-    super(configuration, persisterLock, lastPersisterSuccess);
+    super(configuration, persisterLock, lastPersisterSuccess, managedThreadPoolFactory);
     this.taskManager = taskManager;
     this.historyManager = historyManager;
     this.deployManager = deployManager;
@@ -59,7 +65,7 @@ public class SingularityTaskHistoryPersister
   public void runActionOnPoll() {
     LOG.info("Attempting to grab persister lock");
     persisterLock.lock();
-    boolean persisterSuccess = true;
+    AtomicBoolean persisterSuccess = new AtomicBoolean(true);
     try {
       LOG.info("Checking inactive task ids for task history persistence");
 
@@ -68,47 +74,58 @@ public class SingularityTaskHistoryPersister
       requestIds.sort(
         Comparator.comparingLong(taskManager::getTaskCountForRequest).reversed()
       );
+      List<CompletableFuture<Void>> futures = new ArrayList<>();
       for (String requestId : requestIds) {
-        try {
-          LOG.debug("Checking request {}", requestId);
-          List<SingularityTaskId> taskIds = taskManager.getTaskIdsForRequest(requestId);
-          taskIds.removeAll(taskManager.getActiveTaskIdsForRequest(requestId));
-          taskIds.removeAll(taskManager.getLBCleanupTasks());
-          List<SingularityPendingDeploy> pendingDeploys = deployManager.getPendingDeploys();
-          taskIds =
-            taskIds
-              .stream()
-              .filter(
-                taskId ->
-                  !isPartOfPendingDeploy(pendingDeploys, taskId) &&
-                  !couldReturnWithRecoveredAgent(taskId)
-              )
-              .sorted(SingularityTaskId.STARTED_AT_COMPARATOR_DESC)
-              .collect(Collectors.toList());
-          int forRequest = 0;
-          int transferred = 0;
-          for (SingularityTaskId taskId : taskIds) {
-            if (moveToHistoryOrCheckForPurge(taskId, forRequest)) {
-              LOG.debug("Transferred task {}", taskId);
-              transferred++;
-            } else {
-              persisterSuccess = false;
-            }
+        futures.add(
+          CompletableFuture.runAsync(
+            () -> {
+              try {
+                LOG.debug("Checking request {}", requestId);
+                List<SingularityTaskId> taskIds = taskManager.getTaskIdsForRequest(
+                  requestId
+                );
+                taskIds.removeAll(taskManager.getActiveTaskIdsForRequest(requestId));
+                taskIds.removeAll(taskManager.getLBCleanupTasks());
+                List<SingularityPendingDeploy> pendingDeploys = deployManager.getPendingDeploys();
+                taskIds =
+                  taskIds
+                    .stream()
+                    .filter(
+                      taskId ->
+                        !isPartOfPendingDeploy(pendingDeploys, taskId) &&
+                        !couldReturnWithRecoveredAgent(taskId)
+                    )
+                    .sorted(SingularityTaskId.STARTED_AT_COMPARATOR_DESC)
+                    .collect(Collectors.toList());
+                int forRequest = 0;
+                int transferred = 0;
+                for (SingularityTaskId taskId : taskIds) {
+                  if (moveToHistoryOrCheckForPurge(taskId, forRequest)) {
+                    LOG.debug("Transferred task {}", taskId);
+                    transferred++;
+                  } else {
+                    persisterSuccess.set(false);
+                  }
 
-            forRequest++;
-          }
-          LOG.debug(
-            "Transferred {} out of {} inactive task ids in {}",
-            transferred,
-            taskIds.size(),
-            JavaUtils.duration(start)
-          );
-        } catch (Exception e) {
-          LOG.error("Could not persist", e);
-        }
+                  forRequest++;
+                }
+                LOG.debug(
+                  "Transferred {} out of {} inactive task ids in {}",
+                  transferred,
+                  taskIds.size(),
+                  JavaUtils.duration(start)
+                );
+              } catch (Exception e) {
+                LOG.error("Could not persist", e);
+              }
+            },
+            persisterExecutor
+          )
+        );
       }
+      CompletableFutures.allOf(futures).join();
     } finally {
-      if (persisterSuccess) {
+      if (persisterSuccess.get()) {
         lastPersisterSuccess.set(System.currentTimeMillis());
         LOG.info(
           "Finished run on task history persister at {}",


### PR DESCRIPTION
This allows parallel execution of persister tasks within a type of persister (e.g. 5 parallel executions for the tsak history persister). The number of these is configurable as `historyPollerConcurrency`