### PR TITLE
Add a class of scheduler-related metrics to expose more easily

### DIFF
--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosModule.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularityMesosModule.java
@@ -36,6 +36,7 @@ public class SingularityMesosModule extends AbstractModule {
     bind(SingularitySchedulerLock.class).in(Scopes.SINGLETON);
     bind(SingularityMesosSchedulerClient.class).in(Scopes.SINGLETON);
     bind(TaskLagGuardrail.class).in(Scopes.SINGLETON);
+    bind(SingularitySchedulerMetrics.class).in(Scopes.SINGLETON);
 
     Multibinder.newSetBinder(binder(), DeployAcceptanceHook.class);
   }

--- a/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySchedulerMetrics.java
+++ b/SingularityService/src/main/java/com/hubspot/singularity/mesos/SingularitySchedulerMetrics.java
@@ -1,0 +1,58 @@
+package com.hubspot.singularity.mesos;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.MetricRegistry;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+@Singleton
+public class SingularitySchedulerMetrics {
+  private final Histogram offerLoopTime;
+  private final Counter tasksScheduled;
+  private final Histogram offerLoopTasksRemaining;
+  private final Histogram deployPollerTime;
+  private final Histogram lbUpdateTime;
+  private final Histogram offerLoopOverLoadedHosts;
+  private final Histogram offerLoopNoMatches;
+
+  @Inject
+  SingularitySchedulerMetrics(MetricRegistry metricRegistry) {
+    this.offerLoopTime = metricRegistry.histogram("offer-loop.time");
+    this.tasksScheduled = metricRegistry.counter("tasks-scheduled");
+    this.offerLoopTasksRemaining = metricRegistry.histogram("offer-loop.tasks-remaining");
+    this.deployPollerTime = metricRegistry.histogram("deploy-poller-time");
+    this.lbUpdateTime = metricRegistry.histogram("lb-update-time");
+    this.offerLoopOverLoadedHosts =
+      metricRegistry.histogram("offer-loop.overloaded-hosts");
+    this.offerLoopNoMatches = metricRegistry.histogram("offer-loop.no-matches");
+  }
+
+  public Histogram getOfferLoopTime() {
+    return offerLoopTime;
+  }
+
+  public Counter getTasksScheduled() {
+    return tasksScheduled;
+  }
+
+  public Histogram getOfferLoopTasksRemaining() {
+    return offerLoopTasksRemaining;
+  }
+
+  public Histogram getDeployPollerTime() {
+    return deployPollerTime;
+  }
+
+  public Histogram getLbUpdateTime() {
+    return lbUpdateTime;
+  }
+
+  public Histogram getOfferLoopOverLoadedHosts() {
+    return offerLoopOverLoadedHosts;
+  }
+
+  public Histogram getOfferLoopNoMatches() {
+    return offerLoopNoMatches;
+  }
+}


### PR DESCRIPTION
Give us a better view of scheduler performance without having to dig through all of the log statements