### PR TITLE
Handle combined `cpu,cpuacct` cgroup mountpoints

### DIFF
--- a/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorCgroupCfsChecker.java
+++ b/SingularityExecutor/src/main/java/com/hubspot/singularity/executor/SingularityExecutorCgroupCfsChecker.java
@@ -66,11 +66,16 @@ public class SingularityExecutorCgroupCfsChecker extends WatchServiceHelper {
       )
     );
     for (String cgroup : cgroups) {
-      if (cgroup.contains(":cpu:")) {
-        String[] segments = cgroup.split(":");
-        String cgroupPath = getBaseCgroupPath() + segments[segments.length - 1];
-        LOG.info("Will start watcher for directory {}", cgroupPath);
-        return Paths.get(cgroupPath);
+      String[] segments = cgroup.split(":", 3);
+      if (segments.length == 3) {
+        String[] subsystems = segments[1].split(",");
+        for (String subsystem : subsystems) {
+          if (subsystem.equals("cpu")) {
+            String cgroupPath = getBaseCgroupPath() + segments[2];
+            LOG.info("Will start watcher for directory {}", cgroupPath);
+            return Paths.get(cgroupPath);
+          }
+        }
       }
     }
     throw new RuntimeException(


### PR DESCRIPTION
Disclaimer: untested, need someone to get this built for me so we can test internally, but wanted to get the ball rolling.

On HubSpot's legacy systems, cgroups look like:
```
4:cpuacct:/hs_high_priority/mesos/83df193b-5cd3-4393-986a-f992dd284b03
3:cpu:/hs_high_priority/mesos/83df193b-5cd3-4393-986a-f992dd284b03
```
but on centos 8 systems, they look like:
```
2:cpu,cpuacct:/hs_high_priority/mesos/fb69d013-4e17-45fe-b47b-dde6a177a3a3
```
Parsers for `/proc/pid/cgroup` are supposed to split the subsystems field on `,` to determine which subsystems the line is for. Additionally, they should do a maxsplit of 3 to deal with cgroup names that may contain semicolons.

This PR should fix this error on CentOS 8 hosts:
```
java.lang.RuntimeException: Found no cpu cgroup from output [11:freezer:/hs_high_priority/mesos/f99d4218-bb4d-49f9-bd10-b47be89c3936, 10:devices:/system.slice/mesos-slave.service, 9:memory:/hs_high_priority/mesos/f99d4218-bb4d-49f9-bd10-b47be89c3936, 8:cpuset:/, 7:hugetlb:/, 6:blkio:/system.slice/mesos-slave.service, 5:net_cls,net_prio:/, 4:pids:/system.slice/mesos-slave.service, 3:perf_event:/, 2:cpu,cpuacct:/hs_high_priority/mesos/f99d4218-bb4d-49f9-bd10-b47be89c3936, 1:name=systemd:/hs_high_priority/mesos/f99d4218-bb4d-49f9-bd10-b47be89c3936]
        at com.hubspot.singularity.executor.SingularityExecutorCgroupCfsChecker.getCpuCgroupDirectory(SingularityExecutorCgroupCfsChecker.java:77)
        at com.hubspot.singularity.executor.SingularityExecutorCgroupCfsChecker.<init>(SingularityExecutorCgroupCfsChecker.java:53)
        at com.hubspot.singularity.executor.SingularityExecutorMonitor.lambda$startCgroupWatcher$0(SingularityExecutorMonitor.java:528)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
```