### PR TITLE
Add large scale down flag to client

### DIFF
--- a/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
+++ b/SingularityClient/src/main/java/com/hubspot/singularity/client/SingularityClient.java
@@ -698,6 +698,15 @@ public class SingularityClient {
     return executeRequest(hostToUri, type, body, Method.PUT, Optional.empty());
   }
 
+  private HttpResponse put(
+    Function<String, String> hostToUri,
+    String type,
+    Optional<?> body,
+    Map<String, Object> queryParams
+  ) {
+    return executeRequest(hostToUri, type, body, Method.PUT, Optional.of(queryParams));
+  }
+
   private <T> Optional<T> post(
     Function<String, String> hostToUri,
     String type,
@@ -1039,12 +1048,24 @@ public class SingularityClient {
     String requestId,
     SingularityScaleRequest scaleRequest
   ) {
+    scaleSingularityRequest(requestId, scaleRequest, Optional.empty());
+  }
+
+  public void scaleSingularityRequest(
+    String requestId,
+    SingularityScaleRequest scaleRequest,
+    Optional<Boolean> largeScaleDownAcknowledged
+  ) {
     final Function<String, String> requestUri = host ->
       String.format(REQUEST_SCALE_FORMAT, getApiBase(host), requestId);
     put(
       requestUri,
       String.format("Scale of Request %s", requestId),
-      Optional.of(scaleRequest)
+      Optional.of(scaleRequest),
+      Collections.singletonMap(
+        "largeScaleDownAcknowledged",
+        largeScaleDownAcknowledged.orElse(false)
+      )
     );
   }
 


### PR DESCRIPTION
Flag was added to endpoint [here](https://github.com/HubSpot/Singularity/pull/2275/files#diff-05dc8661deba9fc538b4bf1e7cc39260843cf5a0ca98070ef7cc5319b898000cR1785), but not to client. 