### PR TITLE
Handle tasks which no longer have data in zk

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosSchedulerImpl.java
@@ -787,7 +787,7 @@ public class SingularityMesosSchedulerImpl extends SingularityMesosScheduler {
             );
           }
           if (result == StatusUpdateResult.KILL_TASK) {
-            LOG.info(
+            LOG.warn(
               "Killing a task {} which Singularity has no remaining active state for. It will be given 1 minute to shut down gracefully",
               status.getTaskId().getValue()
             );


### PR DESCRIPTION
Follow up to #2281 

Separate handling for tasks with missing data, before the isDuplicateOrIgnorable check. We canot actually recover these, so kill them before they become an issue. Creating a cleanup for them doesn't actually do anything because the cleaner short circuits on missing task data