### PR TITLE
Various bug fixes and stability improvements

### DIFF
--- a/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskIdHistory.java
+++ b/SingularityBase/src/main/java/com/hubspot/singularity/SingularityTaskIdHistory.java
@@ -17,7 +17,6 @@ public class SingularityTaskIdHistory implements Comparable<SingularityTaskIdHis
   private final Optional<ExtendedTaskState> lastTaskState;
   private final Optional<String> runId;
 
-  @SuppressFBWarnings("NP_NULL_PARAM_DEREF")
   public static SingularityTaskIdHistory fromTaskIdAndTaskAndUpdates(
     SingularityTaskId taskId,
     SingularityTask task,
@@ -26,10 +25,15 @@ public class SingularityTaskIdHistory implements Comparable<SingularityTaskIdHis
     ExtendedTaskState lastTaskState = null;
     long updatedAt = taskId.getStartedAt();
 
-    if (updates != null && !updates.isEmpty()) {
-      SingularityTaskHistoryUpdate lastUpdate = Collections.max(updates);
-      lastTaskState = lastUpdate.getTaskState();
-      updatedAt = lastUpdate.getTimestamp();
+    if (updates != null) {
+      Optional<SingularityTaskHistoryUpdate> maybeLastUpdate = updates
+        .stream()
+        .filter(Objects::nonNull)
+        .max(SingularityTaskHistoryUpdate::compareTo);
+      if (maybeLastUpdate.isPresent()) {
+        lastTaskState = maybeLastUpdate.get().getTaskState();
+        updatedAt = maybeLastUpdate.get().getTimestamp();
+      }
     }
 
     return new SingularityTaskIdHistory(

--- a/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/config/SingularityConfiguration.java
@@ -458,6 +458,7 @@ public class SingularityConfiguration extends Configuration {
   private boolean skipPersistingTooLongTaskIds = false;
 
   private boolean allowEmptyRequestInstances = false;
+  private boolean verifyTaskDataWrites = false;
 
   public long getAskDriverToKillTasksAgainAfterMillis() {
     return askDriverToKillTasksAgainAfterMillis;
@@ -2150,5 +2151,13 @@ public class SingularityConfiguration extends Configuration {
 
   public void setAllowEmptyRequestInstances(boolean allowEmptyRequestInstances) {
     this.allowEmptyRequestInstances = allowEmptyRequestInstances;
+  }
+
+  public boolean isVerifyTaskDataWrites() {
+    return verifyTaskDataWrites;
+  }
+
+  public void setVerifyTaskDataWrites(boolean verifyTaskDataWrites) {
+    this.verifyTaskDataWrites = verifyTaskDataWrites;
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/CuratorManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/CuratorManager.java
@@ -319,7 +319,7 @@ public abstract class CuratorManager {
         cachedValue.isPresent() &&
         (
           !shouldCheckExists.isPresent() ||
-          (shouldCheckExists.get().booleanValue() && checkExists(path).isPresent())
+          (shouldCheckExists.get() && checkExists(path).isPresent())
         )
       ) {
         return cachedValue;
@@ -332,9 +332,7 @@ public abstract class CuratorManager {
     try {
       GetDataBuilder bldr = curator.getData();
 
-      if (stat.isPresent()) {
-        bldr.storingStatIn(stat.get());
-      }
+      stat.ifPresent(bldr::storingStatIn);
 
       byte[] data = bldr.forPath(path);
 
@@ -347,9 +345,7 @@ public abstract class CuratorManager {
 
       final T object = transcoder.fromBytes(data);
 
-      if (zkCache.isPresent()) {
-        zkCache.get().set(path, object);
-      }
+      zkCache.ifPresent(tZkCache -> tZkCache.set(path, object));
 
       return Optional.of(object);
     } catch (NoNodeException nne) {
@@ -380,7 +376,7 @@ public abstract class CuratorManager {
   ) {
     return getData(
       path,
-      Optional.<Stat>empty(),
+      Optional.empty(),
       transcoder,
       Optional.of(zkCache),
       Optional.of(shouldCheckExists)
@@ -390,10 +386,10 @@ public abstract class CuratorManager {
   protected Optional<String> getStringData(String path) {
     return getData(
       path,
-      Optional.<Stat>empty(),
+      Optional.empty(),
       StringTranscoder.INSTANCE,
-      Optional.<ZkCache<String>>empty(),
-      Optional.<Boolean>empty()
+      Optional.empty(),
+      Optional.empty()
     );
   }
 }

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -1254,6 +1254,9 @@ public class TaskManager extends CuratorAsyncManager {
   public List<SingularityPendingTaskId> getPendingTaskIdsForRequest(
     final String requestId
   ) {
+    if (leaderCache.active()) {
+      return leaderCache.getPendingTaskIdsForRequest(requestId);
+    }
     return getChildrenAsIds(getPendingForRequestPath(requestId), pendingTaskIdTranscoder);
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/TaskManager.java
@@ -486,10 +486,12 @@ public class TaskManager extends CuratorAsyncManager {
   }
 
   private List<SingularityTaskId> getActiveTaskIdsUncached() {
-    return getAsyncNestedChildIdsAsList(
-      LAST_ACTIVE_TASK_STATUSES_PATH_ROOT,
-      LAST_ACTIVE_TASK_STATUSES_PATH_ROOT,
-      taskIdTranscoder
+    return new ArrayList<>(
+      getAsyncNestedChildIdsAsList(
+        LAST_ACTIVE_TASK_STATUSES_PATH_ROOT,
+        LAST_ACTIVE_TASK_STATUSES_PATH_ROOT,
+        taskIdTranscoder
+      )
     );
   }
 

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/curator/ZkClientsLoadDistributor.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/curator/ZkClientsLoadDistributor.java
@@ -10,6 +10,7 @@ public class ZkClientsLoadDistributor {
   private static final Logger LOG = LoggerFactory.getLogger(
     ZkClientsLoadDistributor.class
   );
+  private static final ThreadLocal<Integer> ZK_CONTEXT = new ThreadLocal<>();
 
   private final List<CuratorFramework> curatorFrameworks;
   private final AtomicInteger curatorIndex;
@@ -40,8 +41,11 @@ public class ZkClientsLoadDistributor {
   }
 
   public CuratorFramework getCuratorFramework() {
-    int ci = curatorIndex.getAndUpdate(i -> (i + 1) % curatorFrameworks.size());
-    return curatorFrameworks.get(ci);
+    if (ZK_CONTEXT.get() == null) {
+      int ci = curatorIndex.getAndUpdate(i -> (i + 1) % curatorFrameworks.size());
+      ZK_CONTEXT.set(ci);
+    }
+    return curatorFrameworks.get(ZK_CONTEXT.get());
   }
 
   public List<CuratorFramework> getAll() {

--- a/SingularityService/src/main/java/com/hubspot/singularity/data/usage/JDBITaskUsageManager.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/data/usage/JDBITaskUsageManager.java
@@ -36,6 +36,10 @@ public class JDBITaskUsageManager implements TaskUsageManager {
     SingularityTaskId taskId,
     SingularityTaskUsage usage
   ) {
+    if (taskId.getId().length() > 200) {
+      LOG.warn("Skipping too long task id in usage table: {}", taskId);
+      return;
+    }
     taskUsageJDBI.saveSpecificTaskUsage(
       taskId.getRequestId(),
       taskId.getId(),

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
@@ -9,6 +9,7 @@ import com.github.rholder.retry.WaitStrategies;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.hubspot.mesos.JavaUtils;
@@ -43,6 +44,7 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -178,6 +180,8 @@ public class SingularityMesosSchedulerImpl extends SingularityMesosScheduler {
             }
             startup.startup(newMasterInfo);
             state.setMesosSchedulerState(MesosSchedulerState.SUBSCRIBED);
+            // Recheck for inconsistent state in case we started receiving/denying status updates while running startup
+            recheckState();
             restartInProgress.set(false);
             handleQueuedStatusUpdates();
           },
@@ -186,6 +190,15 @@ public class SingularityMesosSchedulerImpl extends SingularityMesosScheduler {
         ),
       subscribeExecutor
     );
+  }
+
+  private void recheckState() {
+    ExecutorService startupExecutor = Executors.newFixedThreadPool(
+      configuration.getSchedulerStartupConcurrency(),
+      new ThreadFactoryBuilder().setNameFormat("startup-%d").build()
+    );
+    startup.checkSchedulerForInconsistentState(startupExecutor);
+    startupExecutor.shutdown();
   }
 
   @Timed

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
@@ -180,10 +180,10 @@ public class SingularityMesosSchedulerImpl extends SingularityMesosScheduler {
             }
             startup.startup(newMasterInfo);
             state.setMesosSchedulerState(MesosSchedulerState.SUBSCRIBED);
-            // Recheck for inconsistent state in case we started receiving/denying status updates while running startup
-            recheckState();
             restartInProgress.set(false);
             handleQueuedStatusUpdates();
+            // Recheck for inconsistent state in case we started receiving/denying status updates while running startup
+            recheckState();
           },
           "subscribed",
           false

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosStatusUpdateHandler.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosStatusUpdateHandler.java
@@ -575,6 +575,19 @@ public class SingularityMesosStatusUpdateHandler {
           "Task %s is active but is missing task data",
           taskId
         );
+        taskManager.createTaskCleanup(
+          new SingularityTaskCleanup(
+            Optional.empty(),
+            TaskCleanupType.UNHEALTHY_NEW_TASK,
+            System.currentTimeMillis(),
+            taskIdObj,
+            Optional.of(
+              "Task is active but had no task data. Unable to continue running"
+            ),
+            Optional.empty(),
+            Optional.empty()
+          )
+        );
         exceptionNotifier.notify(message);
         LOG.error(message);
       }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityStartup.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityStartup.java
@@ -132,8 +132,12 @@ class SingularityStartup {
     LOG.info("Finished startup after {}", JavaUtils.duration(start));
   }
 
-  private Map<SingularityDeployKey, SingularityPendingTaskId> getDeployKeyToPendingTaskId() {
-    final List<SingularityPendingTaskId> pendingTaskIds = taskManager.getPendingTaskIds();
+  private Map<SingularityDeployKey, SingularityPendingTaskId> getDeployKeyToPendingTaskId(
+    String requestId
+  ) {
+    final List<SingularityPendingTaskId> pendingTaskIds = taskManager.getPendingTaskIdsForRequest(
+      requestId
+    );
     final Map<SingularityDeployKey, SingularityPendingTaskId> deployKeyToPendingTaskId = Maps.newHashMapWithExpectedSize(
       pendingTaskIds.size()
     );
@@ -163,8 +167,6 @@ class SingularityStartup {
   ) {
     final long now = System.currentTimeMillis();
 
-    final Map<SingularityDeployKey, SingularityPendingTaskId> deployKeyToPendingTaskId = getDeployKeyToPendingTaskId();
-
     List<CompletableFuture<Void>> checkFutures = new ArrayList<>();
     for (String requestId : requestManager.getAllRequestIds()) {
       checkFutures.add(
@@ -172,6 +174,10 @@ class SingularityStartup {
           () ->
             lock.runWithRequestLock(
               () -> {
+                final Map<SingularityDeployKey, SingularityPendingTaskId> deployKeyToPendingTaskId = getDeployKeyToPendingTaskId(
+                  requestId
+                );
+
                 Optional<SingularityRequestWithState> maybeWithState = requestManager.getRequest(
                   requestId
                 );

--- a/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/scheduler/SingularityCleaner.java
@@ -1626,6 +1626,10 @@ public class SingularityCleaner {
         return CheckLBState.DONE;
       case FAILED:
       case CANCELED:
+        if (lbDeleteUpdate.getMessage().orElse("").contains("Invalid request due to")) {
+          LOG.warn("Unable to complete LB delete for {}", loadBalancerRequestId);
+          return CheckLBState.DONE;
+        }
         LOG.error(
           "LB delete request {} ({}) got unexpected response {}",
           lbDeleteUpdate,

--- a/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
+++ b/SingularityService/src/test/java/com/hubspot/singularity/scheduler/SingularitySchedulerTest.java
@@ -2623,13 +2623,12 @@ public class SingularitySchedulerTest extends SingularitySchedulerTestBase {
     Assertions.assertTrue(taskManager.isActiveTask(taskOne.getTaskId()));
 
     statusUpdate(taskOne, TaskState.TASK_RUNNING);
-    statusUpdate(taskOne, TaskState.TASK_FAILED);
-
-    Assertions.assertTrue(!taskManager.isActiveTask(taskOne.getTaskId()));
-
-    Assertions.assertEquals(
-      2,
-      taskManager.getTaskHistoryUpdates(taskOne.getTaskId()).size()
+    List<SingularityTaskHistoryUpdate> updates = taskManager.getTaskHistoryUpdates(
+      taskOne.getTaskId()
+    );
+    Assertions.assertEquals(2, updates.size());
+    Assertions.assertTrue(
+      updates.stream().anyMatch(t -> t.getTaskState() == ExtendedTaskState.TASK_CLEANING)
     );
   }
 


### PR DESCRIPTION
- An LB delete that gets back `Invalid request...` will never be able to complete. Junk it and move on
- Clean up a number of deprecated things in CuratorAsyncManager and prefer more lambdas over old style
- In the load balanced curator, attempt to use the same curator client for the same thread where possible to avoid race conditions hitting possibly different zk instances
- For tasks that do not have any active task data when they hit status updates, clean them up. These will only cause issues if allowed to persist (and will never actually be added to LB)
- Fix a possible overflow in length for task usage column with task ids oover 200 chars. This fails gracefully and is fine to leave empty
- Rerun the scheduler check after marking as started during startup. this should fix a case where a status update came in but we did not schedule a new pending task for it yet because we were not marked as started